### PR TITLE
refactor(bootstrap): clean up component templates and effects

### DIFF
--- a/packages/dynamic-forms-bootstrap/src/lib/fields/button/bs-button.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/button/bs-button.component.ts
@@ -21,7 +21,7 @@ import { BsButtonComponent, BsButtonProps } from './bs-button.type';
     '[id]': '`${key()}`',
     '[attr.data-testid]': 'key()',
     '[class]': 'className()',
-    '[hidden]': 'hidden()',
+    '[attr.hidden]': 'hidden() || null',
   },
   template: `
     @let buttonId = key() + '-button';

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/checkbox/bs-checkbox.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/checkbox/bs-checkbox.component.ts
@@ -10,8 +10,7 @@ import { AsyncPipe } from '@angular/common';
   imports: [FormField, DynamicTextPipe, AsyncPipe],
   styleUrl: '../../styles/_form-field.scss',
   template: `
-    @let f = field(); @let checkboxId = key() + '-checkbox'; @let ariaInvalid = this.ariaInvalid(); @let ariaRequired = this.ariaRequired();
-    @let ariaDescribedBy = this.ariaDescribedBy();
+    @let f = field(); @let checkboxId = key() + '-checkbox';
 
     <div
       class="form-check"
@@ -28,9 +27,9 @@ import { AsyncPipe } from '@angular/common';
         class="form-check-input"
         [class.is-invalid]="f().invalid() && f().touched()"
         [attr.tabindex]="tabIndex()"
-        [attr.aria-invalid]="ariaInvalid"
-        [attr.aria-required]="ariaRequired"
-        [attr.aria-describedby]="ariaDescribedBy"
+        [attr.aria-invalid]="ariaInvalid()"
+        [attr.aria-required]="ariaRequired()"
+        [attr.aria-describedby]="ariaDescribedBy()"
       />
       <label [for]="checkboxId" class="form-check-label">
         {{ label() | dynamicText | async }}

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/datepicker/bs-datepicker.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/datepicker/bs-datepicker.component.ts
@@ -11,8 +11,7 @@ import { InputConstraintsDirective } from '../../directives/input-constraints.di
   imports: [FormField, DynamicTextPipe, AsyncPipe, InputConstraintsDirective],
   styleUrl: '../../styles/_form-field.scss',
   template: `
-    @let f = field(); @let p = props(); @let ariaInvalid = this.ariaInvalid(); @let ariaRequired = this.ariaRequired();
-    @let ariaDescribedBy = this.ariaDescribedBy(); @let inputId = key() + '-input';
+    @let f = field(); @let p = props(); @let inputId = key() + '-input';
     @if (p?.floatingLabel) {
       <!-- Floating label variant -->
       <div class="form-floating mb-3">
@@ -25,9 +24,9 @@ import { InputConstraintsDirective } from '../../directives/input-constraints.di
           [dfMin]="minAsString()"
           [dfMax]="maxAsString()"
           [attr.tabindex]="tabIndex()"
-          [attr.aria-invalid]="ariaInvalid"
-          [attr.aria-required]="ariaRequired"
-          [attr.aria-describedby]="ariaDescribedBy"
+          [attr.aria-invalid]="ariaInvalid()"
+          [attr.aria-required]="ariaRequired()"
+          [attr.aria-describedby]="ariaDescribedBy()"
           class="form-control"
           [class.form-control-sm]="p?.size === 'sm'"
           [class.form-control-lg]="p?.size === 'lg'"
@@ -62,9 +61,9 @@ import { InputConstraintsDirective } from '../../directives/input-constraints.di
           [dfMin]="minAsString()"
           [dfMax]="maxAsString()"
           [attr.tabindex]="tabIndex()"
-          [attr.aria-invalid]="ariaInvalid"
-          [attr.aria-required]="ariaRequired"
-          [attr.aria-describedby]="ariaDescribedBy"
+          [attr.aria-invalid]="ariaInvalid()"
+          [attr.aria-required]="ariaRequired()"
+          [attr.aria-describedby]="ariaDescribedBy()"
           class="form-control"
           [class.form-control-sm]="p?.size === 'sm'"
           [class.form-control-lg]="p?.size === 'lg'"

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/input/bs-input.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/input/bs-input.component.ts
@@ -11,12 +11,8 @@ import { BOOTSTRAP_CONFIG } from '../../models/bootstrap-config.token';
   imports: [FormField, DynamicTextPipe, AsyncPipe],
   styleUrl: '../../styles/_form-field.scss',
   template: `
-    @let f = field(); @let p = props(); @let effectiveSize = this.effectiveSize();
-    @let effectiveFloatingLabel = this.effectiveFloatingLabel();
-    @let inputId = key() + '-input';
-    @let ariaInvalid = this.ariaInvalid(); @let ariaRequired = this.ariaRequired();
-    @let ariaDescribedBy = this.ariaDescribedBy();
-    @if (effectiveFloatingLabel) {
+    @let f = field(); @let p = props(); @let inputId = key() + '-input';
+    @if (effectiveFloatingLabel()) {
       <!-- Floating label variant -->
       <div class="form-floating mb-3">
         <input
@@ -26,12 +22,12 @@ import { BOOTSTRAP_CONFIG } from '../../models/bootstrap-config.token';
           [type]="p?.type ?? 'text'"
           [placeholder]="(placeholder() | dynamicText | async) ?? ''"
           [attr.tabindex]="tabIndex()"
-          [attr.aria-invalid]="ariaInvalid"
-          [attr.aria-required]="ariaRequired"
-          [attr.aria-describedby]="ariaDescribedBy"
+          [attr.aria-invalid]="ariaInvalid()"
+          [attr.aria-required]="ariaRequired()"
+          [attr.aria-describedby]="ariaDescribedBy()"
           class="form-control"
-          [class.form-control-sm]="effectiveSize === 'sm'"
-          [class.form-control-lg]="effectiveSize === 'lg'"
+          [class.form-control-sm]="effectiveSize() === 'sm'"
+          [class.form-control-lg]="effectiveSize() === 'lg'"
           [class.form-control-plaintext]="p?.plaintext"
           [class.is-invalid]="f().invalid() && f().touched()"
           [class.is-valid]="f().valid() && f().touched() && p?.validFeedback"
@@ -61,12 +57,12 @@ import { BOOTSTRAP_CONFIG } from '../../models/bootstrap-config.token';
           [type]="p?.type ?? 'text'"
           [placeholder]="(placeholder() | dynamicText | async) ?? ''"
           [attr.tabindex]="tabIndex()"
-          [attr.aria-invalid]="ariaInvalid"
-          [attr.aria-required]="ariaRequired"
-          [attr.aria-describedby]="ariaDescribedBy"
+          [attr.aria-invalid]="ariaInvalid()"
+          [attr.aria-required]="ariaRequired()"
+          [attr.aria-describedby]="ariaDescribedBy()"
           class="form-control"
-          [class.form-control-sm]="effectiveSize === 'sm'"
-          [class.form-control-lg]="effectiveSize === 'lg'"
+          [class.form-control-sm]="effectiveSize() === 'sm'"
+          [class.form-control-lg]="effectiveSize() === 'lg'"
           [class.form-control-plaintext]="p?.plaintext"
           [class.is-invalid]="f().invalid() && f().touched()"
           [class.is-valid]="f().valid() && f().touched() && p?.validFeedback"

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/multi-checkbox/bs-multi-checkbox.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/multi-checkbox/bs-multi-checkbox.component.ts
@@ -12,8 +12,6 @@ import { AsyncPipe } from '@angular/common';
   styleUrl: '../../styles/_form-field.scss',
   template: `
     @let f = field();
-    @let ariaInvalid = this.ariaInvalid(); @let ariaRequired = this.ariaRequired();
-    @let ariaDescribedBy = this.ariaDescribedBy();
     @let checked = checkedValuesMap();
     @if (label(); as label) {
       <div class="form-label">{{ label | dynamicText | async }}</div>
@@ -32,13 +30,13 @@ import { AsyncPipe } from '@angular/common';
             [id]="key() + '_' + i"
             [checked]="checked['' + option.value]"
             [disabled]="f().disabled() || option.disabled"
-            (change)="onCheckboxChange(option, $any($event.target).checked)"
+            (change)="onCheckboxChange(option, $event)"
             class="form-check-input"
             [class.is-invalid]="f().invalid() && f().touched()"
             [attr.tabindex]="tabIndex()"
-            [attr.aria-invalid]="ariaInvalid"
-            [attr.aria-required]="ariaRequired"
-            [attr.aria-describedby]="ariaDescribedBy"
+            [attr.aria-invalid]="ariaInvalid()"
+            [attr.aria-required]="ariaRequired()"
+            [attr.aria-describedby]="ariaDescribedBy()"
           />
           <label [for]="key() + '_' + i" class="form-check-label">
             {{ option.label | dynamicText | async }}
@@ -141,7 +139,8 @@ export default class BsMultiCheckboxFieldComponent implements BsMultiCheckboxCom
     });
   }
 
-  onCheckboxChange(option: FieldOption<ValueType>, checked: boolean): void {
+  onCheckboxChange(option: FieldOption<ValueType>, event: Event): void {
+    const checked = (event.target as HTMLInputElement).checked;
     this.valueViewModel.update((currentOptions: FieldOption<ValueType>[]) => {
       if (checked) {
         return currentOptions.some((opt: FieldOption<ValueType>) => opt.value === option.value)

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/radio/bs-radio-group.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/radio/bs-radio-group.component.ts
@@ -32,7 +32,6 @@ export interface BsRadioGroupProps {
   imports: [DynamicTextPipe, AsyncPipe],
   template: `
     @let props = properties();
-    @let ariaDescribedBy = this.ariaDescribedBy();
     @if (props?.buttonGroup) {
       <div class="btn-group" role="group" [attr.aria-label]="label() | dynamicText | async">
         @for (option of options(); track option.value; let i = $index) {
@@ -43,7 +42,7 @@ export interface BsRadioGroupProps {
             [checked]="value() === option.value"
             (change)="onRadioChange(option.value)"
             [disabled]="disabled() || option.disabled || false"
-            [attr.aria-describedby]="ariaDescribedBy"
+            [attr.aria-describedby]="ariaDescribedBy()"
             class="btn-check"
             [id]="name() + '_' + i"
             autocomplete="off"
@@ -68,7 +67,7 @@ export interface BsRadioGroupProps {
             [checked]="value() === option.value"
             (change)="onRadioChange(option.value)"
             [disabled]="disabled() || option.disabled || false"
-            [attr.aria-describedby]="ariaDescribedBy"
+            [attr.aria-describedby]="ariaDescribedBy()"
             class="form-check-input"
             [id]="name() + '_' + i"
           />

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/radio/bs-radio.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/radio/bs-radio.component.ts
@@ -12,7 +12,6 @@ import { BsRadioGroupComponent } from './bs-radio-group.component';
   styleUrl: '../../styles/_form-field.scss',
   template: `
     @let f = field();
-    @let ariaDescribedBy = this.ariaDescribedBy();
 
     <div class="mb-3">
       @if (label(); as label) {
@@ -20,11 +19,11 @@ import { BsRadioGroupComponent } from './bs-radio-group.component';
       }
 
       <df-bs-radio-group
-        [formField]="$any(f)"
+        [formField]="f"
         [label]="label()"
         [options]="options()"
         [properties]="props()"
-        [ariaDescribedBy]="ariaDescribedBy"
+        [ariaDescribedBy]="ariaDescribedBy()"
       />
 
       @if (props()?.helpText; as helpText) {

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/select/bs-select.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/select/bs-select.component.ts
@@ -10,8 +10,7 @@ import { AsyncPipe } from '@angular/common';
   imports: [FormField, DynamicTextPipe, AsyncPipe],
   styleUrl: '../../styles/_form-field.scss',
   template: `
-    @let f = field(); @let selectId = key() + '-select'; @let ariaInvalid = this.ariaInvalid(); @let ariaRequired = this.ariaRequired();
-    @let ariaDescribedBy = this.ariaDescribedBy();
+    @let f = field(); @let selectId = key() + '-select';
 
     <div class="mb-3">
       @if (label(); as label) {
@@ -26,9 +25,9 @@ import { AsyncPipe } from '@angular/common';
         [class.is-invalid]="f().invalid() && f().touched()"
         [multiple]="props()?.multiple || false"
         [size]="props()?.htmlSize"
-        [attr.aria-invalid]="ariaInvalid"
-        [attr.aria-required]="ariaRequired"
-        [attr.aria-describedby]="ariaDescribedBy"
+        [attr.aria-invalid]="ariaInvalid()"
+        [attr.aria-required]="ariaRequired()"
+        [attr.aria-describedby]="ariaDescribedBy()"
       >
         @if (placeholder(); as placeholder) {
           <option value="" disabled [selected]="!f().value()">{{ placeholder | dynamicText | async }}</option>

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/slider/bs-slider.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/slider/bs-slider.component.ts
@@ -11,8 +11,7 @@ import { InputConstraintsDirective } from '../../directives/input-constraints.di
   imports: [FormField, DynamicTextPipe, AsyncPipe, InputConstraintsDirective],
   styleUrl: '../../styles/_form-field.scss',
   template: `
-    @let f = field(); @let inputId = key() + '-input'; @let ariaInvalid = this.ariaInvalid(); @let ariaRequired = this.ariaRequired();
-    @let ariaDescribedBy = this.ariaDescribedBy();
+    @let f = field(); @let inputId = key() + '-input';
 
     <div class="mb-3">
       @if (label(); as label) {
@@ -33,9 +32,9 @@ import { InputConstraintsDirective } from '../../directives/input-constraints.di
         [dfMax]="props()?.max ?? max()"
         [dfStep]="props()?.step ?? step()"
         [attr.tabindex]="tabIndex()"
-        [attr.aria-invalid]="ariaInvalid"
-        [attr.aria-required]="ariaRequired"
-        [attr.aria-describedby]="ariaDescribedBy"
+        [attr.aria-invalid]="ariaInvalid()"
+        [attr.aria-required]="ariaRequired()"
+        [attr.aria-describedby]="ariaDescribedBy()"
         class="form-range"
       />
 

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/textarea/bs-textarea.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/textarea/bs-textarea.component.ts
@@ -10,8 +10,7 @@ import { AsyncPipe } from '@angular/common';
   imports: [FormField, DynamicTextPipe, AsyncPipe],
   styleUrl: '../../styles/_form-field.scss',
   template: `
-    @let f = field(); @let p = props(); @let ariaInvalid = this.ariaInvalid(); @let ariaRequired = this.ariaRequired();
-    @let ariaDescribedBy = this.ariaDescribedBy(); @let textareaId = key() + '-textarea';
+    @let f = field(); @let p = props(); @let textareaId = key() + '-textarea';
     @if (p?.floatingLabel) {
       <!-- Floating label variant -->
       <div class="form-floating mb-3">
@@ -20,9 +19,9 @@ import { AsyncPipe } from '@angular/common';
           [id]="textareaId"
           [placeholder]="(placeholder() | dynamicText | async) ?? ''"
           [attr.tabindex]="tabIndex()"
-          [attr.aria-invalid]="ariaInvalid"
-          [attr.aria-required]="ariaRequired"
-          [attr.aria-describedby]="ariaDescribedBy"
+          [attr.aria-invalid]="ariaInvalid()"
+          [attr.aria-required]="ariaRequired()"
+          [attr.aria-describedby]="ariaDescribedBy()"
           class="form-control"
           [class.form-control-sm]="p?.size === 'sm'"
           [class.form-control-lg]="p?.size === 'lg'"
@@ -54,9 +53,9 @@ import { AsyncPipe } from '@angular/common';
           [id]="textareaId"
           [placeholder]="(placeholder() | dynamicText | async) ?? ''"
           [attr.tabindex]="tabIndex()"
-          [attr.aria-invalid]="ariaInvalid"
-          [attr.aria-required]="ariaRequired"
-          [attr.aria-describedby]="ariaDescribedBy"
+          [attr.aria-invalid]="ariaInvalid()"
+          [attr.aria-required]="ariaRequired()"
+          [attr.aria-describedby]="ariaDescribedBy()"
           class="form-control"
           [class.form-control-sm]="p?.size === 'sm'"
           [class.form-control-lg]="p?.size === 'lg'"

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/toggle/bs-toggle.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/toggle/bs-toggle.component.ts
@@ -10,8 +10,7 @@ import { AsyncPipe } from '@angular/common';
   imports: [FormField, DynamicTextPipe, AsyncPipe],
   styleUrl: '../../styles/_form-field.scss',
   template: `
-    @let f = field(); @let inputId = key() + '-input'; @let ariaInvalid = this.ariaInvalid(); @let ariaRequired = this.ariaRequired();
-    @let ariaDescribedBy = this.ariaDescribedBy();
+    @let f = field(); @let inputId = key() + '-input';
 
     <div
       class="form-check form-switch"
@@ -28,9 +27,9 @@ import { AsyncPipe } from '@angular/common';
         class="form-check-input"
         [class.is-invalid]="f().invalid() && f().touched()"
         [attr.tabindex]="tabIndex()"
-        [attr.aria-invalid]="ariaInvalid"
-        [attr.aria-required]="ariaRequired"
-        [attr.aria-describedby]="ariaDescribedBy"
+        [attr.aria-invalid]="ariaInvalid()"
+        [attr.aria-required]="ariaRequired()"
+        [attr.aria-describedby]="ariaDescribedBy()"
       />
       <label [for]="inputId" class="form-check-label">
         {{ label() | dynamicText | async }}


### PR DESCRIPTION
## Summary
- Remove redundant `@let` declarations for aria signals in templates, calling signals directly instead
- Fix `$any` casts in `bs-multi-checkbox` and `bs-radio` components with proper typing
- Change `[hidden]` to `[attr.hidden]` with null coalescing in button component

## Files Changed
- `bs-button.component.ts` - Fix hidden binding pattern
- `bs-multi-checkbox.component.ts` - Fix $any cast, remove aria @lets
- `bs-radio.component.ts` - Fix $any cast, remove aria @let
- `bs-radio-group.component.ts` - Remove aria @let
- `bs-input.component.ts` - Remove aria @lets
- `bs-textarea.component.ts` - Remove aria @lets
- `bs-select.component.ts` - Remove aria @lets
- `bs-checkbox.component.ts` - Remove aria @lets
- `bs-toggle.component.ts` - Remove aria @lets
- `bs-slider.component.ts` - Remove aria @lets
- `bs-datepicker.component.ts` - Remove aria @lets

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] Unit tests pass (334 tests)
- [x] Example app builds successfully