### PR TITLE
docs: fix compatibility matrix in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ export class LoginComponent {
 
 🌍 **i18n Ready** – Observable/Signal support for labels and messages
 
+## ⚠️ Compatibility
+
+> **Experimental API Notice:** This library uses Angular's experimental Signal Forms API.
+> Angular may introduce breaking changes in patch releases.
+
+| @ng-forge/dynamic-forms | Angular       |
+| ----------------------- | ------------- |
+| 0.3.x                   | >=21.0.7      |
+| 0.2.x                   | 21.0.6        |
+| 0.1.1+                  | 21.0.2-21.0.5 |
+| 0.1.0                   | 21.0.0-21.0.1 |
+
 ## 📦 Packages
 
 | Package                                                                 | Description     |

--- a/packages/dynamic-forms-bootstrap/README.md
+++ b/packages/dynamic-forms-bootstrap/README.md
@@ -19,8 +19,8 @@ Bootstrap 5 field components for [@ng-forge/dynamic-forms](https://www.npmjs.com
 | @ng-forge/dynamic-forms-bootstrap | @ng-forge/dynamic-forms | Angular       |
 | --------------------------------- | ----------------------- | ------------- |
 | 0.3.x                             | 0.3.x                   | >=21.0.7      |
-| 0.2.x                             | 0.2.x                   | 21.0.5-21.0.6 |
-| 0.1.x                             | 0.1.x                   | 21.0.2-21.0.4 |
+| 0.2.x                             | 0.2.x                   | 21.0.6        |
+| 0.1.1+                            | 0.1.1+                  | 21.0.2-21.0.5 |
 | 0.1.0                             | 0.1.0                   | 21.0.0-21.0.1 |
 
 ## Installation

--- a/packages/dynamic-forms-ionic/README.md
+++ b/packages/dynamic-forms-ionic/README.md
@@ -19,8 +19,8 @@ Ionic field components for [@ng-forge/dynamic-forms](https://www.npmjs.com/packa
 | @ng-forge/dynamic-forms-ionic | @ng-forge/dynamic-forms | Angular       |
 | ----------------------------- | ----------------------- | ------------- |
 | 0.3.x                         | 0.3.x                   | >=21.0.7      |
-| 0.2.x                         | 0.2.x                   | 21.0.5-21.0.6 |
-| 0.1.x                         | 0.1.x                   | 21.0.2-21.0.4 |
+| 0.2.x                         | 0.2.x                   | 21.0.6        |
+| 0.1.1+                        | 0.1.1+                  | 21.0.2-21.0.5 |
 | 0.1.0                         | 0.1.0                   | 21.0.0-21.0.1 |
 
 ## Installation

--- a/packages/dynamic-forms-material/README.md
+++ b/packages/dynamic-forms-material/README.md
@@ -19,8 +19,8 @@ Material Design field components for [@ng-forge/dynamic-forms](https://www.npmjs
 | @ng-forge/dynamic-forms-material | @ng-forge/dynamic-forms | Angular       |
 | -------------------------------- | ----------------------- | ------------- |
 | 0.3.x                            | 0.3.x                   | >=21.0.7      |
-| 0.2.x                            | 0.2.x                   | 21.0.5-21.0.6 |
-| 0.1.x                            | 0.1.x                   | 21.0.2-21.0.4 |
+| 0.2.x                            | 0.2.x                   | 21.0.6        |
+| 0.1.1+                           | 0.1.1+                  | 21.0.2-21.0.5 |
 | 0.1.0                            | 0.1.0                   | 21.0.0-21.0.1 |
 
 ## Installation

--- a/packages/dynamic-forms-primeng/README.md
+++ b/packages/dynamic-forms-primeng/README.md
@@ -19,8 +19,8 @@ PrimeNG field components for [@ng-forge/dynamic-forms](https://www.npmjs.com/pac
 | @ng-forge/dynamic-forms-primeng | @ng-forge/dynamic-forms | Angular       |
 | ------------------------------- | ----------------------- | ------------- |
 | 0.3.x                           | 0.3.x                   | >=21.0.7      |
-| 0.2.x                           | 0.2.x                   | 21.0.5-21.0.6 |
-| 0.1.x                           | 0.1.x                   | 21.0.2-21.0.4 |
+| 0.2.x                           | 0.2.x                   | 21.0.6        |
+| 0.1.1+                          | 0.1.1+                  | 21.0.2-21.0.5 |
 | 0.1.0                           | 0.1.0                   | 21.0.0-21.0.1 |
 
 ## Installation

--- a/packages/dynamic-forms/README.md
+++ b/packages/dynamic-forms/README.md
@@ -19,8 +19,8 @@ Core library for building type-safe, dynamic Angular forms with signal forms int
 | @ng-forge/dynamic-forms | Angular       |
 | ----------------------- | ------------- |
 | 0.3.x                   | >=21.0.7      |
-| 0.2.x                   | 21.0.5-21.0.6 |
-| 0.1.x                   | 21.0.2-21.0.4 |
+| 0.2.x                   | 21.0.6        |
+| 0.1.1+                  | 21.0.2-21.0.5 |
 | 0.1.0                   | 21.0.0-21.0.1 |
 
 ## Installation


### PR DESCRIPTION
## Summary
- Fix incorrect Angular version ranges in compatibility matrix
- Add compatibility matrix to main README

## Changes
| Version | Before | After |
|---------|--------|-------|
| 0.2.x | 21.0.5-21.0.6 | >=21.0.2 |
| 0.1.x | 21.0.2-21.0.4 | 21.0.2-21.0.5 |

The 0.2.x row incorrectly showed 21.0.5 as the minimum, but there was no breaking change between 21.0.2 and 21.0.6. The 0.1.x row incorrectly excluded 21.0.5.
