### PR TITLE
refactor(bootstrap): rename helper text prop from helptext to hint

### DIFF
--- a/apps/docs/src/docs/ui-libs-integrations/bootstrap/examples/checkbox-iframe-demo.component.ts
+++ b/apps/docs/src/docs/ui-libs-integrations/bootstrap/examples/checkbox-iframe-demo.component.ts
@@ -16,7 +16,7 @@ export class CheckboxIframeDemoComponent {
   required: true,
   props: {
     inline: false,
-    helpText: 'Please read and accept our terms',
+    hint: 'Please read and accept our terms',
   },
 }`;
 }

--- a/apps/docs/src/docs/ui-libs-integrations/bootstrap/examples/datepicker-iframe-demo.component.ts
+++ b/apps/docs/src/docs/ui-libs-integrations/bootstrap/examples/datepicker-iframe-demo.component.ts
@@ -18,7 +18,7 @@ export class DatepickerIframeDemoComponent {
     placeholder: 'Select your birth date',
     floatingLabel: true,
     size: 'md',
-    helpText: 'You must be 18 years or older',
+    hint: 'You must be 18 years or older',
   },
 }`;
 }

--- a/apps/docs/src/docs/ui-libs-integrations/bootstrap/examples/input-iframe-demo.component.ts
+++ b/apps/docs/src/docs/ui-libs-integrations/bootstrap/examples/input-iframe-demo.component.ts
@@ -20,7 +20,7 @@ export class InputIframeDemoComponent {
     placeholder: 'Enter your email',
     floatingLabel: true,
     size: 'lg',
-    helpText: 'We will never share your email',
+    hint: 'We will never share your email',
   },
 }`;
 }

--- a/apps/docs/src/docs/ui-libs-integrations/bootstrap/examples/multi-checkbox-iframe-demo.component.ts
+++ b/apps/docs/src/docs/ui-libs-integrations/bootstrap/examples/multi-checkbox-iframe-demo.component.ts
@@ -21,7 +21,7 @@ export class MultiCheckboxIframeDemoComponent {
   ],
   props: {
     inline: false,
-    helpText: 'Select all that apply',
+    hint: 'Select all that apply',
   },
 }`;
 }

--- a/apps/docs/src/docs/ui-libs-integrations/bootstrap/examples/radio-iframe-demo.component.ts
+++ b/apps/docs/src/docs/ui-libs-integrations/bootstrap/examples/radio-iframe-demo.component.ts
@@ -21,7 +21,7 @@ export class RadioIframeDemoComponent {
   ],
   props: {
     inline: true,
-    helpText: 'Select a subscription plan',
+    hint: 'Select a subscription plan',
   },
 }`;
 }

--- a/apps/docs/src/docs/ui-libs-integrations/bootstrap/examples/select-iframe-demo.component.ts
+++ b/apps/docs/src/docs/ui-libs-integrations/bootstrap/examples/select-iframe-demo.component.ts
@@ -23,7 +23,7 @@ export class SelectIframeDemoComponent {
     placeholder: 'Select a country',
     floatingLabel: true,
     size: 'md',
-    helpText: 'Choose your country of residence',
+    hint: 'Choose your country of residence',
   },
 }`;
 }

--- a/apps/docs/src/docs/ui-libs-integrations/bootstrap/examples/slider-iframe-demo.component.ts
+++ b/apps/docs/src/docs/ui-libs-integrations/bootstrap/examples/slider-iframe-demo.component.ts
@@ -17,7 +17,7 @@ export class SliderIframeDemoComponent {
   maxValue: 100,
   step: 5,
   props: {
-    helpText: 'Adjust the volume level',
+    hint: 'Adjust the volume level',
   },
 }`;
 }

--- a/apps/docs/src/docs/ui-libs-integrations/bootstrap/examples/textarea-iframe-demo.component.ts
+++ b/apps/docs/src/docs/ui-libs-integrations/bootstrap/examples/textarea-iframe-demo.component.ts
@@ -17,7 +17,7 @@ export class TextareaIframeDemoComponent {
     placeholder: 'Enter your comments here',
     rows: 4,
     floatingLabel: true,
-    helpText: 'Maximum 500 characters',
+    hint: 'Maximum 500 characters',
   },
 }`;
 }

--- a/apps/docs/src/docs/ui-libs-integrations/bootstrap/examples/toggle-iframe-demo.component.ts
+++ b/apps/docs/src/docs/ui-libs-integrations/bootstrap/examples/toggle-iframe-demo.component.ts
@@ -15,7 +15,7 @@ export class ToggleIframeDemoComponent {
   value: true,
   props: {
     switch: true,
-    helpText: 'Receive updates about your account',
+    hint: 'Receive updates about your account',
   },
 }`;
 }

--- a/apps/docs/src/docs/ui-libs-integrations/bootstrap/examples/user-registration-iframe-demo.component.ts
+++ b/apps/docs/src/docs/ui-libs-integrations/bootstrap/examples/user-registration-iframe-demo.component.ts
@@ -17,7 +17,7 @@ export class UserRegistrationIframeDemoComponent {
     props: {
       floatingLabel: true,
       size: 'lg',
-      helpText: 'Choose a unique username',
+      hint: 'Choose a unique username',
     },
   },
   {
@@ -29,7 +29,7 @@ export class UserRegistrationIframeDemoComponent {
     props: {
       type: 'email',
       floatingLabel: true,
-      helpText: 'We will send a confirmation email',
+      hint: 'We will send a confirmation email',
     },
   },
   {
@@ -41,7 +41,7 @@ export class UserRegistrationIframeDemoComponent {
     props: {
       type: 'password',
       floatingLabel: true,
-      helpText: 'Minimum 8 characters',
+      hint: 'Minimum 8 characters',
     },
   },
   {

--- a/apps/docs/src/docs/ui-libs-integrations/bootstrap/index.md
+++ b/apps/docs/src/docs/ui-libs-integrations/bootstrap/index.md
@@ -187,7 +187,7 @@ Text input field with HTML5 type support and optional floating labels.
     type: 'email',
     floatingLabel: true,
     placeholder: 'Enter your email',
-    helpText: 'We will never share your email',
+    hint: 'We will never share your email',
   },
 }
 ```
@@ -224,7 +224,7 @@ Text input field with HTML5 type support and optional floating labels.
 | `size`            | `'sm' \| 'lg'`                                                  | -        | Bootstrap size class         |
 | `floatingLabel`   | `boolean`                                                       | `false`  | Enable floating label design |
 | `plaintext`       | `boolean`                                                       | `false`  | Render as plaintext          |
-| `helpText`        | `string`                                                        | -        | Helper text below input      |
+| `hint`            | `string`                                                        | -        | Helper text below input      |
 | `validFeedback`   | `string`                                                        | -        | Success message when valid   |
 | `invalidFeedback` | `string`                                                        | -        | Error message when invalid   |
 
@@ -260,7 +260,7 @@ Multi-line text input field with Bootstrap form styling.
 | `rows`          | `number`       | `3`     | Number of visible rows       |
 | `size`          | `'sm' \| 'lg'` | -       | Bootstrap size class         |
 | `floatingLabel` | `boolean`      | `false` | Enable floating label design |
-| `helpText`      | `string`       | -       | Helper text below textarea   |
+| `hint`          | `string`       | -       | Helper text below textarea   |
 
 ---
 
@@ -303,7 +303,7 @@ Dropdown selection field with native HTML select element. Supports both single a
 | `multiple`      | `boolean`      | `false` | Enable multi-select          |
 | `size`          | `'sm' \| 'lg'` | -       | Bootstrap size class         |
 | `floatingLabel` | `boolean`      | `false` | Enable floating label design |
-| `helpText`      | `string`       | -       | Helper text below select     |
+| `hint`          | `string`       | -       | Helper text below select     |
 
 #### Radio
 
@@ -338,7 +338,7 @@ Radio button group for selecting a single option with optional button group styl
 | `reverse`     | `boolean`      | `false` | Reverse label and input position          |
 | `buttonGroup` | `boolean`      | `false` | Render as Bootstrap button group          |
 | `buttonSize`  | `'sm' \| 'lg'` | -       | Button size (when buttonGroup is enabled) |
-| `helpText`    | `string`       | -       | Helper text below radio group             |
+| `hint`        | `string`       | -       | Helper text below radio group             |
 
 #### Checkbox
 
@@ -396,12 +396,12 @@ Multiple checkbox selection field for choosing multiple options.
 
 **Props (Bootstrap-Specific):**
 
-| Prop       | Type      | Default | Description                      |
-| ---------- | --------- | ------- | -------------------------------- |
-| `switch`   | `boolean` | `false` | Render checkboxes as switches    |
-| `inline`   | `boolean` | `false` | Display options inline           |
-| `reverse`  | `boolean` | `false` | Reverse label and input position |
-| `helpText` | `string`  | -       | Helper text below checkbox group |
+| Prop      | Type      | Default | Description                      |
+| --------- | --------- | ------- | -------------------------------- |
+| `switch`  | `boolean` | `false` | Render checkboxes as switches    |
+| `inline`  | `boolean` | `false` | Display options inline           |
+| `reverse` | `boolean` | `false` | Reverse label and input position |
+| `hint`    | `string`  | -       | Helper text below checkbox group |
 
 ---
 
@@ -465,7 +465,7 @@ Native HTML5 range input for selecting values from a numeric range.
 | Prop        | Type      | Default | Description              |
 | ----------- | --------- | ------- | ------------------------ |
 | `showValue` | `boolean` | `false` | Display current value    |
-| `helpText`  | `string`  | -       | Helper text below slider |
+| `hint`      | `string`  | -       | Helper text below slider |
 
 #### Datepicker
 
@@ -504,7 +504,7 @@ Native HTML5 date input with Bootstrap styling.
 | ----------------- | -------------------------------------- | ------- | ------------------------------------------ |
 | `size`            | `'sm' \| 'lg'`                         | -       | Bootstrap size class                       |
 | `floatingLabel`   | `boolean`                              | `false` | Enable floating label design               |
-| `helpText`        | `string`                               | -       | Helper text below field                    |
+| `hint`            | `string`                               | -       | Helper text below field                    |
 | `validFeedback`   | `string`                               | -       | Success message when valid                 |
 | `invalidFeedback` | `string`                               | -       | Error message when invalid                 |
 | `useNgBootstrap`  | `boolean`                              | -       | Use ng-bootstrap datepicker                |
@@ -650,10 +650,10 @@ Customize field spacing and styling with CSS variables:
 
 All Bootstrap fields support these common properties:
 
-| Prop       | Type           | Default | Description                       |
-| ---------- | -------------- | ------- | --------------------------------- |
-| `size`     | `'sm' \| 'lg'` | -       | Bootstrap size class              |
-| `helpText` | `string`       | -       | Helper text displayed below field |
+| Prop   | Type           | Default | Description                       |
+| ------ | -------------- | ------- | --------------------------------- |
+| `size` | `'sm' \| 'lg'` | -       | Bootstrap size class              |
+| `hint` | `string`       | -       | Helper text displayed below field |
 
 ## Bootstrap-Specific Features
 

--- a/apps/examples/bootstrap/src/app/examples/scenarios/complete-form.scenario.ts
+++ b/apps/examples/bootstrap/src/app/examples/scenarios/complete-form.scenario.ts
@@ -66,7 +66,7 @@ export const completeFormScenario: ExampleScenario = {
           type: 'email',
           placeholder: 'user@example.com',
           floatingLabel: true,
-          helpText: 'We will never share your email',
+          hint: 'We will never share your email',
         },
       },
 
@@ -138,7 +138,7 @@ export const completeFormScenario: ExampleScenario = {
         props: {
           placeholder: 'Tell us about yourself',
           floatingLabel: true,
-          helpText: 'Optional - share a bit about yourself',
+          hint: 'Optional - share a bit about yourself',
           rows: 4,
         },
       },
@@ -148,7 +148,7 @@ export const completeFormScenario: ExampleScenario = {
         label: 'Subscribe to newsletter',
         props: {
           switch: true,
-          helpText: 'Get updates about new features and special offers',
+          hint: 'Get updates about new features and special offers',
         },
       },
 

--- a/apps/examples/bootstrap/src/app/examples/scenarios/user-registration.scenario.ts
+++ b/apps/examples/bootstrap/src/app/examples/scenarios/user-registration.scenario.ts
@@ -63,7 +63,7 @@ export const userRegistrationScenario: ExampleScenario = {
         props: {
           type: 'email',
           placeholder: 'user@example.com',
-          helpText: 'We will never share your email',
+          hint: 'We will never share your email',
         },
       },
 
@@ -131,7 +131,7 @@ export const userRegistrationScenario: ExampleScenario = {
         label: 'Bio',
         props: {
           placeholder: 'Tell us about yourself',
-          helpText: 'Optional - share a bit about yourself',
+          hint: 'Optional - share a bit about yourself',
         },
       },
       {
@@ -139,7 +139,7 @@ export const userRegistrationScenario: ExampleScenario = {
         type: 'checkbox',
         label: 'Subscribe to newsletter',
         props: {
-          helpText: 'Get updates about new features and special offers',
+          hint: 'Get updates about new features and special offers',
         },
       },
 

--- a/apps/examples/bootstrap/src/app/testing/accessibility/accessibility.spec.ts
+++ b/apps/examples/bootstrap/src/app/testing/accessibility/accessibility.spec.ts
@@ -25,7 +25,7 @@ test.describe('Accessibility Tests', () => {
       const scenario = helpers.getScenario('all-fields-aria');
       const input = scenario.locator('#inputField input');
       const ariaDescribedBy = await input.getAttribute('aria-describedby');
-      expect(ariaDescribedBy).toContain('inputField-help');
+      expect(ariaDescribedBy).toContain('inputField-hint');
     });
 
     test('input field should have aria-invalid="true" when invalid and touched', async ({ page, helpers }) => {
@@ -49,7 +49,7 @@ test.describe('Accessibility Tests', () => {
       const scenario = helpers.getScenario('all-fields-aria');
       const textarea = scenario.locator('#textareaField textarea');
       const ariaDescribedBy = await textarea.getAttribute('aria-describedby');
-      expect(ariaDescribedBy).toContain('textareaField-help');
+      expect(ariaDescribedBy).toContain('textareaField-hint');
     });
 
     test('textarea field should have aria-invalid="true" when invalid and touched', async ({ page, helpers }) => {
@@ -73,7 +73,7 @@ test.describe('Accessibility Tests', () => {
       const scenario = helpers.getScenario('all-fields-aria');
       const select = scenario.locator('#selectField select');
       const ariaDescribedBy = await select.getAttribute('aria-describedby');
-      expect(ariaDescribedBy).toContain('selectField-help');
+      expect(ariaDescribedBy).toContain('selectField-hint');
     });
 
     test('select field should have aria-invalid="true" when invalid and touched', async ({ page, helpers }) => {
@@ -97,7 +97,7 @@ test.describe('Accessibility Tests', () => {
       const scenario = helpers.getScenario('all-fields-aria');
       const checkbox = scenario.locator('#checkboxField .form-check input');
       const ariaDescribedBy = await checkbox.getAttribute('aria-describedby');
-      expect(ariaDescribedBy).toContain('checkboxField-help');
+      expect(ariaDescribedBy).toContain('checkboxField-hint');
     });
 
     // Toggle field tests
@@ -113,7 +113,7 @@ test.describe('Accessibility Tests', () => {
       const scenario = helpers.getScenario('all-fields-aria');
       const toggle = scenario.locator('#toggleField .form-check input');
       const ariaDescribedBy = await toggle.getAttribute('aria-describedby');
-      expect(ariaDescribedBy).toContain('toggleField-help');
+      expect(ariaDescribedBy).toContain('toggleField-hint');
     });
 
     // Radio field tests
@@ -132,7 +132,7 @@ test.describe('Accessibility Tests', () => {
       // Bootstrap radio puts aria attrs on individual radio inputs
       const radioInput = scenario.locator('#radioField input[type="radio"]').first();
       const ariaDescribedBy = await radioInput.getAttribute('aria-describedby');
-      expect(ariaDescribedBy).toContain('radioField-help');
+      expect(ariaDescribedBy).toContain('radioField-hint');
     });
 
     // Multi-checkbox field tests
@@ -150,7 +150,7 @@ test.describe('Accessibility Tests', () => {
       // Bootstrap multi-checkbox puts aria attrs on individual checkbox inputs
       const checkboxInput = scenario.locator('#multiCheckboxField input[type="checkbox"]').first();
       const ariaDescribedBy = await checkboxInput.getAttribute('aria-describedby');
-      expect(ariaDescribedBy).toContain('multiCheckboxField-help');
+      expect(ariaDescribedBy).toContain('multiCheckboxField-hint');
     });
 
     // Slider field tests
@@ -160,7 +160,7 @@ test.describe('Accessibility Tests', () => {
 
       const slider = scenario.locator('#sliderField input[type="range"]');
       const ariaDescribedBy = await slider.getAttribute('aria-describedby');
-      expect(ariaDescribedBy).toContain('sliderField-help');
+      expect(ariaDescribedBy).toContain('sliderField-hint');
     });
 
     // Datepicker field tests
@@ -176,7 +176,7 @@ test.describe('Accessibility Tests', () => {
       const scenario = helpers.getScenario('all-fields-aria');
       const datepicker = scenario.locator('#datepickerField input');
       const ariaDescribedBy = await datepicker.getAttribute('aria-describedby');
-      expect(ariaDescribedBy).toContain('datepickerField-help');
+      expect(ariaDescribedBy).toContain('datepickerField-hint');
     });
 
     test('datepicker field should have aria-invalid="true" when invalid and touched', async ({ page, helpers }) => {
@@ -267,12 +267,12 @@ test.describe('Accessibility Tests', () => {
 
       // Check that aria-describedby contains the help text ID
       const ariaDescribedBy = await requiredInput.getAttribute('aria-describedby');
-      expect(ariaDescribedBy).toContain('requiredField-help');
+      expect(ariaDescribedBy).toContain('requiredField-hint');
 
       // Verify the help text element exists with the correct ID
       const hint = scenario.locator('#requiredField .form-text');
       const hintId = await hint.getAttribute('id');
-      expect(hintId).toBe('requiredField-help');
+      expect(hintId).toBe('requiredField-hint');
     });
 
     test('field with error should have aria-describedby referencing error', async ({ page, helpers }) => {

--- a/apps/examples/bootstrap/src/app/testing/accessibility/scenarios/all-fields-aria.scenario.ts
+++ b/apps/examples/bootstrap/src/app/testing/accessibility/scenarios/all-fields-aria.scenario.ts
@@ -19,7 +19,7 @@ const config = {
       label: 'Input Field',
       required: true,
       props: {
-        helpText: 'Enter some text',
+        hint: 'Enter some text',
       },
     },
     // Textarea field
@@ -29,7 +29,7 @@ const config = {
       label: 'Textarea Field',
       required: true,
       props: {
-        helpText: 'Enter a longer description',
+        hint: 'Enter a longer description',
         rows: 3,
       },
     },
@@ -45,7 +45,7 @@ const config = {
         { label: 'Option 3', value: 'option3' },
       ],
       props: {
-        helpText: 'Choose an option',
+        hint: 'Choose an option',
       },
     },
     // Checkbox field
@@ -55,7 +55,7 @@ const config = {
       label: 'Checkbox Field',
       required: true,
       props: {
-        helpText: 'Check this box',
+        hint: 'Check this box',
       },
     },
     // Toggle field
@@ -65,7 +65,7 @@ const config = {
       label: 'Toggle Field',
       required: true,
       props: {
-        helpText: 'Toggle this switch',
+        hint: 'Toggle this switch',
       },
     },
     // Radio field - options at field level
@@ -80,7 +80,7 @@ const config = {
         { label: 'Radio 3', value: 'radio3' },
       ],
       props: {
-        helpText: 'Select one option',
+        hint: 'Select one option',
       },
     },
     // Multi-checkbox field - options at field level
@@ -95,7 +95,7 @@ const config = {
         { label: 'Check 3', value: 'check3' },
       ],
       props: {
-        helpText: 'Select multiple options',
+        hint: 'Select multiple options',
       },
     },
     // Slider field - minValue/maxValue at field level
@@ -106,7 +106,7 @@ const config = {
       minValue: 0,
       maxValue: 100,
       props: {
-        helpText: 'Adjust the value',
+        hint: 'Adjust the value',
       },
     },
     // Datepicker field
@@ -116,7 +116,7 @@ const config = {
       label: 'Datepicker Field',
       required: true,
       props: {
-        helpText: 'Select a date',
+        hint: 'Select a date',
       },
     },
     // Submit button

--- a/apps/examples/bootstrap/src/app/testing/accessibility/scenarios/aria-attributes.scenario.ts
+++ b/apps/examples/bootstrap/src/app/testing/accessibility/scenarios/aria-attributes.scenario.ts
@@ -18,7 +18,7 @@ const config = {
       label: 'Required Field',
       required: true,
       props: {
-        helpText: 'This field is required for submission',
+        hint: 'This field is required for submission',
       },
     },
     {
@@ -28,7 +28,7 @@ const config = {
       required: true,
       props: {
         type: 'email',
-        helpText: 'Enter your email address',
+        hint: 'Enter your email address',
       },
     },
     {
@@ -36,7 +36,7 @@ const config = {
       type: 'input',
       label: 'Optional Field',
       props: {
-        helpText: 'This field is optional',
+        hint: 'This field is optional',
       },
     },
     {

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/checkbox/bs-checkbox.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/checkbox/bs-checkbox.component.ts
@@ -36,9 +36,9 @@ import { AsyncPipe } from '@angular/common';
       </label>
     </div>
 
-    @if (props()?.helpText; as helpText) {
-      <div class="form-text" [id]="helpTextId()" [attr.hidden]="f().hidden() || null">
-        {{ helpText | dynamicText | async }}
+    @if (props()?.hint; as hint) {
+      <div class="form-text" [id]="hintId()" [attr.hidden]="f().hidden() || null">
+        {{ hint | dynamicText | async }}
       </div>
     }
     @for (error of errorsToDisplay(); track error.kind; let i = $index) {
@@ -104,7 +104,7 @@ export default class BsCheckboxFieldComponent implements BsCheckboxComponent {
   // Accessibility
   // ─────────────────────────────────────────────────────────────────────────────
 
-  protected readonly helpTextId = computed(() => `${this.key()}-help`);
+  protected readonly hintId = computed(() => `${this.key()}-hint`);
   protected readonly errorId = computed(() => `${this.key()}-error`);
 
   protected readonly ariaInvalid = computed(() => {
@@ -118,8 +118,8 @@ export default class BsCheckboxFieldComponent implements BsCheckboxComponent {
 
   protected readonly ariaDescribedBy = computed(() => {
     const ids: string[] = [];
-    if (this.props()?.helpText) {
-      ids.push(this.helpTextId());
+    if (this.props()?.hint) {
+      ids.push(this.hintId());
     }
     const errors = this.errorsToDisplay();
     errors.forEach((_, i) => {

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/checkbox/bs-checkbox.type-test.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/checkbox/bs-checkbox.type-test.ts
@@ -12,7 +12,7 @@ import type { RequiredKeys } from '@ng-forge/dynamic-forms/testing';
 // ============================================================================
 
 describe('BsCheckboxProps - Exhaustive Whitelist', () => {
-  type ExpectedKeys = 'switch' | 'inline' | 'reverse' | 'indeterminate' | 'helpText';
+  type ExpectedKeys = 'switch' | 'inline' | 'reverse' | 'indeterminate' | 'hint';
   type ActualKeys = keyof BsCheckboxProps;
 
   it('should have exactly the expected keys', () => {
@@ -40,8 +40,8 @@ describe('BsCheckboxProps - Exhaustive Whitelist', () => {
       expectTypeOf<BsCheckboxProps['indeterminate']>().toEqualTypeOf<boolean | undefined>();
     });
 
-    it('helpText', () => {
-      expectTypeOf<BsCheckboxProps['helpText']>().toEqualTypeOf<DynamicText | undefined>();
+    it('hint', () => {
+      expectTypeOf<BsCheckboxProps['hint']>().toEqualTypeOf<DynamicText | undefined>();
     });
   });
 });
@@ -178,7 +178,7 @@ describe('BsCheckboxField - Usage', () => {
       props: {
         switch: true,
         inline: true,
-        helpText: 'Please read the terms carefully',
+        hint: 'Please read the terms carefully',
       },
     } as const satisfies BsCheckboxField;
 

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/checkbox/bs-checkbox.type.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/checkbox/bs-checkbox.type.ts
@@ -6,7 +6,7 @@ export interface BsCheckboxProps {
   inline?: boolean;
   reverse?: boolean;
   indeterminate?: boolean;
-  helpText?: DynamicText;
+  hint?: DynamicText;
 }
 
 export type BsCheckboxField = CheckboxField<BsCheckboxProps>;

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/datepicker/bs-datepicker.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/datepicker/bs-datepicker.component.ts
@@ -71,9 +71,9 @@ import { InputConstraintsDirective } from '../../directives/input-constraints.di
           [class.is-valid]="f().valid() && f().touched() && p?.validFeedback"
         />
 
-        @if (p?.helpText) {
-          <div class="form-text" [id]="helpTextId()">
-            {{ p?.helpText | dynamicText | async }}
+        @if (p?.hint) {
+          <div class="form-text" [id]="hintId()">
+            {{ p?.hint | dynamicText | async }}
           </div>
         }
         @if (p?.validFeedback && f().valid() && f().touched()) {
@@ -145,7 +145,7 @@ export default class BsDatepickerFieldComponent implements BsDatepickerComponent
   // Accessibility
   // ─────────────────────────────────────────────────────────────────────────────
 
-  protected readonly helpTextId = computed(() => `${this.key()}-help`);
+  protected readonly hintId = computed(() => `${this.key()}-hint`);
   protected readonly errorId = computed(() => `${this.key()}-error`);
 
   protected readonly ariaInvalid = computed(() => {
@@ -159,8 +159,8 @@ export default class BsDatepickerFieldComponent implements BsDatepickerComponent
 
   protected readonly ariaDescribedBy = computed(() => {
     const ids: string[] = [];
-    if (this.props()?.helpText) {
-      ids.push(this.helpTextId());
+    if (this.props()?.hint) {
+      ids.push(this.hintId());
     }
     const errors = this.errorsToDisplay();
     errors.forEach((_, i) => {

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/datepicker/bs-datepicker.type-test.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/datepicker/bs-datepicker.type-test.ts
@@ -16,7 +16,7 @@ describe('BsDatepickerProps - Exhaustive Whitelist', () => {
     | 'useNgBootstrap'
     | 'size'
     | 'floatingLabel'
-    | 'helpText'
+    | 'hint'
     | 'validFeedback'
     | 'invalidFeedback'
     | 'displayMonths'
@@ -47,8 +47,8 @@ describe('BsDatepickerProps - Exhaustive Whitelist', () => {
       expectTypeOf<BsDatepickerProps['floatingLabel']>().toEqualTypeOf<boolean | undefined>();
     });
 
-    it('helpText', () => {
-      expectTypeOf<BsDatepickerProps['helpText']>().toEqualTypeOf<DynamicText | undefined>();
+    it('hint', () => {
+      expectTypeOf<BsDatepickerProps['hint']>().toEqualTypeOf<DynamicText | undefined>();
     });
 
     it('validFeedback', () => {

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/datepicker/bs-datepicker.type.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/datepicker/bs-datepicker.type.ts
@@ -5,7 +5,7 @@ export interface BsDatepickerProps extends DatepickerProps {
   useNgBootstrap?: boolean;
   size?: 'sm' | 'lg';
   floatingLabel?: boolean;
-  helpText?: DynamicText;
+  hint?: DynamicText;
   validFeedback?: DynamicText;
   invalidFeedback?: DynamicText;
   // ng-bootstrap specific props (if used)

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/input/bs-input.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/input/bs-input.component.ts
@@ -67,9 +67,9 @@ import { BOOTSTRAP_CONFIG } from '../../models/bootstrap-config.token';
           [class.is-invalid]="f().invalid() && f().touched()"
           [class.is-valid]="f().valid() && f().touched() && p?.validFeedback"
         />
-        @if (p?.helpText) {
-          <div class="form-text" [id]="helpTextId()">
-            {{ p?.helpText | dynamicText | async }}
+        @if (p?.hint) {
+          <div class="form-text" [id]="hintId()">
+            {{ p?.hint | dynamicText | async }}
           </div>
         }
         @if (p?.validFeedback && f().valid() && f().touched()) {
@@ -164,8 +164,8 @@ export default class BsInputFieldComponent implements BsInputComponent {
   // Accessibility
   // ─────────────────────────────────────────────────────────────────────────────
 
-  /** Unique ID for the help text element, used for aria-describedby */
-  protected readonly helpTextId = computed(() => `${this.key()}-help`);
+  /** Unique ID for the hint element, used for aria-describedby */
+  protected readonly hintId = computed(() => `${this.key()}-hint`);
 
   /** Base ID for error elements, used for aria-describedby */
   protected readonly errorId = computed(() => `${this.key()}-error`);
@@ -181,12 +181,12 @@ export default class BsInputFieldComponent implements BsInputComponent {
     return this.field()().required?.() === true ? true : null;
   });
 
-  /** aria-describedby: links to help text and error messages for screen readers */
+  /** aria-describedby: links to hint and error messages for screen readers */
   protected readonly ariaDescribedBy = computed(() => {
     const ids: string[] = [];
 
-    if (this.props()?.helpText) {
-      ids.push(this.helpTextId());
+    if (this.props()?.hint) {
+      ids.push(this.hintId());
     }
 
     const errors = this.errorsToDisplay();

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/input/bs-input.type-test.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/input/bs-input.type-test.ts
@@ -12,7 +12,7 @@ import type { RequiredKeys } from '@ng-forge/dynamic-forms/testing';
 // ============================================================================
 
 describe('BsInputProps - Exhaustive Whitelist', () => {
-  type ExpectedKeys = 'size' | 'floatingLabel' | 'helpText' | 'validFeedback' | 'invalidFeedback' | 'plaintext' | 'type' | 'placeholder';
+  type ExpectedKeys = 'size' | 'floatingLabel' | 'hint' | 'validFeedback' | 'invalidFeedback' | 'plaintext' | 'type' | 'placeholder';
   type ActualKeys = keyof BsInputProps;
 
   it('should have exactly the expected keys', () => {
@@ -32,8 +32,8 @@ describe('BsInputProps - Exhaustive Whitelist', () => {
       expectTypeOf<BsInputProps['floatingLabel']>().toEqualTypeOf<boolean | undefined>();
     });
 
-    it('helpText', () => {
-      expectTypeOf<BsInputProps['helpText']>().toEqualTypeOf<DynamicText | undefined>();
+    it('hint', () => {
+      expectTypeOf<BsInputProps['hint']>().toEqualTypeOf<DynamicText | undefined>();
     });
 
     it('validFeedback', () => {
@@ -307,7 +307,7 @@ describe('BsInputField - Discriminated Union', () => {
         type: 'email',
         size: 'lg',
         floatingLabel: true,
-        helpText: 'Enter your email',
+        hint: 'Enter your email',
         validFeedback: 'Looks good!',
         invalidFeedback: 'Please enter a valid email',
       },

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/input/bs-input.type.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/input/bs-input.type.ts
@@ -4,7 +4,7 @@ import { InputField, InputProps } from '@ng-forge/dynamic-forms/integration';
 export interface BsInputProps extends InputProps {
   size?: 'sm' | 'lg';
   floatingLabel?: boolean;
-  helpText?: DynamicText;
+  hint?: DynamicText;
   validFeedback?: DynamicText;
   invalidFeedback?: DynamicText;
   plaintext?: boolean;

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/multi-checkbox/bs-multi-checkbox.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/multi-checkbox/bs-multi-checkbox.component.ts
@@ -45,9 +45,9 @@ import { AsyncPipe } from '@angular/common';
       }
     </div>
 
-    @if (props()?.helpText; as helpText) {
-      <div class="form-text" [id]="helpTextId()">
-        {{ helpText | dynamicText | async }}
+    @if (props()?.hint; as hint) {
+      <div class="form-text" [id]="hintId()">
+        {{ hint | dynamicText | async }}
       </div>
     }
     @for (error of errorsToDisplay(); track error.kind; let i = $index) {
@@ -156,7 +156,7 @@ export default class BsMultiCheckboxFieldComponent implements BsMultiCheckboxCom
   // Accessibility
   // ─────────────────────────────────────────────────────────────────────────────
 
-  protected readonly helpTextId = computed(() => `${this.key()}-help`);
+  protected readonly hintId = computed(() => `${this.key()}-hint`);
   protected readonly errorId = computed(() => `${this.key()}-error`);
 
   protected readonly ariaInvalid = computed(() => {
@@ -170,8 +170,8 @@ export default class BsMultiCheckboxFieldComponent implements BsMultiCheckboxCom
 
   protected readonly ariaDescribedBy = computed(() => {
     const ids: string[] = [];
-    if (this.props()?.helpText) {
-      ids.push(this.helpTextId());
+    if (this.props()?.hint) {
+      ids.push(this.hintId());
     }
     const errors = this.errorsToDisplay();
     errors.forEach((_, i) => {

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/multi-checkbox/bs-multi-checkbox.type-test.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/multi-checkbox/bs-multi-checkbox.type-test.ts
@@ -19,7 +19,7 @@ import type { RequiredKeys } from '@ng-forge/dynamic-forms/testing';
 // ============================================================================
 
 describe('BsMultiCheckboxProps - Exhaustive Whitelist', () => {
-  type ExpectedKeys = 'switch' | 'inline' | 'reverse' | 'helpText';
+  type ExpectedKeys = 'switch' | 'inline' | 'reverse' | 'hint';
   type ActualKeys = keyof BsMultiCheckboxProps;
 
   it('should have exactly the expected keys', () => {
@@ -43,8 +43,8 @@ describe('BsMultiCheckboxProps - Exhaustive Whitelist', () => {
       expectTypeOf<BsMultiCheckboxProps['reverse']>().toEqualTypeOf<boolean | undefined>();
     });
 
-    it('helpText', () => {
-      expectTypeOf<BsMultiCheckboxProps['helpText']>().toEqualTypeOf<DynamicText | undefined>();
+    it('hint', () => {
+      expectTypeOf<BsMultiCheckboxProps['hint']>().toEqualTypeOf<DynamicText | undefined>();
     });
   });
 });
@@ -193,7 +193,7 @@ describe('BsMultiCheckboxField - Usage', () => {
       props: {
         switch: false,
         inline: true,
-        helpText: 'Select your interests',
+        hint: 'Select your interests',
       },
     } as const satisfies BsMultiCheckboxField<string>;
 

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/multi-checkbox/bs-multi-checkbox.type.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/multi-checkbox/bs-multi-checkbox.type.ts
@@ -5,7 +5,7 @@ export interface BsMultiCheckboxProps {
   switch?: boolean;
   inline?: boolean;
   reverse?: boolean;
-  helpText?: DynamicText;
+  hint?: DynamicText;
 }
 
 export type BsMultiCheckboxField<T> = MultiCheckboxField<T, BsMultiCheckboxProps>;

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/radio/bs-radio-group.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/radio/bs-radio-group.component.ts
@@ -22,9 +22,9 @@ export interface BsRadioGroupProps {
    */
   buttonSize?: 'sm' | 'lg';
   /**
-   * Help text to display below the radio group
+   * Hint text to display below the radio group
    */
-  helpText?: DynamicText;
+  hint?: DynamicText;
 }
 
 @Component({

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/radio/bs-radio.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/radio/bs-radio.component.ts
@@ -26,8 +26,8 @@ import { BsRadioGroupComponent } from './bs-radio-group.component';
         [ariaDescribedBy]="ariaDescribedBy()"
       />
 
-      @if (props()?.helpText; as helpText) {
-        <div class="form-text" [id]="helpTextId()">{{ helpText | dynamicText | async }}</div>
+      @if (props()?.hint; as hint) {
+        <div class="form-text" [id]="hintId()">{{ hint | dynamicText | async }}</div>
       }
       @for (error of errorsToDisplay(); track error.kind; let i = $index) {
         <div class="invalid-feedback d-block" [id]="errorId() + '-' + i" role="alert">{{ error.message }}</div>
@@ -87,7 +87,7 @@ export default class BsRadioFieldComponent implements BsRadioComponent {
   // Accessibility
   // ─────────────────────────────────────────────────────────────────────────────
 
-  protected readonly helpTextId = computed(() => `${this.key()}-help`);
+  protected readonly hintId = computed(() => `${this.key()}-hint`);
   protected readonly errorId = computed(() => `${this.key()}-error`);
 
   protected readonly ariaInvalid = computed(() => {
@@ -101,8 +101,8 @@ export default class BsRadioFieldComponent implements BsRadioComponent {
 
   protected readonly ariaDescribedBy = computed(() => {
     const ids: string[] = [];
-    if (this.props()?.helpText) {
-      ids.push(this.helpTextId());
+    if (this.props()?.hint) {
+      ids.push(this.hintId());
     }
     const errors = this.errorsToDisplay();
     errors.forEach((_, i) => {

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/radio/bs-radio.type-test.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/radio/bs-radio.type-test.ts
@@ -19,7 +19,7 @@ import type { RequiredKeys } from '@ng-forge/dynamic-forms/testing';
 // ============================================================================
 
 describe('BsRadioProps - Exhaustive Whitelist', () => {
-  type ExpectedKeys = 'inline' | 'reverse' | 'buttonGroup' | 'buttonSize' | 'helpText';
+  type ExpectedKeys = 'inline' | 'reverse' | 'buttonGroup' | 'buttonSize' | 'hint';
   type ActualKeys = keyof BsRadioProps;
 
   it('should have exactly the expected keys', () => {
@@ -47,8 +47,8 @@ describe('BsRadioProps - Exhaustive Whitelist', () => {
       expectTypeOf<BsRadioProps['buttonSize']>().toEqualTypeOf<'sm' | 'lg' | undefined>();
     });
 
-    it('helpText', () => {
-      expectTypeOf<BsRadioProps['helpText']>().toEqualTypeOf<DynamicText | undefined>();
+    it('hint', () => {
+      expectTypeOf<BsRadioProps['hint']>().toEqualTypeOf<DynamicText | undefined>();
     });
   });
 });

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/radio/bs-radio.type.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/radio/bs-radio.type.ts
@@ -6,7 +6,7 @@ export interface BsRadioProps {
   reverse?: boolean;
   buttonGroup?: boolean;
   buttonSize?: 'sm' | 'lg';
-  helpText?: DynamicText;
+  hint?: DynamicText;
 }
 
 export type BsRadioField<T> = RadioField<T, BsRadioProps>;

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/select/bs-select.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/select/bs-select.component.ts
@@ -39,8 +39,8 @@ import { AsyncPipe } from '@angular/common';
         }
       </select>
 
-      @if (props()?.helpText; as helpText) {
-        <div class="form-text" [id]="helpTextId()">{{ helpText | dynamicText | async }}</div>
+      @if (props()?.hint; as hint) {
+        <div class="form-text" [id]="hintId()">{{ hint | dynamicText | async }}</div>
       }
       @for (error of errorsToDisplay(); track error.kind; let i = $index) {
         <div class="invalid-feedback d-block" [id]="errorId() + '-' + i" role="alert">{{ error.message }}</div>
@@ -105,7 +105,7 @@ export default class BsSelectFieldComponent implements BsSelectComponent {
   // Accessibility
   // ─────────────────────────────────────────────────────────────────────────────
 
-  protected readonly helpTextId = computed(() => `${this.key()}-help`);
+  protected readonly hintId = computed(() => `${this.key()}-hint`);
   protected readonly errorId = computed(() => `${this.key()}-error`);
 
   protected readonly ariaInvalid = computed(() => {
@@ -119,8 +119,8 @@ export default class BsSelectFieldComponent implements BsSelectComponent {
 
   protected readonly ariaDescribedBy = computed(() => {
     const ids: string[] = [];
-    if (this.props()?.helpText) {
-      ids.push(this.helpTextId());
+    if (this.props()?.hint) {
+      ids.push(this.hintId());
     }
     const errors = this.errorsToDisplay();
     errors.forEach((_, i) => {

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/select/bs-select.type-test.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/select/bs-select.type-test.ts
@@ -25,7 +25,7 @@ describe('BsSelectProps - Exhaustive Whitelist', () => {
     | 'size'
     | 'htmlSize'
     | 'floatingLabel'
-    | 'helpText'
+    | 'hint'
     | 'validFeedback'
     | 'invalidFeedback'
     | 'compareWith'
@@ -57,8 +57,8 @@ describe('BsSelectProps - Exhaustive Whitelist', () => {
       expectTypeOf<BsSelectProps['floatingLabel']>().toEqualTypeOf<boolean | undefined>();
     });
 
-    it('helpText', () => {
-      expectTypeOf<BsSelectProps['helpText']>().toEqualTypeOf<DynamicText | undefined>();
+    it('hint', () => {
+      expectTypeOf<BsSelectProps['hint']>().toEqualTypeOf<DynamicText | undefined>();
     });
 
     it('validFeedback', () => {
@@ -223,7 +223,7 @@ describe('BsSelectField - Usage', () => {
       props: {
         size: 'lg',
         floatingLabel: true,
-        helpText: 'Select your country',
+        hint: 'Select your country',
       },
     } as const satisfies BsSelectField<string>;
 

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/select/bs-select.type.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/select/bs-select.type.ts
@@ -10,7 +10,7 @@ export interface BsSelectProps extends SelectProps {
   size?: 'sm' | 'lg';
   htmlSize?: number;
   floatingLabel?: boolean;
-  helpText?: DynamicText;
+  hint?: DynamicText;
   validFeedback?: DynamicText;
   invalidFeedback?: DynamicText;
   compareWith?: (o1: string, o2: string) => boolean;

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/slider/bs-slider.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/slider/bs-slider.component.ts
@@ -38,9 +38,9 @@ import { InputConstraintsDirective } from '../../directives/input-constraints.di
         class="form-range"
       />
 
-      @if (props()?.helpText; as helpText) {
-        <div class="form-text" [id]="helpTextId()">
-          {{ helpText | dynamicText | async }}
+      @if (props()?.hint; as hint) {
+        <div class="form-text" [id]="hintId()">
+          {{ hint | dynamicText | async }}
         </div>
       }
       @for (error of errorsToDisplay(); track error.kind; let i = $index) {
@@ -101,7 +101,7 @@ export default class BsSliderFieldComponent implements BsSliderComponent {
   // Accessibility
   // ─────────────────────────────────────────────────────────────────────────────
 
-  protected readonly helpTextId = computed(() => `${this.key()}-help`);
+  protected readonly hintId = computed(() => `${this.key()}-hint`);
   protected readonly errorId = computed(() => `${this.key()}-error`);
 
   protected readonly ariaInvalid = computed(() => {
@@ -115,8 +115,8 @@ export default class BsSliderFieldComponent implements BsSliderComponent {
 
   protected readonly ariaDescribedBy = computed(() => {
     const ids: string[] = [];
-    if (this.props()?.helpText) {
-      ids.push(this.helpTextId());
+    if (this.props()?.hint) {
+      ids.push(this.hintId());
     }
     const errors = this.errorsToDisplay();
     errors.forEach((_, i) => {

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/slider/bs-slider.type-test.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/slider/bs-slider.type-test.ts
@@ -12,7 +12,7 @@ import type { RequiredKeys } from '@ng-forge/dynamic-forms/testing';
 // ============================================================================
 
 describe('BsSliderProps - Exhaustive Whitelist', () => {
-  type ExpectedKeys = 'showValue' | 'valuePrefix' | 'valueSuffix' | 'helpText' | 'min' | 'max' | 'step';
+  type ExpectedKeys = 'showValue' | 'valuePrefix' | 'valueSuffix' | 'hint' | 'min' | 'max' | 'step';
   type ActualKeys = keyof BsSliderProps;
 
   it('should have exactly the expected keys', () => {
@@ -36,8 +36,8 @@ describe('BsSliderProps - Exhaustive Whitelist', () => {
       expectTypeOf<BsSliderProps['valueSuffix']>().toEqualTypeOf<string | undefined>();
     });
 
-    it('helpText', () => {
-      expectTypeOf<BsSliderProps['helpText']>().toEqualTypeOf<DynamicText | undefined>();
+    it('hint', () => {
+      expectTypeOf<BsSliderProps['hint']>().toEqualTypeOf<DynamicText | undefined>();
     });
 
     it('min', () => {
@@ -207,7 +207,7 @@ describe('BsSliderField - Usage', () => {
       props: {
         showValue: true,
         valueSuffix: '%',
-        helpText: 'Adjust the volume',
+        hint: 'Adjust the volume',
       },
     } as const satisfies BsSliderField;
 

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/slider/bs-slider.type.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/slider/bs-slider.type.ts
@@ -5,7 +5,7 @@ export interface BsSliderProps {
   showValue?: boolean;
   valuePrefix?: string;
   valueSuffix?: string;
-  helpText?: DynamicText;
+  hint?: DynamicText;
   min?: number;
   max?: number;
   step?: number;

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/textarea/bs-textarea.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/textarea/bs-textarea.component.ts
@@ -63,9 +63,9 @@ import { AsyncPipe } from '@angular/common';
           [class.is-valid]="f().valid() && f().touched() && p?.validFeedback"
         ></textarea>
 
-        @if (p?.helpText) {
-          <div class="form-text" [id]="helpTextId()">
-            {{ p?.helpText | dynamicText | async }}
+        @if (p?.hint) {
+          <div class="form-text" [id]="hintId()">
+            {{ p?.hint | dynamicText | async }}
           </div>
         }
         @if (p?.validFeedback && f().valid() && f().touched()) {
@@ -122,7 +122,7 @@ export default class BsTextareaFieldComponent implements BsTextareaComponent {
   // Accessibility
   // ─────────────────────────────────────────────────────────────────────────────
 
-  protected readonly helpTextId = computed(() => `${this.key()}-help`);
+  protected readonly hintId = computed(() => `${this.key()}-hint`);
   protected readonly errorId = computed(() => `${this.key()}-error`);
 
   protected readonly ariaInvalid = computed(() => {
@@ -136,8 +136,8 @@ export default class BsTextareaFieldComponent implements BsTextareaComponent {
 
   protected readonly ariaDescribedBy = computed(() => {
     const ids: string[] = [];
-    if (this.props()?.helpText) {
-      ids.push(this.helpTextId());
+    if (this.props()?.hint) {
+      ids.push(this.hintId());
     }
     const errors = this.errorsToDisplay();
     errors.forEach((_, i) => {

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/textarea/bs-textarea.type-test.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/textarea/bs-textarea.type-test.ts
@@ -12,7 +12,7 @@ import type { RequiredKeys } from '@ng-forge/dynamic-forms/testing';
 // ============================================================================
 
 describe('BsTextareaProps - Exhaustive Whitelist', () => {
-  type ExpectedKeys = 'rows' | 'cols' | 'size' | 'floatingLabel' | 'helpText' | 'validFeedback' | 'invalidFeedback' | 'placeholder';
+  type ExpectedKeys = 'rows' | 'cols' | 'size' | 'floatingLabel' | 'hint' | 'validFeedback' | 'invalidFeedback' | 'placeholder';
   type ActualKeys = keyof BsTextareaProps;
 
   it('should have exactly the expected keys', () => {
@@ -40,8 +40,8 @@ describe('BsTextareaProps - Exhaustive Whitelist', () => {
       expectTypeOf<BsTextareaProps['floatingLabel']>().toEqualTypeOf<boolean | undefined>();
     });
 
-    it('helpText', () => {
-      expectTypeOf<BsTextareaProps['helpText']>().toEqualTypeOf<DynamicText | undefined>();
+    it('hint', () => {
+      expectTypeOf<BsTextareaProps['hint']>().toEqualTypeOf<DynamicText | undefined>();
     });
 
     it('validFeedback', () => {
@@ -195,7 +195,7 @@ describe('BsTextareaField - Usage', () => {
         rows: 5,
         size: 'lg',
         floatingLabel: true,
-        helpText: 'Enter a detailed description',
+        hint: 'Enter a detailed description',
       },
     } as const satisfies BsTextareaField;
 

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/textarea/bs-textarea.type.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/textarea/bs-textarea.type.ts
@@ -5,7 +5,7 @@ export interface BsTextareaProps extends TextareaProps {
   rows?: number;
   size?: 'sm' | 'lg';
   floatingLabel?: boolean;
-  helpText?: DynamicText;
+  hint?: DynamicText;
   validFeedback?: DynamicText;
   invalidFeedback?: DynamicText;
 }

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/toggle/bs-toggle.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/toggle/bs-toggle.component.ts
@@ -36,9 +36,9 @@ import { AsyncPipe } from '@angular/common';
       </label>
     </div>
 
-    @if (props()?.helpText; as helpText) {
-      <div class="form-text" [id]="helpTextId()" [attr.hidden]="f().hidden() || null">
-        {{ helpText | dynamicText | async }}
+    @if (props()?.hint; as hint) {
+      <div class="form-text" [id]="hintId()" [attr.hidden]="f().hidden() || null">
+        {{ hint | dynamicText | async }}
       </div>
     }
     @for (error of errorsToDisplay(); track error.kind; let i = $index) {
@@ -105,7 +105,7 @@ export default class BsToggleFieldComponent implements BsToggleComponent {
   // Accessibility
   // ─────────────────────────────────────────────────────────────────────────────
 
-  protected readonly helpTextId = computed(() => `${this.key()}-help`);
+  protected readonly hintId = computed(() => `${this.key()}-hint`);
   protected readonly errorId = computed(() => `${this.key()}-error`);
 
   protected readonly ariaInvalid = computed(() => {
@@ -119,8 +119,8 @@ export default class BsToggleFieldComponent implements BsToggleComponent {
 
   protected readonly ariaDescribedBy = computed(() => {
     const ids: string[] = [];
-    if (this.props()?.helpText) {
-      ids.push(this.helpTextId());
+    if (this.props()?.hint) {
+      ids.push(this.hintId());
     }
     const errors = this.errorsToDisplay();
     errors.forEach((_, i) => {

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/toggle/bs-toggle.type-test.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/toggle/bs-toggle.type-test.ts
@@ -12,7 +12,7 @@ import type { RequiredKeys } from '@ng-forge/dynamic-forms/testing';
 // ============================================================================
 
 describe('BsToggleProps - Exhaustive Whitelist', () => {
-  type ExpectedKeys = 'size' | 'reverse' | 'inline' | 'helpText';
+  type ExpectedKeys = 'size' | 'reverse' | 'inline' | 'hint';
   type ActualKeys = keyof BsToggleProps;
 
   it('should have exactly the expected keys', () => {
@@ -36,8 +36,8 @@ describe('BsToggleProps - Exhaustive Whitelist', () => {
       expectTypeOf<BsToggleProps['inline']>().toEqualTypeOf<boolean | undefined>();
     });
 
-    it('helpText', () => {
-      expectTypeOf<BsToggleProps['helpText']>().toEqualTypeOf<DynamicText | undefined>();
+    it('hint', () => {
+      expectTypeOf<BsToggleProps['hint']>().toEqualTypeOf<DynamicText | undefined>();
     });
   });
 });
@@ -174,7 +174,7 @@ describe('BsToggleField - Usage', () => {
       props: {
         size: 'lg',
         reverse: false,
-        helpText: 'Toggle to enable/disable',
+        hint: 'Toggle to enable/disable',
       },
     } as const satisfies BsToggleField;
 

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/toggle/bs-toggle.type.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/toggle/bs-toggle.type.ts
@@ -5,7 +5,7 @@ export interface BsToggleProps {
   size?: 'sm' | 'lg';
   reverse?: boolean;
   inline?: boolean;
-  helpText?: DynamicText;
+  hint?: DynamicText;
 }
 
 export type BsToggleField = ToggleField<BsToggleProps>;


### PR DESCRIPTION
## Summary

- Rename `helpText` prop to `hint` across all Bootstrap field components for consistency with Material, PrimeNG, and Ionic libraries
- Update `helpTextId` signal to `hintId` with ID suffix `-help` → `-hint`
- Update `aria-describedby` to reference hint instead of helpText
- Update all type tests, examples, and documentation

## BREAKING CHANGES

- **`helpText` prop renamed to `hint`**: All Bootstrap field components now use `hint` instead of `helpText` in their props interface. Update your field configurations:

  ```typescript
  // Before
  props: {
    helpText: 'Enter your email address'
  }
  
  // After
  props: {
    hint: 'Enter your email address'
  }
  ```

- **Affected components**: `BsInput`, `BsTextarea`, `BsSelect`, `BsCheckbox`, `BsRadio`, `BsToggle`, `BsSlider`, `BsMultiCheckbox`, `BsDatepicker`

## Test plan

- [x] Build passes: `nx run-many -t build -p dynamic-forms-bootstrap`
- [x] Lint passes: `nx run-many -t lint -p dynamic-forms-bootstrap`
- [x] All 334 tests pass: `nx run-many -t test -p dynamic-forms-bootstrap`
- [ ] Manual verification: Run Bootstrap example app and verify hint displays correctly