### PR TITLE
fix(dynamic-forms): resolve build warnings

### DIFF
--- a/packages/dynamic-forms-bootstrap/src/lib/fields/radio/bs-radio.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/radio/bs-radio.component.ts
@@ -18,7 +18,6 @@ import { BsRadioGroupComponent } from './bs-radio-group.component';
   styleUrl: '../../styles/_form-field.scss',
   template: `
     @let f = field();
-    @let ariaInvalid = this.ariaInvalid(); @let ariaRequired = this.ariaRequired();
     @let ariaDescribedBy = this.ariaDescribedBy();
 
     <div class="mb-3">

--- a/packages/dynamic-forms-material/src/lib/fields/checkbox/mat-checkbox.component.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/checkbox/mat-checkbox.component.ts
@@ -13,7 +13,6 @@ import { explicitEffect } from 'ngxtension/explicit-effect';
   imports: [MatCheckbox, Field, MatError, DynamicTextPipe, AsyncPipe],
   template: `
     @let f = field();
-    @let ariaInvalid = this.ariaInvalid(); @let ariaRequired = this.ariaRequired();
     @let ariaDescribedBy = this.ariaDescribedBy();
 
     <mat-checkbox
@@ -22,7 +21,7 @@ import { explicitEffect } from 'ngxtension/explicit-effect';
       [indeterminate]="props()?.indeterminate || false"
       [color]="props()?.color || 'primary'"
       [disableRipple]="effectiveDisableRipple()"
-      [required]="!!f().required?.()"
+      [required]="!!f().required()"
       [aria-describedby]="ariaDescribedBy"
       [attr.tabindex]="tabIndex()"
       [attr.hidden]="f().hidden() || null"

--- a/packages/dynamic-forms-material/src/lib/fields/toggle/mat-toggle.component.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/toggle/mat-toggle.component.ts
@@ -13,7 +13,6 @@ import { MATERIAL_CONFIG } from '../../models/material-config.token';
   imports: [MatSlideToggle, Field, MatError, DynamicTextPipe, AsyncPipe],
   template: `
     @let f = field();
-    @let ariaInvalid = this.ariaInvalid(); @let ariaRequired = this.ariaRequired();
     @let ariaDescribedBy = this.ariaDescribedBy();
 
     <mat-slide-toggle
@@ -22,7 +21,7 @@ import { MATERIAL_CONFIG } from '../../models/material-config.token';
       [labelPosition]="props()?.labelPosition || 'after'"
       [hideIcon]="props()?.hideIcon || false"
       [disableRipple]="effectiveDisableRipple()"
-      [required]="!!f().required?.()"
+      [required]="!!f().required()"
       [aria-describedby]="ariaDescribedBy"
       [attr.tabindex]="tabIndex()"
       class="toggle-container"

--- a/packages/dynamic-forms/src/lib/fields/row/row-field.component.scss
+++ b/packages/dynamic-forms/src/lib/fields/row/row-field.component.scss
@@ -1,4 +1,5 @@
 // Row-specific styling overrides and customizations
+@use 'sass:math';
 @use '../../styles/grid-system.scss';
 
 :host {
@@ -18,8 +19,8 @@
   // Use ::ng-deep because child components have their own view encapsulation
   @for $i from 1 through 12 {
     ::ng-deep > .df-col-#{$i} {
-      flex: 0 0 calc(#{percentage(calc($i / 12))} - var(--df-grid-gap) * #{calc((12 - $i) / 12)});
-      max-width: calc(#{percentage(calc($i / 12))} - var(--df-grid-gap) * #{calc((12 - $i) / 12)});
+      flex: 0 0 calc(#{math.percentage(math.div($i, 12))} - var(--df-grid-gap) * #{math.div((12 - $i), 12)});
+      max-width: calc(#{math.percentage(math.div($i, 12))} - var(--df-grid-gap) * #{math.div((12 - $i), 12)});
     }
   }
 


### PR DESCRIPTION
## Summary

- Fix Sass deprecation warnings by replacing deprecated `percentage()` function with `math.percentage()` and `math.div()` in `row-field.component.scss`
- Remove unused `@let` declarations (`ariaInvalid`, `ariaRequired`) from templates in:
  - `bs-radio.component.ts`
  - `mat-checkbox.component.ts`
  - `mat-toggle.component.ts`
- Remove unnecessary optional chain operator (`?.`) on `f().required()` where the type does not include `null`/`undefined` (NG8107 warning)

## Test plan

- [ ] Verify build completes without warnings: `pnpm nx run-many --target=build --all`
- [ ] Run tests to ensure no regressions: `pnpm nx run-many --target=test --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)