### PR TITLE
chore(release): bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.2.0 (2025-12-23)
+
+### ♻️ Code Refactoring
+
+- **dynamic-forms:** replace any types with unknown for improved type safety ([#106](https://github.com/ng-forge/ng-forge/pull/106))
+- **dynamic-forms:** centralize error prefix in base error class ([#113](https://github.com/ng-forge/ng-forge/pull/113))
+- **dynamic-forms:** extract shared utilities and simplify input templates ([#116](https://github.com/ng-forge/ng-forge/pull/116))
+- **dynamic-forms:** simplify logger configuration ([#118](https://github.com/ng-forge/ng-forge/pull/118))
+
+### ❤️ Thank You
+
+- Antim Prisacaru @antimprisacaru
+
 ## 0.1.3 (2025-12-20)
 
 ### 🚀 Features

--- a/packages/dynamic-forms-bootstrap/package.json
+++ b/packages/dynamic-forms-bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-bootstrap",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Bootstrap 5 integration for @ng-forge/dynamic-forms. Pre-built Bootstrap form components.",
   "type": "module",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@angular/common": ">=21.0.6",
     "@angular/core": ">=21.0.6",
     "@angular/forms": ">=21.0.6",
-    "@ng-forge/dynamic-forms": "~0.1.3",
+    "@ng-forge/dynamic-forms": "~0.2.0",
     "rxjs": ">=7.0.0"
   }
 }

--- a/packages/dynamic-forms-bootstrap/project.json
+++ b/packages/dynamic-forms-bootstrap/project.json
@@ -7,7 +7,7 @@
   "implicitDependencies": ["dynamic-forms"],
   "release": {
     "version": {
-      "manifestRootsToUpdate": ["dist/{projectRoot}"],
+      "manifestRootsToUpdate": ["{projectRoot}", "dist/{projectRoot}"],
       "currentVersionResolver": "git-tag",
       "fallbackCurrentVersionResolver": "disk"
     }

--- a/packages/dynamic-forms-ionic/package.json
+++ b/packages/dynamic-forms-ionic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-ionic",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Ionic integration for @ng-forge/dynamic-forms. Pre-built Ionic form components for mobile and desktop.",
   "type": "module",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "@angular/core": ">=21.0.6",
     "@angular/forms": ">=21.0.6",
     "@ionic/angular": ">=7.0.0",
-    "@ng-forge/dynamic-forms": "~0.1.3",
+    "@ng-forge/dynamic-forms": "~0.2.0",
     "rxjs": ">=7.0.0"
   },
   "dependencies": {

--- a/packages/dynamic-forms-ionic/project.json
+++ b/packages/dynamic-forms-ionic/project.json
@@ -7,7 +7,7 @@
   "implicitDependencies": ["dynamic-forms"],
   "release": {
     "version": {
-      "manifestRootsToUpdate": ["dist/{projectRoot}"],
+      "manifestRootsToUpdate": ["{projectRoot}", "dist/{projectRoot}"],
       "currentVersionResolver": "git-tag",
       "fallbackCurrentVersionResolver": "disk"
     }

--- a/packages/dynamic-forms-material/package.json
+++ b/packages/dynamic-forms-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-material",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Angular Material integration for @ng-forge/dynamic-forms. Pre-built Material Design form components.",
   "type": "module",
   "license": "MIT",
@@ -32,7 +32,7 @@
     "@angular/core": ">=21.0.6",
     "@angular/forms": ">=21.0.6",
     "@angular/material": ">=21.0.5",
-    "@ng-forge/dynamic-forms": "~0.1.3",
+    "@ng-forge/dynamic-forms": "~0.2.0",
     "rxjs": ">=7.0.0"
   }
 }

--- a/packages/dynamic-forms-material/project.json
+++ b/packages/dynamic-forms-material/project.json
@@ -7,7 +7,7 @@
   "implicitDependencies": ["dynamic-forms"],
   "release": {
     "version": {
-      "manifestRootsToUpdate": ["dist/{projectRoot}"],
+      "manifestRootsToUpdate": ["{projectRoot}", "dist/{projectRoot}"],
       "currentVersionResolver": "git-tag",
       "fallbackCurrentVersionResolver": "disk"
     }

--- a/packages/dynamic-forms-primeng/package.json
+++ b/packages/dynamic-forms-primeng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-primeng",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "PrimeNG integration for @ng-forge/dynamic-forms. Pre-built PrimeNG form components.",
   "type": "module",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@angular/common": ">=21.0.6",
     "@angular/core": ">=21.0.6",
     "@angular/forms": ">=21.0.6",
-    "@ng-forge/dynamic-forms": "~0.1.3",
+    "@ng-forge/dynamic-forms": "~0.2.0",
     "primeng": ">=17.0.0",
     "rxjs": ">=7.0.0"
   }

--- a/packages/dynamic-forms-primeng/project.json
+++ b/packages/dynamic-forms-primeng/project.json
@@ -7,7 +7,7 @@
   "implicitDependencies": ["dynamic-forms"],
   "release": {
     "version": {
-      "manifestRootsToUpdate": ["dist/{projectRoot}"],
+      "manifestRootsToUpdate": ["{projectRoot}", "dist/{projectRoot}"],
       "currentVersionResolver": "git-tag",
       "fallbackCurrentVersionResolver": "disk"
     }

--- a/packages/dynamic-forms/package.json
+++ b/packages/dynamic-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Type-safe, signal-powered dynamic forms for Angular. Build complex forms from configuration with full TypeScript inference.",
   "type": "module",
   "license": "MIT",

--- a/packages/dynamic-forms/project.json
+++ b/packages/dynamic-forms/project.json
@@ -6,7 +6,7 @@
   "projectType": "library",
   "release": {
     "version": {
-      "manifestRootsToUpdate": ["dist/{projectRoot}"],
+      "manifestRootsToUpdate": ["{projectRoot}", "dist/{projectRoot}"],
       "currentVersionResolver": "git-tag",
       "fallbackCurrentVersionResolver": "disk"
     }


### PR DESCRIPTION
## Summary
- Bump all package versions to 0.2.0
- Update inter-package peerDependencies
- Generate changelog from v0.1.3
- Fix manifestRootsToUpdate config to update both source and dist package.json

## Packages Updated
- @ng-forge/dynamic-forms: 0.1.3 -> 0.2.0
- @ng-forge/dynamic-forms-bootstrap: 0.1.3 -> 0.2.0
- @ng-forge/dynamic-forms-ionic: 0.1.3 -> 0.2.0
- @ng-forge/dynamic-forms-material: 0.1.3 -> 0.2.0
- @ng-forge/dynamic-forms-primeng: 0.1.3 -> 0.2.0

## Changelog

### ♻️ Code Refactoring

- **dynamic-forms:** replace any types with unknown for improved type safety ([#106](https://github.com/ng-forge/ng-forge/pull/106))
- **dynamic-forms:** centralize error prefix in base error class ([#113](https://github.com/ng-forge/ng-forge/pull/113))
- **dynamic-forms:** extract shared utilities and simplify input templates ([#116](https://github.com/ng-forge/ng-forge/pull/116))
- **dynamic-forms:** simplify logger configuration ([#118](https://github.com/ng-forge/ng-forge/pull/118))

## Next Steps
After merging, trigger the Release workflow manually from GitHub Actions to publish to npm.