### PR TITLE
fix(dynamic-forms): comprehensive API fixes for type inference and silent failures

### DIFF
--- a/packages/dynamic-form-mcp/scripts/generate-registry.ts
+++ b/packages/dynamic-form-mcp/scripts/generate-registry.ts
@@ -403,7 +403,7 @@ const CORE_FIELD_TYPES: FieldTypeInfo[] = [
       },
     },
     validationSupported: false,
-    source: 'adapter',
+    source: 'core',
     allowedIn: ['top-level', 'page', 'row', 'group', 'array'],
     example: `{
   key: 'sectionTitle',
@@ -722,6 +722,40 @@ const CORE_FIELD_TYPES: FieldTypeInfo[] = [
   label: 'Submit Form'
 }`,
     minimalExample: `{ key: 'submit', type: 'submit', label: 'Submit' }`,
+  },
+  {
+    type: 'addArrayItem',
+    category: 'button',
+    description: 'Button to add a new item to an array field. Must be placed within or near the array container.',
+    valueType: undefined,
+    baseInterface: 'FieldDef',
+    props: {},
+    validationSupported: false,
+    source: 'adapter',
+    allowedIn: ['array', 'row', 'group'],
+    example: `{
+  key: 'addContact',
+  type: 'addArrayItem',
+  label: 'Add Contact'
+}`,
+    minimalExample: `{ key: 'add', type: 'addArrayItem', label: 'Add Item' }`,
+  },
+  {
+    type: 'removeArrayItem',
+    category: 'button',
+    description: 'Button to remove the current item from an array field. Typically placed within each array item template.',
+    valueType: undefined,
+    baseInterface: 'FieldDef',
+    props: {},
+    validationSupported: false,
+    source: 'adapter',
+    allowedIn: ['array', 'row', 'group'],
+    example: `{
+  key: 'removeContact',
+  type: 'removeArrayItem',
+  label: 'Remove'
+}`,
+    minimalExample: `{ key: 'remove', type: 'removeArrayItem', label: 'Remove' }`,
   },
 ];
 
@@ -1070,8 +1104,8 @@ const UI_ADAPTERS: UIAdapterInfo[] = [
         },
       },
       {
-        type: 'calendar',
-        componentName: 'PrimeCalendarComponent',
+        type: 'datepicker',
+        componentName: 'PrimeDatepickerComponent',
         additionalProps: {
           showIcon: {
             name: 'showIcon',

--- a/packages/dynamic-form-mcp/src/registry/field-types.json
+++ b/packages/dynamic-form-mcp/src/registry/field-types.json
@@ -242,7 +242,7 @@
       }
     },
     "validationSupported": false,
-    "source": "adapter",
+    "source": "core",
     "allowedIn": ["top-level", "page", "row", "group", "array"],
     "example": "{\n  key: 'sectionTitle',\n  type: 'text',\n  label: 'Personal Information',\n  props: { elementType: 'h2' }\n}",
     "minimalExample": "{ key: 'header', type: 'text', label: 'Section Title' }"
@@ -462,5 +462,29 @@
     "allowedIn": ["top-level", "page", "row", "group", "array"],
     "example": "{\n  key: 'submit',\n  type: 'submit',\n  label: 'Submit Form'\n}",
     "minimalExample": "{ key: 'submit', type: 'submit', label: 'Submit' }"
+  },
+  {
+    "type": "addArrayItem",
+    "category": "button",
+    "description": "Button to add a new item to an array field. Must be placed within or near the array container.",
+    "baseInterface": "FieldDef",
+    "props": {},
+    "validationSupported": false,
+    "source": "adapter",
+    "allowedIn": ["array", "row", "group"],
+    "example": "{\n  key: 'addContact',\n  type: 'addArrayItem',\n  label: 'Add Contact'\n}",
+    "minimalExample": "{ key: 'add', type: 'addArrayItem', label: 'Add Item' }"
+  },
+  {
+    "type": "removeArrayItem",
+    "category": "button",
+    "description": "Button to remove the current item from an array field. Typically placed within each array item template.",
+    "baseInterface": "FieldDef",
+    "props": {},
+    "validationSupported": false,
+    "source": "adapter",
+    "allowedIn": ["array", "row", "group"],
+    "example": "{\n  key: 'removeContact',\n  type: 'removeArrayItem',\n  label: 'Remove'\n}",
+    "minimalExample": "{ key: 'remove', type: 'removeArrayItem', label: 'Remove' }"
   }
 ]

--- a/packages/dynamic-form-mcp/src/registry/ui-adapters.json
+++ b/packages/dynamic-form-mcp/src/registry/ui-adapters.json
@@ -148,8 +148,8 @@
         }
       },
       {
-        "type": "calendar",
-        "componentName": "PrimeCalendarComponent",
+        "type": "datepicker",
+        "componentName": "PrimeDatepickerComponent",
         "additionalProps": {
           "showIcon": {
             "name": "showIcon",

--- a/packages/dynamic-forms-primeng/src/lib/fields/select/prime-select.type-test.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/select/prime-select.type-test.ts
@@ -19,7 +19,7 @@ import type { RequiredKeys } from '@ng-forge/utils';
 // ============================================================================
 
 describe('PrimeSelectProps - Exhaustive Whitelist', () => {
-  type ExpectedKeys = 'multiple' | 'filter' | 'placeholder' | 'showClear' | 'styleClass' | 'hint';
+  type ExpectedKeys = 'multiple' | 'filter' | 'placeholder' | 'showClear' | 'styleClass' | 'hint' | 'compareWith';
   type ActualKeys = keyof PrimeSelectProps;
 
   it('should have exactly the expected keys', () => {
@@ -53,6 +53,12 @@ describe('PrimeSelectProps - Exhaustive Whitelist', () => {
 
     it('hint', () => {
       expectTypeOf<PrimeSelectProps['hint']>().toEqualTypeOf<DynamicText | undefined>();
+    });
+
+    it('compareWith', () => {
+      type CompareWithType = PrimeSelectProps['compareWith'];
+      // compareWith is a function or undefined
+      expectTypeOf<undefined>().toMatchTypeOf<CompareWithType>();
     });
   });
 });

--- a/packages/dynamic-forms-primeng/src/lib/fields/select/prime-select.type.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/select/prime-select.type.ts
@@ -29,6 +29,10 @@ export interface PrimeSelectProps extends SelectProps {
    * Hint text displayed below the select.
    */
   hint?: DynamicText;
+  /**
+   * Custom comparison function for determining equality of option values.
+   */
+  compareWith?: (o1: ValueType, o2: ValueType) => boolean;
 }
 
 export type PrimeSelectField<T> = SelectField<T, PrimeSelectProps>;

--- a/packages/dynamic-forms/integration/src/mappers/button/button-field-mapper.ts
+++ b/packages/dynamic-forms/integration/src/mappers/button/button-field-mapper.ts
@@ -1,0 +1,35 @@
+import { computed, inject, Signal } from '@angular/core';
+import { buildBaseInputs, DEFAULT_PROPS, FormEvent } from '@ng-forge/dynamic-forms';
+import { ButtonField } from '../../definitions';
+
+/**
+ * Maps a button field to component inputs.
+ *
+ * Unlike value field mappers, button fields do not participate in form values
+ * and do not need field tree resolution or validation messages.
+ *
+ * Button-specific properties:
+ * - event: The FormEvent constructor to emit when clicked
+ * - eventArgs: Optional arguments to pass to the event constructor
+ *
+ * @param fieldDef The button field definition
+ * @returns Signal containing Record of input names to values for ngComponentOutlet
+ */
+export function buttonFieldMapper<TProps, TEvent extends FormEvent>(
+  fieldDef: ButtonField<TProps, TEvent>,
+): Signal<Record<string, unknown>> {
+  const defaultProps = inject(DEFAULT_PROPS);
+
+  return computed(() => {
+    const inputs = buildBaseInputs(fieldDef, defaultProps());
+
+    // Add button-specific properties
+    inputs['event'] = fieldDef.event;
+
+    if (fieldDef.eventArgs !== undefined) {
+      inputs['eventArgs'] = fieldDef.eventArgs;
+    }
+
+    return inputs;
+  });
+}

--- a/packages/dynamic-forms/integration/src/mappers/datepicker/datepicker-field-mapper.ts
+++ b/packages/dynamic-forms/integration/src/mappers/datepicker/datepicker-field-mapper.ts
@@ -1,4 +1,5 @@
-import { computed, Signal } from '@angular/core';
+import { computed, inject, Signal } from '@angular/core';
+import { DEFAULT_PROPS, DEFAULT_VALIDATION_MESSAGES } from '@ng-forge/dynamic-forms';
 import { DatepickerField } from '../../definitions';
 import { resolveValueFieldContext, buildValueFieldInputs } from '../value/value-field.mapper';
 
@@ -15,9 +16,11 @@ import { resolveValueFieldContext, buildValueFieldInputs } from '../value/value-
  */
 export function datepickerFieldMapper<TProps>(fieldDef: DatepickerField<TProps>): Signal<Record<string, unknown>> {
   const ctx = resolveValueFieldContext(fieldDef.key);
+  const defaultProps = inject(DEFAULT_PROPS);
+  const defaultValidationMessages = inject(DEFAULT_VALIDATION_MESSAGES);
 
   return computed(() => {
-    const inputs = buildValueFieldInputs(fieldDef, ctx);
+    const inputs = buildValueFieldInputs(fieldDef, ctx, defaultProps(), defaultValidationMessages());
 
     // Add datepicker-specific properties
     if (fieldDef.minDate !== undefined) {

--- a/packages/dynamic-forms/integration/src/mappers/index.ts
+++ b/packages/dynamic-forms/integration/src/mappers/index.ts
@@ -5,3 +5,6 @@ export { checkboxFieldMapper } from './checkbox/checkbox-field-mapper';
 export { datepickerFieldMapper } from './datepicker/datepicker-field-mapper';
 export { optionsFieldMapper } from './select/options-field-mapper';
 export type { FieldWithOptions } from './select/options-field-mapper';
+export { textareaFieldMapper } from './textarea/textarea-field-mapper';
+export { sliderFieldMapper } from './slider/slider-field-mapper';
+export { buttonFieldMapper } from './button/button-field-mapper';

--- a/packages/dynamic-forms/integration/src/mappers/select/options-field-mapper.ts
+++ b/packages/dynamic-forms/integration/src/mappers/select/options-field-mapper.ts
@@ -1,8 +1,8 @@
-import { computed, Signal } from '@angular/core';
+import { computed, inject, Signal } from '@angular/core';
 import { SelectField } from '../../definitions';
 import { RadioField } from '../../definitions';
 import { MultiCheckboxField } from '../../definitions';
-import { BaseValueField } from '@ng-forge/dynamic-forms';
+import { BaseValueField, DEFAULT_PROPS, DEFAULT_VALIDATION_MESSAGES } from '@ng-forge/dynamic-forms';
 import { resolveValueFieldContext, buildValueFieldInputs } from '../value/value-field.mapper';
 
 /**
@@ -23,10 +23,12 @@ export type FieldWithOptions<T = unknown, TProps = unknown> =
  */
 export function optionsFieldMapper<T, TProps>(fieldDef: FieldWithOptions<T, TProps>): Signal<Record<string, unknown>> {
   const ctx = resolveValueFieldContext(fieldDef.key);
+  const defaultProps = inject(DEFAULT_PROPS);
+  const defaultValidationMessages = inject(DEFAULT_VALIDATION_MESSAGES);
 
   return computed(() => {
     // Cast to BaseValueField - safe because all FieldWithOptions types extend BaseValueField
-    const inputs = buildValueFieldInputs(fieldDef as BaseValueField<TProps, unknown>, ctx);
+    const inputs = buildValueFieldInputs(fieldDef as BaseValueField<TProps, unknown>, ctx, defaultProps(), defaultValidationMessages());
 
     // Add options property
     inputs['options'] = fieldDef.options;

--- a/packages/dynamic-forms/integration/src/mappers/slider/slider-field-mapper.ts
+++ b/packages/dynamic-forms/integration/src/mappers/slider/slider-field-mapper.ts
@@ -1,0 +1,38 @@
+import { computed, inject, Signal } from '@angular/core';
+import { DEFAULT_PROPS, DEFAULT_VALIDATION_MESSAGES } from '@ng-forge/dynamic-forms';
+import { SliderField } from '../../definitions';
+import { resolveValueFieldContext, buildValueFieldInputs } from '../value/value-field.mapper';
+
+/**
+ * Maps a slider field to component inputs.
+ *
+ * Extends the base value field mapper by adding slider-specific properties:
+ * - minValue: Minimum slider value
+ * - maxValue: Maximum slider value
+ * - step: Step increment for the slider
+ *
+ * @param fieldDef The slider field definition
+ * @returns Signal containing Record of input names to values for ngComponentOutlet
+ */
+export function sliderFieldMapper<TProps>(fieldDef: SliderField<TProps>): Signal<Record<string, unknown>> {
+  const ctx = resolveValueFieldContext(fieldDef.key);
+  const defaultProps = inject(DEFAULT_PROPS);
+  const defaultValidationMessages = inject(DEFAULT_VALIDATION_MESSAGES);
+
+  return computed(() => {
+    const inputs = buildValueFieldInputs(fieldDef, ctx, defaultProps(), defaultValidationMessages());
+
+    // Add slider-specific properties (these are at field level, not in props)
+    if (fieldDef.minValue !== undefined) {
+      inputs['minValue'] = fieldDef.minValue;
+    }
+    if (fieldDef.maxValue !== undefined) {
+      inputs['maxValue'] = fieldDef.maxValue;
+    }
+    if (fieldDef.step !== undefined) {
+      inputs['step'] = fieldDef.step;
+    }
+
+    return inputs;
+  });
+}

--- a/packages/dynamic-forms/integration/src/mappers/textarea/textarea-field-mapper.ts
+++ b/packages/dynamic-forms/integration/src/mappers/textarea/textarea-field-mapper.ts
@@ -1,0 +1,43 @@
+import { computed, inject, Signal } from '@angular/core';
+import { DEFAULT_PROPS, DEFAULT_VALIDATION_MESSAGES } from '@ng-forge/dynamic-forms';
+import { TextareaField } from '../../definitions';
+import { resolveValueFieldContext, buildValueFieldInputs } from '../value/value-field.mapper';
+
+/**
+ * Maps a textarea field to component inputs.
+ *
+ * Extends the base value field mapper by adding textarea-specific properties:
+ * - rows: Number of visible text rows
+ * - cols: Number of visible text columns
+ * - maxLength: Maximum character length (also used for validation)
+ *
+ * @param fieldDef The textarea field definition
+ * @returns Signal containing Record of input names to values for ngComponentOutlet
+ */
+export function textareaFieldMapper<TProps>(fieldDef: TextareaField<TProps>): Signal<Record<string, unknown>> {
+  const ctx = resolveValueFieldContext(fieldDef.key);
+  const defaultProps = inject(DEFAULT_PROPS);
+  const defaultValidationMessages = inject(DEFAULT_VALIDATION_MESSAGES);
+
+  return computed(() => {
+    const inputs = buildValueFieldInputs(fieldDef, ctx, defaultProps(), defaultValidationMessages());
+
+    // Add textarea-specific properties from props
+    const props = fieldDef.props as Record<string, unknown> | undefined;
+    if (props && typeof props === 'object') {
+      if (props['rows'] !== undefined) {
+        inputs['rows'] = props['rows'];
+      }
+      if (props['cols'] !== undefined) {
+        inputs['cols'] = props['cols'];
+      }
+    }
+
+    // maxLength is at field level for validation
+    if (fieldDef.maxLength !== undefined) {
+      inputs['maxLength'] = fieldDef.maxLength;
+    }
+
+    return inputs;
+  });
+}

--- a/packages/dynamic-forms/src/lib/core/cross-field/cross-field-collector.ts
+++ b/packages/dynamic-forms/src/lib/core/cross-field/cross-field-collector.ts
@@ -196,7 +196,13 @@ function convertBuiltInToCustomValidator(config: BuiltInValidatorConfig): Custom
       validationExpression = `fieldValue == null || (typeof fieldValue !== 'string' && !Array.isArray(fieldValue)) || fieldValue.length <= (${expression})`;
       break;
     case 'pattern':
-      validationExpression = `fieldValue == null || new RegExp(${expression}).test(fieldValue)`;
+      // Validate regex pattern before injection to prevent runtime errors
+      try {
+        new RegExp(expression);
+      } catch {
+        throw new Error(`Invalid regex pattern in cross-field validator: ${expression}`);
+      }
+      validationExpression = `fieldValue == null || new RegExp(${JSON.stringify(expression)}).test(fieldValue)`;
       break;
     default:
       throw new Error(`Cannot convert ${config.type} validator to custom validator`);

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-orchestrator.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-orchestrator.ts
@@ -133,7 +133,9 @@ export class DerivationOrchestrator {
 
         takeUntilDestroyed(this.destroyRef),
       )
-      .subscribe();
+      .subscribe({
+        error: (err) => this.logger.error('Derivation onChange stream error', err),
+      });
   }
 
   private setupDebouncedStream(): void {
@@ -178,7 +180,9 @@ export class DerivationOrchestrator {
 
         takeUntilDestroyed(this.destroyRef),
       )
-      .subscribe();
+      .subscribe({
+        error: (err) => this.logger.error('Derivation debounced stream error', err),
+      });
   }
 
   private createPeriodStream(

--- a/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.ts
@@ -33,14 +33,20 @@ export function evaluateCondition(expression: ConditionalExpression, context: Ev
 }
 
 function evaluateFieldValueCondition(expression: ConditionalExpression, context: EvaluationContext): boolean {
-  if (!expression.fieldPath || !expression.operator) return false;
+  if (!expression.fieldPath || !expression.operator) {
+    context.logger.debug('Invalid fieldValue condition config: missing fieldPath or operator', expression);
+    return false;
+  }
 
   const fieldValue = getNestedValue(context.formValue, expression.fieldPath);
   return compareValues(fieldValue, expression.value, expression.operator);
 }
 
 function evaluateFormValueCondition(expression: ConditionalExpression, context: EvaluationContext): boolean {
-  if (!expression.operator) return false;
+  if (!expression.operator) {
+    context.logger.debug('Invalid formValue condition config: missing operator', expression);
+    return false;
+  }
   return compareValues(context.formValue, expression.value, expression.operator);
 }
 

--- a/packages/dynamic-forms/src/lib/core/registry/root-form-registry.service.ts
+++ b/packages/dynamic-forms/src/lib/core/registry/root-form-registry.service.ts
@@ -121,7 +121,7 @@ export class RootFormRegistryService {
           return rootValue as Record<string, unknown>;
         }
       } catch {
-        // Ignore errors when reading form value
+        // Ignore errors when reading form value - can happen during initialization
       }
     }
 

--- a/packages/dynamic-forms/src/lib/core/validation/async-http-validator.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/validation/async-http-validator.spec.ts
@@ -124,9 +124,7 @@ describe('Async and HTTP Validator Integration', () => {
         });
       });
 
-      it('should warn when async validator not found', () => {
-        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-
+      it('should throw error when async validator not found', () => {
         runInInjectionContext(injector, () => {
           const formValue = signal({ field: 'value' });
           const config: AsyncValidatorConfig = {
@@ -134,21 +132,15 @@ describe('Async and HTTP Validator Integration', () => {
             functionName: 'nonexistent',
           };
 
-          const formInstance = form(
-            formValue,
-            schema<typeof formValue>((path) => {
-              applyValidator(config, path.field);
-            }),
-          );
-          rootFormRegistry.registerRootForm(formInstance);
+          expect(() => {
+            form(
+              formValue,
+              schema<typeof formValue>((path) => {
+                applyValidator(config, path.field);
+              }),
+            );
+          }).toThrow('[Dynamic Forms] Async validator "nonexistent" not found');
         });
-
-        expect(consoleWarnSpy).toHaveBeenCalledWith(
-          '[Dynamic Forms]',
-          expect.stringContaining('Async validator "nonexistent" not found in registry'),
-        );
-
-        consoleWarnSpy.mockRestore();
       });
 
       it('should apply async validator with conditional logic', () => {
@@ -332,9 +324,7 @@ describe('Async and HTTP Validator Integration', () => {
         });
       });
 
-      it('should warn when HTTP validator not found', () => {
-        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-
+      it('should throw error when HTTP validator not found', () => {
         runInInjectionContext(injector, () => {
           const formValue = signal({ field: 'value' });
           const config: HttpValidatorConfig = {
@@ -342,21 +332,15 @@ describe('Async and HTTP Validator Integration', () => {
             functionName: 'nonexistent',
           };
 
-          const formInstance = form(
-            formValue,
-            schema<typeof formValue>((path) => {
-              applyValidator(config, path.field);
-            }),
-          );
-          rootFormRegistry.registerRootForm(formInstance);
+          expect(() => {
+            form(
+              formValue,
+              schema<typeof formValue>((path) => {
+                applyValidator(config, path.field);
+              }),
+            );
+          }).toThrow('[Dynamic Forms] HTTP validator "nonexistent" not found');
         });
-
-        expect(consoleWarnSpy).toHaveBeenCalledWith(
-          '[Dynamic Forms]',
-          expect.stringContaining('HTTP validator "nonexistent" not found in registry'),
-        );
-
-        consoleWarnSpy.mockRestore();
       });
 
       it('should apply HTTP validator with conditional logic', () => {

--- a/packages/dynamic-forms/src/lib/core/validation/validator-factory.ts
+++ b/packages/dynamic-forms/src/lib/core/validation/validator-factory.ts
@@ -16,6 +16,7 @@ import {
 } from '@angular/forms/signals';
 import { inject } from '@angular/core';
 import { DynamicFormLogger } from '../../providers/features/logger/logger.token';
+import { DynamicFormError } from '../../errors/dynamic-form-error';
 import {
   AsyncValidatorConfig,
   CustomValidatorConfig,
@@ -176,11 +177,7 @@ function createFunctionValidator(
   const validatorFn = registry.getValidator(functionName);
 
   if (!validatorFn) {
-    logger.warn(
-      `Custom validator "${functionName}" not found in registry. ` +
-        `Ensure it's registered using customFnConfig.validators or check the function name for typos.`,
-    );
-    return () => null;
+    throw new DynamicFormError(`Custom validator "${functionName}" not found. Register it with customFnConfig.validators.`);
   }
 
   return (ctx: FieldContext<unknown>) => validatorFn(ctx, config.params);
@@ -241,16 +238,11 @@ function createExpressionValidator(
  * - onError: Optional handler for resource errors
  */
 function applyAsyncValidator(config: AsyncValidatorConfig, fieldPath: SchemaPath<unknown>): void {
-  const logger = inject(DynamicFormLogger);
   const registry = inject(FunctionRegistryService);
   const validatorConfig = registry.getAsyncValidator(config.functionName);
 
   if (!validatorConfig) {
-    logger.warn(
-      `Async validator "${config.functionName}" not found in registry. ` +
-        `Ensure it's registered using customFnConfig.asyncValidators or check the function name for typos.`,
-    );
-    return;
+    throw new DynamicFormError(`Async validator "${config.functionName}" not found. Register it with customFnConfig.asyncValidators.`);
   }
 
   const whenLogic = createConditionalLogic(config.when);
@@ -276,16 +268,11 @@ function applyAsyncValidator(config: AsyncValidatorConfig, fieldPath: SchemaPath
  * - onError: Optional handler for HTTP errors
  */
 function applyHttpValidator(config: HttpValidatorConfig, fieldPath: SchemaPath<unknown>): void {
-  const logger = inject(DynamicFormLogger);
   const registry = inject(FunctionRegistryService);
   const httpValidatorConfig = registry.getHttpValidator(config.functionName);
 
   if (!httpValidatorConfig) {
-    logger.warn(
-      `HTTP validator "${config.functionName}" not found in registry. ` +
-        `Ensure it's registered using customFnConfig.httpValidators or check the function name for typos.`,
-    );
-    return;
+    throw new DynamicFormError(`HTTP validator "${config.functionName}" not found. Register it with customFnConfig.httpValidators.`);
   }
 
   const whenLogic = createConditionalLogic(config.when);

--- a/packages/dynamic-forms/src/lib/fields/array/array-field.component.ts
+++ b/packages/dynamic-forms/src/lib/fields/array/array-field.component.ts
@@ -253,10 +253,12 @@ export default class ArrayFieldComponent<TModel extends Record<string, unknown> 
 
     const rawValue = getFieldDefaultValue(fieldTemplate, this.rawFieldRegistry());
     const valueHandling = getFieldValueHandling(fieldTemplate.type, this.rawFieldRegistry());
+    const templateType = fieldTemplate.type;
 
-    // For fields with 'include' value handling (bare fields like input, checkbox, etc.),
-    // wrap the value in an object using the field's key since arrays contain objects
-    const value = valueHandling === 'include' && fieldTemplate.key ? { [fieldTemplate.key]: rawValue } : rawValue;
+    // Container fields (group, row) already have their own structure, so use rawValue as-is.
+    // For value fields with 'include' handling, wrap in an object using the field's key.
+    const isContainer = templateType === 'group' || templateType === 'row';
+    const value = isContainer ? rawValue : valueHandling === 'include' && fieldTemplate.key ? { [fieldTemplate.key]: rawValue } : rawValue;
 
     const newArray = [...currentArray];
     newArray.splice(insertIndex, 0, value);

--- a/packages/dynamic-forms/src/lib/providers/dynamic-form-providers.ts
+++ b/packages/dynamic-forms/src/lib/providers/dynamic-form-providers.ts
@@ -7,6 +7,7 @@ import { FieldDef } from '../definitions/base/field-def';
 import { DynamicFormFeature, isDynamicFormFeature } from './features/dynamic-form-feature';
 import { DynamicFormLogger } from './features/logger/logger.token';
 import { ConsoleLogger } from './features/logger/console-logger';
+import type { InferFormValue as RealInferFormValue } from '../models/types/form-value-inference';
 
 // Re-export global types for module augmentation
 export type { DynamicFormFieldRegistry, AvailableFieldTypes } from '../models/registry';
@@ -30,13 +31,9 @@ type ExtractFieldDef<T> = T extends FieldTypeDefinition<infer F> ? F : never;
 type FieldDefUnion<T extends FieldTypeDefinition[]> = ExtractFieldDef<T[number]>;
 
 /**
- * Infer form value type from field definitions
- * Note: Full value type inference requires complex recursive type mapping.
- * Using unknown as placeholder until full inference is implemented.
+ * Infer form value type from field definitions using the real inference type.
  */
-type InferFormValue<TFieldDefs extends FieldDef<unknown>[]> = {
-  [K in TFieldDefs[number]['key']]: unknown;
-};
+type InferFormValue<TFieldDefs extends FieldDef<unknown>[]> = RealInferFormValue<TFieldDefs>;
 
 /**
  * Provider result with type inference

--- a/packages/dynamic-forms/src/lib/utils/resolve-field/resolve-field.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/resolve-field/resolve-field.spec.ts
@@ -87,7 +87,7 @@ describe('resolve-field', () => {
       expect(onError).toHaveBeenCalledWith(fieldDef, error);
     });
 
-    it('should not call onError when destroyed during error handling', async () => {
+    it('should not call onError when component is destroyed', async () => {
       const fieldDef: FieldDef<unknown> = { type: 'unknown', key: 'testField' };
       const error = new Error('Component not found');
       const loadTypeComponent = vi.fn().mockImplementation(async () => {
@@ -107,6 +107,7 @@ describe('resolve-field', () => {
       const result = await firstValueFrom(resolveField(fieldDef, context));
 
       expect(result).toBeUndefined();
+      // onError should NOT be called when destroyed to avoid accessing cleaned-up state
       expect(onError).not.toHaveBeenCalled();
     });
 

--- a/packages/dynamic-forms/src/lib/utils/resolve-field/resolve-field.ts
+++ b/packages/dynamic-forms/src/lib/utils/resolve-field/resolve-field.ts
@@ -74,7 +74,7 @@ export function resolveField(fieldDef: FieldDef<unknown>, context: ResolveFieldC
       };
     }),
     catchError((error) => {
-      // Only handle errors if component hasn't been destroyed
+      // Only call onError if component is not destroyed to avoid accessing cleaned-up state
       if (!context.destroyRef.destroyed) {
         context.onError?.(fieldDef, error);
       }


### PR DESCRIPTION
## Summary

This PR addresses API issues discovered during an audit, organized into 9 phases:

### Phase 1: Type Inference Fixes (Issues 1-8)
- Add array field handling to `InferFormValue` type
- Exclude navigation button types (`next`, `previous`, `addArrayItem`, `removeArrayItem`) from form value inference
- Handle hidden fields as non-optional (they have required `value` property)
- Remove redundant `TModel` intersection in dynamic-form component
- Gate `(submitted)` output on form validity (now emits `TModel`, not `Partial<TModel>`)
- Add proper generics to submission handler (remove `any` types)
- Fix `InferFormValue` stub in providers to use real implementation

### Phase 2: Silent Failure Logging (Issues 10-15)
- Add logging for `errorParams` evaluation failures in schema-builder
- Add debug logging for invalid condition configs
- Throw error for missing custom validators (was only warning)

### Phase 3: Runtime Bug Fixes (Issue 9)
- Fix array values wrapping - only wrap when template is a non-container field

### Phase 4: Cross-Field Validation (Issues 16-19)
- Add logging for missing source fields in cross-field validators
- Implement nested field path resolution (dot notation support)
- Validate regex patterns before injection in cross-field validators
- Add circular dependency detection

### Phase 5: Subscription Error Handlers (Issues 20-21)
- Add error handlers to derivation orchestrator subscriptions

### Phase 6: UI Library Consistency (Issues 22-24)
- Add `compareWith` property to PrimeNG select (matches Material/Bootstrap)

### Phase 7: MCP Registry Sync (Issues 25-29)
- Add `addArrayItem` and `removeArrayItem` button types
- Fix text field source to `'core'` (was incorrectly `'adapter'`)
- Fix PrimeNG `calendar` → `datepicker` naming

### Phase 8: Integration Package (Issues 30-32)
- Add missing field mappers: `textareaFieldMapper`, `sliderFieldMapper`, `buttonFieldMapper`
- Fix `datepickerFieldMapper` and `optionsFieldMapper` to inject `DEFAULT_PROPS` and `DEFAULT_VALIDATION_MESSAGES`

### Phase 9: Analysis Complete
Issues 33-40 were analyzed and determined to be:
- Already addressed (computed provides memoization for injectors)
- Intentional design decisions (`refCount: false` in shareReplay)
- Out of scope for this API fix PR (large-scale naming refactoring)
- Feature additions (array-level validation with minItems/maxItems)

### Not Changed (Intentionally Silent)
- `root-form-registry.service.ts` error handling - silently returns empty object during form initialization (expected behavior)
- `row-field.component.ts` disabled property - silently returns false on error (defensive default)
- `resolve-field.ts` error handler - respects `destroyRef.destroyed` to avoid accessing cleaned-up state
- Ionic `maxlength` prop - kept lowercase to match Ionic/HTML attribute convention

## BREAKING CHANGES

### `(submitted)` output behavior change

**Before:** The `(submitted)` output emitted form values on every submit event, regardless of form validity. The emitted type was `Partial<TModel> | undefined`.

**After:** The `(submitted)` output now **only emits when the form is valid**. The emitted type is `TModel` (complete, validated data).

**Migration:** If you need to handle submit events when the form is invalid, use the `(events)` output instead:

```typescript
// Before
<form [dynamic-form]="config" (submitted)="onSubmit($event)">

// After - if you need invalid submissions
<form [dynamic-form]="config" (events)="onEvent($event)">

// In component:
onEvent(event: FormEvent) {
  if (event.type === 'submit') {
    // Handle submit regardless of validity
  }
}
```

### Missing custom validators now throw

**Before:** Missing custom validators logged a warning and continued.

**After:** Missing custom validators throw a `DynamicFormError`. Register validators with `customFnConfig.validators`.

## Test Plan

- [x] All existing tests pass (1583 dynamic-forms + 468 material + 336 bootstrap + 330 primeng + 334 ionic)
- [x] All packages build successfully
- [x] Lint passes
- [x] MCP registry regenerated and synced