### PR TITLE
chore(release): v0.1.2

### DIFF
--- a/packages/dynamic-forms-bootstrap/package.json
+++ b/packages/dynamic-forms-bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-bootstrap",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Bootstrap 5 integration for @ng-forge/dynamic-forms. Pre-built Bootstrap form components.",
   "type": "module",
   "license": "MIT",

--- a/packages/dynamic-forms-ionic/package.json
+++ b/packages/dynamic-forms-ionic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-ionic",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Ionic integration for @ng-forge/dynamic-forms. Pre-built Ionic form components for mobile and desktop.",
   "type": "module",
   "license": "MIT",

--- a/packages/dynamic-forms-material/package.json
+++ b/packages/dynamic-forms-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-material",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Angular Material integration for @ng-forge/dynamic-forms. Pre-built Material Design form components.",
   "type": "module",
   "license": "MIT",

--- a/packages/dynamic-forms-primeng/package.json
+++ b/packages/dynamic-forms-primeng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-primeng",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "PrimeNG integration for @ng-forge/dynamic-forms. Pre-built PrimeNG form components.",
   "type": "module",
   "license": "MIT",

--- a/packages/dynamic-forms/package.json
+++ b/packages/dynamic-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Type-safe, signal-powered dynamic forms for Angular. Build complex forms from configuration with full TypeScript inference.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump all package versions from 0.1.1 to 0.1.2

## Changes since v0.1.1
- feat(dynamic-forms): improve form value type inference and add field type utilities (#99)
- fix(dynamic-forms): resolve build warnings (#102)
- fix(dynamic-forms): infer number type for input fields with props.type: 'number' (#104)
- refactor(dynamic-forms): encapsulate effects and subscriptions in constructor-called methods (#101)
- docs: improve package readmes and metadata (#100)

## Packages
- @ng-forge/dynamic-forms
- @ng-forge/dynamic-forms-bootstrap
- @ng-forge/dynamic-forms-material
- @ng-forge/dynamic-forms-primeng
- @ng-forge/dynamic-forms-ionic