### PR TITLE
ci(release): add nightly publish workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,9 +10,6 @@ permissions:
   id-token: write
   actions: read
 
-env:
-  LIBRARY_PACKAGES: 'dynamic-forms dynamic-forms-material dynamic-forms-bootstrap dynamic-forms-ionic dynamic-forms-primeng dynamic-form-mcp openapi-generator'
-
 jobs:
   check:
     name: Check for relevant changes
@@ -76,86 +73,16 @@ jobs:
           echo "should_publish=true" >> "$GITHUB_OUTPUT"
           echo "nightly_version=${NIGHTLY_VERSION}" >> "$GITHUB_OUTPUT"
 
-  release:
+  publish:
     name: Publish nightly
-    runs-on: ubuntu-latest
     needs: check
     if: needs.check.outputs.should_publish == 'true'
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: main
-          fetch-depth: 0
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: 10.28.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Strip preVersionCommand
-        # The configured preVersionCommand builds with stale versions; we build
-        # ourselves after the bump so the dist contains the nightly version.
-        run: |
-          node -e "
-            const fs = require('fs');
-            const cfg = JSON.parse(fs.readFileSync('nx.json', 'utf8'));
-            if (cfg.release?.version?.preVersionCommand !== undefined) {
-              delete cfg.release.version.preVersionCommand;
-              fs.writeFileSync('nx.json', JSON.stringify(cfg, null, 2));
-            }
-          "
-
-      - name: Bump source versions to nightly
-        run: |
-          pnpm nx release version "${{ needs.check.outputs.nightly_version }}" \
-            --git-commit=false --git-tag=false --stage-changes=false
-
-      - name: Build libraries
-        run: pnpm nx run-many -t build -p ${{ env.LIBRARY_PACKAGES }}
-
-      - name: Verify build outputs
-        run: |
-          for pkg in ${{ env.LIBRARY_PACKAGES }}; do
-            if [ ! -d "dist/packages/$pkg" ]; then
-              echo "::error::Build output missing for $pkg"
-              exit 1
-            fi
-          done
-
-      - name: Upgrade npm for OIDC Trusted Publisher support
-        run: npm install -g npm@latest
-
-      - name: Publish nightly to npm
-        run: |
-          for pkg in ${{ env.LIBRARY_PACKAGES }}; do
-            npm publish dist/packages/$pkg --access public --provenance --tag nightly
-          done
-
-      - name: Summary
-        run: |
-          {
-            echo "## Nightly Release \`${{ needs.check.outputs.nightly_version }}\`"
-            echo ""
-            echo "Published with npm dist-tag \`nightly\`. Install via:"
-            echo ""
-            echo '```bash'
-            echo "pnpm add @ng-forge/dynamic-forms@nightly"
-            echo '```'
-            echo ""
-            echo "### Packages"
-            for pkg in ${{ env.LIBRARY_PACKAGES }}; do
-              echo "- \`@ng-forge/$pkg@${{ needs.check.outputs.nightly_version }}\`"
-            done
-          } >> "$GITHUB_STEP_SUMMARY"
+    uses: ./.github/workflows/release.yml
+    with:
+      version: ${{ needs.check.outputs.nightly_version }}
+      dist-tag: nightly
+      create-github-release: false
+    permissions:
+      contents: read
+      id-token: write
+      actions: read

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,10 @@ on:
   workflow_dispatch:
 
 permissions:
+  # `contents: read` is sufficient because the publish path passes
+  # `create-github-release: false` to release.yml, gating all writes (tag push,
+  # GitHub release). If you ever flip that to true for nightlies, bump this to
+  # `contents: write` to avoid a silent 403.
   contents: read
   id-token: write
   actions: read
@@ -17,6 +21,7 @@ jobs:
     outputs:
       should_publish: ${{ steps.gate.outputs.should_publish }}
       nightly_version: ${{ steps.gate.outputs.nightly_version }}
+      sha: ${{ steps.gate.outputs.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -43,8 +48,17 @@ jobs:
           # Bump-worthy commit types per nx.json release.conventionalCommits:
           # feat, fix, perf, revert. Everything else (docs/ci/chore/test/build/style/refactor)
           # is classified semverBump:none and should not trigger a nightly.
+          # Disable pipefail for this pipeline so we can distinguish grep's "no matches"
+          # (exit 1, fine) from a real grep error (exit ≥2, fail loud).
+          set +o pipefail
           RELEVANT=$(git log "${LAST_TAG}..HEAD" --pretty=format:'%s' \
-            | grep -cE '^(feat|fix|perf|revert)(\([^)]+\))?!?: ' || true)
+            | grep -cE '^(feat|fix|perf|revert)(\([^)]+\))?!?: ')
+          GREP_EXIT=$?
+          set -o pipefail
+          if [ "$GREP_EXIT" -gt 1 ]; then
+            echo "::error::grep failed unexpectedly (exit $GREP_EXIT)"
+            exit 1
+          fi
 
           echo "Relevant commits since $LAST_TAG: $RELEVANT"
 
@@ -54,17 +68,28 @@ jobs:
             exit 0
           fi
 
+          # Capture the SHA NOW so the publish job uses the same commit (no race
+          # against in-flight commits that would desync the SHA-in-version from
+          # the actually-shipped code).
+          FULL_SHA=$(git rev-parse HEAD)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+
           LAST_VERSION=${LAST_TAG#v}
           NEXT_PATCH=$(node -e "const [M,m,p]='${LAST_VERSION}'.split('.').map(Number); console.log(\`\${M}.\${m}.\${p+1}\`)")
           DATE=$(date -u +%Y%m%d)
-          SHORT_SHA=$(git rev-parse --short HEAD)
           NIGHTLY_VERSION="${NEXT_PATCH}-nightly.${DATE}.${SHORT_SHA}"
 
           echo "Proposed nightly version: $NIGHTLY_VERSION"
 
-          # Idempotency: skip if this exact SHA has already been published as a nightly today.
-          if npm view '@ng-forge/dynamic-forms' versions --json 2>/dev/null \
-            | grep -q "\"${NIGHTLY_VERSION}\""; then
+          # Idempotency: skip if this exact SHA-tagged version has already been
+          # published. Fail loudly on real registry errors instead of silently
+          # treating them as "version not found" — masking would let us
+          # double-publish if npm view itself was the thing that broke.
+          if ! VERSIONS_JSON=$(npm view '@ng-forge/dynamic-forms' versions --json); then
+            echo "::error::npm registry lookup failed"
+            exit 1
+          fi
+          if echo "$VERSIONS_JSON" | grep -q "\"${NIGHTLY_VERSION}\""; then
             echo "Nightly ${NIGHTLY_VERSION} is already on npm — skipping"
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -72,6 +97,7 @@ jobs:
 
           echo "should_publish=true" >> "$GITHUB_OUTPUT"
           echo "nightly_version=${NIGHTLY_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "sha=${FULL_SHA}" >> "$GITHUB_OUTPUT"
 
   publish:
     name: Publish nightly
@@ -82,6 +108,7 @@ jobs:
       version: ${{ needs.check.outputs.nightly_version }}
       dist-tag: nightly
       create-github-release: false
+      ref: ${{ needs.check.outputs.sha }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,161 @@
+name: Nightly Release
+
+on:
+  schedule:
+    - cron: '27 1 * * *' # 01:27 UTC daily (~04:27 EEST) — after the late-night commit window, off the hour to avoid GH Actions cron stampede
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+  actions: read
+
+env:
+  LIBRARY_PACKAGES: 'dynamic-forms dynamic-forms-material dynamic-forms-bootstrap dynamic-forms-ionic dynamic-forms-primeng dynamic-form-mcp openapi-generator'
+
+jobs:
+  check:
+    name: Check for relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.gate.outputs.should_publish }}
+      nightly_version: ${{ steps.gate.outputs.nightly_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Detect relevant changes & compute version
+        id: gate
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          LAST_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*nightly*' 2>/dev/null || echo "")
+
+          if [ -z "$LAST_TAG" ]; then
+            echo "::warning::No prior stable tag found — skipping nightly"
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Last stable tag: $LAST_TAG"
+
+          # Bump-worthy commit types per nx.json release.conventionalCommits:
+          # feat, fix, perf, revert. Everything else (docs/ci/chore/test/build/style/refactor)
+          # is classified semverBump:none and should not trigger a nightly.
+          RELEVANT=$(git log "${LAST_TAG}..HEAD" --pretty=format:'%s' \
+            | grep -cE '^(feat|fix|perf|revert)(\([^)]+\))?!?: ' || true)
+
+          echo "Relevant commits since $LAST_TAG: $RELEVANT"
+
+          if [ "$RELEVANT" -eq 0 ]; then
+            echo "No version-bumping commits since last stable — skipping nightly"
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          LAST_VERSION=${LAST_TAG#v}
+          NEXT_PATCH=$(node -e "const [M,m,p]='${LAST_VERSION}'.split('.').map(Number); console.log(\`\${M}.\${m}.\${p+1}\`)")
+          DATE=$(date -u +%Y%m%d)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          NIGHTLY_VERSION="${NEXT_PATCH}-nightly.${DATE}.${SHORT_SHA}"
+
+          echo "Proposed nightly version: $NIGHTLY_VERSION"
+
+          # Idempotency: skip if this exact SHA has already been published as a nightly today.
+          if npm view '@ng-forge/dynamic-forms' versions --json 2>/dev/null \
+            | grep -q "\"${NIGHTLY_VERSION}\""; then
+            echo "Nightly ${NIGHTLY_VERSION} is already on npm — skipping"
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          echo "nightly_version=${NIGHTLY_VERSION}" >> "$GITHUB_OUTPUT"
+
+  release:
+    name: Publish nightly
+    runs-on: ubuntu-latest
+    needs: check
+    if: needs.check.outputs.should_publish == 'true'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10.28.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Strip preVersionCommand
+        # The configured preVersionCommand builds with stale versions; we build
+        # ourselves after the bump so the dist contains the nightly version.
+        run: |
+          node -e "
+            const fs = require('fs');
+            const cfg = JSON.parse(fs.readFileSync('nx.json', 'utf8'));
+            if (cfg.release?.version?.preVersionCommand !== undefined) {
+              delete cfg.release.version.preVersionCommand;
+              fs.writeFileSync('nx.json', JSON.stringify(cfg, null, 2));
+            }
+          "
+
+      - name: Bump source versions to nightly
+        run: |
+          pnpm nx release version "${{ needs.check.outputs.nightly_version }}" \
+            --git-commit=false --git-tag=false --stage-changes=false
+
+      - name: Build libraries
+        run: pnpm nx run-many -t build -p ${{ env.LIBRARY_PACKAGES }}
+
+      - name: Verify build outputs
+        run: |
+          for pkg in ${{ env.LIBRARY_PACKAGES }}; do
+            if [ ! -d "dist/packages/$pkg" ]; then
+              echo "::error::Build output missing for $pkg"
+              exit 1
+            fi
+          done
+
+      - name: Upgrade npm for OIDC Trusted Publisher support
+        run: npm install -g npm@latest
+
+      - name: Publish nightly to npm
+        run: |
+          for pkg in ${{ env.LIBRARY_PACKAGES }}; do
+            npm publish dist/packages/$pkg --access public --provenance --tag nightly
+          done
+
+      - name: Summary
+        run: |
+          {
+            echo "## Nightly Release \`${{ needs.check.outputs.nightly_version }}\`"
+            echo ""
+            echo "Published with npm dist-tag \`nightly\`. Install via:"
+            echo ""
+            echo '```bash'
+            echo "pnpm add @ng-forge/dynamic-forms@nightly"
+            echo '```'
+            echo ""
+            echo "### Packages"
+            for pkg in ${{ env.LIBRARY_PACKAGES }}; do
+              echo "- \`@ng-forge/$pkg@${{ needs.check.outputs.nightly_version }}\`"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,22 @@ on:
         options:
           - dry-run
           - publish
+  workflow_call:
+    inputs:
+      version:
+        description: 'Exact version to publish. If unset, uses the version already in package.json (stable release path).'
+        type: string
+        required: false
+      dist-tag:
+        description: 'npm dist-tag to publish under.'
+        type: string
+        required: false
+        default: 'latest'
+      create-github-release:
+        description: 'Create git tag, changelog, and GitHub release.'
+        type: boolean
+        required: false
+        default: true
 
 permissions:
   contents: write
@@ -91,6 +107,11 @@ jobs:
     name: Release Libraries
     runs-on: ubuntu-latest
     needs: check-ci
+    # Run when check-ci succeeds (workflow_dispatch) or is skipped (workflow_call — caller is responsible for its own gating).
+    if: |
+      always() &&
+      (needs.check-ci.result == 'success' || needs.check-ci.result == 'skipped') &&
+      github.event_name != 'push'
 
     steps:
       - name: Checkout
@@ -109,14 +130,35 @@ jobs:
         with:
           node-version: '22'
           cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Get version from package.json
+      - name: Bump source versions (workflow_call path)
+        if: ${{ inputs.version != '' && inputs.version != null }}
+        # Strip the configured preVersionCommand to avoid a wasted stale-version build;
+        # we build explicitly below after the bump so dist/ picks up the new version.
+        run: |
+          node -e "
+            const fs = require('fs');
+            const cfg = JSON.parse(fs.readFileSync('nx.json', 'utf8'));
+            if (cfg.release?.version?.preVersionCommand !== undefined) {
+              delete cfg.release.version.preVersionCommand;
+              fs.writeFileSync('nx.json', JSON.stringify(cfg, null, 2));
+            }
+          "
+          pnpm nx release version "${{ inputs.version }}" \
+            --git-commit=false --git-tag=false --stage-changes=false
+
+      - name: Get version
         id: version
         run: |
-          VERSION=$(node -p "require('./packages/dynamic-forms/package.json').version")
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION=$(node -p "require('./packages/dynamic-forms/package.json').version")
+          fi
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "📦 Releasing version: $VERSION"
@@ -136,13 +178,15 @@ jobs:
           done
 
       - name: Configure Git
+        if: ${{ inputs.create-github-release != false }}
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
       - name: Generate Changelog
+        if: ${{ inputs.create-github-release != false }}
         run: |
-          PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          PREV_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*nightly*' 2>/dev/null || echo "")
 
           if [ -z "$PREV_TAG" ]; then
             CHANGELOG=$(git log --pretty=format:"- %s (%h)" --no-merges -50)
@@ -159,6 +203,7 @@ jobs:
           EOF
 
       - name: Create Git Tag
+        if: ${{ inputs.create-github-release != false }}
         run: |
           if git rev-parse "v${{ env.VERSION }}" >/dev/null 2>&1; then
             echo "❌ Tag v${{ env.VERSION }} already exists!"
@@ -168,6 +213,7 @@ jobs:
           git push origin "v${{ env.VERSION }}"
 
       - name: Create GitHub Release
+        if: ${{ inputs.create-github-release != false }}
         uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ env.VERSION }}
@@ -179,29 +225,39 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to npm (dry-run)
-        if: ${{ inputs.mode == 'dry-run' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'dry-run' }}
         run: pnpm nx release publish --access public --dry-run
 
       - name: Upgrade npm for OIDC Trusted Publisher support
-        if: ${{ inputs.mode == 'publish' }}
+        if: ${{ github.event_name == 'workflow_call' || inputs.mode == 'publish' }}
         run: npm install -g npm@latest
 
       - name: Publish to npm
-        if: ${{ inputs.mode == 'publish' }}
+        if: ${{ github.event_name == 'workflow_call' || inputs.mode == 'publish' }}
         run: |
+          DIST_TAG="${{ inputs.dist-tag }}"
+          DIST_TAG="${DIST_TAG:-latest}"
+          echo "Publishing with dist-tag: $DIST_TAG"
           for pkg in ${{ env.LIBRARY_PACKAGES }}; do
-            npm publish dist/packages/$pkg --access public --provenance
+            npm publish dist/packages/$pkg --access public --provenance --tag "$DIST_TAG"
           done
 
       - name: Summary
         run: |
+          DIST_TAG="${{ inputs.dist-tag }}"
+          DIST_TAG="${DIST_TAG:-latest}"
           echo "## Release v${{ env.VERSION }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Published packages:" >> $GITHUB_STEP_SUMMARY
+          echo "### Published packages (dist-tag: \`$DIST_TAG\`):" >> $GITHUB_STEP_SUMMARY
           for pkg in ${{ env.LIBRARY_PACKAGES }}; do
             echo "- \`@ng-forge/$pkg@${{ env.VERSION }}\`" >> $GITHUB_STEP_SUMMARY
           done
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Links:" >> $GITHUB_STEP_SUMMARY
-          echo "- [GitHub Release](https://github.com/${{ github.repository }}/releases/tag/v${{ env.VERSION }})" >> $GITHUB_STEP_SUMMARY
-          echo "- [npm](https://www.npmjs.com/package/@ng-forge/dynamic-forms/v/${{ env.VERSION }})" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ inputs.create-github-release }}" != "false" ]; then
+            echo "### Links:" >> $GITHUB_STEP_SUMMARY
+            echo "- [GitHub Release](https://github.com/${{ github.repository }}/releases/tag/v${{ env.VERSION }})" >> $GITHUB_STEP_SUMMARY
+            echo "- [npm](https://www.npmjs.com/package/@ng-forge/dynamic-forms/v/${{ env.VERSION }})" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### npm" >> $GITHUB_STEP_SUMMARY
+            echo "- [npm](https://www.npmjs.com/package/@ng-forge/dynamic-forms/v/${{ env.VERSION }})" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,10 @@ on:
         type: boolean
         required: false
         default: true
+      ref:
+        description: 'Git ref/SHA to check out and publish. Pin this from the caller to avoid races against in-flight commits.'
+        type: string
+        required: false
 
 permissions:
   contents: write
@@ -107,7 +111,10 @@ jobs:
     name: Release Libraries
     runs-on: ubuntu-latest
     needs: check-ci
-    # Run when check-ci succeeds (workflow_dispatch) or is skipped (workflow_call — caller is responsible for its own gating).
+    # `always()` is load-bearing: it lets this job run even when `check-ci` is *skipped*
+    # (the workflow_call path, where the caller has already gated). Without `always()`,
+    # `needs: check-ci` would short-circuit the job whenever check-ci doesn't run.
+    # Don't drop it without rethinking the gating.
     if: |
       always() &&
       (needs.check-ci.result == 'success' || needs.check-ci.result == 'skipped') &&
@@ -117,6 +124,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          # Pin to the caller-provided ref when present (avoids racing in-flight
+          # commits between gate and publish). Falls back to the workflow's default
+          # ref otherwise (workflow_dispatch on the dispatched branch).
+          ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -137,8 +148,12 @@ jobs:
 
       - name: Bump source versions (workflow_call path)
         if: ${{ inputs.version != '' && inputs.version != null }}
-        # Strip the configured preVersionCommand to avoid a wasted stale-version build;
-        # we build explicitly below after the bump so dist/ picks up the new version.
+        # Strips the configured preVersionCommand to avoid a wasted stale-version
+        # build (we build explicitly below after the bump). The mutation is ephemeral
+        # — the runner discards its checkout after the job, so nx.json on disk is
+        # never affected.
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           node -e "
             const fs = require('fs');
@@ -148,20 +163,26 @@ jobs:
               fs.writeFileSync('nx.json', JSON.stringify(cfg, null, 2));
             }
           "
-          pnpm nx release version "${{ inputs.version }}" \
+          pnpm nx release version "$INPUT_VERSION" \
             --git-commit=false --git-tag=false --stage-changes=false
 
-      - name: Get version
-        id: version
+      - name: Resolve version + dist-tag
+        id: resolve
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_DIST_TAG: ${{ inputs.dist-tag }}
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            VERSION="${{ inputs.version }}"
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
           else
             VERSION=$(node -p "require('./packages/dynamic-forms/package.json').version")
           fi
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "📦 Releasing version: $VERSION"
+          DIST_TAG="${INPUT_DIST_TAG:-latest}"
+
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "DIST_TAG=$DIST_TAG" >> "$GITHUB_ENV"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "📦 Releasing version: $VERSION (dist-tag: $DIST_TAG)"
 
       - name: Build libraries
         run: pnpm nx run-many -t build -p ${{ env.LIBRARY_PACKAGES }}
@@ -235,29 +256,27 @@ jobs:
       - name: Publish to npm
         if: ${{ github.event_name == 'workflow_call' || inputs.mode == 'publish' }}
         run: |
-          DIST_TAG="${{ inputs.dist-tag }}"
-          DIST_TAG="${DIST_TAG:-latest}"
           echo "Publishing with dist-tag: $DIST_TAG"
           for pkg in ${{ env.LIBRARY_PACKAGES }}; do
-            npm publish dist/packages/$pkg --access public --provenance --tag "$DIST_TAG"
+            npm publish "dist/packages/$pkg" --access public --provenance --tag "$DIST_TAG"
           done
 
       - name: Summary
         run: |
-          DIST_TAG="${{ inputs.dist-tag }}"
-          DIST_TAG="${DIST_TAG:-latest}"
-          echo "## Release v${{ env.VERSION }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Published packages (dist-tag: \`$DIST_TAG\`):" >> $GITHUB_STEP_SUMMARY
-          for pkg in ${{ env.LIBRARY_PACKAGES }}; do
-            echo "- \`@ng-forge/$pkg@${{ env.VERSION }}\`" >> $GITHUB_STEP_SUMMARY
-          done
-          echo "" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ inputs.create-github-release }}" != "false" ]; then
-            echo "### Links:" >> $GITHUB_STEP_SUMMARY
-            echo "- [GitHub Release](https://github.com/${{ github.repository }}/releases/tag/v${{ env.VERSION }})" >> $GITHUB_STEP_SUMMARY
-            echo "- [npm](https://www.npmjs.com/package/@ng-forge/dynamic-forms/v/${{ env.VERSION }})" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "### npm" >> $GITHUB_STEP_SUMMARY
-            echo "- [npm](https://www.npmjs.com/package/@ng-forge/dynamic-forms/v/${{ env.VERSION }})" >> $GITHUB_STEP_SUMMARY
-          fi
+          {
+            echo "## Release v${{ env.VERSION }}"
+            echo ""
+            echo "### Published packages (dist-tag: \`$DIST_TAG\`):"
+            for pkg in ${{ env.LIBRARY_PACKAGES }}; do
+              echo "- \`@ng-forge/$pkg@${{ env.VERSION }}\`"
+            done
+            echo ""
+            if [ "${{ inputs.create-github-release }}" != "false" ]; then
+              echo "### Links:"
+              echo "- [GitHub Release](https://github.com/${{ github.repository }}/releases/tag/v${{ env.VERSION }})"
+              echo "- [npm](https://www.npmjs.com/package/@ng-forge/dynamic-forms/v/${{ env.VERSION }})"
+            else
+              echo "### npm"
+              echo "- [npm](https://www.npmjs.com/package/@ng-forge/dynamic-forms/v/${{ env.VERSION }})"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
Adds nightly npm publishing and refactors `release.yml` so both stable releases and nightlies share a single Trusted Publisher entry on npm.

### `nightly.yml` (new)
- Cron-driven daily publish under the `nightly` dist-tag.
- Runs at **01:27 UTC** (~04:27 EEST) — minute offset to dodge GitHub's cron stampede.
- **Gate:** publishes only when `feat`/`fix`/`perf`/`revert` commits exist since the last stable `v*` tag. `docs`/`ci`/`chore`/`test`/`build`/`style`/`refactor` don't trigger a nightly (matches `nx.json`'s `semverBump: none` classification).
- **Version format:** `<next-patch>-nightly.<YYYYMMDD>.<short-sha>` — e.g. `0.7.1-nightly.20260422.8a21b2fbf`. SHA-in-version + `npm view` check makes the workflow idempotent across re-runs on the same commit.
- Does **not** git-commit, tag, or update `CHANGELOG.md`.
- Calls `release.yml` via `workflow_call` for the actual build + publish.

### `release.yml` (refactored to be reusable)
- Adds `workflow_call` trigger alongside the existing `workflow_dispatch` and `push: release-*` triggers — no behavior change for the stable release flow.
- New inputs: `version` (string, optional), `dist-tag` (string, default `latest`), `create-github-release` (boolean, default `true`).
- When `inputs.version` is set (workflow_call path), runs `nx release version <ver>` to bump source `package.json`s + inter-package peerDeps before build. Strips `preVersionCommand` at runtime to skip a wasted stale-version build.
- Tag, changelog, and GitHub-release steps are gated on `inputs.create-github-release` — defaults preserve the stable path; nightly passes `false`.
- `npm publish` now uses `--tag ${{ inputs.dist-tag || 'latest' }}` so `latest` is unaffected by nightlies.
- `release` job's `if:` loosened so it runs on `workflow_call` (where `check-ci` is skipped — the nightly gate is the caller's responsibility) as well as `workflow_dispatch` (after `check-ci` passes).

### Why one workflow + reusable, not two separate workflows
npm Trusted Publishers are tied to a specific workflow filename, and **only one entry is allowed per package**. Routing nightly through `release.yml` means the existing Trusted Publisher registration covers both stable and nightly publishes — no manual reconfiguration needed.

## Test plan
- [ ] Merge this PR.
- [ ] Manually `workflow_dispatch` the **Nightly** workflow on `main` to verify the gate computes the expected version and the publish succeeds end-to-end.
- [ ] Confirm `npm view @ng-forge/dynamic-forms dist-tags` shows `nightly` pointing at the new version, and `latest` is unchanged.
- [ ] Confirm `pnpm add @ng-forge/dynamic-forms@nightly` resolves the nightly build.
- [ ] Sanity-check that the next stable release flow (PR-based via `/release` skill) still works as before — no `version` input means the workflow uses the bumped `package.json`, runs the changelog/tag/release steps, and publishes under `latest`.

## Consumer usage
```bash
pnpm add @ng-forge/dynamic-forms@nightly
```
All 7 packages (`dynamic-forms`, `dynamic-forms-material`, `dynamic-forms-bootstrap`, `dynamic-forms-ionic`, `dynamic-forms-primeng`, `dynamic-form-mcp`, `openapi-generator`) publish together on the same nightly version.