### PR TITLE
chore(release): bump version to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and uses [Conventional Commits](https://www.conventionalcommits.org/).
 
+## [0.7.0](https://github.com/ng-forge/ng-forge/compare/v0.6.1...v0.7.0) (2026-03-27)
+
+### 🚀 Features
+
+- **docs:** migrate from ng-doc to Analog with Forge design language ([#295](https://github.com/ng-forge/ng-forge/pull/295))
+- **docs:** add StackBlitz button to live examples ([#310](https://github.com/ng-forge/ng-forge/pull/310))
+- **dynamic-forms:** add exhaustive switch guards for compile-time safety ([#301](https://github.com/ng-forge/ng-forge/pull/301))
+- **dynamic-forms:** adopt resource snapshot composition for async conditions ([#303](https://github.com/ng-forge/ng-forge/pull/303))
+- **dynamic-forms:** add openapi-generator package and field scope metadata ([#284](https://github.com/ng-forge/ng-forge/pull/284))
+- **examples:** unify example apps into sandbox with shared testing infrastructure ([#292](https://github.com/ng-forge/ng-forge/pull/292))
+
+### 🐛 Bug Fixes
+
+- **config:** suppress baseUrl deprecation error in TypeScript 5.9.3 ([#306](https://github.com/ng-forge/ng-forge/pull/306))
+- **config:** decouple type-test tsconfigs from deprecated baseUrl ([#308](https://github.com/ng-forge/ng-forge/pull/308))
+- **docs:** post-migration improvements and PrimeNG style cache fix ([#297](https://github.com/ng-forge/ng-forge/pull/297))
+- **docs:** pre-render landing page content for LLM crawlers ([#299](https://github.com/ng-forge/ng-forge/pull/299))
+- **dynamic-forms:** preserve row containers in side groups ([#296](https://github.com/ng-forge/ng-forge/pull/296))
+- **dynamic-forms:** remove eval/Function literals from comments to avoid false positives ([#298](https://github.com/ng-forge/ng-forge/pull/298))
+- **dynamic-forms:** restore mobile row wrapping ([#305](https://github.com/ng-forge/ng-forge/pull/305))
+
+### ♻️ Code Refactoring
+
+- **examples:** move e2e apps from apps/examples to apps/e2e ([#294](https://github.com/ng-forge/ng-forge/pull/294))
+
+### 📚 Documentation
+
+- **config:** add verification guidelines and /verify skill from usage insights ([ca67f1801](https://github.com/ng-forge/ng-forge/commit/ca67f1801))
+
+### ❤️ Thank You
+
+- Antim Prisacaru @antimprisacaru
+- Francesco Raso @0xfraso
+
 ## [0.6.1](https://github.com/ng-forge/ng-forge/compare/v0.6.0...v0.6.1) (2026-02-28)
 
 ### 🚀 Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ng-forge/source",
   "type": "module",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "MIT",
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/packages/dynamic-form-mcp/package.json
+++ b/packages/dynamic-form-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-form-mcp",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "MCP server for ng-forge dynamic forms - AI-assisted form schema generation",
   "type": "module",
   "license": "MIT",
@@ -51,11 +51,11 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@ng-forge/dynamic-forms": "^0.6.0",
-    "@ng-forge/dynamic-forms-bootstrap": "^0.6.0",
-    "@ng-forge/dynamic-forms-ionic": "^0.6.0",
-    "@ng-forge/dynamic-forms-material": "^0.6.0",
-    "@ng-forge/dynamic-forms-primeng": "^0.6.0",
+    "@ng-forge/dynamic-forms": "^0.7.0",
+    "@ng-forge/dynamic-forms-bootstrap": "^0.7.0",
+    "@ng-forge/dynamic-forms-ionic": "^0.7.0",
+    "@ng-forge/dynamic-forms-material": "^0.7.0",
+    "@ng-forge/dynamic-forms-primeng": "^0.7.0",
     "tsx": "^4.19.0"
   }
 }

--- a/packages/dynamic-forms-bootstrap/package.json
+++ b/packages/dynamic-forms-bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-bootstrap",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Bootstrap 5 integration for @ng-forge/dynamic-forms. Pre-built Bootstrap form components.",
   "type": "module",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@angular/common": "~21.2.0",
     "@angular/core": "~21.2.0",
     "@angular/forms": "~21.2.0",
-    "@ng-forge/dynamic-forms": "~0.6.0",
+    "@ng-forge/dynamic-forms": "~0.7.0",
     "rxjs": ">=7.0.0"
   }
 }

--- a/packages/dynamic-forms-ionic/package.json
+++ b/packages/dynamic-forms-ionic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-ionic",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Ionic integration for @ng-forge/dynamic-forms. Pre-built Ionic form components for mobile and desktop.",
   "type": "module",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "@angular/core": "~21.2.0",
     "@angular/forms": "~21.2.0",
     "@ionic/angular": ">=7.0.0",
-    "@ng-forge/dynamic-forms": "~0.6.0",
+    "@ng-forge/dynamic-forms": "~0.7.0",
     "rxjs": ">=7.0.0"
   },
   "dependencies": {

--- a/packages/dynamic-forms-material/package.json
+++ b/packages/dynamic-forms-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-material",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Angular Material integration for @ng-forge/dynamic-forms. Pre-built Material Design form components.",
   "type": "module",
   "license": "MIT",
@@ -32,7 +32,7 @@
     "@angular/core": "~21.2.0",
     "@angular/forms": "~21.2.0",
     "@angular/material": "~21.2.0",
-    "@ng-forge/dynamic-forms": "~0.6.0",
+    "@ng-forge/dynamic-forms": "~0.7.0",
     "rxjs": ">=7.0.0"
   }
 }

--- a/packages/dynamic-forms-primeng/package.json
+++ b/packages/dynamic-forms-primeng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-primeng",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "PrimeNG integration for @ng-forge/dynamic-forms. Pre-built PrimeNG form components.",
   "type": "module",
   "license": "MIT",
@@ -31,7 +31,7 @@
     "@angular/common": "~21.2.0",
     "@angular/core": "~21.2.0",
     "@angular/forms": "~21.2.0",
-    "@ng-forge/dynamic-forms": "~0.6.0",
+    "@ng-forge/dynamic-forms": "~0.7.0",
     "primeng": ">=17.0.0",
     "rxjs": ">=7.0.0"
   }

--- a/packages/dynamic-forms/package.json
+++ b/packages/dynamic-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Type-safe, signal-powered dynamic forms for Angular. Build complex forms from configuration with full TypeScript inference.",
   "type": "module",
   "license": "MIT",

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/openapi-generator",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Generate @ng-forge/dynamic-forms configurations from OpenAPI specs",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump all package versions to 0.7.0
- Update inter-package peerDependencies
- Generate changelog from v0.6.1

## Packages Updated
- @ng-forge/dynamic-forms: 0.6.1 -> 0.7.0
- @ng-forge/dynamic-forms-bootstrap: 0.6.1 -> 0.7.0
- @ng-forge/dynamic-forms-ionic: 0.6.1 -> 0.7.0
- @ng-forge/dynamic-forms-material: 0.6.1 -> 0.7.0
- @ng-forge/dynamic-forms-primeng: 0.6.1 -> 0.7.0
- @ng-forge/dynamic-form-mcp: 0.6.1 -> 0.7.0
- @ng-forge/openapi-generator: 0.6.0 -> 0.7.0

## Changelog

### 🚀 Features
- **docs:** migrate from ng-doc to Analog with Forge design language (#295)
- **docs:** add StackBlitz button to live examples (#310)
- **dynamic-forms:** add exhaustive switch guards for compile-time safety (#301)
- **dynamic-forms:** adopt resource snapshot composition for async conditions (#303)
- **dynamic-forms:** add openapi-generator package and field scope metadata (#284)
- **examples:** unify example apps into sandbox with shared testing infrastructure (#292)

### 🐛 Bug Fixes
- **config:** suppress baseUrl deprecation error in TypeScript 5.9.3 (#306)
- **config:** decouple type-test tsconfigs from deprecated baseUrl (#308)
- **docs:** post-migration improvements and PrimeNG style cache fix (#297)
- **docs:** pre-render landing page content for LLM crawlers (#299)
- **dynamic-forms:** preserve row containers in side groups (#296)
- **dynamic-forms:** remove eval/Function literals from comments to avoid false positives (#298)
- **dynamic-forms:** restore mobile row wrapping (#305)

### ♻️ Code Refactoring
- **examples:** move e2e apps from apps/examples to apps/e2e (#294)

## Next Steps
After merging, trigger the Release workflow manually from GitHub Actions to create the tag, GitHub release, and publish to npm.