### PR TITLE
chore(release): bump version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 0.3.1 (2026-01-14)
+
+### 🚀 Features
+
+- **docs:** add interactive demo and syntax highlighting to landing page ([#132](https://github.com/ng-forge/ng-forge/pull/132))
+- **docs:** add link title attributes and improve example input theming ([#138](https://github.com/ng-forge/ng-forge/pull/138))
+
+### 🐛 Bug Fixes
+
+- **core:** add unique ids to form field inner elements ([#136](https://github.com/ng-forge/ng-forge/pull/136), [#131](https://github.com/ng-forge/ng-forge/issues/131))
+- **dynamic-forms:** bind classname to container field components ([#137](https://github.com/ng-forge/ng-forge/pull/137), [#133](https://github.com/ng-forge/ng-forge/issues/133))
+
+### ⏪ Reverts
+
+- **docs:** feat(docs): add new landing page with improved design (#127) ([#127](https://github.com/ng-forge/ng-forge/pull/127))
+
+### ❤️ Thank You
+
+- Antim Prisacaru @antimprisacaru
+
 ## 0.3.0 (2026-01-12)
 
 ### 🚀 Features

--- a/packages/dynamic-forms-bootstrap/package.json
+++ b/packages/dynamic-forms-bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-bootstrap",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Bootstrap 5 integration for @ng-forge/dynamic-forms. Pre-built Bootstrap form components.",
   "type": "module",
   "license": "MIT",

--- a/packages/dynamic-forms-ionic/package.json
+++ b/packages/dynamic-forms-ionic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-ionic",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Ionic integration for @ng-forge/dynamic-forms. Pre-built Ionic form components for mobile and desktop.",
   "type": "module",
   "license": "MIT",

--- a/packages/dynamic-forms-material/package.json
+++ b/packages/dynamic-forms-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-material",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Angular Material integration for @ng-forge/dynamic-forms. Pre-built Material Design form components.",
   "type": "module",
   "license": "MIT",

--- a/packages/dynamic-forms-primeng/package.json
+++ b/packages/dynamic-forms-primeng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-primeng",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "PrimeNG integration for @ng-forge/dynamic-forms. Pre-built PrimeNG form components.",
   "type": "module",
   "license": "MIT",

--- a/packages/dynamic-forms/package.json
+++ b/packages/dynamic-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Type-safe, signal-powered dynamic forms for Angular. Build complex forms from configuration with full TypeScript inference.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump all package versions to 0.3.1
- Update inter-package peerDependencies
- Generate changelog from v0.3.0

## Packages Updated
- @ng-forge/dynamic-forms: 0.3.0 -> 0.3.1
- @ng-forge/dynamic-forms-bootstrap: 0.3.0 -> 0.3.1
- @ng-forge/dynamic-forms-ionic: 0.3.0 -> 0.3.1
- @ng-forge/dynamic-forms-material: 0.3.0 -> 0.3.1
- @ng-forge/dynamic-forms-primeng: 0.3.0 -> 0.3.1

## Changelog

### 🐛 Bug Fixes

- **core:** add unique ids to form field inner elements ([#136](https://github.com/ng-forge/ng-forge/pull/136), [#131](https://github.com/ng-forge/ng-forge/issues/131))
- **dynamic-forms:** bind classname to container field components ([#137](https://github.com/ng-forge/ng-forge/pull/137), [#133](https://github.com/ng-forge/ng-forge/issues/133))

### 🚀 Features (Docs only)

- **docs:** add interactive demo and syntax highlighting to landing page ([#132](https://github.com/ng-forge/ng-forge/pull/132))
- **docs:** add link title attributes and improve example input theming ([#138](https://github.com/ng-forge/ng-forge/pull/138))

## Next Steps
After merging, trigger the Release workflow manually from GitHub Actions to publish to npm.