### PR TITLE
fix(config): prevent docs SSR build OOM in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,8 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Build documentation
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
         run: |
           echo "Building documentation..."
           pnpm run build:docs

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -136,7 +136,7 @@ jobs:
           restore-keys: nx-${{ runner.os }}-
 
       - name: Build affected libraries
-        run: pnpm nx affected -t build --base=origin/main
+        run: pnpm nx affected -t build --base=origin/main --exclude='docs,*-examples'
 
       - name: Verify package integrity
         run: |
@@ -269,6 +269,8 @@ jobs:
           key: build-${{ github.sha }}-${{ hashFiles('packages/**') }}
 
       - name: Build docs if affected
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
         run: |
           if pnpm nx show projects --affected --base=origin/main | grep -q docs; then
             echo "Building documentation..."


### PR DESCRIPTION
## Summary
- Exclude `docs` and `*-examples` from the PR `build` job's `nx affected` since they're already built separately in the `build-apps` job — this was causing the docs SSR build to run in a process with no heap size increase, OOMing at 4GB+
- Add `NODE_OPTIONS: --max-old-space-size=8192` to the docs build steps in both `pr-check.yml` and `ci.yml` as a safety net

Fixes the OOM in #335.

## Test plan
- [ ] Verify PR check CI passes without OOM
- [ ] Verify docs still builds in the `build-apps` job