### PR TITLE
feat(docs): add vercel speed insights integration

### DIFF
--- a/apps/docs/src/main.ts
+++ b/apps/docs/src/main.ts
@@ -1,8 +1,10 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { inject as injectVercelAnalytics } from '@vercel/analytics';
+import { injectSpeedInsights } from '@vercel/speed-insights';
 import { appConfig } from './app/app.config';
 import { App } from './app/app';
 
 injectVercelAnalytics();
+injectSpeedInsights();
 
 bootstrapApplication(App, appConfig).catch((err) => console.error(err));

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "@ng-doc/ui-kit": "^21.0.0",
     "@primeuix/themes": "^2.0.2",
     "@vercel/analytics": "^1.6.1",
+    "@vercel/speed-insights": "^1.3.1",
     "bootstrap": "^5.3.8",
     "date-fns": "^4.1.0",
     "express": "^5.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.6.1
         version: 1.6.1(react@19.2.3)
+      '@vercel/speed-insights':
+        specifier: ^1.3.1
+        version: 1.3.1(react@19.2.3)
       bootstrap:
         specifier: ^5.3.8
         version: 5.3.8(@popperjs/core@2.11.8)
@@ -4044,6 +4047,29 @@ packages:
     resolution: {integrity: sha512-68326CAWJmd6P1cUgUmufor5d4ocPbpLxiy9TKG6U/a4aWEx9aC+NIzaDI6GmBZVpt3+MkO3OwnQ2YcgJg12Qw==}
     engines: {node: '>=20'}
     hasBin: true
+
+  '@vercel/speed-insights@1.3.1':
+    resolution: {integrity: sha512-PbEr7FrMkUrGYvlcLHGkXdCkxnylCWePx7lPxxq36DNdfo9mcUjLOmqOyPDHAOgnfqgGGdmE3XI9L/4+5fr+vQ==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@verdaccio/auth@8.0.0-next-8.28':
     resolution: {integrity: sha512-tM0URyKFq1dGFaoBN0whT1SDur1lBKG+pkQwxgJIXgH04DmefLCH63pn/K1iDDfLwqyxMewpmvMTBS390SSR+A==}
@@ -15795,6 +15821,10 @@ snapshots:
       - encoding
       - rollup
       - supports-color
+
+  '@vercel/speed-insights@1.3.1(react@19.2.3)':
+    optionalDependencies:
+      react: 19.2.3
 
   '@verdaccio/auth@8.0.0-next-8.28':
     dependencies:


### PR DESCRIPTION
## Summary
- Add `@vercel/speed-insights` package to track Web Vitals in production
- Integrate with existing Vercel Analytics setup in `main.ts`
- Automatically tracks LCP, FID, CLS, TTFB, and INP metrics

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] Deploy to Vercel preview and verify `/_vercel/speed-insights/script.js` is loaded
- [ ] Check Speed Insights dashboard after deployment