### PR TITLE
refactor(dynamic-forms): encapsulate effects and subscriptions in constructor-called methods

### DIFF
--- a/packages/dynamic-forms/src/lib/fields/group/group-field.component.ts
+++ b/packages/dynamic-forms/src/lib/fields/group/group-field.component.ts
@@ -253,14 +253,25 @@ export default class GroupFieldComponent<TModel = Record<string, unknown>> {
   );
 
   // ─────────────────────────────────────────────────────────────────────────────
-  // Effects
+  // Constructor
   // ─────────────────────────────────────────────────────────────────────────────
 
-  private readonly emitInitializedOnFieldsResolved = explicitEffect([this.resolvedFields], ([fields]) => {
-    if (fields.length > 0) {
-      emitComponentInitialized(this.eventBus, 'group', this.field().key, this.injector);
-    }
-  });
+  constructor() {
+    this.setupEffects();
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Private Methods
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  private setupEffects(): void {
+    // Emit initialization event when fields are resolved
+    explicitEffect([this.resolvedFields], ([fields]) => {
+      if (fields.length > 0) {
+        emitComponentInitialized(this.eventBus, 'group', this.field().key, this.injector);
+      }
+    });
+  }
 }
 
 export { GroupFieldComponent };

--- a/packages/dynamic-forms/src/lib/fields/page/page-field.component.ts
+++ b/packages/dynamic-forms/src/lib/fields/page/page-field.component.ts
@@ -132,12 +132,23 @@ export default class PageFieldComponent {
   );
 
   // ─────────────────────────────────────────────────────────────────────────────
-  // Effects
+  // Constructor
   // ─────────────────────────────────────────────────────────────────────────────
 
-  private readonly emitInitializedOnFieldsResolved = explicitEffect([this.resolvedFields], ([fields]) => {
-    if (fields.length > 0) {
-      emitComponentInitialized(this.eventBus, 'page', this.field().key, this.injector);
-    }
-  });
+  constructor() {
+    this.setupEffects();
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Private Methods
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  private setupEffects(): void {
+    // Emit initialization event when fields are resolved
+    explicitEffect([this.resolvedFields], ([fields]) => {
+      if (fields.length > 0) {
+        emitComponentInitialized(this.eventBus, 'page', this.field().key, this.injector);
+      }
+    });
+  }
 }

--- a/packages/dynamic-forms/src/lib/fields/row/row-field.component.ts
+++ b/packages/dynamic-forms/src/lib/fields/row/row-field.component.ts
@@ -102,14 +102,25 @@ export default class RowFieldComponent {
   );
 
   // ─────────────────────────────────────────────────────────────────────────────
-  // Effects
+  // Constructor
   // ─────────────────────────────────────────────────────────────────────────────
 
-  private readonly emitInitializedOnFieldsResolved = explicitEffect([this.resolvedFields], ([fields]) => {
-    if (fields.length > 0) {
-      emitComponentInitialized(this.eventBus, 'row', this.field().key, this.injector);
-    }
-  });
+  constructor() {
+    this.setupEffects();
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Private Methods
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  private setupEffects(): void {
+    // Emit initialization event when fields are resolved
+    explicitEffect([this.resolvedFields], ([fields]) => {
+      if (fields.length > 0) {
+        emitComponentInitialized(this.eventBus, 'row', this.field().key, this.injector);
+      }
+    });
+  }
 }
 
 export { RowFieldComponent };


### PR DESCRIPTION
## Summary

- Move all `explicitEffect()` and subscription class properties into private `setupEffects()` and `setupEventHandlers()` methods called from the constructor
- Encapsulates reactive setup logic and prevents exposing effects/subscriptions as class properties
- Remove hardcoded error announcement logic (`errorAnnouncement` signal, live region template, `countErrors` method) - not translatable, users should handle accessibility announcements with proper i18n

## Components Refactored

| Component | Effects | Subscriptions |
|-----------|---------|---------------|
| `DynamicForm` | 4 | 3 |
| `GroupFieldComponent` | 1 | - |
| `PageFieldComponent` | 1 | - |
| `RowFieldComponent` | 1 | - |
| `ArrayFieldComponent` | 1 | 2 |

## Test plan

- [x] Build passes
- [x] Lint passes
- [x] All 1697 unit tests pass