### PR TITLE
fix(dynamic-forms): wire slider range consistently across adapters

### DIFF
--- a/apps/e2e/bootstrap/src/app/testing/bootstrap-components/bootstrap-components.spec.ts
+++ b/apps/e2e/bootstrap/src/app/testing/bootstrap-components/bootstrap-components.spec.ts
@@ -161,11 +161,12 @@ test.describe('Bootstrap Components Tests', () => {
       const slider = scenario.locator('#temperature input[type="range"]');
       await expect(slider).toBeVisible();
 
-      // Verify slider has the configured initial value
+      // Field-level minValue/maxValue must reach the rendered <input type="range">
+      // via the dfBsInputConstraints directive. Regression guard for the original
+      // wiring bug — see fix(dynamic-forms): wire slider range consistently across adapters.
+      await expect(slider).toHaveAttribute('min', '10');
+      await expect(slider).toHaveAttribute('max', '30');
       await expect(slider).toHaveValue('20');
-
-      // Note: min/max validation is enforced by the form framework
-      // Testing exact HTML attributes would require additional mapper implementation
     });
 
     test('should work with step increments', async ({ page, helpers }) => {

--- a/apps/e2e/ionic/src/app/testing/ionic-components/ionic-components.spec.ts
+++ b/apps/e2e/ionic/src/app/testing/ionic-components/ionic-components.spec.ts
@@ -71,7 +71,7 @@ test.describe('Ionic Components Tests', () => {
       expect(newValue).toBe(75);
     });
 
-    test('should respect min and max bounds', async ({ page, helpers }) => {
+    test('should respect field-level min and max bounds', async ({ page, helpers }) => {
       await page.goto('/#/testing/ionic-components/range-component');
       await page.waitForLoadState('networkidle');
 
@@ -81,7 +81,10 @@ test.describe('Ionic Components Tests', () => {
       const range = scenario.locator('#volume ion-range');
       await expect(range).toBeVisible({ timeout: 5000 });
 
-      // Verify min and max attributes
+      // The scenario sets minValue/maxValue at the field level (NOT in props).
+      // The component must resolve via f().min?.()/f().max?.(), so this assertion
+      // is a regression guard for the original wiring bug — see
+      // fix(dynamic-forms): wire slider range consistently across adapters.
       const min = await range.evaluate((el: HTMLIonRangeElement) => el.min);
       const max = await range.evaluate((el: HTMLIonRangeElement) => el.max);
 

--- a/apps/e2e/ionic/src/app/testing/ionic-components/scenarios/range-component.scenario.ts
+++ b/apps/e2e/ionic/src/app/testing/ionic-components/scenarios/range-component.scenario.ts
@@ -8,10 +8,13 @@ const config = {
       type: 'slider',
       label: 'Volume',
       value: 50,
+      // Field-level slider config — adapter components must read these, not just
+      // adapter-specific props.min / props.max. See fix(dynamic-forms): wire slider
+      // range consistently across adapters.
+      minValue: 0,
+      maxValue: 100,
+      step: 1,
       props: {
-        min: 0,
-        max: 100,
-        step: 1,
         pin: true,
         ticks: true,
         snaps: true,

--- a/apps/e2e/material/src/app/testing/material-components/material-components.spec.ts
+++ b/apps/e2e/material/src/app/testing/material-components/material-components.spec.ts
@@ -162,12 +162,12 @@ test.describe('Material Components Tests', () => {
       const slider = scenario.locator('#temperature input[type="range"]');
       await expect(slider).toBeVisible();
 
-      // Verify slider has the configured initial value
-      const value = await slider.inputValue();
-      expect(value).toBe('20');
-
-      // Note: min/max validation is enforced by the form framework
-      // Testing exact HTML attributes would require additional mapper implementation
+      // Field-level minValue/maxValue must reach the rendered <input type="range">.
+      // Regression guard for the original wiring bug — see fix(dynamic-forms): wire
+      // slider range consistently across adapters.
+      await expect(slider).toHaveAttribute('min', '10');
+      await expect(slider).toHaveAttribute('max', '30');
+      await expect(slider).toHaveValue('20');
     });
 
     test('should work with step increments', async ({ page, helpers }) => {

--- a/apps/e2e/primeng/src/app/testing/primeng-components/primeng-components.spec.ts
+++ b/apps/e2e/primeng/src/app/testing/primeng-components/primeng-components.spec.ts
@@ -153,6 +153,23 @@ test.describe('PrimeNG Components Tests', () => {
       const slider = scenario.locator('#lockedSlider p-slider');
       await expect(slider).toHaveClass(/p-disabled/);
     });
+
+    test('should respect field-level min and max bounds', async ({ page, helpers }) => {
+      await page.goto('/#/test/primeng-components/slider-bounds');
+      await page.waitForLoadState('networkidle');
+
+      const scenario = helpers.getScenario('slider-bounds');
+      await expect(scenario).toBeVisible();
+
+      // PrimeNG renders the slider handle with role="slider" and aria-valuemin/max
+      // reflecting the [min] / [max] component inputs. Field-level minValue/maxValue
+      // must propagate to those bounds — regression guard for the original wiring bug.
+      const handle = scenario.locator('#temperature [role="slider"]');
+      await expect(handle).toBeVisible();
+      await expect(handle).toHaveAttribute('aria-valuemin', '10');
+      await expect(handle).toHaveAttribute('aria-valuemax', '30');
+      await expect(handle).toHaveAttribute('aria-valuenow', '20');
+    });
   });
 
   test.describe('Toggle Component', () => {

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/slider/bs-slider.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/slider/bs-slider.component.ts
@@ -29,9 +29,9 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
         dfBsInputConstraints
         [formField]="f"
         [id]="inputId"
-        [dfMin]="props()?.min ?? min()"
-        [dfMax]="props()?.max ?? max()"
-        [dfStep]="props()?.step ?? step()"
+        [dfMin]="f().min?.() ?? props()?.min ?? min()"
+        [dfMax]="f().max?.() ?? props()?.max ?? max()"
+        [dfStep]="step() ?? props()?.step ?? 1"
         [attr.tabindex]="tabIndex()"
         [attr.aria-invalid]="ariaInvalid()"
         [attr.aria-required]="ariaRequired()"
@@ -79,7 +79,7 @@ export default class BsSliderFieldComponent implements BsSliderComponent {
 
   readonly min = input<number>(0);
   readonly max = input<number>(100);
-  readonly step = input<number>(1);
+  readonly step = input<number>();
 
   readonly props = input<BsSliderProps>();
   readonly validationMessages = input<ValidationMessages>();

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/slider/bs-slider.type.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/slider/bs-slider.type.ts
@@ -6,8 +6,20 @@ export interface BsSliderProps {
   valuePrefix?: string;
   valueSuffix?: string;
   hint?: DynamicText;
+  /**
+   * Adapter-level override for the slider minimum.
+   * Field-level `minValue` (or the validator `min`) takes precedence.
+   */
   min?: number;
+  /**
+   * Adapter-level override for the slider maximum.
+   * Field-level `maxValue` (or the validator `max`) takes precedence.
+   */
   max?: number;
+  /**
+   * Adapter-level override for the slider step increment.
+   * Field-level `step` on `SliderField` takes precedence.
+   */
   step?: number;
 }
 

--- a/packages/dynamic-forms-ionic/src/lib/fields/slider/ionic-slider.component.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/slider/ionic-slider.component.ts
@@ -19,9 +19,9 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
       [formField]="f"
       [label]="(label() | dynamicText | async) ?? undefined"
       [labelPlacement]="props()?.labelPlacement ?? 'stacked'"
-      [min]="props()?.min ?? 0"
-      [max]="props()?.max ?? 100"
-      [step]="props()?.step ?? 1"
+      [min]="f().min?.() ?? props()?.min ?? 0"
+      [max]="f().max?.() ?? props()?.max ?? 100"
+      [step]="step() ?? props()?.step ?? 1"
       [dualKnobs]="props()?.dualKnobs ?? false"
       [pin]="props()?.pin ?? false"
       [pinFormatter]="props()?.pinFormatter ?? defaultPinFormatter"
@@ -70,6 +70,7 @@ export default class IonicSliderFieldComponent implements IonicSliderComponent {
   readonly placeholder = input<DynamicText>();
   readonly className = input<string>('');
   readonly tabIndex = input<number>();
+  readonly step = input<number>();
 
   readonly props = input<IonicSliderProps>();
   readonly meta = input<FieldMeta>();

--- a/packages/dynamic-forms-ionic/src/lib/fields/slider/ionic-slider.type.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/slider/ionic-slider.type.ts
@@ -2,8 +2,20 @@ import { DynamicText, ValueFieldComponent } from '@ng-forge/dynamic-forms';
 import { SliderField } from '@ng-forge/dynamic-forms/integration';
 
 export interface IonicSliderProps {
+  /**
+   * Adapter-level override for the slider minimum.
+   * Field-level `minValue` (or the validator `min`) takes precedence.
+   */
   min?: number;
+  /**
+   * Adapter-level override for the slider maximum.
+   * Field-level `maxValue` (or the validator `max`) takes precedence.
+   */
   max?: number;
+  /**
+   * Adapter-level override for the slider step increment.
+   * Field-level `step` on `SliderField` takes precedence.
+   */
   step?: number;
   dualKnobs?: boolean;
   pin?: boolean;

--- a/packages/dynamic-forms-material/src/lib/fields/slider/mat-slider.component.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/slider/mat-slider.component.ts
@@ -22,7 +22,7 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
     <mat-slider
       [min]="f().min?.() ?? 0"
       [max]="f().max?.() ?? 100"
-      [step]="props()?.step ?? 1"
+      [step]="step() ?? props()?.step ?? 1"
       [discrete]="props()?.thumbLabel || props()?.showThumbLabel"
       [showTickMarks]="props()?.tickInterval !== undefined"
       [color]="props()?.color || 'primary'"
@@ -76,6 +76,7 @@ export default class MatSliderFieldComponent implements MatSliderComponent {
 
   readonly className = input<string>('');
   readonly tabIndex = input<number>();
+  readonly step = input<number>();
 
   readonly props = input<MatSliderProps>();
   readonly meta = input<InputMeta>();

--- a/packages/dynamic-forms-primeng/src/lib/fields/slider/prime-slider.component.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/slider/prime-slider.component.ts
@@ -22,7 +22,9 @@ import { createAriaDescribedBySignal } from '../../utils/create-aria-described-b
       <p-slider
         [id]="key()"
         [formField]="f"
-        [step]="props()?.step ?? 1"
+        [min]="f().min?.() ?? props()?.min ?? 0"
+        [max]="f().max?.() ?? props()?.max ?? 100"
+        [step]="step() ?? props()?.step ?? 1"
         [range]="props()?.range || false"
         [orientation]="props()?.orientation || 'horizontal'"
         [attr.tabindex]="tabIndex()"
@@ -64,6 +66,7 @@ export default class PrimeSliderFieldComponent implements PrimeSliderComponent {
   readonly placeholder = input<DynamicText>();
   readonly className = input<string>('');
   readonly tabIndex = input<number>();
+  readonly step = input<number>();
 
   readonly props = input<PrimeSliderProps>();
   readonly meta = input<FieldMeta>();

--- a/packages/dynamic-forms-primeng/src/lib/fields/slider/prime-slider.type.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/slider/prime-slider.type.ts
@@ -4,14 +4,24 @@ import { SliderField } from '@ng-forge/dynamic-forms/integration';
 export interface PrimeSliderProps {
   /**
    * Minimum value of the slider.
+   *
+   * Adapter-level override. Field-level `minValue` (or the validator `min`) takes
+   * precedence — set this only when you need a render-only override that should
+   * not flow into form validation.
    */
   min?: number;
   /**
    * Maximum value of the slider.
+   *
+   * Adapter-level override. Field-level `maxValue` (or the validator `max`) takes
+   * precedence — set this only when you need a render-only override that should
+   * not flow into form validation.
    */
   max?: number;
   /**
    * Step increment for slider values.
+   *
+   * Adapter-level override. Field-level `step` on `SliderField` takes precedence.
    */
   step?: number;
   /**


### PR DESCRIPTION
## Summary

Three slider adapters didn't honour field-level range config:

- **PrimeNG slider** had no `[min]` / `[max]` bindings at all — the range was hardcoded to 0–100.
- **Ionic slider** read only `props()?.min` / `props()?.max`, ignoring field-level `minValue` / `maxValue` that the MCP server documents as canonical.
- **Bootstrap slider** preferred `props.min` over the field-tree validator — field-level config was overridden whenever any props existed.

**PrimeNG, Bootstrap, and Ionic now match Material's precedence (`field-tree validator → props → default`). Material itself was already correct, doesn't expose a props-level override, and isn't gaining one in this PR.**

## Per-adapter behaviour

| Adapter | min / max binding | step binding |
|---|---|---|
| **Material** *(unchanged for min/max)* | `f().min?.() ?? 0` / `f().max?.() ?? 100` | `step() ?? props()?.step ?? 1` *(was `props()?.step ?? 1`)* |
| **Bootstrap** | `f().min?.() ?? props()?.min ?? min()` / `f().max?.() ?? props()?.max ?? max()` | `step() ?? props()?.step ?? 1` |
| **PrimeNG** | `f().min?.() ?? props()?.min ?? 0` / `f().max?.() ?? props()?.max ?? 100` | `step() ?? props()?.step ?? 1` |
| **Ionic** | `f().min?.() ?? props()?.min ?? 0` / `f().max?.() ?? props()?.max ?? 100` | `step() ?? props()?.step ?? 1` |

`MatSliderProps` intentionally has no `min` / `max` keys — Material consumers configure range via field-level `minValue` / `maxValue` only. The other three adapters keep `props.min` / `props.max` / `props.step` as adapter-level overrides for cases where the slider's render bounds should differ from a form-level validator (rare but supported), with JSDoc updated to call out that field-level wins.

Also added a `step` input to Material, PrimeNG, and Ionic slider components so the mapper's `step` output reaches the template (previously only Bootstrap had this input; the three others read `step` from props, ignoring the field-level value).

Part of the broader audit following #345.

## ⚠ Behavioural notes (private adapter API, but worth flagging)

These affect direct `<df-mat-slider …>` / `<df-bs-slider …>` consumers, not field-config-driven usage:

- **Bootstrap `step` input default removed.** Was `input<number>(1)`, now `input<number>()`. CodeRabbit flagged that with the prior default, the new template chain `step() ?? props()?.step ?? 1` could never reach `props.step`. With the default gone, the chain works. Consumers reading `step()` directly now see `undefined` until set.
- **Bootstrap `step` precedence flip.** Previously `props.step ?? step()` (props won). Now `step() ?? props()?.step` (the explicit `[step]` input wins). Mapper-driven path is unaffected (the mapper writes only one of these). Direct consumers setting both `[step]="x"` and `props="{step: y}"` now resolve to `x` where they previously resolved to `y`. Intentional — aligns with the new "field-level → props → default" precedence.

## Regression coverage

Added DOM-level assertions per adapter so future refactors can't silently re-break this:

- **Material** (`material-components.spec.ts`): `toHaveAttribute('min', '10')` / `'max', '30'` against `#temperature input[type="range"]`.
- **Bootstrap** (`bootstrap-components.spec.ts`): same — verifies the `dfBsInputConstraints` directive flows the values through.
- **PrimeNG** (`primeng-components.spec.ts`): new `should respect field-level min and max bounds` test asserting `aria-valuemin` / `aria-valuemax` / `aria-valuenow` on the slider handle (`[role="slider"]`).
- **Ionic** (`ionic-components.spec.ts`): the existing `should respect min and max bounds` test was reading bounds from `props.min` / `props.max` (the buggy code path) — would have passed pre-PR. The scenario now sets `minValue` / `maxValue` at the field level (props keeps `pin` / `ticks` / `snaps` only), so the assertion now exercises the actual fix.

## What did NOT change

- **Material types.** `MatSliderProps` remains styling-only (`color`, `appearance`, `thumbLabel`, `tickInterval`, etc.). No `min` / `max` added.
- **Mapper outputs.** `sliderFieldMapper` still writes `inputs['minValue']` / `inputs['maxValue']` / `inputs['step']`. The first two remain dead outputs (no component reads them; bounds come from `f().min?.()` instead). Worth removing in a follow-up cleanup — flagged for the broader audit, not part of this bugfix.
- **Bootstrap dead `min` / `max` component inputs.** `bs-slider.component.ts:80-81` still exposes `min = input<number>(0)` / `max = input<number>(100)` that the mapper never writes — they only fire for hand-rolled `<df-bs-slider [min]="…" />` usage. Material/PrimeNG/Ionic don't have them. Out of scope for this bugfix, follow-up candidate.
- **No config migration** — every existing slider config still works.

## MCP server

Confirmed not affected. This change is component-template-only; canonical naming (`minValue` / `maxValue` at field level) is unchanged, and `packages/dynamic-form-mcp/` documentation/scaffolding/validation already point users at field-level. No MCP updates required.

## Test plan

- [x] `nx run-many -t build` — all 6 packages
- [x] `nx run-many -t test -p dynamic-forms,dynamic-forms-material,dynamic-forms-bootstrap,dynamic-forms-primeng,dynamic-forms-ionic` — all pass
- [x] `nx run-many -t lint -p dynamic-forms-{material,bootstrap,primeng,ionic}` — clean
- [x] DOM regression tests added per adapter (see above)