### PR TITLE
fix(material,bootstrap,primeng,ionic): set side-effects to true for module augmentation

### DIFF
--- a/apps/docs/src/docs/ui-libs-integrations/bootstrap/index.md
+++ b/apps/docs/src/docs/ui-libs-integrations/bootstrap/index.md
@@ -128,6 +128,16 @@ export class ContactFormComponent {
 }
 ```
 
+## Type Augmentation
+
+Importing this package automatically extends `@ng-forge/dynamic-forms` with Bootstrap-specific field types via TypeScript module augmentation. If you need type safety in a file without importing specific exports, use a bare import:
+
+```typescript
+import '@ng-forge/dynamic-forms-bootstrap';
+```
+
+---
+
 ## Complete Form Example
 
 Here's a full registration form showcasing multiple Bootstrap field types:

--- a/apps/docs/src/docs/ui-libs-integrations/ionic/index.md
+++ b/apps/docs/src/docs/ui-libs-integrations/ionic/index.md
@@ -123,6 +123,16 @@ export class ContactFormComponent {
 }
 ```
 
+## Type Augmentation
+
+Importing this package automatically extends `@ng-forge/dynamic-forms` with Ionic-specific field types via TypeScript module augmentation. If you need type safety in a file without importing specific exports, use a bare import:
+
+```typescript
+import '@ng-forge/dynamic-forms-ionic';
+```
+
+---
+
 ## Complete Form Example
 
 Here's a full registration form showcasing multiple Ionic field types optimized for mobile:

--- a/apps/docs/src/docs/ui-libs-integrations/material/index.md
+++ b/apps/docs/src/docs/ui-libs-integrations/material/index.md
@@ -127,6 +127,16 @@ export class ContactFormComponent {
 }
 ```
 
+## Type Augmentation
+
+Importing this package automatically extends `@ng-forge/dynamic-forms` with Material-specific field types via TypeScript module augmentation. If you need type safety in a file without importing specific exports, use a bare import:
+
+```typescript
+import '@ng-forge/dynamic-forms-material';
+```
+
+---
+
 ## Complete Form Example
 
 Here's a full registration form showcasing multiple Material Design field types:

--- a/apps/docs/src/docs/ui-libs-integrations/primeng/index.md
+++ b/apps/docs/src/docs/ui-libs-integrations/primeng/index.md
@@ -133,6 +133,16 @@ export class ContactFormComponent {
 }
 ```
 
+## Type Augmentation
+
+Importing this package automatically extends `@ng-forge/dynamic-forms` with PrimeNG-specific field types via TypeScript module augmentation. If you need type safety in a file without importing specific exports, use a bare import:
+
+```typescript
+import '@ng-forge/dynamic-forms-primeng';
+```
+
+---
+
 ## Complete Form Example
 
 Here's a full registration form showcasing multiple PrimeNG field types:

--- a/packages/dynamic-forms-bootstrap/package.json
+++ b/packages/dynamic-forms-bootstrap/package.json
@@ -23,7 +23,7 @@
     "form-builder",
     "ng-forge"
   ],
-  "sideEffects": false,
+  "sideEffects": true,
   "engines": {
     "node": ">=20"
   },

--- a/packages/dynamic-forms-ionic/package.json
+++ b/packages/dynamic-forms-ionic/package.json
@@ -24,7 +24,7 @@
     "form-builder",
     "ng-forge"
   ],
-  "sideEffects": false,
+  "sideEffects": true,
   "engines": {
     "node": ">=20"
   },

--- a/packages/dynamic-forms-material/package.json
+++ b/packages/dynamic-forms-material/package.json
@@ -23,7 +23,7 @@
     "form-builder",
     "ng-forge"
   ],
-  "sideEffects": false,
+  "sideEffects": true,
   "engines": {
     "node": ">=20"
   },

--- a/packages/dynamic-forms-primeng/package.json
+++ b/packages/dynamic-forms-primeng/package.json
@@ -23,7 +23,7 @@
     "form-builder",
     "ng-forge"
   ],
-  "sideEffects": false,
+  "sideEffects": true,
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
## Summary

- Set `sideEffects: true` in package.json for all UI integration packages (material, bootstrap, primeng, ionic)
- Add "Type Augmentation" documentation section to each UI lib's docs explaining how module augmentation works and why side-effects are enabled

## Context

UI integration packages use TypeScript module augmentation via side-effect imports like:
```typescript
import './types/registry-augmentation';
```

When users do bare imports like `import '@ng-forge/dynamic-forms-material'` just for type augmentation, bundlers would previously warn or remove the import because `sideEffects: false` was set. Setting `sideEffects: true` ensures bundlers preserve these imports.

## Test plan

- [ ] Verify bare imports no longer produce bundler warnings
- [ ] Confirm type augmentation still works correctly
- [ ] Check docs render properly