### PR TITLE
refactor(dynamic-forms): centralize error prefix in base error class

### DIFF
--- a/packages/dynamic-forms/src/lib/core/expressions/parser/evaluator.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/parser/evaluator.ts
@@ -171,7 +171,7 @@ export class Evaluator {
         return this.evaluateArrayLiteral(node);
 
       default:
-        throw new ExpressionParserError(`[Dynamic Forms] Unknown node type: ${(node as { type: string }).type}`, 0, this.expression);
+        throw new ExpressionParserError(`Unknown node type: ${(node as { type: string }).type}`, 0, this.expression);
     }
   }
 
@@ -191,11 +191,7 @@ export class Evaluator {
 
     // Block access to dangerous properties that could leak information or enable attacks
     if (BLOCKED_PROPERTIES.has(node.property)) {
-      throw new ExpressionParserError(
-        `[Dynamic Forms] Property "${node.property}" is not accessible for security reasons`,
-        0,
-        this.expression,
-      );
+      throw new ExpressionParserError(`Property "${node.property}" is not accessible for security reasons`, 0, this.expression);
     }
 
     // Allow property access on plain objects and primitives
@@ -255,7 +251,7 @@ export class Evaluator {
         return (left as number) <= (right as number);
 
       default:
-        throw new ExpressionParserError(`[Dynamic Forms] Unknown binary operator: ${node.operator}`, 0, this.expression);
+        throw new ExpressionParserError(`Unknown binary operator: ${node.operator}`, 0, this.expression);
     }
   }
 
@@ -270,14 +266,14 @@ export class Evaluator {
       case '+':
         return +(operand as number);
       default:
-        throw new ExpressionParserError(`[Dynamic Forms] Unknown unary operator: ${node.operator}`, 0, this.expression);
+        throw new ExpressionParserError(`Unknown unary operator: ${node.operator}`, 0, this.expression);
     }
   }
 
   private evaluateCallExpression(node: { callee: ASTNode; arguments: ASTNode[] }): unknown {
     // Only allow method calls (member access), not arbitrary function calls
     if (node.callee.type !== 'MemberAccess') {
-      throw new ExpressionParserError('[Dynamic Forms] Only method calls are allowed, not arbitrary function calls', 0, this.expression);
+      throw new ExpressionParserError('Only method calls are allowed, not arbitrary function calls', 0, this.expression);
     }
 
     const obj = this.evaluate(node.callee.object);
@@ -285,16 +281,12 @@ export class Evaluator {
 
     // Block access to dangerous properties (must check before method call)
     if (BLOCKED_PROPERTIES.has(methodName)) {
-      throw new ExpressionParserError(
-        `[Dynamic Forms] Property "${methodName}" is not accessible for security reasons`,
-        0,
-        this.expression,
-      );
+      throw new ExpressionParserError(`Property "${methodName}" is not accessible for security reasons`, 0, this.expression);
     }
 
     // Check if the method is in the instance method whitelist
     if (!this.isMethodSafe(obj, methodName)) {
-      throw new ExpressionParserError(`[Dynamic Forms] Method "${methodName}" is not allowed for security reasons`, 0, this.expression);
+      throw new ExpressionParserError(`Method "${methodName}" is not allowed for security reasons`, 0, this.expression);
     }
 
     // Evaluate arguments

--- a/packages/dynamic-forms/src/lib/core/expressions/parser/expression-parser.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/parser/expression-parser.ts
@@ -106,7 +106,7 @@ export class ExpressionParser {
       }
       // Wrap other errors for consistency
       throw new ExpressionParserError(
-        `[Dynamic Forms] Error evaluating expression: ${error instanceof Error ? error.message : String(error)}`,
+        `Error evaluating expression: ${error instanceof Error ? error.message : String(error)}`,
         0,
         expression,
       );

--- a/packages/dynamic-forms/src/lib/core/expressions/parser/parser.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/parser/parser.ts
@@ -23,7 +23,7 @@ export class Parser {
     this.current = 0;
 
     if (this.isAtEnd()) {
-      throw new ExpressionParserError('[Dynamic Forms] Empty expression', 0, this.expression);
+      throw new ExpressionParserError('Empty expression', 0, this.expression);
     }
 
     return this.parseExpression();
@@ -122,7 +122,7 @@ export class Parser {
       if (this.match(TokenType.DOT)) {
         // Member access: obj.property
         if (!this.check(TokenType.IDENTIFIER)) {
-          throw new ExpressionParserError('[Dynamic Forms] Expected property name after "."', this.peek().position, this.expression);
+          throw new ExpressionParserError('Expected property name after "."', this.peek().position, this.expression);
         }
         const property = this.advance().value;
         node = { type: 'MemberAccess', object: node, property };
@@ -184,7 +184,7 @@ export class Parser {
       return expr;
     }
 
-    throw new ExpressionParserError(`[Dynamic Forms] Unexpected token: ${this.peek().value}`, this.peek().position, this.expression);
+    throw new ExpressionParserError(`Unexpected token: ${this.peek().value}`, this.peek().position, this.expression);
   }
 
   private parseArgumentList(): ASTNode[] {
@@ -246,6 +246,6 @@ export class Parser {
   private consume(type: TokenType, message: string): Token {
     if (this.check(type)) return this.advance();
 
-    throw new ExpressionParserError(`[Dynamic Forms] ${message}`, this.peek().position, this.expression);
+    throw new ExpressionParserError(message, this.peek().position, this.expression);
   }
 }

--- a/packages/dynamic-forms/src/lib/core/expressions/parser/tokenizer.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/parser/tokenizer.ts
@@ -103,7 +103,7 @@ export class Tokenizer {
       }
     }
 
-    throw new ExpressionParserError('[Dynamic Forms] Unterminated string literal', start, this.expression);
+    throw new ExpressionParserError('Unterminated string literal', start, this.expression);
   }
 
   private readNumber(): Token {
@@ -219,7 +219,7 @@ export class Tokenizer {
       case ']':
         return { type: TokenType.RBRACKET, value: ']', position: start };
       default:
-        throw new ExpressionParserError(`[Dynamic Forms] Unexpected character: ${char}`, start, this.expression);
+        throw new ExpressionParserError(`Unexpected character: ${char}`, start, this.expression);
     }
   }
 }

--- a/packages/dynamic-forms/src/lib/core/expressions/parser/types.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/parser/types.ts
@@ -1,3 +1,5 @@
+import { DynamicFormError } from '../../../errors/dynamic-form-error';
+
 /**
  * Token types for expression parsing
  */
@@ -102,7 +104,7 @@ export interface ArrayLiteralNode {
 /**
  * Parser error with position information
  */
-export class ExpressionParserError extends Error {
+export class ExpressionParserError extends DynamicFormError {
   constructor(
     message: string,
     public position: number,

--- a/packages/dynamic-forms/src/lib/errors/dynamic-form-error.ts
+++ b/packages/dynamic-forms/src/lib/errors/dynamic-form-error.ts
@@ -1,0 +1,15 @@
+/**
+ * Base error class for all Dynamic Forms errors.
+ *
+ * This class centralizes the `[Dynamic Forms]` prefix, ensuring consistent
+ * error messaging across the library without requiring each error site to
+ * manually include the prefix.
+ */
+export class DynamicFormError extends Error {
+  private static readonly PREFIX = '[Dynamic Forms]';
+
+  constructor(message: string) {
+    super(`${DynamicFormError.PREFIX} ${message}`);
+    this.name = 'DynamicFormError';
+  }
+}

--- a/packages/dynamic-forms/src/lib/errors/index.ts
+++ b/packages/dynamic-forms/src/lib/errors/index.ts
@@ -1,0 +1,1 @@
+export { DynamicFormError } from './dynamic-form-error';

--- a/packages/dynamic-forms/src/lib/fields/group/group-field.component.ts
+++ b/packages/dynamic-forms/src/lib/fields/group/group-field.component.ts
@@ -30,6 +30,7 @@ import { createSchemaFromFields } from '../../core/schema-builder';
 import { EventBus } from '../../events/event.bus';
 import { SubmitEvent } from '../../events/constants/submit.event';
 import { flattenFields } from '../../utils/flattener/field-flattener';
+import { DynamicFormError } from '../../errors/dynamic-form-error';
 
 /**
  * Container component for rendering nested form groups.
@@ -174,8 +175,8 @@ export default class GroupFieldComponent<TModel extends Record<string, unknown> 
     const child = parentForm[groupKey];
 
     if (!child) {
-      throw new Error(
-        `[Dynamic Forms] Group field "${groupKey}" not found in parent form. ` + `Ensure the parent form schema includes this group field.`,
+      throw new DynamicFormError(
+        `Group field "${groupKey}" not found in parent form. ` + `Ensure the parent form schema includes this group field.`,
       );
     }
 

--- a/packages/dynamic-forms/src/lib/index.ts
+++ b/packages/dynamic-forms/src/lib/index.ts
@@ -136,6 +136,9 @@ export {
 
 export type { FormEvent, FormEventConstructor, TokenContext, ArrayItemContext } from './events';
 
+// Errors
+export { DynamicFormError } from './errors/dynamic-form-error';
+
 // ============================================================
 // INTERNAL EXPORTS - Used by integration entrypoint
 // These are stable APIs for UI library authors

--- a/packages/dynamic-forms/src/lib/utils/form-validation/form-mode-validator.ts
+++ b/packages/dynamic-forms/src/lib/utils/form-validation/form-mode-validator.ts
@@ -1,6 +1,7 @@
 import { detectFormMode, FormModeDetectionResult, isPageField } from '../../models/types/form-mode';
 import { RegisteredFieldTypes } from '../../models/registry';
 import { validatePageNesting } from '../../definitions/default/page-field';
+import { DynamicFormError } from '../../errors/dynamic-form-error';
 
 /**
  * Comprehensive form configuration validator that checks:
@@ -53,12 +54,11 @@ export class FormModeValidator {
     const result = this.validateFormConfiguration(fields);
 
     if (!result.isValid) {
-      const errorMessage = [
-        `[Dynamic Forms] Invalid form configuration (${result.mode} mode):`,
-        ...result.errors.map((error) => `  - ${error}`),
-      ].join('\n');
+      const errorMessage = [`Invalid form configuration (${result.mode} mode):`, ...result.errors.map((error) => `  - ${error}`)].join(
+        '\n',
+      );
 
-      throw new Error(errorMessage);
+      throw new DynamicFormError(errorMessage);
     }
   }
 

--- a/packages/dynamic-forms/src/lib/utils/inject-field-registry/inject-field-registry.ts
+++ b/packages/dynamic-forms/src/lib/utils/inject-field-registry/inject-field-registry.ts
@@ -1,4 +1,5 @@
 import { inject, Type } from '@angular/core';
+import { DynamicFormError } from '../../errors/dynamic-form-error';
 import { FIELD_REGISTRY, FieldTypeDefinition } from '../../models/field-type';
 
 /**
@@ -104,7 +105,7 @@ export function injectFieldRegistry() {
       const fieldType = registry.get(name);
 
       if (!fieldType) {
-        throw new Error(`[Dynamic Forms] Field type "${name}" is not registered`);
+        throw new DynamicFormError(`Field type "${name}" is not registered`);
       }
 
       // Handle async loading
@@ -114,11 +115,11 @@ export function injectFieldRegistry() {
           // Handle ES module imports - extract default export if needed
           return (result as any)?.default || result;
         } catch (error) {
-          throw new Error(`[Dynamic Forms] Failed to load component for field type "${name}": ${error}`);
+          throw new DynamicFormError(`Failed to load component for field type "${name}": ${error}`);
         }
       }
 
-      throw new Error(`[Dynamic Forms] Field type "${name}" has no component or loadComponent function`);
+      throw new DynamicFormError(`Field type "${name}" has no component or loadComponent function`);
     },
 
     /**


### PR DESCRIPTION
## Summary
- Create `DynamicFormError` base class that centralizes the `[Dynamic Forms]` prefix for all library errors
- Update `ExpressionParserError` to extend `DynamicFormError`
- Remove redundant `[Dynamic Forms]` prefixes from error messages since they're now added by the base class
- Replace plain `Error` throws with `DynamicFormError` across the codebase

## Changes
- New `DynamicFormError` class in `errors/dynamic-form-error.ts`
- Updated error handling in:
  - Expression parser (`evaluator.ts`, `parser.ts`, `tokenizer.ts`, `expression-parser.ts`)
  - Field registry (`inject-field-registry.ts`)
  - Form validation (`form-mode-validator.ts`)
  - Group field component (`group-field.component.ts`)
- Export `DynamicFormError` from main entrypoint

## Test plan
- [x] All 1431 tests pass
- [x] Build succeeds
- [x] Lint passes (only pre-existing warnings)