### PR TITLE
chore(config): allow breaking-change exclamation mark in commit subjects

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -54,5 +54,9 @@ export default {
     'header-max-length': [2, 'always', 100],
     'body-leading-blank': [2, 'always'],
     'footer-leading-blank': [2, 'always'],
+    // Allow the Conventional Commits breaking-change marker (e.g. `feat!: ...`).
+    // The Angular preset disables this in favor of a `BREAKING CHANGE:` footer;
+    // we enable both so PR titles can flag breaking changes inline.
+    'subject-exclamation-mark': [0],
   },
 };


### PR DESCRIPTION
## Summary

- Disables the `subject-exclamation-mark` rule inherited from `@commitlint/config-angular`, so Conventional Commits breaking-change markers (`feat!: ...`, `feat(scope)!: ...`) are accepted in PR titles and commit subjects.
- `BREAKING CHANGE:` footer continues to work; both forms are now supported.
- Surfaced during PR #356 review, where a `feat!:` title was blocked despite being the correct marker for that PR's breaking change.

## Test plan

- [x] `echo "feat!: drop legacy API support" | pnpm exec commitlint` → passes
- [x] `echo "feat(forms)!: require new config shape" | pnpm exec commitlint` → passes
- [x] `echo "feat(forms): add async validator" | pnpm exec commitlint` → passes (non-breaking case unaffected)
- [x] `echo "wat: nonsense" | pnpm exec commitlint` → still fails with `type-enum`
- [x] `echo "feat(not-a-real-scope): x" | pnpm exec commitlint` → still fails with `scope-enum`