### PR TITLE
test(dynamic-forms): add value two-way binding e2e tests

### DIFF
--- a/apps/examples/core/src/app/testing/config-change/config-change.routes.ts
+++ b/apps/examples/core/src/app/testing/config-change/config-change.routes.ts
@@ -31,6 +31,10 @@ const routes: Routes = [
     path: 'config-swap-pages',
     loadComponent: () => import('./scenarios/config-swap-pages.component').then((m) => m.ConfigSwapPagesComponent),
   },
+  {
+    path: 'value-binding',
+    loadComponent: () => import('./scenarios/value-binding.component').then((m) => m.ValueBindingComponent),
+  },
 ];
 
 export default routes;

--- a/apps/examples/core/src/app/testing/config-change/config-change.spec.ts
+++ b/apps/examples/core/src/app/testing/config-change/config-change.spec.ts
@@ -312,6 +312,95 @@ test.describe('Config Change E2E Tests', () => {
     });
   });
 
+  test.describe('Value Two-Way Binding', () => {
+    test('should update form fields when value is set programmatically', async ({ page, helpers }) => {
+      await page.goto('/#/test/config-change/value-binding');
+      await page.waitForLoadState('networkidle');
+      const scenario = helpers.getScenario('value-binding');
+      await expect(scenario).toBeVisible({ timeout: 10000 });
+
+      const firstNameInput = scenario.locator('#firstName input');
+      const lastNameInput = scenario.locator('#lastName input');
+      const emailInput = scenario.locator('#email input');
+      await expect(firstNameInput).toBeVisible({ timeout: 5000 });
+
+      // Fields should start empty
+      await expect(firstNameInput).toHaveValue('', { timeout: 5000 });
+      await expect(lastNameInput).toHaveValue('', { timeout: 5000 });
+      await expect(emailInput).toHaveValue('', { timeout: 5000 });
+
+      // Set value A programmatically
+      await scenario.locator('[data-testid="set-value-a"]').click();
+
+      // Form fields should reflect the new value
+      await expect(firstNameInput).toHaveValue('Alice', { timeout: 5000 });
+      await expect(lastNameInput).toHaveValue('Smith', { timeout: 5000 });
+      await expect(emailInput).toHaveValue('alice@example.com', { timeout: 5000 });
+    });
+
+    test('should update form fields when value changes to a different preset', async ({ page, helpers }) => {
+      await page.goto('/#/test/config-change/value-binding');
+      await page.waitForLoadState('networkidle');
+      const scenario = helpers.getScenario('value-binding');
+      await expect(scenario).toBeVisible({ timeout: 10000 });
+
+      const firstNameInput = scenario.locator('#firstName input');
+      const lastNameInput = scenario.locator('#lastName input');
+      const emailInput = scenario.locator('#email input');
+
+      // Set value A
+      await scenario.locator('[data-testid="set-value-a"]').click();
+      await expect(firstNameInput).toHaveValue('Alice', { timeout: 5000 });
+
+      // Switch to value B
+      await scenario.locator('[data-testid="set-value-b"]').click();
+
+      // Form fields should update to value B
+      await expect(firstNameInput).toHaveValue('Bob', { timeout: 5000 });
+      await expect(lastNameInput).toHaveValue('Builder', { timeout: 5000 });
+      await expect(emailInput).toHaveValue('bob@example.com', { timeout: 5000 });
+    });
+
+    test('should clear form fields when value is cleared', async ({ page, helpers }) => {
+      await page.goto('/#/test/config-change/value-binding');
+      await page.waitForLoadState('networkidle');
+      const scenario = helpers.getScenario('value-binding');
+      await expect(scenario).toBeVisible({ timeout: 10000 });
+
+      const firstNameInput = scenario.locator('#firstName input');
+      const lastNameInput = scenario.locator('#lastName input');
+      const emailInput = scenario.locator('#email input');
+
+      // Set value A first
+      await scenario.locator('[data-testid="set-value-a"]').click();
+      await expect(firstNameInput).toHaveValue('Alice', { timeout: 5000 });
+
+      // Clear value
+      await scenario.locator('[data-testid="clear-value"]').click();
+
+      // Form fields should be empty
+      await expect(firstNameInput).toHaveValue('', { timeout: 5000 });
+      await expect(lastNameInput).toHaveValue('', { timeout: 5000 });
+      await expect(emailInput).toHaveValue('', { timeout: 5000 });
+    });
+
+    test('should reflect programmatic value in debug output', async ({ page, helpers }) => {
+      await page.goto('/#/test/config-change/value-binding');
+      await page.waitForLoadState('networkidle');
+      const scenario = helpers.getScenario('value-binding');
+      await expect(scenario).toBeVisible({ timeout: 10000 });
+
+      // Set value A
+      await scenario.locator('[data-testid="set-value-a"]').click();
+
+      // Debug output should contain the value
+      const debugOutput = scenario.locator('[data-testid="form-value-value-binding"]');
+      await expect(debugOutput).toContainText('Alice', { timeout: 5000 });
+      await expect(debugOutput).toContainText('Smith', { timeout: 5000 });
+      await expect(debugOutput).toContainText('alice@example.com', { timeout: 5000 });
+    });
+  });
+
   test.describe('Config Swap with Pages', () => {
     test('should render initial two-page config', async ({ page, helpers }) => {
       await page.goto('/#/test/config-change/config-swap-pages');

--- a/apps/examples/core/src/app/testing/config-change/config-change.suite.ts
+++ b/apps/examples/core/src/app/testing/config-change/config-change.suite.ts
@@ -5,6 +5,7 @@ import { configAddFieldsScenario } from './scenarios/config-add-fields.scenario'
 import { configRemoveFieldsScenario } from './scenarios/config-remove-fields.scenario';
 import { configSwapWithArraysScenario } from './scenarios/config-swap-with-arrays.scenario';
 import { configSwapPagesScenario } from './scenarios/config-swap-pages.scenario';
+import { valueBindingScenario } from './scenarios/value-binding.scenario';
 
 /**
  * Config Change Suite
@@ -23,6 +24,7 @@ export const configChangeSuite: TestSuite = {
     configRemoveFieldsScenario,
     configSwapWithArraysScenario,
     configSwapPagesScenario,
+    valueBindingScenario,
   ],
 };
 

--- a/apps/examples/core/src/app/testing/config-change/scenarios/value-binding.component.ts
+++ b/apps/examples/core/src/app/testing/config-change/scenarios/value-binding.component.ts
@@ -1,0 +1,75 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { JsonPipe } from '@angular/common';
+import { DynamicForm } from '@ng-forge/dynamic-forms';
+import { presetValueA, presetValueB, valueBindingConfig } from './value-binding.scenario';
+
+/**
+ * Route component for the value two-way binding test.
+ * Has buttons that programmatically set the form value signal
+ * to verify the [(value)] binding updates form fields.
+ */
+@Component({
+  selector: 'example-value-binding',
+  imports: [DynamicForm, JsonPipe],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="test-page">
+      <h1>Value Two-Way Binding</h1>
+
+      <section class="test-scenario" data-testid="value-binding">
+        <h2>Value Two-Way Binding</h2>
+        <p class="scenario-description">Programmatically set [(value)] and verify form fields update</p>
+
+        <div class="value-controls">
+          <button type="button" data-testid="set-value-a" (click)="setValueA()">Set Value A</button>
+          <button type="button" data-testid="set-value-b" (click)="setValueB()">Set Value B</button>
+          <button type="button" data-testid="clear-value" (click)="clearValue()">Clear Value</button>
+        </div>
+
+        <form [dynamic-form]="config" [(value)]="formValue"></form>
+
+        <details class="debug-output" open>
+          <summary>Debug Output</summary>
+          <pre data-testid="form-value-value-binding">{{ formValue() | json }}</pre>
+        </details>
+      </section>
+    </div>
+  `,
+  styleUrl: '../../test-styles.scss',
+  styles: [
+    `
+      .value-controls {
+        display: flex;
+        gap: 0.5rem;
+        margin-bottom: 1rem;
+        flex-wrap: wrap;
+      }
+      .value-controls button {
+        padding: 0.5rem 1rem;
+        border: 1px solid #ccc;
+        background: #f5f5f5;
+        cursor: pointer;
+        border-radius: 4px;
+      }
+      .value-controls button:hover {
+        background: #e0e0e0;
+      }
+    `,
+  ],
+})
+export class ValueBindingComponent {
+  readonly config = valueBindingConfig;
+  readonly formValue = signal<Record<string, unknown>>({});
+
+  setValueA(): void {
+    this.formValue.set({ ...presetValueA });
+  }
+
+  setValueB(): void {
+    this.formValue.set({ ...presetValueB });
+  }
+
+  clearValue(): void {
+    this.formValue.set({});
+  }
+}

--- a/apps/examples/core/src/app/testing/config-change/scenarios/value-binding.scenario.ts
+++ b/apps/examples/core/src/app/testing/config-change/scenarios/value-binding.scenario.ts
@@ -1,0 +1,61 @@
+import { FormConfig } from '@ng-forge/dynamic-forms';
+import { TestScenario } from '../../shared/types';
+
+/**
+ * Tests that programmatically setting the [(value)] two-way binding
+ * updates the form fields, and that config changes reflect correct values.
+ */
+
+export const valueBindingConfig = {
+  fields: [
+    {
+      key: 'firstName',
+      type: 'input',
+      label: 'First Name',
+      props: {
+        placeholder: 'Enter first name',
+      },
+    },
+    {
+      key: 'lastName',
+      type: 'input',
+      label: 'Last Name',
+      props: {
+        placeholder: 'Enter last name',
+      },
+    },
+    {
+      key: 'email',
+      type: 'input',
+      label: 'Email',
+      props: {
+        type: 'email',
+        placeholder: 'Enter email',
+      },
+    },
+    {
+      key: 'submit',
+      type: 'submit',
+      label: 'Submit',
+    },
+  ],
+} as const satisfies FormConfig;
+
+export const presetValueA: Record<string, unknown> = {
+  firstName: 'Alice',
+  lastName: 'Smith',
+  email: 'alice@example.com',
+};
+
+export const presetValueB: Record<string, unknown> = {
+  firstName: 'Bob',
+  lastName: 'Builder',
+  email: 'bob@example.com',
+};
+
+export const valueBindingScenario: TestScenario = {
+  testId: 'value-binding',
+  title: 'Value Two-Way Binding',
+  description: 'Programmatically set [(value)] and verify form fields update',
+  config: valueBindingConfig,
+};


### PR DESCRIPTION
## Summary
- Adds E2E tests verifying that the `[(value)]` two-way binding updates form fields when set programmatically
- Covers: setting a value preset, switching between presets, clearing values, and verifying debug output
- Uses a dedicated `ValueBindingComponent` with buttons to trigger value changes via signal

## Test plan
- [x] All 4 new tests pass locally (`nx e2e core-examples --grep "Value Two-Way Binding"`)
- [ ] CI passes