### PR TITLE
chore(config): improve claude code setup with hooks, skills, and documentation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,29 @@
+{
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm prettier --write \"$CLAUDE_FILE_PATH\" 2>/dev/null || true"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if [[ \"$CLAUDE_FILE_PATH\" == *\".env\"* ]]; then echo 'Blocked: Cannot edit .env files'; exit 1; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/e2e-update.md
+++ b/.claude/skills/e2e-update.md
@@ -1,0 +1,139 @@
+---
+name: e2e-update
+description: Update E2E screenshots using Docker for cross-platform consistency
+disable-model-invocation: true
+---
+
+# E2E Screenshot Update Skill
+
+Updates Playwright E2E screenshots using Docker to ensure cross-platform consistency.
+
+## Why Docker?
+
+Font rendering differs between macOS, Linux, and CI environments. Running screenshot updates in Docker ensures the screenshots match what CI expects.
+
+## Required User Input
+
+The user **must** specify which example app(s) to update:
+
+- `material` - Material Design examples
+- `bootstrap` - Bootstrap examples
+- `primeng` - PrimeNG examples
+- `ionic` - Ionic examples
+- `all` - All example apps
+
+## Commands
+
+### Update single library screenshots
+
+```bash
+# Material
+pnpm e2e:material:update
+
+# Bootstrap
+pnpm e2e:bootstrap:update
+
+# PrimeNG
+pnpm e2e:primeng:update
+
+# Ionic
+pnpm e2e:ionic:update
+```
+
+### Update all screenshots
+
+```bash
+pnpm e2e:all:update
+```
+
+### Run E2E tests without updating (validation)
+
+```bash
+# Single library
+pnpm e2e:material
+pnpm e2e:bootstrap
+pnpm e2e:primeng
+pnpm e2e:ionic
+
+# All
+pnpm e2e:all
+```
+
+## Workflow
+
+### 1. Make visual changes to components
+
+Edit the component templates, styles, or behavior that affects rendering.
+
+### 2. Run E2E tests to see failures
+
+```bash
+pnpm e2e:{library}
+```
+
+This shows which screenshots differ from the baseline.
+
+### 3. Review the changes are intentional
+
+Ensure the visual changes are expected before updating baselines.
+
+### 4. Update screenshots in Docker
+
+```bash
+pnpm e2e:{library}:update
+```
+
+### 5. Verify the updates
+
+```bash
+pnpm e2e:{library}
+```
+
+All tests should now pass.
+
+### 6. Commit the updated screenshots
+
+```bash
+git add apps/examples/*/src/app/testing/__snapshots__/
+git commit -m "test({library}): update snapshots for {change description}"
+```
+
+## Troubleshooting
+
+### Docker not running
+
+```
+Error: Cannot connect to Docker daemon
+```
+
+Start Docker Desktop or the Docker service.
+
+### Cache issues
+
+If tests behave unexpectedly or you see "Unrecognized Cache Artifacts":
+
+```bash
+pnpm e2e:clean
+```
+
+Then re-run the update command.
+
+### Running with fresh cache
+
+```bash
+./scripts/playwright-docker.sh {library}-examples --clean --update-snapshots
+```
+
+## Screenshot Locations
+
+Screenshots are stored in:
+
+```
+apps/examples/{library}-examples/src/app/testing/__snapshots__/
+```
+
+## Important Notes
+
+- **Never run `--update-snapshots` locally** outside Docker
+- Screenshots updated locally will fail in CI due to font rendering differences
+- Always use the `pnpm e2e:*:update` commands which run in Docker

--- a/.claude/skills/mcp-builder/LICENSE.txt
+++ b/.claude/skills/mcp-builder/LICENSE.txt
@@ -1,0 +1,190 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025 Anthropic, PBC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.claude/skills/mcp-builder/SKILL.md
+++ b/.claude/skills/mcp-builder/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: mcp-builder
+description: Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services using Node/TypeScript (MCP SDK).
+license: Complete terms in LICENSE.txt
+---
+
+# MCP Server Development Guide
+
+## Overview
+
+Create MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. The quality of an MCP server is measured by how well it enables LLMs to accomplish real-world tasks.
+
+---
+
+# Process
+
+## High-Level Workflow
+
+Creating a high-quality MCP server involves four main phases:
+
+### Phase 1: Deep Research and Planning
+
+#### 1.1 Understand Modern MCP Design
+
+**API Coverage vs. Workflow Tools:**
+Balance comprehensive API endpoint coverage with specialized workflow tools. Workflow tools can be more convenient for specific tasks, while comprehensive coverage gives agents flexibility to compose operations. Performance varies by client—some clients benefit from code execution that combines basic tools, while others work better with higher-level workflows. When uncertain, prioritize comprehensive API coverage.
+
+**Tool Naming and Discoverability:**
+Clear, descriptive tool names help agents find the right tools quickly. Use consistent prefixes (e.g., `github_create_issue`, `github_list_repos`) and action-oriented naming.
+
+**Context Management:**
+Agents benefit from concise tool descriptions and the ability to filter/paginate results. Design tools that return focused, relevant data. Some clients support code execution which can help agents filter and process data efficiently.
+
+**Actionable Error Messages:**
+Error messages should guide agents toward solutions with specific suggestions and next steps.
+
+#### 1.2 Study MCP Protocol Documentation
+
+**Navigate the MCP specification:**
+
+Start with the sitemap to find relevant pages: `https://modelcontextprotocol.io/sitemap.xml`
+
+Then fetch specific pages with `.md` suffix for markdown format (e.g., `https://modelcontextprotocol.io/specification/draft.md`).
+
+Key pages to review:
+
+- Specification overview and architecture
+- Transport mechanisms (streamable HTTP, stdio)
+- Tool, resource, and prompt definitions
+
+#### 1.3 Study Framework Documentation
+
+**Recommended stack:**
+
+- **Language**: TypeScript (high-quality SDK support and good compatibility in many execution environments e.g. MCPB. Plus AI models are good at generating TypeScript code, benefiting from its broad usage, static typing and good linting tools)
+- **Transport**: Streamable HTTP for remote servers, using stateless JSON (simpler to scale and maintain, as opposed to stateful sessions and streaming responses). stdio for local servers.
+
+**Load framework documentation:**
+
+- **MCP Best Practices**: [View Best Practices](./reference/mcp_best_practices.md) - Core guidelines
+
+**For TypeScript:**
+
+- **TypeScript SDK**: Use WebFetch to load `https://raw.githubusercontent.com/modelcontextprotocol/typescript-sdk/main/README.md`
+- [TypeScript Guide](./reference/node_mcp_server.md) - TypeScript patterns and examples
+
+#### 1.4 Plan Your Implementation
+
+**Understand the API:**
+Review the service's API documentation to identify key endpoints, authentication requirements, and data models. Use web search and WebFetch as needed.
+
+**Tool Selection:**
+Prioritize comprehensive API coverage. List endpoints to implement, starting with the most common operations.
+
+---
+
+### Phase 2: Implementation
+
+#### 2.1 Set Up Project Structure
+
+See the TypeScript guide for project setup:
+
+- [TypeScript Guide](./reference/node_mcp_server.md) - Project structure, package.json, tsconfig.json
+
+#### 2.2 Implement Core Infrastructure
+
+Create shared utilities:
+
+- API client with authentication
+- Error handling helpers
+- Response formatting (JSON/Markdown)
+- Pagination support
+
+#### 2.3 Implement Tools
+
+For each tool:
+
+**Input Schema:**
+
+- Use Zod for validation
+- Include constraints and clear descriptions
+- Add examples in field descriptions
+
+**Output Schema:**
+
+- Define `outputSchema` where possible for structured data
+- Use `structuredContent` in tool responses (TypeScript SDK feature)
+- Helps clients understand and process tool outputs
+
+**Tool Description:**
+
+- Concise summary of functionality
+- Parameter descriptions
+- Return type schema
+
+**Implementation:**
+
+- Async/await for I/O operations
+- Proper error handling with actionable messages
+- Support pagination where applicable
+- Return both text content and structured data when using modern SDKs
+
+**Annotations:**
+
+- `readOnlyHint`: true/false
+- `destructiveHint`: true/false
+- `idempotentHint`: true/false
+- `openWorldHint`: true/false
+
+---
+
+### Phase 3: Review and Test
+
+#### 3.1 Code Quality
+
+Review for:
+
+- No duplicated code (DRY principle)
+- Consistent error handling
+- Full type coverage
+- Clear tool descriptions
+
+#### 3.2 Build and Test
+
+- Run `npm run build` to verify compilation
+- Test with MCP Inspector: `npx @modelcontextprotocol/inspector`
+
+See the TypeScript guide for detailed testing approaches and quality checklists.
+
+---
+
+### Phase 4: Create Evaluations
+
+After implementing your MCP server, create comprehensive evaluations to test its effectiveness.
+
+**Load [Evaluation Guide](./reference/evaluation.md) for complete evaluation guidelines.**
+
+#### 4.1 Understand Evaluation Purpose
+
+Use evaluations to test whether LLMs can effectively use your MCP server to answer realistic, complex questions.
+
+#### 4.2 Create 10 Evaluation Questions
+
+To create effective evaluations, follow the process outlined in the evaluation guide:
+
+1. **Tool Inspection**: List available tools and understand their capabilities
+2. **Content Exploration**: Use READ-ONLY operations to explore available data
+3. **Question Generation**: Create 10 complex, realistic questions
+4. **Answer Verification**: Solve each question yourself to verify answers
+
+#### 4.3 Evaluation Requirements
+
+Ensure each question is:
+
+- **Independent**: Not dependent on other questions
+- **Read-only**: Only non-destructive operations required
+- **Complex**: Requiring multiple tool calls and deep exploration
+- **Realistic**: Based on real use cases humans would care about
+- **Verifiable**: Single, clear answer that can be verified by string comparison
+- **Stable**: Answer won't change over time
+
+#### 4.4 Output Format
+
+Create an XML file with this structure:
+
+```xml
+<evaluation>
+  <qa_pair>
+    <question>Find discussions about AI model launches with animal codenames. One model needed a specific safety designation that uses the format ASL-X. What number X was being determined for the model named after a spotted wild cat?</question>
+    <answer>3</answer>
+  </qa_pair>
+<!-- More qa_pairs... -->
+</evaluation>
+```
+
+---
+
+# Reference Files
+
+## Documentation Library
+
+Load these resources as needed during development:
+
+### Core MCP Documentation (Load First)
+
+- **MCP Protocol**: Start with sitemap at `https://modelcontextprotocol.io/sitemap.xml`, then fetch specific pages with `.md` suffix
+- [MCP Best Practices](./reference/mcp_best_practices.md) - Universal MCP guidelines including:
+  - Server and tool naming conventions
+  - Response format guidelines (JSON vs Markdown)
+  - Pagination best practices
+  - Transport selection (streamable HTTP vs stdio)
+  - Security and error handling standards
+
+### SDK Documentation (Load During Phase 1/2)
+
+- **TypeScript SDK**: Fetch from `https://raw.githubusercontent.com/modelcontextprotocol/typescript-sdk/main/README.md`
+
+### TypeScript Implementation Guide (Load During Phase 2)
+
+- [TypeScript Implementation Guide](./reference/node_mcp_server.md) - Complete TypeScript guide with:
+  - Project structure
+  - Zod schema patterns
+  - Tool registration with `server.registerTool`
+  - Complete working examples
+  - Quality checklist
+
+### Evaluation Guide (Load During Phase 4)
+
+- [Evaluation Guide](./reference/evaluation.md) - Complete evaluation creation guide with:
+  - Question creation guidelines
+  - Answer verification strategies
+  - XML format specifications
+  - Example questions and answers
+  - Running an evaluation with the provided scripts

--- a/.claude/skills/mcp-builder/reference/evaluation.md
+++ b/.claude/skills/mcp-builder/reference/evaluation.md
@@ -1,0 +1,175 @@
+# MCP Server Evaluation Guide
+
+## Overview
+
+This document provides guidance on creating comprehensive evaluations for MCP servers. Evaluations test whether LLMs can effectively use your MCP server to answer realistic, complex questions.
+
+---
+
+## Quick Reference
+
+### Evaluation Requirements
+
+- Create 10 human-readable questions
+- Questions must be READ-ONLY, INDEPENDENT, NON-DESTRUCTIVE
+- Each question requires multiple tool calls
+- Answers must be single, verifiable values
+- Answers must be STABLE (won't change over time)
+
+### Output Format
+
+```xml
+<evaluation>
+   <qa_pair>
+      <question>Your question here</question>
+      <answer>Single verifiable answer</answer>
+   </qa_pair>
+</evaluation>
+```
+
+---
+
+## Purpose of Evaluations
+
+The measure of quality of an MCP server is NOT how well the server implements tools, but how well these implementations enable LLMs to answer realistic and difficult questions.
+
+## Question Guidelines
+
+### Core Requirements
+
+1. **Questions MUST be independent** - Not dependent on other questions
+2. **Questions MUST require ONLY NON-DESTRUCTIVE operations**
+3. **Questions must be REALISTIC, CLEAR, CONCISE, and COMPLEX**
+4. **Questions must require deep exploration** - Multiple tool calls
+5. **Questions must not be solvable with straightforward keyword search**
+
+### Complexity and Depth
+
+- Consider multi-hop questions requiring sequential tool calls
+- May require paging through multiple pages of results
+- Must require deep understanding, not surface-level knowledge
+- Should stress-test tool return values with large responses
+
+### Stability
+
+- Questions must be designed so the answer DOES NOT CHANGE
+- Do not ask about current state (reactions, members, etc.)
+- Use historical/closed data
+
+## Answer Guidelines
+
+### Verification
+
+Answers must be VERIFIABLE via direct string comparison:
+
+- User ID, user name, display name
+- Channel ID, channel name
+- URL, title
+- Numerical quantity
+- Timestamp, datetime
+- Boolean (True/False)
+- Multiple choice answer
+
+### Readability
+
+Answers should prefer HUMAN-READABLE formats:
+
+- Names, datetime, file name, URL, yes/no
+
+### Stability
+
+- Look at old/closed content
+- Create questions based on concepts unlikely to change
+- Be specific to avoid confusion with future data
+
+## Good Question Examples
+
+**Multi-hop question (GitHub MCP)**
+
+```xml
+<qa_pair>
+   <question>Find the repository that was archived in Q3 2023 and had previously been the most forked project. What was the primary programming language?</question>
+   <answer>Python</answer>
+</qa_pair>
+```
+
+**Context-based question (Project Management MCP)**
+
+```xml
+<qa_pair>
+   <question>Locate the initiative focused on improving customer onboarding completed in late 2023. What was the project lead's role title?</question>
+   <answer>Product Manager</answer>
+</qa_pair>
+```
+
+## Poor Question Examples
+
+**Answer changes over time**
+
+```xml
+<qa_pair>
+   <question>How many open issues are currently assigned?</question>
+   <answer>47</answer>
+</qa_pair>
+```
+
+**Too easy with keyword search**
+
+```xml
+<qa_pair>
+   <question>Find the PR with title "Add authentication feature"</question>
+   <answer>developer123</answer>
+</qa_pair>
+```
+
+## Running Evaluations
+
+### Setup
+
+```bash
+pip install anthropic mcp
+export ANTHROPIC_API_KEY=your_api_key
+```
+
+### Local STDIO Server
+
+```bash
+python scripts/evaluation.py \
+  -t stdio \
+  -c python \
+  -a my_mcp_server.py \
+  evaluation.xml
+```
+
+### HTTP Server
+
+```bash
+python scripts/evaluation.py \
+  -t http \
+  -u https://example.com/mcp \
+  -H "Authorization: Bearer token123" \
+  evaluation.xml
+```
+
+## Command-Line Options
+
+```
+-t, --transport    Transport type: stdio, sse, or http
+-m, --model        Claude model to use
+-c, --command      Command to run MCP server
+-a, --args         Arguments for the command
+-e, --env          Environment variables (KEY=VALUE)
+-u, --url          MCP server URL (for sse/http)
+-H, --header       HTTP headers
+-o, --output       Output file for report
+```
+
+## Quality Checklist
+
+- [ ] 10 independent questions
+- [ ] All questions use read-only operations
+- [ ] Questions require multiple tool calls
+- [ ] Answers are single verifiable values
+- [ ] Answers are stable over time
+- [ ] Questions are realistic use cases
+- [ ] Answers verified by solving yourself

--- a/.claude/skills/mcp-builder/reference/mcp_best_practices.md
+++ b/.claude/skills/mcp-builder/reference/mcp_best_practices.md
@@ -1,0 +1,264 @@
+# MCP Server Best Practices
+
+## Quick Reference
+
+### Server Naming
+
+- **Node/TypeScript**: `{service}-mcp-server` (e.g., `slack-mcp-server`)
+
+### Tool Naming
+
+- Use snake_case with service prefix
+- Format: `{service}_{action}_{resource}`
+- Example: `slack_send_message`, `github_create_issue`
+
+### Response Formats
+
+- Support both JSON and Markdown formats
+- JSON for programmatic processing
+- Markdown for human readability
+
+### Pagination
+
+- Always respect `limit` parameter
+- Return `has_more`, `next_offset`, `total_count`
+- Default to 20-50 items
+
+### Transport
+
+- **Streamable HTTP**: For remote servers, multi-client scenarios
+- **stdio**: For local integrations, command-line tools
+- Avoid SSE (deprecated in favor of streamable HTTP)
+
+---
+
+## Server Naming Conventions
+
+Follow this standardized naming pattern:
+
+**Node/TypeScript**: Use format `{service}-mcp-server` (lowercase with hyphens)
+
+- Examples: `slack-mcp-server`, `github-mcp-server`, `jira-mcp-server`
+
+The name should be general, descriptive of the service being integrated, easy to infer from the task description, and without version numbers.
+
+---
+
+## Tool Naming and Design
+
+### Tool Naming
+
+1. **Use snake_case**: `search_users`, `create_project`, `get_channel_info`
+2. **Include service prefix**: Anticipate that your MCP server may be used alongside other MCP servers
+   - Use `slack_send_message` instead of just `send_message`
+   - Use `github_create_issue` instead of just `create_issue`
+3. **Be action-oriented**: Start with verbs (get, list, search, create, etc.)
+4. **Be specific**: Avoid generic names that could conflict with other servers
+
+### Tool Design
+
+- Tool descriptions must narrowly and unambiguously describe functionality
+- Descriptions must precisely match actual functionality
+- Provide tool annotations (readOnlyHint, destructiveHint, idempotentHint, openWorldHint)
+- Keep tool operations focused and atomic
+
+---
+
+## Response Formats
+
+All tools that return data should support multiple formats:
+
+### JSON Format (`response_format="json"`)
+
+- Machine-readable structured data
+- Include all available fields and metadata
+- Consistent field names and types
+- Use for programmatic processing
+
+### Markdown Format (`response_format="markdown"`, typically default)
+
+- Human-readable formatted text
+- Use headers, lists, and formatting for clarity
+- Convert timestamps to human-readable format
+- Show display names with IDs in parentheses
+- Omit verbose metadata
+
+---
+
+## Pagination
+
+For tools that list resources:
+
+- **Always respect the `limit` parameter**
+- **Implement pagination**: Use `offset` or cursor-based pagination
+- **Return pagination metadata**: Include `has_more`, `next_offset`/`next_cursor`, `total_count`
+- **Never load all results into memory**: Especially important for large datasets
+- **Default to reasonable limits**: 20-50 items is typical
+
+Example pagination response:
+
+```json
+{
+  "total": 150,
+  "count": 20,
+  "offset": 0,
+  "items": [...],
+  "has_more": true,
+  "next_offset": 20
+}
+```
+
+---
+
+## Transport Options
+
+### Streamable HTTP
+
+**Best for**: Remote servers, web services, multi-client scenarios
+
+**Characteristics**:
+
+- Bidirectional communication over HTTP
+- Supports multiple simultaneous clients
+- Can be deployed as a web service
+- Enables server-to-client notifications
+
+**Use when**:
+
+- Serving multiple clients simultaneously
+- Deploying as a cloud service
+- Integration with web applications
+
+### stdio
+
+**Best for**: Local integrations, command-line tools
+
+**Characteristics**:
+
+- Standard input/output stream communication
+- Simple setup, no network configuration needed
+- Runs as a subprocess of the client
+
+**Use when**:
+
+- Building tools for local development environments
+- Integrating with desktop applications
+- Single-user, single-session scenarios
+
+**Note**: stdio servers should NOT log to stdout (use stderr for logging)
+
+### Transport Selection
+
+| Criterion      | stdio  | Streamable HTTP |
+| -------------- | ------ | --------------- |
+| **Deployment** | Local  | Remote          |
+| **Clients**    | Single | Multiple        |
+| **Complexity** | Low    | Medium          |
+| **Real-time**  | No     | Yes             |
+
+---
+
+## Security Best Practices
+
+### Authentication and Authorization
+
+**OAuth 2.1**:
+
+- Use secure OAuth 2.1 with certificates from recognized authorities
+- Validate access tokens before processing requests
+- Only accept tokens specifically intended for your server
+
+**API Keys**:
+
+- Store API keys in environment variables, never in code
+- Validate keys on server startup
+- Provide clear error messages when authentication fails
+
+### Input Validation
+
+- Sanitize file paths to prevent directory traversal
+- Validate URLs and external identifiers
+- Check parameter sizes and ranges
+- Prevent command injection in system calls
+- Use schema validation (Zod) for all inputs
+
+### Error Handling
+
+- Don't expose internal errors to clients
+- Log security-relevant errors server-side
+- Provide helpful but not revealing error messages
+- Clean up resources after errors
+
+### DNS Rebinding Protection
+
+For streamable HTTP servers running locally:
+
+- Enable DNS rebinding protection
+- Validate the `Origin` header on all incoming connections
+- Bind to `127.0.0.1` rather than `0.0.0.0`
+
+---
+
+## Tool Annotations
+
+Provide annotations to help clients understand tool behavior:
+
+| Annotation        | Type    | Default | Description                                             |
+| ----------------- | ------- | ------- | ------------------------------------------------------- |
+| `readOnlyHint`    | boolean | false   | Tool does not modify its environment                    |
+| `destructiveHint` | boolean | true    | Tool may perform destructive updates                    |
+| `idempotentHint`  | boolean | false   | Repeated calls with same args have no additional effect |
+| `openWorldHint`   | boolean | true    | Tool interacts with external entities                   |
+
+**Important**: Annotations are hints, not security guarantees. Clients should not make security-critical decisions based solely on annotations.
+
+---
+
+## Error Handling
+
+- Use standard JSON-RPC error codes
+- Report tool errors within result objects (not protocol-level errors)
+- Provide helpful, specific error messages with suggested next steps
+- Don't expose internal implementation details
+- Clean up resources properly on errors
+
+Example error handling:
+
+```typescript
+try {
+  const result = performOperation();
+  return { content: [{ type: 'text', text: result }] };
+} catch (error) {
+  return {
+    isError: true,
+    content: [
+      {
+        type: 'text',
+        text: `Error: ${error.message}. Try using filter='active_only' to reduce results.`,
+      },
+    ],
+  };
+}
+```
+
+---
+
+## Testing Requirements
+
+Comprehensive testing should cover:
+
+- **Functional testing**: Verify correct execution with valid/invalid inputs
+- **Integration testing**: Test interaction with external systems
+- **Security testing**: Validate auth, input sanitization, rate limiting
+- **Performance testing**: Check behavior under load, timeouts
+- **Error handling**: Ensure proper error reporting and cleanup
+
+---
+
+## Documentation Requirements
+
+- Provide clear documentation of all tools and capabilities
+- Include working examples (at least 3 per major feature)
+- Document security considerations
+- Specify required permissions and access levels
+- Document rate limits and performance characteristics

--- a/.claude/skills/mcp-builder/reference/node_mcp_server.md
+++ b/.claude/skills/mcp-builder/reference/node_mcp_server.md
@@ -1,0 +1,273 @@
+# Node/TypeScript MCP Server Implementation Guide
+
+## Overview
+
+This document provides Node/TypeScript-specific best practices and examples for implementing MCP servers using the MCP TypeScript SDK.
+
+---
+
+## Quick Reference
+
+### Key Imports
+
+```typescript
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import express from 'express';
+import { z } from 'zod';
+```
+
+### Server Initialization
+
+```typescript
+const server = new McpServer({
+  name: 'service-mcp-server',
+  version: '1.0.0',
+});
+```
+
+### Tool Registration Pattern
+
+```typescript
+server.registerTool(
+  'tool_name',
+  {
+    title: 'Tool Display Name',
+    description: 'What the tool does',
+    inputSchema: { param: z.string() },
+    outputSchema: { result: z.string() },
+  },
+  async ({ param }) => {
+    const output = { result: `Processed: ${param}` };
+    return {
+      content: [{ type: 'text', text: JSON.stringify(output) }],
+      structuredContent: output,
+    };
+  },
+);
+```
+
+---
+
+## Server Naming Convention
+
+Node/TypeScript MCP servers must follow this naming pattern:
+
+- **Format**: `{service}-mcp-server` (lowercase with hyphens)
+- **Examples**: `github-mcp-server`, `jira-mcp-server`, `stripe-mcp-server`
+
+## Project Structure
+
+```
+{service}-mcp-server/
+├── package.json
+├── tsconfig.json
+├── README.md
+├── src/
+│   ├── index.ts          # Main entry point
+│   ├── types.ts          # TypeScript type definitions
+│   ├── tools/            # Tool implementations
+│   ├── services/         # API clients and utilities
+│   ├── schemas/          # Zod validation schemas
+│   └── constants.ts      # Shared constants
+└── dist/                 # Built JavaScript files
+```
+
+## Tool Implementation
+
+### Tool Naming
+
+Use snake_case with service prefix:
+
+- Use `slack_send_message` instead of just `send_message`
+- Use `github_create_issue` instead of just `create_issue`
+
+### Tool Structure
+
+```typescript
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+const server = new McpServer({
+  name: 'example-mcp',
+  version: '1.0.0',
+});
+
+const UserSearchInputSchema = z
+  .object({
+    query: z
+      .string()
+      .min(2, 'Query must be at least 2 characters')
+      .max(200, 'Query must not exceed 200 characters')
+      .describe('Search string to match against names/emails'),
+    limit: z.number().int().min(1).max(100).default(20).describe('Maximum results to return'),
+    offset: z.number().int().min(0).default(0).describe('Number of results to skip for pagination'),
+    response_format: z.nativeEnum(ResponseFormat).default(ResponseFormat.MARKDOWN).describe('Output format'),
+  })
+  .strict();
+
+type UserSearchInput = z.infer<typeof UserSearchInputSchema>;
+
+server.registerTool(
+  'example_search_users',
+  {
+    title: 'Search Example Users',
+    description: `Search for users in the Example system by name, email, or team.`,
+    inputSchema: UserSearchInputSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+  },
+  async (params: UserSearchInput) => {
+    // Implementation
+  },
+);
+```
+
+## Zod Schemas for Input Validation
+
+```typescript
+import { z } from 'zod';
+
+const CreateUserSchema = z
+  .object({
+    name: z.string().min(1, 'Name is required').max(100, 'Name must not exceed 100 characters'),
+    email: z.string().email('Invalid email format'),
+    age: z.number().int('Age must be a whole number').min(0, 'Age cannot be negative'),
+  })
+  .strict();
+
+enum ResponseFormat {
+  MARKDOWN = 'markdown',
+  JSON = 'json',
+}
+
+const SearchSchema = z.object({
+  response_format: z.nativeEnum(ResponseFormat).default(ResponseFormat.MARKDOWN).describe('Output format'),
+});
+```
+
+## Error Handling
+
+```typescript
+import axios, { AxiosError } from 'axios';
+
+function handleApiError(error: unknown): string {
+  if (error instanceof AxiosError) {
+    if (error.response) {
+      switch (error.response.status) {
+        case 404:
+          return 'Error: Resource not found. Please check the ID is correct.';
+        case 403:
+          return 'Error: Permission denied.';
+        case 429:
+          return 'Error: Rate limit exceeded. Please wait.';
+        default:
+          return `Error: API request failed with status ${error.response.status}`;
+      }
+    }
+  }
+  return `Error: ${error instanceof Error ? error.message : String(error)}`;
+}
+```
+
+## Package Configuration
+
+### package.json
+
+```json
+{
+  "name": "{service}-mcp-server",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "start": "node dist/index.js",
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.6.1",
+    "axios": "^1.7.9",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}
+```
+
+### tsconfig.json
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+## Transport Options
+
+### stdio (Local)
+
+```typescript
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+async function runStdio() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+```
+
+### Streamable HTTP (Remote)
+
+```typescript
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import express from 'express';
+
+async function runHTTP() {
+  const app = express();
+  app.use(express.json());
+
+  app.post('/mcp', async (req, res) => {
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    });
+    res.on('close', () => transport.close());
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  });
+
+  app.listen(3000);
+}
+```
+
+## Quality Checklist
+
+- [ ] All tools registered using `registerTool` with complete configuration
+- [ ] All tools include `title`, `description`, `inputSchema`, and `annotations`
+- [ ] All Zod schemas have proper constraints with `.strict()` enforcement
+- [ ] Error messages are clear and actionable
+- [ ] TypeScript strict mode enabled
+- [ ] No use of `any` type
+- [ ] Pagination implemented where applicable
+- [ ] `npm run build` completes successfully

--- a/.claude/skills/new-field.md
+++ b/.claude/skills/new-field.md
@@ -1,0 +1,162 @@
+---
+name: new-field
+description: Scaffold a new dynamic form field component for one or more UI libraries (Material, Bootstrap, PrimeNG, Ionic)
+---
+
+# New Field Skill
+
+Scaffolds a new dynamic form field component across the ng-forge UI libraries.
+
+## Required User Input
+
+The user **must** provide:
+
+1. **Field name** (e.g., `color-picker`, `file-upload`, `autocomplete`)
+2. **Target libraries** (default: all four)
+
+If not specified, ask:
+
+> What should the field be called? (e.g., `color-picker`)
+> Which libraries? (material, bootstrap, primeng, ionic, or all)
+
+## Field Naming Conventions
+
+| Library   | Component Prefix | File Prefix | Example                                     |
+| --------- | ---------------- | ----------- | ------------------------------------------- |
+| Material  | `Mat`            | `mat-`      | `MatColorPicker`, `mat-color-picker.ts`     |
+| Bootstrap | `Bs`             | `bs-`       | `BsColorPicker`, `bs-color-picker.ts`       |
+| PrimeNG   | `Prime`          | `prime-`    | `PrimeColorPicker`, `prime-color-picker.ts` |
+| Ionic     | `Ionic`          | `ionic-`    | `IonicColorPicker`, `ionic-color-picker.ts` |
+
+## Directory Structure
+
+Each field follows this structure:
+
+```
+packages/dynamic-forms-{library}/src/lib/fields/{field-name}/
+├── {prefix}-{field-name}.ts          # Component
+├── {prefix}-{field-name}.spec.ts     # Unit tests
+└── index.ts                          # Barrel export
+```
+
+## Implementation Steps
+
+### 1. Analyze existing field as reference
+
+Before creating, examine an existing similar field for patterns:
+
+```bash
+ls packages/dynamic-forms-material/src/lib/fields/input/
+```
+
+Read the component to understand the pattern:
+
+- How props are defined
+- How the field extends base classes
+- How Angular Material/Bootstrap/PrimeNG/Ionic components are integrated
+
+### 2. Create the field component
+
+For each target library, create the component file following these patterns:
+
+**Component structure:**
+
+```typescript
+import { ChangeDetectionStrategy, Component, computed } from '@angular/core';
+import { ForgeFieldBase } from '@ng-forge/dynamic-forms';
+// Import UI library components
+
+// Define props interface
+export interface {Prefix}{FieldName}Props {
+  // Field-specific props
+  label?: string;
+  placeholder?: string;
+  hint?: string;
+  // Add field-specific props here
+}
+
+@Component({
+  selector: 'forge-{library}-{field-name}',
+  template: `
+    <!-- Template using UI library components -->
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    // Required imports
+  ],
+})
+export class {Prefix}{FieldName} extends ForgeFieldBase<{ValueType}, {Prefix}{FieldName}Props> {
+  // Component implementation
+}
+```
+
+### 3. Create unit tests
+
+Create spec file with tests covering:
+
+- Component creation
+- Props binding
+- Value changes
+- Validation states
+- Accessibility
+
+Use existing tests as reference:
+
+```bash
+cat packages/dynamic-forms-material/src/lib/fields/input/mat-input.spec.ts | head -100
+```
+
+### 4. Create barrel export
+
+Create `index.ts`:
+
+```typescript
+export * from './{prefix}-{field-name}';
+```
+
+### 5. Register the field
+
+Add to the library's field registry in `packages/dynamic-forms-{library}/src/lib/fields/index.ts`:
+
+```typescript
+export * from './{field-name}';
+```
+
+### 6. Add type definition
+
+Update `packages/dynamic-forms-{library}/src/lib/types.ts` to include the new field type.
+
+### 7. Run verification
+
+```bash
+# Build the affected library
+nx build dynamic-forms-{library}
+
+# Run tests
+nx test dynamic-forms-{library}
+
+# Run lint
+nx lint dynamic-forms-{library}
+```
+
+## Example Usage
+
+User: `/new-field color-picker material`
+
+This creates:
+
+- `packages/dynamic-forms-material/src/lib/fields/color-picker/mat-color-picker.ts`
+- `packages/dynamic-forms-material/src/lib/fields/color-picker/mat-color-picker.spec.ts`
+- `packages/dynamic-forms-material/src/lib/fields/color-picker/index.ts`
+- Updates to registry and types
+
+## Checklist
+
+Before completing, verify:
+
+- [ ] Component follows library patterns
+- [ ] Props interface is properly typed
+- [ ] Unit tests pass
+- [ ] Build succeeds
+- [ ] Lint passes
+- [ ] Exports are registered

--- a/.mcp.json
+++ b/.mcp.json
@@ -16,6 +16,10 @@
     "chrome-devtools": {
       "command": "npx",
       "args": ["chrome-devtools-mcp@latest"]
+    },
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add PostToolUse hook for auto-formatting on Edit/Write
- Add PreToolUse hook to block .env file edits  
- Add context7 MCP server for library documentation lookup
- Add `/new-field` skill for scaffolding field components across UI libraries
- Add `/e2e-update` skill for Docker-based screenshot updates
- Update CLAUDE.md with `derivedFrom` pattern for async signal derivations
- Update CLAUDE.md with memoization, error handling, and file structure documentation
- Fix test file naming conventions (`.type-test.ts` vs `.type.ts`)

## Changes

### Hooks (`.claude/settings.json`)
- **PostToolUse**: Auto-runs `prettier --write` after Edit/Write operations
- **PreToolUse**: Blocks edits to `.env` files for security

### MCP Servers (`.mcp.json`)
- Added **context7** for Angular Material, PrimeNG, Ionic, Bootstrap documentation lookup

### Skills
- **`/new-field`**: Scaffolds new form field components with correct naming conventions
- **`/e2e-update`**: Documents Docker-based E2E screenshot update workflow

### CLAUDE.md Updates
- Added `derivedFrom` from ngxtension as preferred async derivation pattern
- Added `outputFromObservable()` as acceptable for event stream outputs
- New Memoization section documenting `memoize()` utility
- New Error Handling section documenting `DynamicFormError` and `DynamicFormLogger`
- New File Structure section with naming conventions per UI library
- Fixed test file naming: `.type-test.ts` (type tests) vs `.type.ts` (type definitions)

## Test plan

- [x] Prettier formatting passes
- [x] Commitlint validation passes
- [ ] Manual verification: New Claude Code session picks up hooks and MCP server
- [ ] Manual verification: `/new-field` and `/e2e-update` skills are accessible