### PR TITLE
fix(dynamic-forms): show only first validation error instead of all errors

### DIFF
--- a/apps/examples/bootstrap/src/app/testing/accessibility/accessibility.spec.ts
+++ b/apps/examples/bootstrap/src/app/testing/accessibility/accessibility.spec.ts
@@ -539,7 +539,7 @@ test.describe('Accessibility Tests', () => {
       await expect(hint).toHaveText('This field is required for submission');
     });
 
-    test('hint should remain visible when field displays errors', async ({ page, helpers }) => {
+    test('hint should be hidden when field displays errors', async ({ page, helpers }) => {
       const scenario = helpers.getScenario('aria-attributes');
       await expect(scenario).toBeVisible();
 
@@ -554,12 +554,12 @@ test.describe('Accessibility Tests', () => {
       await input.focus();
       await input.blur();
 
-      // Both error and hint should be visible
+      // Error should be visible, hint should be hidden
       await expect(error).toBeVisible();
-      await expect(hint).toBeVisible();
+      await expect(hint).not.toBeVisible();
     });
 
-    test('error should disappear when errors are cleared but hint remains', async ({ page, helpers }) => {
+    test('hint should reappear when errors are cleared', async ({ page, helpers }) => {
       const scenario = helpers.getScenario('aria-attributes');
       await expect(scenario).toBeVisible();
 
@@ -571,17 +571,17 @@ test.describe('Accessibility Tests', () => {
       await input.focus();
       await input.blur();
       await expect(error).toBeVisible();
-      await expect(hint).toBeVisible();
+      await expect(hint).not.toBeVisible();
 
       // Fix the error by entering a value
       await input.fill('valid value');
 
-      // Error should be hidden, hint should still be visible
+      // Error should be hidden, hint should reappear
       await expect(error).not.toBeVisible();
       await expect(hint).toBeVisible();
     });
 
-    test('aria-describedby should include both hint and error when errors appear', async ({ page, helpers }) => {
+    test('aria-describedby should switch from hint to error when errors appear', async ({ page, helpers }) => {
       const scenario = helpers.getScenario('aria-attributes');
       await expect(scenario).toBeVisible();
 
@@ -596,13 +596,13 @@ test.describe('Accessibility Tests', () => {
       await input.focus();
       await input.blur();
 
-      // Now aria-describedby should reference both hint and error
+      // Now aria-describedby should reference error only (not hint)
       ariaDescribedBy = await input.getAttribute('aria-describedby');
       expect(ariaDescribedBy).toContain('requiredField-error');
-      expect(ariaDescribedBy).toContain('requiredField-hint');
+      expect(ariaDescribedBy).not.toContain('requiredField-hint');
     });
 
-    test('aria-describedby should only reference hint when errors are cleared', async ({ page, helpers }) => {
+    test('aria-describedby should switch back to hint when errors are cleared', async ({ page, helpers }) => {
       const scenario = helpers.getScenario('aria-attributes');
       await expect(scenario).toBeVisible();
 
@@ -614,7 +614,7 @@ test.describe('Accessibility Tests', () => {
 
       let ariaDescribedBy = await input.getAttribute('aria-describedby');
       expect(ariaDescribedBy).toContain('requiredField-error');
-      expect(ariaDescribedBy).toContain('requiredField-hint');
+      expect(ariaDescribedBy).not.toContain('requiredField-hint');
 
       // Clear error
       await input.fill('valid value');

--- a/apps/examples/ionic/src/app/testing/accessibility/accessibility.spec.ts
+++ b/apps/examples/ionic/src/app/testing/accessibility/accessibility.spec.ts
@@ -363,10 +363,7 @@ test.describe('Accessibility Tests', () => {
       await expect(hint).toHaveText('This field is required for submission');
     });
 
-    // Note: Ionic's ion-input with helperText property does NOT support showing both
-    // hint and error simultaneously. Ionic internally manages the helper text visibility.
-    // This is a limitation of Ionic's component, so we test Ionic's actual behavior.
-    test('hint should be hidden when field displays errors (Ionic limitation)', async ({ page, helpers }) => {
+    test('hint should be hidden when field displays errors', async ({ page, helpers }) => {
       const scenario = helpers.getScenario('aria-attributes');
       await expect(scenario).toBeVisible();
 
@@ -382,7 +379,7 @@ test.describe('Accessibility Tests', () => {
       await input.blur();
       await page.waitForTimeout(200);
 
-      // Error should be visible, hint hidden (Ionic's internal behavior)
+      // Error should be visible, hint should be hidden
       await expect(error).toBeVisible();
       await expect(hint).not.toBeVisible();
     });
@@ -411,7 +408,7 @@ test.describe('Accessibility Tests', () => {
       await expect(hint).toBeVisible();
     });
 
-    test('aria-describedby should include both hint and error when errors appear', async ({ page, helpers }) => {
+    test('aria-describedby should switch from hint to error when errors appear', async ({ page, helpers }) => {
       const scenario = helpers.getScenario('aria-attributes');
       await expect(scenario).toBeVisible();
 
@@ -427,13 +424,13 @@ test.describe('Accessibility Tests', () => {
       await input.blur();
       await page.waitForTimeout(200);
 
-      // Now aria-describedby should reference both hint and error
+      // Now aria-describedby should reference error only (not hint)
       ariaDescribedBy = await input.getAttribute('aria-describedby');
       expect(ariaDescribedBy).toContain('requiredField-error');
-      expect(ariaDescribedBy).toContain('requiredField-hint');
+      expect(ariaDescribedBy).not.toContain('requiredField-hint');
     });
 
-    test('aria-describedby should only reference hint when errors are cleared', async ({ page, helpers }) => {
+    test('aria-describedby should switch back to hint when errors are cleared', async ({ page, helpers }) => {
       const scenario = helpers.getScenario('aria-attributes');
       await expect(scenario).toBeVisible();
 
@@ -446,7 +443,7 @@ test.describe('Accessibility Tests', () => {
 
       let ariaDescribedBy = await input.getAttribute('aria-describedby');
       expect(ariaDescribedBy).toContain('requiredField-error');
-      expect(ariaDescribedBy).toContain('requiredField-hint');
+      expect(ariaDescribedBy).not.toContain('requiredField-hint');
 
       // Clear error
       await input.fill('valid value');

--- a/apps/examples/material/src/app/testing/accessibility/accessibility.spec.ts
+++ b/apps/examples/material/src/app/testing/accessibility/accessibility.spec.ts
@@ -565,7 +565,7 @@ test.describe('Accessibility Tests', () => {
       await expect(hint).toHaveText('This field is required for submission');
     });
 
-    test('hint should remain visible when field displays errors', async ({ page, helpers }) => {
+    test('hint should be hidden when field displays errors', async ({ page, helpers }) => {
       const scenario = helpers.getScenario('aria-attributes');
       await expect(scenario).toBeVisible();
 
@@ -581,12 +581,12 @@ test.describe('Accessibility Tests', () => {
       await input.blur();
       await page.waitForTimeout(200);
 
-      // Both error and hint should be visible
+      // Error should be visible, hint should be hidden
       await expect(error).toBeVisible();
-      await expect(hint).toBeVisible();
+      await expect(hint).not.toBeVisible();
     });
 
-    test('error should disappear when errors are cleared but hint remains', async ({ page, helpers }) => {
+    test('hint should reappear when errors are cleared', async ({ page, helpers }) => {
       const scenario = helpers.getScenario('aria-attributes');
       await expect(scenario).toBeVisible();
 
@@ -599,18 +599,18 @@ test.describe('Accessibility Tests', () => {
       await input.blur();
       await page.waitForTimeout(200);
       await expect(error).toBeVisible();
-      await expect(hint).toBeVisible();
+      await expect(hint).not.toBeVisible();
 
       // Fix the error by entering a value
       await input.fill('valid value');
       await page.waitForTimeout(200);
 
-      // Error should be hidden, hint should still be visible
+      // Error should be hidden, hint should reappear
       await expect(error).not.toBeVisible();
       await expect(hint).toBeVisible();
     });
 
-    test('aria-describedby should include both hint and error when errors appear', async ({ page, helpers }) => {
+    test('aria-describedby should switch from hint to error when errors appear', async ({ page, helpers }) => {
       const scenario = helpers.getScenario('aria-attributes');
       await expect(scenario).toBeVisible();
 
@@ -626,13 +626,13 @@ test.describe('Accessibility Tests', () => {
       await input.blur();
       await page.waitForTimeout(200);
 
-      // Now aria-describedby should reference both hint and error
+      // Now aria-describedby should reference error only (not hint)
       ariaDescribedBy = await input.getAttribute('aria-describedby');
       expect(ariaDescribedBy).toContain('requiredField-error');
-      expect(ariaDescribedBy).toContain('requiredField-hint');
+      expect(ariaDescribedBy).not.toContain('requiredField-hint');
     });
 
-    test('aria-describedby should only reference hint when errors are cleared', async ({ page, helpers }) => {
+    test('aria-describedby should switch back to hint when errors are cleared', async ({ page, helpers }) => {
       const scenario = helpers.getScenario('aria-attributes');
       await expect(scenario).toBeVisible();
 
@@ -645,7 +645,7 @@ test.describe('Accessibility Tests', () => {
 
       let ariaDescribedBy = await input.getAttribute('aria-describedby');
       expect(ariaDescribedBy).toContain('requiredField-error');
-      expect(ariaDescribedBy).toContain('requiredField-hint');
+      expect(ariaDescribedBy).not.toContain('requiredField-hint');
 
       // Clear error
       await input.fill('valid value');

--- a/apps/examples/primeng/src/app/testing/accessibility/accessibility.spec.ts
+++ b/apps/examples/primeng/src/app/testing/accessibility/accessibility.spec.ts
@@ -615,7 +615,7 @@ test.describe('Accessibility Tests', () => {
       await expect(hint).toHaveText('This field is required for submission');
     });
 
-    test('hint should remain visible when field displays errors', async ({ page, helpers }) => {
+    test('hint should be hidden when field displays errors', async ({ page, helpers }) => {
       const scenario = helpers.getScenario('aria-attributes');
       await expect(scenario).toBeVisible();
 
@@ -631,12 +631,12 @@ test.describe('Accessibility Tests', () => {
       await input.blur();
       await page.waitForTimeout(200);
 
-      // Both error and hint should be visible
+      // Error should be visible, hint should be hidden
       await expect(error).toBeVisible();
-      await expect(hint).toBeVisible();
+      await expect(hint).not.toBeVisible();
     });
 
-    test('error should disappear when errors are cleared but hint remains', async ({ page, helpers }) => {
+    test('hint should reappear when errors are cleared', async ({ page, helpers }) => {
       const scenario = helpers.getScenario('aria-attributes');
       await expect(scenario).toBeVisible();
 
@@ -649,18 +649,18 @@ test.describe('Accessibility Tests', () => {
       await input.blur();
       await page.waitForTimeout(200);
       await expect(error).toBeVisible();
-      await expect(hint).toBeVisible();
+      await expect(hint).not.toBeVisible();
 
       // Fix the error by entering a value
       await input.fill('valid value');
       await page.waitForTimeout(200);
 
-      // Error should be hidden, hint should still be visible
+      // Error should be hidden, hint should reappear
       await expect(error).not.toBeVisible();
       await expect(hint).toBeVisible();
     });
 
-    test('aria-describedby should include both hint and error when errors appear', async ({ page, helpers }) => {
+    test('aria-describedby should switch from hint to error when errors appear', async ({ page, helpers }) => {
       const scenario = helpers.getScenario('aria-attributes');
       await expect(scenario).toBeVisible();
 
@@ -676,13 +676,13 @@ test.describe('Accessibility Tests', () => {
       await input.blur();
       await page.waitForTimeout(200);
 
-      // Now aria-describedby should reference both hint and error
+      // Now aria-describedby should reference error only (not hint)
       ariaDescribedBy = await input.getAttribute('aria-describedby');
       expect(ariaDescribedBy).toContain('requiredField-error');
-      expect(ariaDescribedBy).toContain('requiredField-hint');
+      expect(ariaDescribedBy).not.toContain('requiredField-hint');
     });
 
-    test('aria-describedby should only reference hint when errors are cleared', async ({ page, helpers }) => {
+    test('aria-describedby should switch back to hint when errors are cleared', async ({ page, helpers }) => {
       const scenario = helpers.getScenario('aria-attributes');
       await expect(scenario).toBeVisible();
 
@@ -695,7 +695,7 @@ test.describe('Accessibility Tests', () => {
 
       let ariaDescribedBy = await input.getAttribute('aria-describedby');
       expect(ariaDescribedBy).toContain('requiredField-error');
-      expect(ariaDescribedBy).toContain('requiredField-hint');
+      expect(ariaDescribedBy).not.toContain('requiredField-hint');
 
       // Clear error
       await input.fill('valid value');

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/checkbox/bs-checkbox.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/checkbox/bs-checkbox.component.ts
@@ -37,11 +37,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
       </label>
     </div>
 
-    @if (props()?.hint; as hint) {
-      <div class="form-text" [id]="hintId()" [attr.hidden]="f().hidden() || null">{{ hint | dynamicText | async }}</div>
-    }
     @if (errorsToDisplay()[0]; as error) {
       <div class="invalid-feedback d-block" [id]="errorId()" role="alert">{{ error.message }}</div>
+    } @else if (props()?.hint; as hint) {
+      <div class="form-text" [id]="hintId()" [attr.hidden]="f().hidden() || null">{{ hint | dynamicText | async }}</div>
     }
   `,
   styles: [

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/datepicker/bs-datepicker.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/datepicker/bs-datepicker.component.ts
@@ -77,11 +77,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
             {{ p?.validFeedback | dynamicText | async }}
           </div>
         }
-        @if (p?.hint) {
-          <div class="form-text" [id]="hintId()">{{ p?.hint | dynamicText | async }}</div>
-        }
         @if (errorsToDisplay()[0]; as error) {
           <div class="invalid-feedback d-block" [id]="errorId()" role="alert">{{ error.message }}</div>
+        } @else if (p?.hint) {
+          <div class="form-text" [id]="hintId()">{{ p?.hint | dynamicText | async }}</div>
         }
       </div>
     }

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/input/bs-input.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/input/bs-input.component.ts
@@ -73,11 +73,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
             {{ p?.validFeedback | dynamicText | async }}
           </div>
         }
-        @if (p?.hint) {
-          <div class="form-text" [id]="hintId()">{{ p?.hint | dynamicText | async }}</div>
-        }
         @if (errorsToDisplay()[0]; as error) {
           <div class="invalid-feedback d-block" [id]="errorId()" role="alert">{{ error.message }}</div>
+        } @else if (p?.hint) {
+          <div class="form-text" [id]="hintId()">{{ p?.hint | dynamicText | async }}</div>
         }
       </div>
     }

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/multi-checkbox/bs-multi-checkbox.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/multi-checkbox/bs-multi-checkbox.component.ts
@@ -46,11 +46,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
       }
     </div>
 
-    @if (props()?.hint; as hint) {
-      <div class="form-text" [id]="hintId()">{{ hint | dynamicText | async }}</div>
-    }
     @if (errorsToDisplay()[0]; as error) {
       <div class="invalid-feedback d-block" [id]="errorId()" role="alert">{{ error.message }}</div>
+    } @else if (props()?.hint; as hint) {
+      <div class="form-text" [id]="hintId()">{{ hint | dynamicText | async }}</div>
     }
   `,
   styles: [

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/radio/bs-radio.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/radio/bs-radio.component.ts
@@ -27,11 +27,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
         [ariaDescribedBy]="ariaDescribedBy()"
       />
 
-      @if (props()?.hint; as hint) {
-        <div class="form-text" [id]="hintId()">{{ hint | dynamicText | async }}</div>
-      }
       @if (errorsToDisplay()[0]; as error) {
         <div class="invalid-feedback d-block" [id]="errorId()" role="alert">{{ error.message }}</div>
+      } @else if (props()?.hint; as hint) {
+        <div class="form-text" [id]="hintId()">{{ hint | dynamicText | async }}</div>
       }
     </div>
   `,

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/select/bs-select.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/select/bs-select.component.ts
@@ -40,11 +40,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
         }
       </select>
 
-      @if (props()?.hint; as hint) {
-        <div class="form-text" [id]="hintId()">{{ hint | dynamicText | async }}</div>
-      }
       @if (errorsToDisplay()[0]; as error) {
         <div class="invalid-feedback d-block" [id]="errorId()" role="alert">{{ error.message }}</div>
+      } @else if (props()?.hint; as hint) {
+        <div class="form-text" [id]="hintId()">{{ hint | dynamicText | async }}</div>
       }
     </div>
   `,

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/slider/bs-slider.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/slider/bs-slider.component.ts
@@ -39,11 +39,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
         class="form-range"
       />
 
-      @if (props()?.hint; as hint) {
-        <div class="form-text" [id]="hintId()">{{ hint | dynamicText | async }}</div>
-      }
       @if (errorsToDisplay()[0]; as error) {
         <div class="invalid-feedback d-block" [id]="errorId()" role="alert">{{ error.message }}</div>
+      } @else if (props()?.hint; as hint) {
+        <div class="form-text" [id]="hintId()">{{ hint | dynamicText | async }}</div>
       }
     </div>
   `,

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/textarea/bs-textarea.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/textarea/bs-textarea.component.ts
@@ -69,11 +69,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
             {{ p?.validFeedback | dynamicText | async }}
           </div>
         }
-        @if (p?.hint) {
-          <div class="form-text" [id]="hintId()">{{ p?.hint | dynamicText | async }}</div>
-        }
         @if (errorsToDisplay()[0]; as error) {
           <div class="invalid-feedback d-block" [id]="errorId()" role="alert">{{ error.message }}</div>
+        } @else if (p?.hint) {
+          <div class="form-text" [id]="hintId()">{{ p?.hint | dynamicText | async }}</div>
         }
       </div>
     }

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/toggle/bs-toggle.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/toggle/bs-toggle.component.ts
@@ -37,11 +37,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
       </label>
     </div>
 
-    @if (props()?.hint; as hint) {
-      <div class="form-text" [id]="hintId()" [attr.hidden]="f().hidden() || null">{{ hint | dynamicText | async }}</div>
-    }
     @if (errorsToDisplay()[0]; as error) {
       <div class="invalid-feedback d-block" [id]="errorId()" role="alert">{{ error.message }}</div>
+    } @else if (props()?.hint; as hint) {
+      <div class="form-text" [id]="hintId()" [attr.hidden]="f().hidden() || null">{{ hint | dynamicText | async }}</div>
     }
   `,
   styles: [

--- a/packages/dynamic-forms-bootstrap/src/lib/utils/create-aria-described-by.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/utils/create-aria-described-by.ts
@@ -3,14 +3,14 @@ import { ResolvedError } from '@ng-forge/dynamic-forms/integration';
 
 /**
  * Creates a signal that computes the aria-describedby value based on errors and hint state.
- * Both hint and error are included when present - hint is always shown, and only the first
- * error is displayed.
+ * Errors take precedence over hints - when errors are displayed, the hint is hidden.
+ * Only the first error is displayed (single error ID, not indexed).
  *
  * @param errorsToDisplay Signal containing the array of errors currently being displayed
  * @param errorId Signal containing the ID for the error element (single error only)
  * @param hintId Signal containing the ID for the hint element
  * @param hasHint Function that returns true if a hint is configured
- * @returns Signal containing the aria-describedby value (space-separated IDs) or null
+ * @returns Signal containing the aria-describedby value or null
  */
 export function createAriaDescribedBySignal(
   errorsToDisplay: Signal<ResolvedError[]>,
@@ -19,13 +19,12 @@ export function createAriaDescribedBySignal(
   hasHint: () => boolean,
 ): Signal<string | null> {
   return computed(() => {
-    const parts: string[] = [];
-    if (hasHint()) {
-      parts.push(hintId());
-    }
     if (errorsToDisplay().length > 0) {
-      parts.push(errorId());
+      return errorId();
     }
-    return parts.length > 0 ? parts.join(' ') : null;
+    if (hasHint()) {
+      return hintId();
+    }
+    return null;
   });
 }

--- a/packages/dynamic-forms-ionic/src/lib/fields/checkbox/ionic-checkbox.component.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/checkbox/ionic-checkbox.component.ts
@@ -31,8 +31,7 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
 
     @if (errorsToDisplay()[0]; as error) {
       <ion-note color="danger" class="df-ion-error" [id]="errorId()" role="alert">{{ error.message }}</ion-note>
-    }
-    @if (props()?.hint; as hint) {
+    } @else if (props()?.hint; as hint) {
       <ion-note class="df-ion-hint" [id]="hintId()">{{ hint | dynamicText | async }}</ion-note>
     }
   `,

--- a/packages/dynamic-forms-ionic/src/lib/fields/datepicker/ionic-datepicker.component.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/datepicker/ionic-datepicker.component.ts
@@ -57,8 +57,7 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
     />
     @if (errorsToDisplay()[0]; as error) {
       <ion-note color="danger" class="df-ion-error" [id]="errorId()" role="alert">{{ error.message }}</ion-note>
-    }
-    @if (props()?.hint; as hint) {
+    } @else if (props()?.hint; as hint) {
       <ion-note class="df-ion-hint" [id]="hintId()">{{ hint | dynamicText | async }}</ion-note>
     }
 

--- a/packages/dynamic-forms-ionic/src/lib/fields/input/ionic-input.component.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/input/ionic-input.component.ts
@@ -29,7 +29,7 @@ import { IONIC_CONFIG } from '../../models/ionic-config.token';
       [fill]="effectiveFill()"
       [shape]="effectiveShape()"
       [readonly]="f().readonly()"
-      [helperText]="(props()?.hint | dynamicText | async) ?? undefined"
+      [helperText]="errorsToDisplay().length === 0 ? ((props()?.hint | dynamicText | async) ?? undefined) : undefined"
       [attr.tabindex]="tabIndex()"
       [attr.aria-invalid]="ariaInvalid()"
       [attr.aria-required]="ariaRequired()"

--- a/packages/dynamic-forms-ionic/src/lib/fields/multi-checkbox/ionic-multi-checkbox.component.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/multi-checkbox/ionic-multi-checkbox.component.ts
@@ -45,8 +45,7 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
 
     @if (errorsToDisplay()[0]; as error) {
       <ion-note color="danger" class="df-ion-error" [id]="errorId()" role="alert">{{ error.message }}</ion-note>
-    }
-    @if (props()?.hint; as hint) {
+    } @else if (props()?.hint; as hint) {
       <ion-note class="df-ion-hint" [id]="hintId()">{{ hint | dynamicText | async }}</ion-note>
     }
   `,

--- a/packages/dynamic-forms-ionic/src/lib/fields/radio/ionic-radio.component.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/radio/ionic-radio.component.ts
@@ -42,8 +42,7 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
 
     @if (errorsToDisplay()[0]; as error) {
       <ion-note color="danger" class="df-ion-error" [id]="errorId()" role="alert">{{ error.message }}</ion-note>
-    }
-    @if (props()?.hint; as hint) {
+    } @else if (props()?.hint; as hint) {
       <ion-note class="df-ion-hint" [id]="hintId()">{{ hint | dynamicText | async }}</ion-note>
     }
   `,

--- a/packages/dynamic-forms-ionic/src/lib/fields/select/ionic-select.component.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/select/ionic-select.component.ts
@@ -42,8 +42,7 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
     </ion-select>
     @if (errorsToDisplay()[0]; as error) {
       <ion-note color="danger" class="df-ion-error" [id]="errorId()" role="alert">{{ error.message }}</ion-note>
-    }
-    @if (props()?.hint; as hint) {
+    } @else if (props()?.hint; as hint) {
       <ion-note class="df-ion-hint" [id]="hintId()">{{ hint | dynamicText | async }}</ion-note>
     }
   `,

--- a/packages/dynamic-forms-ionic/src/lib/fields/slider/ionic-slider.component.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/slider/ionic-slider.component.ts
@@ -36,8 +36,7 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
 
     @if (errorsToDisplay()[0]; as error) {
       <ion-note color="danger" class="df-ion-error" [id]="errorId()" role="alert">{{ error.message }}</ion-note>
-    }
-    @if (props()?.hint; as hint) {
+    } @else if (props()?.hint; as hint) {
       <ion-note class="df-ion-hint" [id]="hintId()">{{ hint | dynamicText | async }}</ion-note>
     }
   `,

--- a/packages/dynamic-forms-ionic/src/lib/fields/textarea/ionic-textarea.component.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/textarea/ionic-textarea.component.ts
@@ -28,7 +28,7 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
       [fill]="props()?.fill ?? 'outline'"
       [shape]="props()?.shape"
       [readonly]="f().readonly()"
-      [helperText]="(props()?.hint | dynamicText | async) ?? undefined"
+      [helperText]="errorsToDisplay().length === 0 ? ((props()?.hint | dynamicText | async) ?? undefined) : undefined"
       [attr.tabindex]="tabIndex()"
       [attr.aria-invalid]="ariaInvalid()"
       [attr.aria-required]="ariaRequired()"

--- a/packages/dynamic-forms-ionic/src/lib/fields/toggle/ionic-toggle.component.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/toggle/ionic-toggle.component.ts
@@ -31,8 +31,7 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
 
     @if (errorsToDisplay()[0]; as error) {
       <ion-note color="danger" class="df-ion-error" [id]="errorId()" role="alert">{{ error.message }}</ion-note>
-    }
-    @if (props()?.hint; as hint) {
+    } @else if (props()?.hint; as hint) {
       <ion-note class="df-ion-hint" [id]="hintId()">{{ hint | dynamicText | async }}</ion-note>
     }
   `,

--- a/packages/dynamic-forms-ionic/src/lib/utils/create-aria-described-by.ts
+++ b/packages/dynamic-forms-ionic/src/lib/utils/create-aria-described-by.ts
@@ -3,14 +3,14 @@ import { ResolvedError } from '@ng-forge/dynamic-forms/integration';
 
 /**
  * Creates a signal that computes the aria-describedby value based on errors and hint state.
- * Both hint and error are included when present - hint is always shown, and only the first
- * error is displayed.
+ * Errors take precedence over hints - when errors are displayed, the hint is hidden.
+ * Only the first error is displayed (single error ID, not indexed).
  *
  * @param errorsToDisplay Signal containing the array of errors currently being displayed
  * @param errorId Signal containing the ID for the error element (single error only)
  * @param hintId Signal containing the ID for the hint element
  * @param hasHint Function that returns true if a hint is configured
- * @returns Signal containing the aria-describedby value (space-separated IDs) or null
+ * @returns Signal containing the aria-describedby value or null
  */
 export function createAriaDescribedBySignal(
   errorsToDisplay: Signal<ResolvedError[]>,
@@ -19,13 +19,12 @@ export function createAriaDescribedBySignal(
   hasHint: () => boolean,
 ): Signal<string | null> {
   return computed(() => {
-    const parts: string[] = [];
-    if (hasHint()) {
-      parts.push(hintId());
-    }
     if (errorsToDisplay().length > 0) {
-      parts.push(errorId());
+      return errorId();
     }
-    return parts.length > 0 ? parts.join(' ') : null;
+    if (hasHint()) {
+      return hintId();
+    }
+    return null;
   });
 }

--- a/packages/dynamic-forms-material/src/lib/fields/checkbox/mat-checkbox.component.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/checkbox/mat-checkbox.component.ts
@@ -31,11 +31,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
       {{ label() | dynamicText | async }}
     </mat-checkbox>
 
-    @if (props()?.hint; as hint) {
-      <div class="mat-hint" [id]="hintId()" [attr.hidden]="f().hidden() || null">{{ hint | dynamicText | async }}</div>
-    }
     @if (errorsToDisplay()[0]; as error) {
       <mat-error [id]="errorId()" [attr.hidden]="f().hidden() || null">{{ error.message }}</mat-error>
+    } @else if (props()?.hint; as hint) {
+      <div class="mat-hint" [id]="hintId()" [attr.hidden]="f().hidden() || null">{{ hint | dynamicText | async }}</div>
     }
   `,
   styleUrl: '../../styles/_form-field.scss',

--- a/packages/dynamic-forms-material/src/lib/fields/datepicker/mat-datepicker.component.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/datepicker/mat-datepicker.component.ts
@@ -59,11 +59,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
       <mat-datepicker-toggle matIconSuffix [for]="picker" />
       <mat-datepicker #picker [startAt]="startAt()" [startView]="props()?.startView || 'month'" [touchUi]="props()?.touchUi ?? false" />
 
-      @if (props()?.hint; as hint) {
-        <mat-hint [id]="hintId()">{{ hint | dynamicText | async }}</mat-hint>
-      }
       @if (errorsToDisplay()[0]; as error) {
         <mat-error [id]="errorId()">{{ error.message }}</mat-error>
+      } @else if (props()?.hint; as hint) {
+        <mat-hint [id]="hintId()">{{ hint | dynamicText | async }}</mat-hint>
       }
     </mat-form-field>
   `,

--- a/packages/dynamic-forms-material/src/lib/fields/input/mat-input.component.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/input/mat-input.component.ts
@@ -32,11 +32,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
         [attr.aria-required]="ariaRequired()"
         [attr.aria-describedby]="ariaDescribedBy()"
       />
-      @if (props()?.hint; as hint) {
-        <mat-hint [id]="hintId()">{{ hint | dynamicText | async }}</mat-hint>
-      }
       @if (errorsToDisplay()[0]; as error) {
         <mat-error [id]="errorId()">{{ error.message }}</mat-error>
+      } @else if (props()?.hint; as hint) {
+        <mat-hint [id]="hintId()">{{ hint | dynamicText | async }}</mat-hint>
       }
     </mat-form-field>
   `,

--- a/packages/dynamic-forms-material/src/lib/fields/multi-checkbox/mat-multi-checkbox.component.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/multi-checkbox/mat-multi-checkbox.component.ts
@@ -42,11 +42,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
       }
     </div>
 
-    @if (props()?.hint; as hint) {
-      <div class="mat-hint" [id]="hintId()">{{ hint | dynamicText | async }}</div>
-    }
     @if (errorsToDisplay()[0]; as error) {
       <mat-error [id]="errorId()">{{ error.message }}</mat-error>
+    } @else if (props()?.hint; as hint) {
+      <div class="mat-hint" [id]="hintId()">{{ hint | dynamicText | async }}</div>
     }
   `,
   styleUrl: '../../styles/_form-field.scss',

--- a/packages/dynamic-forms-material/src/lib/fields/radio/mat-radio.component.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/radio/mat-radio.component.ts
@@ -38,11 +38,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
       }
     </mat-radio-group>
 
-    @if (props()?.hint; as hint) {
-      <div class="mat-hint" [id]="hintId()">{{ hint | dynamicText | async }}</div>
-    }
     @if (errorsToDisplay()[0]; as error) {
       <mat-error [id]="errorId()">{{ error.message }}</mat-error>
+    } @else if (props()?.hint; as hint) {
+      <div class="mat-hint" [id]="hintId()">{{ hint | dynamicText | async }}</div>
     }
   `,
   styleUrl: '../../styles/_form-field.scss',

--- a/packages/dynamic-forms-material/src/lib/fields/select/mat-select.component.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/select/mat-select.component.ts
@@ -39,11 +39,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
         }
       </mat-select>
 
-      @if (props()?.hint; as hint) {
-        <mat-hint [id]="hintId()">{{ hint | dynamicText | async }}</mat-hint>
-      }
       @if (errorsToDisplay()[0]; as error) {
         <mat-error [id]="errorId()">{{ error.message }}</mat-error>
+      } @else if (props()?.hint; as hint) {
+        <mat-hint [id]="hintId()">{{ hint | dynamicText | async }}</mat-hint>
       }
     </mat-form-field>
   `,

--- a/packages/dynamic-forms-material/src/lib/fields/slider/mat-slider.component.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/slider/mat-slider.component.ts
@@ -38,11 +38,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
       />
     </mat-slider>
 
-    @if (props()?.hint; as hint) {
-      <div class="mat-hint" [id]="hintId()">{{ hint | dynamicText | async }}</div>
-    }
     @if (errorsToDisplay()[0]; as error) {
       <mat-error [id]="errorId()">{{ error.message }}</mat-error>
+    } @else if (props()?.hint; as hint) {
+      <div class="mat-hint" [id]="hintId()">{{ hint | dynamicText | async }}</div>
     }
   `,
   styleUrl: '../../styles/_form-field.scss',

--- a/packages/dynamic-forms-material/src/lib/fields/textarea/mat-textarea.component.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/textarea/mat-textarea.component.ts
@@ -34,11 +34,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
         [style.resize]="props()?.resize || 'vertical'"
       ></textarea>
 
-      @if (props()?.hint; as hint) {
-        <mat-hint [id]="hintId()">{{ hint | dynamicText | async }}</mat-hint>
-      }
       @if (errorsToDisplay()[0]; as error) {
         <mat-error [id]="errorId()">{{ error.message }}</mat-error>
+      } @else if (props()?.hint; as hint) {
+        <mat-hint [id]="hintId()">{{ hint | dynamicText | async }}</mat-hint>
       }
     </mat-form-field>
   `,

--- a/packages/dynamic-forms-material/src/lib/fields/toggle/mat-toggle.component.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/toggle/mat-toggle.component.ts
@@ -32,11 +32,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
       {{ label() | dynamicText | async }}
     </mat-slide-toggle>
 
-    @if (props()?.hint; as hint) {
-      <div class="mat-hint" [id]="hintId()">{{ hint | dynamicText | async }}</div>
-    }
     @if (errorsToDisplay()[0]; as error) {
       <mat-error [id]="errorId()">{{ error.message }}</mat-error>
+    } @else if (props()?.hint; as hint) {
+      <div class="mat-hint" [id]="hintId()">{{ hint | dynamicText | async }}</div>
     }
   `,
   styleUrl: '../../styles/_form-field.scss',

--- a/packages/dynamic-forms-material/src/lib/utils/create-aria-described-by.ts
+++ b/packages/dynamic-forms-material/src/lib/utils/create-aria-described-by.ts
@@ -3,14 +3,14 @@ import { ResolvedError } from '@ng-forge/dynamic-forms/integration';
 
 /**
  * Creates a signal that computes the aria-describedby value based on errors and hint state.
- * Both hint and error are included when present - hint is always shown, and only the first
- * error is displayed.
+ * Errors take precedence over hints - when errors are displayed, the hint is hidden.
+ * Only the first error is displayed (single error ID, not indexed).
  *
  * @param errorsToDisplay Signal containing the array of errors currently being displayed
  * @param errorId Signal containing the ID for the error element (single error only)
  * @param hintId Signal containing the ID for the hint element
  * @param hasHint Function that returns true if a hint is configured
- * @returns Signal containing the aria-describedby value (space-separated IDs) or null
+ * @returns Signal containing the aria-describedby value or null
  */
 export function createAriaDescribedBySignal(
   errorsToDisplay: Signal<ResolvedError[]>,
@@ -19,13 +19,12 @@ export function createAriaDescribedBySignal(
   hasHint: () => boolean,
 ): Signal<string | null> {
   return computed(() => {
-    const parts: string[] = [];
-    if (hasHint()) {
-      parts.push(hintId());
-    }
     if (errorsToDisplay().length > 0) {
-      parts.push(errorId());
+      return errorId();
     }
-    return parts.length > 0 ? parts.join(' ') : null;
+    if (hasHint()) {
+      return hintId();
+    }
+    return null;
   });
 }

--- a/packages/dynamic-forms-primeng/src/lib/fields/checkbox/prime-checkbox.component.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/checkbox/prime-checkbox.component.ts
@@ -32,11 +32,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
       }
     </div>
 
-    @if (props()?.hint; as hint) {
-      <small class="p-hint" [id]="hintId()" [attr.hidden]="f().hidden() || null">{{ hint | dynamicText | async }}</small>
-    }
     @if (errorsToDisplay()[0]; as error) {
       <small class="p-error" [id]="errorId()" role="alert">{{ error.message }}</small>
+    } @else if (props()?.hint; as hint) {
+      <small class="p-hint" [id]="hintId()" [attr.hidden]="f().hidden() || null">{{ hint | dynamicText | async }}</small>
     }
   `,
   styles: [

--- a/packages/dynamic-forms-primeng/src/lib/fields/datepicker/prime-datepicker.component.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/datepicker/prime-datepicker.component.ts
@@ -41,11 +41,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
         [ariaDescribedBy]="ariaDescribedBy()"
       />
 
-      @if (props()?.hint; as hint) {
-        <small class="df-prime-hint" [id]="hintId()">{{ hint | dynamicText | async }}</small>
-      }
       @if (errorsToDisplay()[0]; as error) {
         <small class="p-error" [id]="errorId()" role="alert">{{ error.message }}</small>
+      } @else if (props()?.hint; as hint) {
+        <small class="df-prime-hint" [id]="hintId()">{{ hint | dynamicText | async }}</small>
       }
     </div>
   `,

--- a/packages/dynamic-forms-primeng/src/lib/fields/input/prime-input.component.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/input/prime-input.component.ts
@@ -32,11 +32,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
         [attr.aria-describedby]="ariaDescribedBy()"
         [class]="inputClasses()"
       />
-      @if (props()?.hint; as hint) {
-        <small class="df-prime-hint" [id]="hintId()">{{ hint | dynamicText | async }}</small>
-      }
       @if (errorsToDisplay()[0]; as error) {
         <small class="p-error" [id]="errorId()" role="alert">{{ error.message }}</small>
+      } @else if (props()?.hint; as hint) {
+        <small class="df-prime-hint" [id]="hintId()">{{ hint | dynamicText | async }}</small>
       }
     </div>
   `,

--- a/packages/dynamic-forms-primeng/src/lib/fields/multi-checkbox/prime-multi-checkbox.component.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/multi-checkbox/prime-multi-checkbox.component.ts
@@ -34,11 +34,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
         </div>
       }
     </div>
-    @if (props()?.hint; as hint) {
-      <small class="p-hint" [id]="hintId()">{{ hint | dynamicText | async }}</small>
-    }
     @if (errorsToDisplay()[0]; as error) {
       <small class="p-error" [id]="errorId()" role="alert">{{ error.message }}</small>
+    } @else if (props()?.hint; as hint) {
+      <small class="p-hint" [id]="hintId()">{{ hint | dynamicText | async }}</small>
     }
   `,
   styles: [

--- a/packages/dynamic-forms-primeng/src/lib/fields/radio/prime-radio.component.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/radio/prime-radio.component.ts
@@ -25,11 +25,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
       [attr.aria-describedby]="ariaDescribedBy()"
     />
 
-    @if (props()?.hint; as hint) {
-      <small class="p-hint" [id]="hintId()" [attr.hidden]="f().hidden() || null">{{ hint | dynamicText | async }}</small>
-    }
     @if (errorsToDisplay()[0]; as error) {
       <small class="p-error" [id]="errorId()" role="alert">{{ error.message }}</small>
+    } @else if (props()?.hint; as hint) {
+      <small class="p-hint" [id]="hintId()" [attr.hidden]="f().hidden() || null">{{ hint | dynamicText | async }}</small>
     }
   `,
   styles: [

--- a/packages/dynamic-forms-primeng/src/lib/fields/select/prime-select.component.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/select/prime-select.component.ts
@@ -34,11 +34,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
         [ariaDescribedBy]="ariaDescribedBy()"
       />
 
-      @if (props()?.hint; as hint) {
-        <small class="df-prime-hint" [id]="hintId()">{{ hint | dynamicText | async }}</small>
-      }
       @if (errorsToDisplay()[0]; as error) {
         <small class="p-error" [id]="errorId()" role="alert">{{ error.message }}</small>
+      } @else if (props()?.hint; as hint) {
+        <small class="df-prime-hint" [id]="hintId()">{{ hint | dynamicText | async }}</small>
       }
     </div>
   `,

--- a/packages/dynamic-forms-primeng/src/lib/fields/slider/prime-slider.component.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/slider/prime-slider.component.ts
@@ -32,11 +32,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
         [styleClass]="sliderClasses()"
       />
 
-      @if (props()?.hint; as hint) {
-        <small class="p-hint" [id]="hintId()">{{ hint | dynamicText | async }}</small>
-      }
       @if (errorsToDisplay()[0]; as error) {
         <small class="p-error" [id]="errorId()" role="alert">{{ error.message }}</small>
+      } @else if (props()?.hint; as hint) {
+        <small class="p-hint" [id]="hintId()">{{ hint | dynamicText | async }}</small>
       }
     </div>
   `,

--- a/packages/dynamic-forms-primeng/src/lib/fields/textarea/prime-textarea.component.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/textarea/prime-textarea.component.ts
@@ -33,11 +33,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
         [styleClass]="textareaClasses()"
       />
 
-      @if (props()?.hint; as hint) {
-        <small class="df-prime-hint" [id]="hintId()">{{ hint | dynamicText | async }}</small>
-      }
       @if (errorsToDisplay()[0]; as error) {
         <small class="p-error" [id]="errorId()" role="alert">{{ error.message }}</small>
+      } @else if (props()?.hint; as hint) {
+        <small class="df-prime-hint" [id]="hintId()">{{ hint | dynamicText | async }}</small>
       }
     </div>
   `,

--- a/packages/dynamic-forms-primeng/src/lib/fields/toggle/prime-toggle.component.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/toggle/prime-toggle.component.ts
@@ -31,11 +31,10 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
         [styleClass]="toggleClasses()"
       />
 
-      @if (props()?.hint; as hint) {
-        <small class="p-hint" [id]="hintId()">{{ hint | dynamicText | async }}</small>
-      }
       @if (errorsToDisplay()[0]; as error) {
         <small class="p-error" [id]="errorId()" role="alert">{{ error.message }}</small>
+      } @else if (props()?.hint; as hint) {
+        <small class="p-hint" [id]="hintId()">{{ hint | dynamicText | async }}</small>
       }
     </div>
   `,

--- a/packages/dynamic-forms-primeng/src/lib/utils/create-aria-described-by.ts
+++ b/packages/dynamic-forms-primeng/src/lib/utils/create-aria-described-by.ts
@@ -3,14 +3,14 @@ import { ResolvedError } from '@ng-forge/dynamic-forms/integration';
 
 /**
  * Creates a signal that computes the aria-describedby value based on errors and hint state.
- * Both hint and error are included when present - hint is always shown, and only the first
- * error is displayed.
+ * Errors take precedence over hints - when errors are displayed, the hint is hidden.
+ * Only the first error is displayed (single error ID, not indexed).
  *
  * @param errorsToDisplay Signal containing the array of errors currently being displayed
  * @param errorId Signal containing the ID for the error element (single error only)
  * @param hintId Signal containing the ID for the hint element
  * @param hasHint Function that returns true if a hint is configured
- * @returns Signal containing the aria-describedby value (space-separated IDs) or null
+ * @returns Signal containing the aria-describedby value or null
  */
 export function createAriaDescribedBySignal(
   errorsToDisplay: Signal<ResolvedError[]>,
@@ -19,13 +19,12 @@ export function createAriaDescribedBySignal(
   hasHint: () => boolean,
 ): Signal<string | null> {
   return computed(() => {
-    const parts: string[] = [];
-    if (hasHint()) {
-      parts.push(hintId());
-    }
     if (errorsToDisplay().length > 0) {
-      parts.push(errorId());
+      return errorId();
     }
-    return parts.length > 0 ? parts.join(' ') : null;
+    if (hasHint()) {
+      return hintId();
+    }
+    return null;
   });
 }


### PR DESCRIPTION
## Summary

- Show only the **first** validation error instead of all errors (reduces visual clutter)
- Simplified error IDs from indexed format (`key-error-0`, `key-error-1`) to single ID (`key-error`)
- Maintain original behavior: hint is hidden when errors are displayed (hint OR error, not both)
- `aria-describedby` switches between hint and error IDs

## Changes

### Components Updated (36 files)
- Material: 9 field components
- Bootstrap: 9 field components  
- PrimeNG: 9 field components
- Ionic: 9 field components

### Utilities Updated (4 files)
- `createAriaDescribedBySignal` in all 4 packages

### Tests Updated (4 files)
- Accessibility tests updated to validate correct behavior

## Test plan

- [x] Build passes
- [x] Lint passes (0 errors)
- [x] Material E2E: 222 tests passed
- [x] Bootstrap E2E: 203 tests passed
- [x] PrimeNG E2E: 182 tests passed
- [x] Ionic E2E: 159 tests passed