### PR TITLE
chore(release): v0.1.1

### DIFF
--- a/packages/dynamic-forms-bootstrap/package.json
+++ b/packages/dynamic-forms-bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-bootstrap",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Bootstrap 5 integration for @ng-forge/dynamic-forms. Pre-built Bootstrap form components.",
   "type": "module",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "@angular/common": "~21.0.5",
     "@angular/core": "~21.0.5",
     "@angular/forms": "~21.0.5",
-    "@ng-forge/dynamic-forms": "0.1.0",
+    "@ng-forge/dynamic-forms": "~0.1.1",
     "rxjs": ">=7.0.0"
   }
 }

--- a/packages/dynamic-forms-ionic/package.json
+++ b/packages/dynamic-forms-ionic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-ionic",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Ionic integration for @ng-forge/dynamic-forms. Pre-built Ionic form components for mobile and desktop.",
   "type": "module",
   "license": "MIT",
@@ -29,7 +29,7 @@
     "@angular/core": "~21.0.5",
     "@angular/forms": "~21.0.5",
     "@ionic/angular": ">=7.0.0",
-    "@ng-forge/dynamic-forms": "0.1.0",
+    "@ng-forge/dynamic-forms": "~0.1.1",
     "rxjs": ">=7.0.0"
   },
   "dependencies": {

--- a/packages/dynamic-forms-material/package.json
+++ b/packages/dynamic-forms-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-material",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Angular Material integration for @ng-forge/dynamic-forms. Pre-built Material Design form components.",
   "type": "module",
   "license": "MIT",
@@ -28,7 +28,7 @@
     "@angular/core": "~21.0.5",
     "@angular/forms": "~21.0.5",
     "@angular/material": "~21.0.0",
-    "@ng-forge/dynamic-forms": "0.1.0",
+    "@ng-forge/dynamic-forms": "~0.1.1",
     "rxjs": ">=7.0.0"
   }
 }

--- a/packages/dynamic-forms-primeng/package.json
+++ b/packages/dynamic-forms-primeng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-primeng",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "PrimeNG integration for @ng-forge/dynamic-forms. Pre-built PrimeNG form components.",
   "type": "module",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "@angular/common": "~21.0.5",
     "@angular/core": "~21.0.5",
     "@angular/forms": "~21.0.5",
-    "@ng-forge/dynamic-forms": "0.1.0",
+    "@ng-forge/dynamic-forms": "~0.1.1",
     "primeng": ">=17.0.0",
     "rxjs": ">=7.0.0"
   }

--- a/packages/dynamic-forms/package.json
+++ b/packages/dynamic-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Type-safe, signal-powered dynamic forms for Angular. Build complex forms from configuration with full TypeScript inference.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bump all packages to version 0.1.1
- Update peer dependency references to `~0.1.1`

### Packages Updated

| Package | Version |
|---------|---------|
| @ng-forge/dynamic-forms | 0.1.1 |
| @ng-forge/dynamic-forms-material | 0.1.1 |
| @ng-forge/dynamic-forms-bootstrap | 0.1.1 |
| @ng-forge/dynamic-forms-primeng | 0.1.1 |
| @ng-forge/dynamic-forms-ionic | 0.1.1 |

## Changelog

This release includes the fix for Angular 21.0.5 Signal Forms API breaking change:
- Updated `childrenMap` entry access from `.tree` to `.reader`
- Added type guards for better type safety
- Upgraded `@angular/material` and `@angular/cdk` to v21

## Test plan

- [x] All packages lint successfully
- [ ] CI passes
- [ ] Publish to npm after merge