### PR TITLE
fix(docs): improve mobile responsiveness for navbar and sidebar

### DIFF
--- a/apps/docs/src/app/app.scss
+++ b/apps/docs/src/app/app.scss
@@ -1,9 +1,19 @@
 .ng-doc-header-controls {
   display: flex;
+  flex-shrink: 0;
 
   a[ng-doc-button-icon],
   button[ng-doc-button-icon],
   ng-doc-theme-toggle {
     margin-left: calc(var(--ng-doc-base-gutter) * 2);
+  }
+
+  // Reduce spacing on narrow screens to prevent overflow
+  @media (max-width: 480px) {
+    a[ng-doc-button-icon],
+    button[ng-doc-button-icon],
+    ng-doc-theme-toggle {
+      margin-left: calc(var(--ng-doc-base-gutter) * 1);
+    }
   }
 }

--- a/apps/docs/src/styles.scss
+++ b/apps/docs/src/styles.scss
@@ -56,6 +56,40 @@ body[data-theme='light'] .logo-dark {
 }
 
 // ============================================
+// RESPONSIVE NAVBAR
+// ============================================
+// On very narrow screens, hide search and reduce spacing to make room for hamburger menu
+@media (max-width: 400px) {
+  ng-doc-navbar {
+    // Hide the search component on very narrow screens
+    ng-doc-search {
+      display: none !important;
+    }
+
+    // Reduce navbar padding
+    .navbar-container {
+      padding-inline: calc(var(--ng-doc-base-gutter) * 1) !important;
+    }
+  }
+}
+
+// ============================================
+// MOBILE SIDEBAR SCROLL FIX
+// ============================================
+// Fix sidebar scroll on iOS Safari where content gets cut off
+// due to safe area insets and browser chrome
+@media (max-width: 1024px) {
+  ng-doc-sidebar {
+    // Ensure sidebar wrapper can scroll fully on mobile
+    .ng-doc-side-bar-wrapper {
+      // Add padding at bottom to account for iOS safe area and ensure
+      // all content is accessible when scrolling
+      padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 80px) !important;
+    }
+  }
+}
+
+// ============================================
 // IFRAME EXAMPLES
 // ============================================
 // PrimeNG and Ionic examples are loaded via iframes


### PR DESCRIPTION
## Summary
- Hide search icon on very narrow screens (≤400px) to ensure hamburger menu stays visible
- Reduce header control spacing on narrow screens to prevent overflow
- Add bottom padding to sidebar wrapper on mobile to fix iOS Safari scroll cutoff where last navigation items were inaccessible

## Test plan
- [x] Tested on iPhone Safari via local network
- [x] Verified navbar controls visible at 320px width
- [x] Verified sidebar scrolls fully to show all navigation items including "API Reference"
- [x] Verified desktop layout unchanged at 1280px