### PR TITLE
chore(deps): ignore angular packages in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,15 +15,6 @@ updates:
       - 'dependencies'
       - 'automated'
     groups:
-      # Group Angular updates together
-      angular:
-        patterns:
-          - '@angular/*'
-          - '@angular-devkit/*'
-          - '@schematics/angular'
-        update-types:
-          - 'minor'
-          - 'patch'
       # Group Nx updates together
       nx:
         patterns:
@@ -78,6 +69,10 @@ updates:
       # Ignore major version updates - review these manually
       - dependency-name: '*'
         update-types: ['version-update:semver-major']
+      # Angular updates are handled manually due to breaking changes between patches
+      - dependency-name: '@angular/*'
+      - dependency-name: '@angular-devkit/*'
+      - dependency-name: '@schematics/angular'
 
   # GitHub Actions
   - package-ecosystem: 'github-actions'


### PR DESCRIPTION
## Summary
- Remove Angular group from dependabot configuration
- Add Angular packages (`@angular/*`, `@angular-devkit/*`, `@schematics/angular`) to the ignore list
- Angular updates will be handled manually due to breaking changes between minor/patch versions

## Related
- Closes dependabot PRs for Angular updates (e.g., #148)

## Test plan
- [ ] Verify dependabot no longer creates PRs for Angular updates