### PR TITLE
chore(release): bump version to 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 0.1.3 (2025-12-20)
+
+### 🚀 Features
+
+- **dynamic-forms:** add configurable logger service ([#105](https://github.com/ng-forge/ng-forge/pull/105))
+- **dynamic-forms:** add secondary entrypoints for integration and testing ([#108](https://github.com/ng-forge/ng-forge/pull/108))
+
+### 🐛 Bug Fixes
+
+- **docs:** improve mobile responsiveness for navbar and sidebar ([#109](https://github.com/ng-forge/ng-forge/pull/109))
+- **dynamic-forms:** infer number type for input fields with props.type: 'number' ([#104](https://github.com/ng-forge/ng-forge/pull/104))
+
+### ♻️ Code Refactoring
+
+- **dynamic-forms:** simplify field tree access using bracket notation ([#107](https://github.com/ng-forge/ng-forge/pull/107))
+
+### ❤️ Thank You
+
+- Antim Prisacaru @antimprisacaru
+- Claude Opus 4.5
+
 ## 0.1.0 (2025-12-11)
 
 ### 🚀 Features

--- a/packages/dynamic-forms-bootstrap/package.json
+++ b/packages/dynamic-forms-bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-bootstrap",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Bootstrap 5 integration for @ng-forge/dynamic-forms. Pre-built Bootstrap form components.",
   "type": "module",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@angular/common": "~21.0.5",
     "@angular/core": "~21.0.5",
     "@angular/forms": "~21.0.5",
-    "@ng-forge/dynamic-forms": "~0.1.1",
+    "@ng-forge/dynamic-forms": "~0.1.3",
     "rxjs": ">=7.0.0"
   }
 }

--- a/packages/dynamic-forms-ionic/package.json
+++ b/packages/dynamic-forms-ionic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-ionic",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Ionic integration for @ng-forge/dynamic-forms. Pre-built Ionic form components for mobile and desktop.",
   "type": "module",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "@angular/core": "~21.0.5",
     "@angular/forms": "~21.0.5",
     "@ionic/angular": ">=7.0.0",
-    "@ng-forge/dynamic-forms": "~0.1.1",
+    "@ng-forge/dynamic-forms": "~0.1.3",
     "rxjs": ">=7.0.0"
   },
   "dependencies": {

--- a/packages/dynamic-forms-material/package.json
+++ b/packages/dynamic-forms-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-material",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Angular Material integration for @ng-forge/dynamic-forms. Pre-built Material Design form components.",
   "type": "module",
   "license": "MIT",
@@ -32,7 +32,7 @@
     "@angular/core": "~21.0.5",
     "@angular/forms": "~21.0.5",
     "@angular/material": "~21.0.0",
-    "@ng-forge/dynamic-forms": "~0.1.1",
+    "@ng-forge/dynamic-forms": "~0.1.3",
     "rxjs": ">=7.0.0"
   }
 }

--- a/packages/dynamic-forms-primeng/package.json
+++ b/packages/dynamic-forms-primeng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-primeng",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "PrimeNG integration for @ng-forge/dynamic-forms. Pre-built PrimeNG form components.",
   "type": "module",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@angular/common": "~21.0.5",
     "@angular/core": "~21.0.5",
     "@angular/forms": "~21.0.5",
-    "@ng-forge/dynamic-forms": "~0.1.1",
+    "@ng-forge/dynamic-forms": "~0.1.3",
     "primeng": ">=17.0.0",
     "rxjs": ">=7.0.0"
   }

--- a/packages/dynamic-forms/package.json
+++ b/packages/dynamic-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Type-safe, signal-powered dynamic forms for Angular. Build complex forms from configuration with full TypeScript inference.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump all package versions from 0.1.2 to 0.1.3
- Update inter-package peerDependencies
- Generate changelog from v0.1.2

## Packages Updated
- @ng-forge/dynamic-forms: 0.1.2 → 0.1.3
- @ng-forge/dynamic-forms-bootstrap: 0.1.2 → 0.1.3
- @ng-forge/dynamic-forms-ionic: 0.1.2 → 0.1.3
- @ng-forge/dynamic-forms-material: 0.1.2 → 0.1.3
- @ng-forge/dynamic-forms-primeng: 0.1.2 → 0.1.3

## Changelog (0.1.3)

### 🚀 Features
- **dynamic-forms:** add configurable logger service (#105)
- **dynamic-forms:** add secondary entrypoints for integration and testing (#108)

### 🐛 Bug Fixes
- **docs:** improve mobile responsiveness for navbar and sidebar (#109)
- **dynamic-forms:** infer number type for input fields with props.type: 'number' (#104)

### ♻️ Code Refactoring
- **dynamic-forms:** simplify field tree access using bracket notation (#107)

## Release Notes
See the generated [GitHub Release](https://github.com/ng-forge/ng-forge/releases/tag/v0.1.3) for full changelog.

## Next Steps
After merging, trigger the Release workflow manually from GitHub Actions to publish to npm.