### PR TITLE
docs: fix broken documentation links, update sitemap and llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="logo.svg" alt="ng-forge Dynamic Forms" width="400"/>
+  <img src="./logo.svg" alt="ng-forge Dynamic Forms" width="400"/>
 </p>
 
 <p align="center">
@@ -98,12 +98,12 @@ export class LoginComponent {
 ## 📖 Documentation
 
 - [Installation](https://ng-forge.com/dynamic-forms/installation)
-- [Field Types](https://ng-forge.com/dynamic-forms/core/field-types)
-- [Validation](https://ng-forge.com/dynamic-forms/core/validation)
-- [Conditional Logic](https://ng-forge.com/dynamic-forms/core/conditional-logic)
-- [Type Safety](https://ng-forge.com/dynamic-forms/core/type-safety)
-- [i18n](https://ng-forge.com/dynamic-forms/core/i18n)
-- [Custom Integrations](https://ng-forge.com/dynamic-forms/deep-dive/custom-integrations)
+- [Field Types](https://ng-forge.com/dynamic-forms/field-types)
+- [Validation](https://ng-forge.com/dynamic-forms/validation/basics)
+- [Conditional Logic](https://ng-forge.com/dynamic-forms/dynamic-behavior/overview)
+- [Type Safety](https://ng-forge.com/dynamic-forms/advanced/basics)
+- [i18n](https://ng-forge.com/dynamic-forms/dynamic-behavior/i18n)
+- [Custom Integrations](https://ng-forge.com/dynamic-forms/advanced/custom-integrations)
 
 ## 🛠️ Development
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -13,8 +13,11 @@ Dynamic Forms provides a powerful way to create dynamic forms in Angular applica
 - Built-in validation with expression-based validators
 - Conditional logic for showing/hiding fields
 - Value derivation for computed fields
+- Property derivation for dynamic field properties
 - Type-safe form configurations
-- Reactive forms under the hood
+- Reactive forms under the hood (Angular Signal Forms)
+- Value exclusion for controlling submitted form data
+- AI integration via MCP server
 
 ## Documentation Structure
 
@@ -27,8 +30,8 @@ Dynamic Forms provides a powerful way to create dynamic forms in Angular applica
 - /ui-libs-integrations/ionic: Ionic integration
 - /ui-libs-integrations/bootstrap: Bootstrap integration
 
-### Schema & Fields
-- /schema-fields/field-types: Available field types (input, select, checkbox, etc.)
+### Field Types
+- /field-types: Available field types (input, select, checkbox, radio, toggle, textarea, datepicker, slider, multi-checkbox, button, submit, next, previous)
 
 ### Validation
 - /validation/basics: Validation configuration basics
@@ -37,8 +40,9 @@ Dynamic Forms provides a powerful way to create dynamic forms in Angular applica
 - /validation/reference: Complete validation reference
 
 ### Dynamic Behavior
-- /dynamic-behavior/conditional-logic: Show/hide fields based on conditions
-- /dynamic-behavior/value-derivation: Computed field values
+- /dynamic-behavior/overview: Conditional logic - show/hide fields based on conditions
+- /dynamic-behavior/derivation: Value derivation - computed field values
+- /dynamic-behavior/derivation/property: Property derivation - dynamic field properties
 - /dynamic-behavior/i18n: Internationalization support
 - /dynamic-behavior/submission: Form submission handling
 
@@ -69,13 +73,17 @@ Dynamic Forms provides a powerful way to create dynamic forms in Angular applica
 - /examples/enterprise-features: Complex multi-condition form
 
 ### Advanced Topics
-- /advanced/type-safety: TypeScript type safety features
+- /advanced/basics: TypeScript type safety features
 - /advanced/events: Form and field event handling
 - /advanced/expression-parser: Expression syntax for validators and conditions
 - /advanced/custom-integrations: Creating custom UI library integrations
+- /advanced/value-exclusion: Controlling which fields are included in submitted form values
+
+### AI Integration
+- /ai-integration: MCP server for AI-assisted form schema generation
 
 ### API Reference
-- /api-reference: Complete API documentation for all packages
+- /api: Complete API documentation for all packages
 
 ## Installation
 
@@ -88,31 +96,25 @@ npm install @ng-forge/dynamic-forms-material
 ## Quick Example
 
 ```typescript
-import { DynamicForm } from '@ng-forge/dynamic-forms';
-import '@ng-forge/dynamic-forms-material';
+import { DynamicForm, type FormConfig, type InferFormValue } from '@ng-forge/dynamic-forms';
 
-const formConfig = {
-  fields: [
-    {
-      key: 'email',
-      type: 'input',
-      props: {
-        label: 'Email',
-        type: 'email',
-        required: true
-      }
-    },
-    {
-      key: 'password',
-      type: 'input',
-      props: {
-        label: 'Password',
-        type: 'password',
-        required: true
-      }
-    }
-  ]
-};
+@Component({
+  imports: [DynamicForm],
+  template: `<form [dynamic-form]="config" (submitted)="onSubmit($event)"></form>`,
+})
+export class LoginComponent {
+  config = {
+    fields: [
+      { key: 'email', type: 'input', value: '', label: 'Email', required: true, email: true },
+      { key: 'password', type: 'input', value: '', label: 'Password', required: true, minLength: 8, props: { type: 'password' } },
+      { type: 'submit', key: 'submit', label: 'Sign In' },
+    ],
+  } as const satisfies FormConfig;
+
+  onSubmit(value: InferFormValue<typeof this.config.fields>) {
+    console.log('Form submitted:', value);
+  }
+}
 ```
 
 ## Repository

--- a/apps/docs/public/sitemap.xml
+++ b/apps/docs/public/sitemap.xml
@@ -16,6 +16,11 @@
 
   <!-- UI Library Integrations -->
   <url>
+    <loc>https://ng-forge.com/dynamic-forms/ui-libs-integrations</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://ng-forge.com/dynamic-forms/ui-libs-integrations/material</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
@@ -36,14 +41,19 @@
     <priority>0.8</priority>
   </url>
 
-  <!-- Schema & Fields -->
+  <!-- Field Types -->
   <url>
-    <loc>https://ng-forge.com/dynamic-forms/schema-fields/field-types</loc>
+    <loc>https://ng-forge.com/dynamic-forms/field-types</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <!-- Validation -->
+  <url>
+    <loc>https://ng-forge.com/dynamic-forms/validation</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
   <url>
     <loc>https://ng-forge.com/dynamic-forms/validation/basics</loc>
     <changefreq>weekly</changefreq>
@@ -67,7 +77,12 @@
 
   <!-- Dynamic Behavior -->
   <url>
-    <loc>https://ng-forge.com/dynamic-forms/dynamic-behavior/conditional-logic</loc>
+    <loc>https://ng-forge.com/dynamic-forms/dynamic-behavior</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ng-forge.com/dynamic-forms/dynamic-behavior/overview</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -79,7 +94,7 @@
   <url>
     <loc>https://ng-forge.com/dynamic-forms/dynamic-behavior/derivation/property</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ng-forge.com/dynamic-forms/dynamic-behavior/i18n</loc>
@@ -93,6 +108,11 @@
   </url>
 
   <!-- Schema Validation -->
+  <url>
+    <loc>https://ng-forge.com/dynamic-forms/schema-validation</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
   <url>
     <loc>https://ng-forge.com/dynamic-forms/schema-validation/overview</loc>
     <changefreq>weekly</changefreq>
@@ -110,6 +130,11 @@
   </url>
 
   <!-- Layout Components -->
+  <url>
+    <loc>https://ng-forge.com/dynamic-forms/prebuilt</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
   <url>
     <loc>https://ng-forge.com/dynamic-forms/prebuilt/form-pages</loc>
     <changefreq>monthly</changefreq>
@@ -200,7 +225,12 @@
 
   <!-- Advanced -->
   <url>
-    <loc>https://ng-forge.com/dynamic-forms/advanced/type-safety</loc>
+    <loc>https://ng-forge.com/dynamic-forms/advanced</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ng-forge.com/dynamic-forms/advanced/basics</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -225,30 +255,17 @@
     <priority>0.6</priority>
   </url>
 
-  <!-- API Reference -->
+  <!-- AI Integration -->
   <url>
-    <loc>https://ng-forge.com/dynamic-forms/api-reference/dynamic-forms</loc>
-    <changefreq>weekly</changefreq>
+    <loc>https://ng-forge.com/dynamic-forms/ai-integration</loc>
+    <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
+
+  <!-- API Reference -->
   <url>
-    <loc>https://ng-forge.com/dynamic-forms/api-reference/dynamic-forms-material</loc>
+    <loc>https://ng-forge.com/dynamic-forms/api</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://ng-forge.com/dynamic-forms/api-reference/dynamic-forms-primeng</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://ng-forge.com/dynamic-forms/api-reference/dynamic-forms-ionic</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://ng-forge.com/dynamic-forms/api-reference/dynamic-forms-bootstrap</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.7</priority>
   </url>
 </urlset>

--- a/packages/dynamic-form-mcp/package.json
+++ b/packages/dynamic-form-mcp/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "author": "ng-forge",
-  "homepage": "https://ng-forge.com/dynamic-forms/mcp",
+  "homepage": "https://ng-forge.com/dynamic-forms/ai-integration",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ng-forge/ng-forge.git",

--- a/packages/dynamic-forms-bootstrap/README.md
+++ b/packages/dynamic-forms-bootstrap/README.md
@@ -90,9 +90,9 @@ Input, Select, Checkbox, Toggle, Button, Submit, Next, Previous, Textarea, Radio
 ## Documentation
 
 - [Bootstrap Integration](https://ng-forge.com/dynamic-forms/ui-libs-integrations/bootstrap)
-- [Field Types](https://ng-forge.com/dynamic-forms/core/field-types)
-- [Validation](https://ng-forge.com/dynamic-forms/core/validation)
-- [Conditional Logic](https://ng-forge.com/dynamic-forms/core/conditional-logic)
+- [Field Types](https://ng-forge.com/dynamic-forms/field-types)
+- [Validation](https://ng-forge.com/dynamic-forms/validation/basics)
+- [Conditional Logic](https://ng-forge.com/dynamic-forms/dynamic-behavior/overview)
 
 ## Changelog
 

--- a/packages/dynamic-forms-ionic/README.md
+++ b/packages/dynamic-forms-ionic/README.md
@@ -105,9 +105,9 @@ Input, Textarea, Select, Checkbox, Radio, Toggle, Datepicker, Slider, Multi-Chec
 ## Documentation
 
 - [Ionic Integration](https://ng-forge.com/dynamic-forms/ui-libs-integrations/ionic)
-- [Field Types](https://ng-forge.com/dynamic-forms/core/field-types)
-- [Validation](https://ng-forge.com/dynamic-forms/core/validation)
-- [Conditional Logic](https://ng-forge.com/dynamic-forms/core/conditional-logic)
+- [Field Types](https://ng-forge.com/dynamic-forms/field-types)
+- [Validation](https://ng-forge.com/dynamic-forms/validation/basics)
+- [Conditional Logic](https://ng-forge.com/dynamic-forms/dynamic-behavior/overview)
 
 ## Changelog
 

--- a/packages/dynamic-forms-material/README.md
+++ b/packages/dynamic-forms-material/README.md
@@ -93,9 +93,9 @@ Input, Textarea, Select, Checkbox, Radio, Datepicker, Slider, Toggle, Multi-Chec
 ## Documentation
 
 - [Material Integration](https://ng-forge.com/dynamic-forms/ui-libs-integrations/material)
-- [Field Types](https://ng-forge.com/dynamic-forms/core/field-types)
-- [Validation](https://ng-forge.com/dynamic-forms/core/validation)
-- [Conditional Logic](https://ng-forge.com/dynamic-forms/core/conditional-logic)
+- [Field Types](https://ng-forge.com/dynamic-forms/field-types)
+- [Validation](https://ng-forge.com/dynamic-forms/validation/basics)
+- [Conditional Logic](https://ng-forge.com/dynamic-forms/dynamic-behavior/overview)
 
 ## Changelog
 

--- a/packages/dynamic-forms-primeng/README.md
+++ b/packages/dynamic-forms-primeng/README.md
@@ -99,9 +99,9 @@ Input, Textarea, Select, Checkbox, Toggle, Radio, Multi-Checkbox, Datepicker, Sl
 ## Documentation
 
 - [PrimeNG Integration](https://ng-forge.com/dynamic-forms/ui-libs-integrations/primeng)
-- [Field Types](https://ng-forge.com/dynamic-forms/core/field-types)
-- [Validation](https://ng-forge.com/dynamic-forms/core/validation)
-- [Conditional Logic](https://ng-forge.com/dynamic-forms/core/conditional-logic)
+- [Field Types](https://ng-forge.com/dynamic-forms/field-types)
+- [Validation](https://ng-forge.com/dynamic-forms/validation/basics)
+- [Conditional Logic](https://ng-forge.com/dynamic-forms/dynamic-behavior/overview)
 
 ## Changelog
 

--- a/packages/dynamic-forms/README.md
+++ b/packages/dynamic-forms/README.md
@@ -89,19 +89,19 @@ This core library requires a UI integration. Choose one:
 | [@ng-forge/dynamic-forms-primeng](https://www.npmjs.com/package/@ng-forge/dynamic-forms-primeng)     | PrimeNG          |
 | [@ng-forge/dynamic-forms-ionic](https://www.npmjs.com/package/@ng-forge/dynamic-forms-ionic)         | Ionic            |
 
-Or [create your own](https://ng-forge.com/dynamic-forms/deep-dive/custom-integrations).
+Or [create your own](https://ng-forge.com/dynamic-forms/advanced/custom-integrations).
 
 ## Documentation
 
 - [Installation](https://ng-forge.com/dynamic-forms/installation)
-- [Field Types](https://ng-forge.com/dynamic-forms/core/field-types)
-- [Validation](https://ng-forge.com/dynamic-forms/core/validation)
-- [Conditional Logic](https://ng-forge.com/dynamic-forms/core/conditional-logic)
-- [Value Derivation](https://ng-forge.com/dynamic-forms/core/derivation)
-- [Type Safety](https://ng-forge.com/dynamic-forms/core/type-safety)
-- [Events](https://ng-forge.com/dynamic-forms/core/events)
-- [i18n](https://ng-forge.com/dynamic-forms/core/i18n)
-- [Custom Integrations](https://ng-forge.com/dynamic-forms/deep-dive/custom-integrations)
+- [Field Types](https://ng-forge.com/dynamic-forms/field-types)
+- [Validation](https://ng-forge.com/dynamic-forms/validation/basics)
+- [Conditional Logic](https://ng-forge.com/dynamic-forms/dynamic-behavior/overview)
+- [Value Derivation](https://ng-forge.com/dynamic-forms/dynamic-behavior/derivation)
+- [Type Safety](https://ng-forge.com/dynamic-forms/advanced/basics)
+- [Events](https://ng-forge.com/dynamic-forms/advanced/events)
+- [i18n](https://ng-forge.com/dynamic-forms/dynamic-behavior/i18n)
+- [Custom Integrations](https://ng-forge.com/dynamic-forms/advanced/custom-integrations)
 
 ## Changelog
 


### PR DESCRIPTION
## Summary

- Fix ~27 broken README links across all 6 package READMEs + root that used non-existent `/core/` and `/deep-dive/` URL prefixes, updating them to match actual ng-doc routes
- Update `sitemap.xml` to match prerendered routes: fix wrong paths (`/schema-fields/field-types` → `/field-types`, `/conditional-logic` → `/overview`, `/type-safety` → `/basics`), add missing pages (`ai-integration`, `value-exclusion`, category index pages), replace stale `/api-reference/*` entries
- Update `llms.txt` with correct routes, missing pages (value-exclusion, ai-integration, property derivation, expression-parser), and modernized code example
- Fix MCP package homepage URL from `/mcp` to `/ai-integration`
- Fix root README logo path for consistency (`logo.svg` → `./logo.svg`)

## Test plan

- [ ] Verify README links resolve correctly on GitHub (click each link after merge)
- [ ] Verify sitemap URLs match deployed docs routes
- [ ] Verify `llms.txt` routes match deployed docs