### PR TITLE
fix(config): use production domain URL for deployment smoke test

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -112,7 +112,7 @@ jobs:
         if: inputs.environment == 'production'
         run: |
           echo "Verifying deployment is accessible..."
-          curl --fail --retry 5 --retry-delay 10 "${{ steps.deploy.outputs.url }}/dynamic-forms/" > /dev/null
+          curl --fail --retry 5 --retry-delay 10 "https://ng-forge.com/dynamic-forms/" > /dev/null
           echo "Deployment verified successfully"
 
       - name: Output Deployment URL


### PR DESCRIPTION
## Summary
- The deploy workflow smoke test was curling the Vercel deployment-specific URL (e.g. `https://ng-forge-xxx.vercel.app/dynamic-forms/`) which returns **401 Unauthorized** due to Vercel's Deployment Protection
- Changed the smoke test to hit the production domain `https://ng-forge.com/dynamic-forms/` instead, which is the actual URL users access and is not behind deployment protection

## Test plan
- [ ] Trigger the deploy workflow manually and verify the smoke test passes