### PR TITLE
chore(release): bump version to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,73 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and uses [Conventional Commits](https://www.conventionalcommits.org/).
 
+## [0.5.1](https://github.com/ng-forge/ng-forge/compare/v0.5.0...v0.5.1) (2026-02-01)
+
+### 🚀 Features
+
+- ⚠️ **dynamic-forms:** remove targetField from derivation API ([#202](https://github.com/ng-forge/ng-forge/pull/202))
+- **dynamic-forms:** add externalData support for conditional logic ([#204](https://github.com/ng-forge/ng-forge/pull/204))
+- **dynamic-forms:** add comprehensive test coverage for stability benchmarks ([#203](https://github.com/ng-forge/ng-forge/pull/203))
+- **dynamic-forms:** add withEventFormValue() feature for attaching form values to events ([#209](https://github.com/ng-forge/ng-forge/pull/209))
+- ⚠️ **mcp:** add dynamic-form-mcp package ([#126](https://github.com/ng-forge/ng-forge/pull/126))
+
+### 🐛 Bug Fixes
+
+- **config:** allow production deploys from any branch and skip smoke test on preview ([#198](https://github.com/ng-forge/ng-forge/pull/198))
+- **dynamic-forms:** comprehensive API fixes for type inference and silent failures ([#206](https://github.com/ng-forge/ng-forge/pull/206))
+
+### ♻️ Code Refactoring
+
+- **mcp:** consolidate to 4 focused tools with improved documentation ([#210](https://github.com/ng-forge/ng-forge/pull/210))
+
+### 📚 Documentation
+
+- add Quick Start examples hub and improve documentation UX ([#188](https://github.com/ng-forge/ng-forge/pull/188))
+
+### ⏪ Reverts
+
+- **dynamic-forms:** feat(dynamic-forms): add internal zod schema validation package (#187) ([#187](https://github.com/ng-forge/ng-forge/pull/187), [#185](https://github.com/ng-forge/ng-forge/issues/185), [#186](https://github.com/ng-forge/ng-forge/issues/186))
+
+### ⚠️ Breaking Changes
+
+- **dynamic-forms:** remove targetField from derivation API ([#202](https://github.com/ng-forge/ng-forge/pull/202))
+  The targetField property has been removed from DerivationLogicConfig.
+  All derivations now target the field they are defined on (self-targeting).
+
+  Migration:
+  - Move derivation logic from source fields to target fields
+  - Remove targetField property from logic configs
+  - Use shorthand 'derivation' property when possible
+
+  Before:
+
+  ```typescript
+  {
+    key: 'quantity',
+    logic: [{
+      type: 'derivation',
+      targetField: 'total',
+      expression: 'formValue.quantity * formValue.unitPrice'
+    }]
+  }
+  ```
+
+  After:
+
+  ```typescript
+  {
+    key: 'total',
+    derivation: 'formValue.quantity * formValue.unitPrice'
+  }
+  ```
+
+- **mcp:** add dynamic-form-mcp package ([#126](https://github.com/ng-forge/ng-forge/pull/126))
+  New MCP server for AI-assisted form schema generation with 4 focused tools:
+  - `ngforge_lookup`: unified documentation
+  - `ngforge_examples`: working code patterns
+  - `ngforge_validate`: config verification
+  - `ngforge_scaffold`: skeleton generator
+
 ## [0.5.0](https://github.com/ng-forge/ng-forge/compare/v0.4.0...v0.5.0) (2026-01-25)
 
 ### 🚀 Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ng-forge/source",
   "type": "module",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/packages/dynamic-form-mcp/package.json
+++ b/packages/dynamic-form-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-form-mcp",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "MCP server for ng-forge dynamic forms - AI-assisted form schema generation",
   "type": "module",
   "license": "MIT",

--- a/packages/dynamic-forms-bootstrap/package.json
+++ b/packages/dynamic-forms-bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-bootstrap",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Bootstrap 5 integration for @ng-forge/dynamic-forms. Pre-built Bootstrap form components.",
   "type": "module",
   "license": "MIT",

--- a/packages/dynamic-forms-ionic/package.json
+++ b/packages/dynamic-forms-ionic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-ionic",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Ionic integration for @ng-forge/dynamic-forms. Pre-built Ionic form components for mobile and desktop.",
   "type": "module",
   "license": "MIT",

--- a/packages/dynamic-forms-material/package.json
+++ b/packages/dynamic-forms-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-material",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Angular Material integration for @ng-forge/dynamic-forms. Pre-built Material Design form components.",
   "type": "module",
   "license": "MIT",

--- a/packages/dynamic-forms-primeng/package.json
+++ b/packages/dynamic-forms-primeng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-primeng",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "PrimeNG integration for @ng-forge/dynamic-forms. Pre-built PrimeNG form components.",
   "type": "module",
   "license": "MIT",

--- a/packages/dynamic-forms/package.json
+++ b/packages/dynamic-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Type-safe, signal-powered dynamic forms for Angular. Build complex forms from configuration with full TypeScript inference.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump all package versions to 0.5.1
- Update inter-package peerDependencies
- Generate changelog from v0.5.0

## Packages Updated
- @ng-forge/dynamic-forms: 0.5.0 -> 0.5.1
- @ng-forge/dynamic-forms-bootstrap: 0.5.0 -> 0.5.1
- @ng-forge/dynamic-forms-ionic: 0.5.0 -> 0.5.1
- @ng-forge/dynamic-forms-material: 0.5.0 -> 0.5.1
- @ng-forge/dynamic-forms-primeng: 0.5.0 -> 0.5.1
- @ng-forge/dynamic-form-mcp: 0.5.0 -> 0.5.1 (first npm publish)

## Changelog

### 🚀 Features
- ⚠️ **dynamic-forms:** remove targetField from derivation API (#202)
- **dynamic-forms:** add externalData support for conditional logic (#204)
- **dynamic-forms:** add comprehensive test coverage for stability benchmarks (#203)
- **dynamic-forms:** add withEventFormValue() feature for attaching form values to events (#209)
- ⚠️ **mcp:** add dynamic-form-mcp package (#126)

### 🐛 Bug Fixes
- **config:** allow production deploys from any branch and skip smoke test on preview (#198)
- **dynamic-forms:** comprehensive API fixes for type inference and silent failures (#206)

### ♻️ Code Refactoring
- **mcp:** consolidate to 4 focused tools with improved documentation (#210)

### 📚 Documentation
- add Quick Start examples hub and improve documentation UX (#188)

## ⚠️ Note: First MCP Package Publish
The `@ng-forge/dynamic-form-mcp` package has never been published to npm. Ensure the npm token has permissions to create new packages under the `@ng-forge` scope.

## Next Steps
After merging, trigger the Release workflow manually from GitHub Actions to create the tag, GitHub release, and publish to npm.