### PR TITLE
chore(release): bump version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,128 @@
+## 0.3.0 (2026-01-12)
+
+### 🚀 Features
+
+- **dynamic-forms:** add hidden field type for storing non-rendered values ([#122](https://github.com/ng-forge/ng-forge/pull/122))
+- **dynamic-forms:** add meta attribute support for wrapped components ([#115](https://github.com/ng-forge/ng-forge/pull/115))
+
+### 📦 Build System
+
+- ⚠️ **deps:** update angular to 21.0.8 with formfield directive migration ([#124](https://github.com/ng-forge/ng-forge/pull/124))
+
+### ✅ Tests
+
+- **forms:** add exhaustive type tests for all ui libraries and core types ([#121](https://github.com/ng-forge/ng-forge/pull/121))
+
+### ⏪ Reverts
+
+- ⚠️ **examples:** test(examples): add visual regression screenshots and e2e infrastructure (#125) ([#125](https://github.com/ng-forge/ng-forge/pull/125))
+
+### ⚠️ Breaking Changes
+
+- **examples:** test(examples): add visual regression screenshots and e2e infrastructure (#125) ([#125](https://github.com/ng-forge/ng-forge/pull/125))
+  CSS class prefix changed from df-ionic-_ to df-ion-_
+  to match naming convention of other UI libs (df-mat-_, df-bs-_, df-prime-\*).
+  Also standardize CSS variables across all UI libs:
+  - Add --df-label-color: inherit to Material, Ionic, PrimeNG
+  - Update Material font sizes from 0.75rem to 0.875rem
+  - All libs now have identical CSS variable sets
+  * refactor(config): extract shared playwright configuration
+    Create createPlaywrightConfig() factory function that generates
+    consistent Playwright configurations for all example apps.
+    Reduces each config file from ~95 lines to 3 lines.
+  - Add playwright-config.ts with APP_PORTS mapping and browser projects
+  - Export createPlaywrightConfig, APP_PORTS, ExampleApp from shared
+  - Update all 4 example apps to use shared config factory
+  * refactor(examples): remove hardcoded test urls
+    Replace hardcoded localhost URLs with path-only format that leverages
+    Playwright's baseURL configuration. This makes tests portable and
+    removes duplication.
+  - Replace http://localhost:42XX/# URLs with /# paths in 45+ spec files
+  - Update testUrl() functions to return path-only format
+  - Remove unused testUrl imports from ionic tests
+  - Clean up BASE_URL imports no longer needed
+  * fix(config): separate playwright config from angular compilation
+    The playwright-config.ts uses Node.js APIs (process.env, node:url)
+    which are not available in Angular's browser compilation context.
+  - Remove playwright-config exports from shared testing index
+  - Update playwright configs to import directly from the specific file
+  - Add comment explaining the separation
+  * fix(ionic): update eslint selector prefix to df-ion
+  * ci(config): add debugging for e2e affected detection
+  * fix(config): install pnpm in playwright docker container
+  * perf(config): run playwright directly in ci instead of docker
+    CI is already Ubuntu Linux, same as the Playwright Docker image.
+    Running directly avoids:
+  - Docker image pull (~1GB)
+  - Container setup overhead
+  - Reinstalling dependencies inside container
+    Docker scripts remain for local development where consistent
+    Linux rendering is needed on Mac/Windows.
+  * Revert "perf(config): run playwright directly in ci instead of docker
+- **deps:** update angular to 21.0.8 with formfield directive migration ([#124](https://github.com/ng-forge/ng-forge/pull/124))
+  Angular 21.0.7 renamed the Signal Forms directive from
+  `Field` to `FormField`. This requires `@angular/*` >= 21.0.7.
+  Angular & Forms changes:
+  - Update all @angular/\* packages to 21.0.8
+  - Rename [field] to [formField] in all UI library templates
+  - Update Field imports to FormField from @angular/forms/signals
+  - Update peer dependencies to require >= 21.0.7
+  - Remove [attr.hidden] from elements with [formField] (not allowed)
+  - Change model.required() to model() in radio group components
+    Dependency updates:
+  - @ng-doc/\*: 20.1.1 → 21.0.0 (Angular 21 support)
+  - @analogjs/\*: 2.1.3 → 2.2.1
+  - @ionic/angular: 8.7.14 → 8.7.16
+  - primeng: 21.0.1 → 21.0.2
+  - ng-packagr: 21.0.0 → 21.0.1
+  - eslint: 9.39.1 → 9.39.2
+  - vite: 7.3.0 → 7.3.1
+  - And other minor/patch updates
+    Cleanup:
+  - Remove ng-doc Angular 21 compatibility patch (no longer needed)
+  * fix(dynamic-forms): disable browser validation to fix ionic hidden field issues
+    Add novalidate attribute to DynamicForm host to prevent browser native
+    validation. This fixes issues with Ionic web components where hidden
+    form controls with required validation would trigger "invalid form
+    control is not focusable" errors during form submission.
+    Angular Signal Forms handles all validation, so browser validation is
+    unnecessary and causes issues with shadow DOM components like Ionic.
+  * fix(primeng,ionic): correct validation styling and error display
+    PrimeNG:
+  - Add CSS override in \_form-field.scss to hide invalid styling when
+    field has not been touched yet (using :host:not(.df-touched) selector)
+  - Add [class.df-touched] binding to all PrimeNG component hosts to
+    track touched state for CSS targeting
+    The issue was that Angular's InteropNgControl.invalid property returns
+    the raw invalid state without considering the touched state, causing
+    PrimeNG to show red borders on pristine required fields.
+    Ionic:
+  - Move error messages outside of Ionic component elements
+  - Remove slot="error" wrappers that were hidden by Ionic's CSS
+  - Add df-ionic-error class to error notes for consistent styling
+  - Update accessibility tests to use new error message selectors
+    The issue was that Ionic web components hide slot="error" content unless
+    the ion-invalid and ion-touched classes are applied, which Angular's
+    Signal Forms directive doesn't do automatically.
+  * fix(ionic,primeng): handle angular 21.0.7 auto-propagation of invalid state
+    Angular 21.0.7+ automatically propagates form state (invalid, required,
+    touched, etc.) to component inputs via the FormField directive. This
+    caused PrimeNG components to show red borders on untouched fields and
+    Ionic components to not show error styling at all.
+    PrimeNG fix:
+  - Add CSS override in \_form-field.scss to hide invalid styling until
+    the field is touched (.df-touched class)
+  - Use ::ng-deep to pierce view encapsulation for PrimeNG components
+    Ionic fix:
+  - Add host class bindings for df-invalid and df-touched
+  - Centralize error styling in shared \_form-field.scss
+  - Use Ionic CSS custom properties for danger color theming
+  - Update all field components to use shared stylesheet
+
+### ❤️ Thank You
+
+- Antim Prisacaru @antimprisacaru
+
 ## 0.2.0 (2025-12-23)
 
 ### ♻️ Code Refactoring

--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ export class LoginComponent {
 
 🌍 **i18n Ready** – Observable/Signal support for labels and messages
 
+## ⚠️ Compatibility
+
+> **Experimental API Notice:** This library uses Angular's experimental Signal Forms API.
+> Angular may introduce breaking changes in patch releases.
+
+| @ng-forge/dynamic-forms | Angular       |
+| ----------------------- | ------------- |
+| 0.3.x                   | >=21.0.7      |
+| 0.2.x                   | 21.0.6        |
+| 0.1.1+                  | 21.0.2-21.0.5 |
+| 0.1.0                   | 21.0.0-21.0.1 |
+
 ## 📦 Packages
 
 | Package                                                                 | Description     |

--- a/packages/dynamic-forms-bootstrap/README.md
+++ b/packages/dynamic-forms-bootstrap/README.md
@@ -18,7 +18,9 @@ Bootstrap 5 field components for [@ng-forge/dynamic-forms](https://www.npmjs.com
 
 | @ng-forge/dynamic-forms-bootstrap | @ng-forge/dynamic-forms | Angular       |
 | --------------------------------- | ----------------------- | ------------- |
-| 0.1.1+                            | 0.1.1+                  | >=21.0.2      |
+| 0.3.x                             | 0.3.x                   | >=21.0.7      |
+| 0.2.x                             | 0.2.x                   | 21.0.5-21.0.6 |
+| 0.1.x                             | 0.1.x                   | 21.0.2-21.0.4 |
 | 0.1.0                             | 0.1.0                   | 21.0.0-21.0.1 |
 
 ## Installation

--- a/packages/dynamic-forms-bootstrap/README.md
+++ b/packages/dynamic-forms-bootstrap/README.md
@@ -19,8 +19,8 @@ Bootstrap 5 field components for [@ng-forge/dynamic-forms](https://www.npmjs.com
 | @ng-forge/dynamic-forms-bootstrap | @ng-forge/dynamic-forms | Angular       |
 | --------------------------------- | ----------------------- | ------------- |
 | 0.3.x                             | 0.3.x                   | >=21.0.7      |
-| 0.2.x                             | 0.2.x                   | 21.0.5-21.0.6 |
-| 0.1.x                             | 0.1.x                   | 21.0.2-21.0.4 |
+| 0.2.x                             | 0.2.x                   | 21.0.6        |
+| 0.1.1+                            | 0.1.1+                  | 21.0.2-21.0.5 |
 | 0.1.0                             | 0.1.0                   | 21.0.0-21.0.1 |
 
 ## Installation

--- a/packages/dynamic-forms-bootstrap/package.json
+++ b/packages/dynamic-forms-bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-bootstrap",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Bootstrap 5 integration for @ng-forge/dynamic-forms. Pre-built Bootstrap form components.",
   "type": "module",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@angular/common": ">=21.0.7",
     "@angular/core": ">=21.0.7",
     "@angular/forms": ">=21.0.7",
-    "@ng-forge/dynamic-forms": "~0.2.0",
+    "@ng-forge/dynamic-forms": "~0.3.0",
     "rxjs": ">=7.0.0"
   }
 }

--- a/packages/dynamic-forms-ionic/README.md
+++ b/packages/dynamic-forms-ionic/README.md
@@ -18,7 +18,9 @@ Ionic field components for [@ng-forge/dynamic-forms](https://www.npmjs.com/packa
 
 | @ng-forge/dynamic-forms-ionic | @ng-forge/dynamic-forms | Angular       |
 | ----------------------------- | ----------------------- | ------------- |
-| 0.1.1+                        | 0.1.1+                  | >=21.0.2      |
+| 0.3.x                         | 0.3.x                   | >=21.0.7      |
+| 0.2.x                         | 0.2.x                   | 21.0.5-21.0.6 |
+| 0.1.x                         | 0.1.x                   | 21.0.2-21.0.4 |
 | 0.1.0                         | 0.1.0                   | 21.0.0-21.0.1 |
 
 ## Installation

--- a/packages/dynamic-forms-ionic/README.md
+++ b/packages/dynamic-forms-ionic/README.md
@@ -19,8 +19,8 @@ Ionic field components for [@ng-forge/dynamic-forms](https://www.npmjs.com/packa
 | @ng-forge/dynamic-forms-ionic | @ng-forge/dynamic-forms | Angular       |
 | ----------------------------- | ----------------------- | ------------- |
 | 0.3.x                         | 0.3.x                   | >=21.0.7      |
-| 0.2.x                         | 0.2.x                   | 21.0.5-21.0.6 |
-| 0.1.x                         | 0.1.x                   | 21.0.2-21.0.4 |
+| 0.2.x                         | 0.2.x                   | 21.0.6        |
+| 0.1.1+                        | 0.1.1+                  | 21.0.2-21.0.5 |
 | 0.1.0                         | 0.1.0                   | 21.0.0-21.0.1 |
 
 ## Installation

--- a/packages/dynamic-forms-ionic/package.json
+++ b/packages/dynamic-forms-ionic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-ionic",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Ionic integration for @ng-forge/dynamic-forms. Pre-built Ionic form components for mobile and desktop.",
   "type": "module",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "@angular/core": ">=21.0.7",
     "@angular/forms": ">=21.0.7",
     "@ionic/angular": ">=7.0.0",
-    "@ng-forge/dynamic-forms": "~0.2.0",
+    "@ng-forge/dynamic-forms": "~0.3.0",
     "rxjs": ">=7.0.0"
   },
   "dependencies": {

--- a/packages/dynamic-forms-material/README.md
+++ b/packages/dynamic-forms-material/README.md
@@ -18,7 +18,9 @@ Material Design field components for [@ng-forge/dynamic-forms](https://www.npmjs
 
 | @ng-forge/dynamic-forms-material | @ng-forge/dynamic-forms | Angular       |
 | -------------------------------- | ----------------------- | ------------- |
-| 0.1.1+                           | 0.1.1+                  | >=21.0.2      |
+| 0.3.x                            | 0.3.x                   | >=21.0.7      |
+| 0.2.x                            | 0.2.x                   | 21.0.5-21.0.6 |
+| 0.1.x                            | 0.1.x                   | 21.0.2-21.0.4 |
 | 0.1.0                            | 0.1.0                   | 21.0.0-21.0.1 |
 
 ## Installation

--- a/packages/dynamic-forms-material/README.md
+++ b/packages/dynamic-forms-material/README.md
@@ -19,8 +19,8 @@ Material Design field components for [@ng-forge/dynamic-forms](https://www.npmjs
 | @ng-forge/dynamic-forms-material | @ng-forge/dynamic-forms | Angular       |
 | -------------------------------- | ----------------------- | ------------- |
 | 0.3.x                            | 0.3.x                   | >=21.0.7      |
-| 0.2.x                            | 0.2.x                   | 21.0.5-21.0.6 |
-| 0.1.x                            | 0.1.x                   | 21.0.2-21.0.4 |
+| 0.2.x                            | 0.2.x                   | 21.0.6        |
+| 0.1.1+                           | 0.1.1+                  | 21.0.2-21.0.5 |
 | 0.1.0                            | 0.1.0                   | 21.0.0-21.0.1 |
 
 ## Installation

--- a/packages/dynamic-forms-material/package.json
+++ b/packages/dynamic-forms-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-material",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Angular Material integration for @ng-forge/dynamic-forms. Pre-built Material Design form components.",
   "type": "module",
   "license": "MIT",
@@ -32,7 +32,7 @@
     "@angular/core": ">=21.0.7",
     "@angular/forms": ">=21.0.7",
     "@angular/material": ">=21.0.5",
-    "@ng-forge/dynamic-forms": "~0.2.0",
+    "@ng-forge/dynamic-forms": "~0.3.0",
     "rxjs": ">=7.0.0"
   }
 }

--- a/packages/dynamic-forms-primeng/README.md
+++ b/packages/dynamic-forms-primeng/README.md
@@ -18,7 +18,9 @@ PrimeNG field components for [@ng-forge/dynamic-forms](https://www.npmjs.com/pac
 
 | @ng-forge/dynamic-forms-primeng | @ng-forge/dynamic-forms | Angular       |
 | ------------------------------- | ----------------------- | ------------- |
-| 0.1.1+                          | 0.1.1+                  | >=21.0.2      |
+| 0.3.x                           | 0.3.x                   | >=21.0.7      |
+| 0.2.x                           | 0.2.x                   | 21.0.5-21.0.6 |
+| 0.1.x                           | 0.1.x                   | 21.0.2-21.0.4 |
 | 0.1.0                           | 0.1.0                   | 21.0.0-21.0.1 |
 
 ## Installation

--- a/packages/dynamic-forms-primeng/README.md
+++ b/packages/dynamic-forms-primeng/README.md
@@ -19,8 +19,8 @@ PrimeNG field components for [@ng-forge/dynamic-forms](https://www.npmjs.com/pac
 | @ng-forge/dynamic-forms-primeng | @ng-forge/dynamic-forms | Angular       |
 | ------------------------------- | ----------------------- | ------------- |
 | 0.3.x                           | 0.3.x                   | >=21.0.7      |
-| 0.2.x                           | 0.2.x                   | 21.0.5-21.0.6 |
-| 0.1.x                           | 0.1.x                   | 21.0.2-21.0.4 |
+| 0.2.x                           | 0.2.x                   | 21.0.6        |
+| 0.1.1+                          | 0.1.1+                  | 21.0.2-21.0.5 |
 | 0.1.0                           | 0.1.0                   | 21.0.0-21.0.1 |
 
 ## Installation

--- a/packages/dynamic-forms-primeng/package.json
+++ b/packages/dynamic-forms-primeng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-primeng",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "PrimeNG integration for @ng-forge/dynamic-forms. Pre-built PrimeNG form components.",
   "type": "module",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@angular/common": ">=21.0.7",
     "@angular/core": ">=21.0.7",
     "@angular/forms": ">=21.0.7",
-    "@ng-forge/dynamic-forms": "~0.2.0",
+    "@ng-forge/dynamic-forms": "~0.3.0",
     "primeng": ">=17.0.0",
     "rxjs": ">=7.0.0"
   }

--- a/packages/dynamic-forms/README.md
+++ b/packages/dynamic-forms/README.md
@@ -19,8 +19,8 @@ Core library for building type-safe, dynamic Angular forms with signal forms int
 | @ng-forge/dynamic-forms | Angular       |
 | ----------------------- | ------------- |
 | 0.3.x                   | >=21.0.7      |
-| 0.2.x                   | 21.0.5-21.0.6 |
-| 0.1.x                   | 21.0.2-21.0.4 |
+| 0.2.x                   | 21.0.6        |
+| 0.1.1+                  | 21.0.2-21.0.5 |
 | 0.1.0                   | 21.0.0-21.0.1 |
 
 ## Installation

--- a/packages/dynamic-forms/README.md
+++ b/packages/dynamic-forms/README.md
@@ -16,10 +16,12 @@ Core library for building type-safe, dynamic Angular forms with signal forms int
 
 ## Compatibility
 
-| @ng-forge/dynamic-forms | Angular       | Notes                              |
-| ----------------------- | ------------- | ---------------------------------- |
-| 0.1.1+                  | >=21.0.2      | Signal forms API signature changed |
-| 0.1.0                   | 21.0.0-21.0.1 | Initial release                    |
+| @ng-forge/dynamic-forms | Angular       |
+| ----------------------- | ------------- |
+| 0.3.x                   | >=21.0.7      |
+| 0.2.x                   | 21.0.5-21.0.6 |
+| 0.1.x                   | 21.0.2-21.0.4 |
+| 0.1.0                   | 21.0.0-21.0.1 |
 
 ## Installation
 

--- a/packages/dynamic-forms/package.json
+++ b/packages/dynamic-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Type-safe, signal-powered dynamic forms for Angular. Build complex forms from configuration with full TypeScript inference.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump all package versions to 0.3.0
- Update inter-package peerDependencies
- Update compatibility matrix in READMEs
- Generate changelog from v0.2.0

## Packages Updated
- @ng-forge/dynamic-forms: 0.2.0 -> 0.3.0
- @ng-forge/dynamic-forms-bootstrap: 0.2.0 -> 0.3.0
- @ng-forge/dynamic-forms-ionic: 0.2.0 -> 0.3.0
- @ng-forge/dynamic-forms-material: 0.2.0 -> 0.3.0
- @ng-forge/dynamic-forms-primeng: 0.2.0 -> 0.3.0

## Changelog

### 🚀 Features
- **dynamic-forms:** add hidden field type for storing non-rendered values (#122)
- **dynamic-forms:** add meta attribute support for wrapped components (#115)

### 📦 Build System
- ⚠️ **deps:** update angular to 21.0.8 with formfield directive migration (#124)

### ✅ Tests
- **forms:** add exhaustive type tests for all ui libraries and core types (#121)

### ⚠️ Breaking Changes
- **deps:** Angular 21.0.7 renamed the Signal Forms directive from `Field` to `FormField`. This requires `@angular/*` >= 21.0.7.