### PR TITLE
fix(config): allow production deploys from any branch and skip smoke test on preview

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -64,9 +64,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: check-ci
-    if: |
-      (inputs.environment == 'preview') ||
-      (inputs.environment == 'production' && github.ref == 'refs/heads/main')
     environment:
       name: ${{ inputs.environment }}
       url: ${{ steps.deploy.outputs.url }}
@@ -112,6 +109,7 @@ jobs:
           echo "Deployed to: $URL"
 
       - name: Smoke test deployment
+        if: inputs.environment == 'production'
         run: |
           echo "Verifying deployment is accessible..."
           curl --fail --retry 5 --retry-delay 10 "${{ steps.deploy.outputs.url }}/dynamic-forms/" > /dev/null


### PR DESCRIPTION
## Summary
- Remove branch restriction that only allowed production deploys from `main`
- Add condition to skip smoke test on preview deployments (preview URLs have password protection which causes 401 errors)

## Test plan
- [ ] Trigger a preview deployment from a feature branch - smoke test should be skipped
- [ ] Trigger a production deployment - smoke test should run against ng-forge.com