### PR TITLE
perf(dynamic-forms): phase 1 invisible bundle trim (~1.4 KB gz-min)

### DIFF
--- a/packages/dynamic-forms/src/lib/core/cross-field/cross-field-detector.ts
+++ b/packages/dynamic-forms/src/lib/core/cross-field/cross-field-detector.ts
@@ -11,20 +11,17 @@ import { CustomFunctionScope } from '../expressions/custom-function-types';
 const FORM_VALUE_ACCESS_PATTERN = /\bformValue\s*(?:\.|\[)/;
 
 /**
- * Regular expressions to extract field paths from formValue expressions.
+ * Combined regex for extracting field paths from formValue expressions.
  *
- * Enhanced to capture full nested paths including dot notation chains:
- * - formValue.fieldName → captures 'fieldName'
- * - formValue.parent.child.grandchild → captures 'parent.child.grandchild'
- * - formValue['field-name'] → captures 'field-name'
- * - formValue["field.with.dots"] → captures 'field.with.dots'
+ * Captures one of three groups per match:
+ * - group 1: dot notation (formValue.parent.child) — JS identifier chars only
+ * - group 2: single-quoted bracket (formValue['field-name']) — allows `-`
+ * - group 3: double-quoted bracket (formValue["field-name"]) — allows `-`
  *
  * Note: Computed property access (formValue[variableName]) is NOT supported
  * and must use explicit dependsOn configuration.
  */
-const FORM_VALUE_DOT_PATTERN = /\bformValue\.([\w.]+)/g;
-const FORM_VALUE_BRACKET_SINGLE_PATTERN = /\bformValue\s*\[\s*'([\w.-]+)'\s*\]/g;
-const FORM_VALUE_BRACKET_DOUBLE_PATTERN = /\bformValue\s*\[\s*"([\w.-]+)"\s*\]/g;
+const FORM_VALUE_PATTERN = /\bformValue\s*(?:\.([\w.]+)|\[\s*'([\w.-]+)'\s*\]|\[\s*"([\w.-]+)"\s*\])/g;
 
 /**
  * Context for cross-field detection, providing access to function scope information.
@@ -172,36 +169,13 @@ export function extractStringDependencies(expression: string): string[] {
  * - 'formValue.simple' → adds 'simple'
  */
 function extractFromExpressionString(expression: string, deps: Set<string>): void {
-  // Extract from dot notation: formValue.fieldName or formValue.parent.child.grandchild
-  const dotMatches = expression.matchAll(FORM_VALUE_DOT_PATTERN);
-  for (const match of dotMatches) {
-    const fullPath = match[1];
+  for (const match of expression.matchAll(FORM_VALUE_PATTERN)) {
+    const fullPath = match[1] ?? match[2] ?? match[3];
+    if (!fullPath) continue;
     // Always add the root field (first segment) as the primary dependency
     const rootField = fullPath.split('.')[0];
     deps.add(rootField);
     // Also add the full path for more precise dependency tracking if nested
-    if (fullPath.includes('.')) {
-      deps.add(fullPath);
-    }
-  }
-
-  // Extract from bracket notation with single quotes: formValue['fieldName']
-  const bracketSingleMatches = expression.matchAll(FORM_VALUE_BRACKET_SINGLE_PATTERN);
-  for (const match of bracketSingleMatches) {
-    const fullPath = match[1];
-    const rootField = fullPath.split('.')[0];
-    deps.add(rootField);
-    if (fullPath.includes('.')) {
-      deps.add(fullPath);
-    }
-  }
-
-  // Extract from bracket notation with double quotes: formValue["fieldName"]
-  const bracketDoubleMatches = expression.matchAll(FORM_VALUE_BRACKET_DOUBLE_PATTERN);
-  for (const match of bracketDoubleMatches) {
-    const fullPath = match[1];
-    const rootField = fullPath.split('.')[0];
-    deps.add(rootField);
     if (fullPath.includes('.')) {
       deps.add(fullPath);
     }

--- a/packages/dynamic-forms/src/lib/core/derivation/async-derivation-stream.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/async-derivation-stream.ts
@@ -12,7 +12,7 @@ import { getNestedValue } from '../expressions/value-utils';
 import { Logger } from '../../providers/features/logger/logger.interface';
 import { DerivationEntry } from './derivation-types';
 import { DerivationLogger } from './derivation-logger.service';
-import { DerivationWarningTracker } from './derivation-warning-tracker';
+import type { WarningTracker } from '../../utils/warning-tracker';
 import { readFieldDirty, resetFieldState, applyValueToForm } from './field-value-utils';
 import { readFieldStateInfo, createFormFieldStateMap } from './field-state-extractor';
 import type { FieldTreeRecord } from '../field-tree-utils';
@@ -45,7 +45,7 @@ export interface AsyncDerivationStreamContext {
   externalData?: () => Record<string, unknown> | undefined;
 
   /** Warning tracker to suppress duplicate missing-field warnings */
-  warningTracker?: DerivationWarningTracker;
+  warningTracker?: WarningTracker;
 }
 
 const LOG_PREFIX = 'Async Derivation -';

--- a/packages/dynamic-forms/src/lib/core/derivation/cycle-detector.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/cycle-detector.ts
@@ -374,7 +374,7 @@ export function validateNoCycles(collection: DerivationCollection, logger?: Logg
   // Warn about bidirectional patterns in dev mode
   if (DEV_MODE && result.bidirectionalPairs && result.bidirectionalPairs.length > 0 && logger) {
     logger.warn(
-      '[Derivation] Bidirectional derivation patterns detected. ' +
+      'Derivation - bidirectional derivation patterns detected. ' +
         'These patterns stabilize via equality checks, but may oscillate with floating-point values ' +
         '(e.g., currency conversions with rounding). ' +
         'Consider adding tolerance-based comparisons for numeric values.',

--- a/packages/dynamic-forms/src/lib/core/derivation/cycle-detector.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/cycle-detector.ts
@@ -374,7 +374,7 @@ export function validateNoCycles(collection: DerivationCollection, logger?: Logg
   // Warn about bidirectional patterns in dev mode
   if (DEV_MODE && result.bidirectionalPairs && result.bidirectionalPairs.length > 0 && logger) {
     logger.warn(
-      'Derivation - bidirectional derivation patterns detected. ' +
+      'Derivation: bidirectional derivation patterns detected. ' +
         'These patterns stabilize via equality checks, but may oscillate with floating-point values ' +
         '(e.g., currency conversions with rounding). ' +
         'Consider adding tolerance-based comparisons for numeric values.',

--- a/packages/dynamic-forms/src/lib/core/derivation/cycle-detector.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/cycle-detector.ts
@@ -1,4 +1,4 @@
-import { isDevMode } from '@angular/core';
+import { DEV_MODE } from '../../utils/dev-mode';
 import { CycleDetectionResult, DerivationCollection } from './derivation-types';
 import { Logger } from '../../providers/features/logger/logger.interface';
 
@@ -372,7 +372,7 @@ export function validateNoCycles(collection: DerivationCollection, logger?: Logg
   }
 
   // Warn about bidirectional patterns in dev mode
-  if (isDevMode() && result.bidirectionalPairs && result.bidirectionalPairs.length > 0 && logger) {
+  if (DEV_MODE && result.bidirectionalPairs && result.bidirectionalPairs.length > 0 && logger) {
     logger.warn(
       '[Derivation] Bidirectional derivation patterns detected. ' +
         'These patterns stabilize via equality checks, but may oscillate with floating-point values ' +

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-applicator.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-applicator.ts
@@ -19,7 +19,7 @@ import {
   DerivationEntry,
   DerivationProcessingResult,
 } from './derivation-types';
-import { DerivationWarningTracker } from './derivation-warning-tracker';
+import type { WarningTracker } from '../../utils/warning-tracker';
 import { MAX_DERIVATION_ITERATIONS } from './derivation-constants';
 import { DerivationLogger } from './derivation-logger.service';
 import { readFieldStateInfo, createFormFieldStateMap } from './field-state-extractor';
@@ -59,7 +59,7 @@ export interface DerivationApplicatorContext {
    * Instance-scoped warning tracker to prevent log spam.
    * If not provided, warnings will be logged every time.
    */
-  warningTracker?: DerivationWarningTracker;
+  warningTracker?: WarningTracker;
 
   /**
    * Derivation logger for debug output.

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-orchestrator.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-orchestrator.ts
@@ -350,7 +350,7 @@ export class DerivationOrchestrator {
         // Validate HttpClient availability
         if (!this.httpClient) {
           this.logger.error(
-            'HTTP Derivation - HttpClient is not available. ' + 'Ensure provideHttpClient() is included in your application providers.',
+            'HTTP Derivation: HttpClient is not available. ' + 'Ensure provideHttpClient() is included in your application providers.',
           );
           return;
         }
@@ -378,7 +378,7 @@ export class DerivationOrchestrator {
 
           this.httpSubscriptions.push(
             stream.subscribe({
-              error: (err) => this.logger.error(`HTTP Derivation - Stream error for '${entry.fieldKey}'`, err),
+              error: (err) => this.logger.error(`HTTP Derivation: Stream error for '${entry.fieldKey}'`, err),
             }),
           );
         }
@@ -462,7 +462,7 @@ export class DerivationOrchestrator {
 
           this.asyncFunctionSubscriptions.push(
             stream.subscribe({
-              error: (err) => this.logger.error(`Async Derivation - Stream error for '${entry.fieldKey}'`, err),
+              error: (err) => this.logger.error(`Async Derivation: Stream error for '${entry.fieldKey}'`, err),
             }),
           );
         }
@@ -591,7 +591,7 @@ function warnAboutWildcardDependencies(logger: Logger, entries: DerivationEntry[
   if (implicitWildcards.length > 0) {
     const derivationDescs = implicitWildcards.map((e) => `${e.fieldKey} (${e.functionName})`);
     logger.warn(
-      'Derivation - custom functions without explicit dependsOn detected. ' +
+      'Derivation: custom functions without explicit dependsOn detected. ' +
         `These run on EVERY form change, which may impact performance (form has ${fieldCount} fields). ` +
         'Consider specifying explicit dependsOn arrays for better performance.',
       derivationDescs,
@@ -605,7 +605,7 @@ function warnAboutMisconfiguredReEngagement(logger: Logger, entries: DerivationE
 
   const fieldKeys = misconfigured.map((e) => e.debugName ?? e.fieldKey);
   logger.warn(
-    'Derivation - reEngageOnDependencyChange without stopOnUserOverride detected. ' +
+    'Derivation: reEngageOnDependencyChange without stopOnUserOverride detected. ' +
       'reEngageOnDependencyChange only takes effect when stopOnUserOverride is true. ' +
       'Either add stopOnUserOverride: true or remove reEngageOnDependencyChange.',
     fieldKeys,

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-orchestrator.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-orchestrator.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@angular/common/http';
-import { computed, DestroyRef, inject, InjectionToken, Injector, isDevMode, isSignal, Signal, untracked } from '@angular/core';
+import { computed, DestroyRef, inject, InjectionToken, Injector, isSignal, Signal, untracked } from '@angular/core';
+import { DEV_MODE } from '../../utils/dev-mode';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { FieldTree } from '@angular/forms/signals';
 import {
@@ -121,8 +122,10 @@ export class DerivationOrchestrator {
       }
 
       validateNoCycles(collection, this.logger);
-      this.warnAboutWildcardDependencies(collection.entries, fields.length);
-      this.warnAboutMisconfiguredReEngagement(collection.entries);
+      if (DEV_MODE) {
+        this.warnAboutWildcardDependencies(collection.entries, fields.length);
+        this.warnAboutMisconfiguredReEngagement(collection.entries);
+      }
 
       return collection;
     });
@@ -508,8 +511,6 @@ export class DerivationOrchestrator {
   }
 
   private warnAboutWildcardDependencies(entries: DerivationEntry[], fieldCount: number): void {
-    if (!isDevMode()) return;
-
     // Find entries with wildcard dependency
     const wildcardEntries = entries.filter((entry) => entry.dependsOn.includes('*'));
     if (wildcardEntries.length === 0) return;
@@ -542,8 +543,6 @@ export class DerivationOrchestrator {
    * `stopOnUserOverride` is enabled — without it, `reEngageOnDependencyChange` is a no-op.
    */
   private warnAboutMisconfiguredReEngagement(entries: DerivationEntry[]): void {
-    if (!isDevMode()) return;
-
     const misconfigured = entries.filter((entry) => entry.reEngageOnDependencyChange && !entry.stopOnUserOverride);
     if (misconfigured.length === 0) return;
 

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-orchestrator.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-orchestrator.ts
@@ -23,6 +23,7 @@ import {
 import { FieldDef } from '../../definitions/base/field-def';
 import { FORM_OPTIONS } from '../../models/field-signal-context.token';
 import { DynamicFormLogger } from '../../providers/features/logger/logger.token';
+import { Logger } from '../../providers/features/logger/logger.interface';
 import { DEFAULT_DEBOUNCE_MS } from '../../utils/debounce/debounce';
 import { getChangedKeys } from '../../utils/object-utils';
 import { FunctionRegistryService } from '../registry';
@@ -123,8 +124,8 @@ export class DerivationOrchestrator {
 
       validateNoCycles(collection, this.logger);
       if (DEV_MODE) {
-        this.warnAboutWildcardDependencies(collection.entries, fields.length);
-        this.warnAboutMisconfiguredReEngagement(collection.entries);
+        warnAboutWildcardDependencies(this.logger, collection.entries, fields.length);
+        warnAboutMisconfiguredReEngagement(this.logger, collection.entries);
       }
 
       return collection;
@@ -510,51 +511,6 @@ export class DerivationOrchestrator {
     return Array.from(periods);
   }
 
-  private warnAboutWildcardDependencies(entries: DerivationEntry[], fieldCount: number): void {
-    // Find entries with wildcard dependency
-    const wildcardEntries = entries.filter((entry) => entry.dependsOn.includes('*'));
-    if (wildcardEntries.length === 0) return;
-
-    // Find implicit wildcards (custom functions without explicit dependsOn)
-    // HTTP and async entries are excluded because they require explicit dependsOn (validated at collection time)
-    const implicitWildcards = wildcardEntries.filter(
-      (entry) =>
-        !entry.http &&
-        !entry.asyncFunctionName &&
-        entry.functionName &&
-        (!entry.originalConfig?.dependsOn || entry.originalConfig.dependsOn.length === 0),
-    );
-
-    if (implicitWildcards.length > 0) {
-      const derivationDescs = implicitWildcards.map((e) => `${e.fieldKey} (${e.functionName})`);
-
-      this.logger.warn(
-        '[Derivation] Derivations using custom functions without explicit dependsOn detected. ' +
-          `These run on EVERY form change, which may impact performance (form has ${fieldCount} fields). ` +
-          'Consider specifying explicit dependsOn arrays for better performance.',
-        derivationDescs,
-      );
-    }
-  }
-
-  /**
-   * Warns about derivations with `reEngageOnDependencyChange: true` but without
-   * `stopOnUserOverride: true`. The re-engagement flag only has an effect when
-   * `stopOnUserOverride` is enabled — without it, `reEngageOnDependencyChange` is a no-op.
-   */
-  private warnAboutMisconfiguredReEngagement(entries: DerivationEntry[]): void {
-    const misconfigured = entries.filter((entry) => entry.reEngageOnDependencyChange && !entry.stopOnUserOverride);
-    if (misconfigured.length === 0) return;
-
-    const fieldKeys = misconfigured.map((e) => e.debugName ?? e.fieldKey);
-    this.logger.warn(
-      '[Derivation] Derivations with reEngageOnDependencyChange but without stopOnUserOverride detected. ' +
-        'reEngageOnDependencyChange only takes effect when stopOnUserOverride is true. ' +
-        'Either add stopOnUserOverride: true or remove reEngageOnDependencyChange.',
-      fieldKeys,
-    );
-  }
-
   /**
    * Resolves external data signals to their current values without creating dependencies.
    *
@@ -613,4 +569,45 @@ export const DERIVATION_ORCHESTRATOR = new InjectionToken<DerivationOrchestrator
  */
 export function injectDerivationOrchestrator(): DerivationOrchestrator {
   return inject(DERIVATION_ORCHESTRATOR);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dev-mode diagnostics (tree-shaken in prod via DEV_MODE gate at call site)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function warnAboutWildcardDependencies(logger: Logger, entries: DerivationEntry[], fieldCount: number): void {
+  const wildcardEntries = entries.filter((entry) => entry.dependsOn.includes('*'));
+  if (wildcardEntries.length === 0) return;
+
+  // HTTP and async entries require explicit dependsOn (validated at collection time)
+  const implicitWildcards = wildcardEntries.filter(
+    (entry) =>
+      !entry.http &&
+      !entry.asyncFunctionName &&
+      entry.functionName &&
+      (!entry.originalConfig?.dependsOn || entry.originalConfig.dependsOn.length === 0),
+  );
+
+  if (implicitWildcards.length > 0) {
+    const derivationDescs = implicitWildcards.map((e) => `${e.fieldKey} (${e.functionName})`);
+    logger.warn(
+      'Derivation - custom functions without explicit dependsOn detected. ' +
+        `These run on EVERY form change, which may impact performance (form has ${fieldCount} fields). ` +
+        'Consider specifying explicit dependsOn arrays for better performance.',
+      derivationDescs,
+    );
+  }
+}
+
+function warnAboutMisconfiguredReEngagement(logger: Logger, entries: DerivationEntry[]): void {
+  const misconfigured = entries.filter((entry) => entry.reEngageOnDependencyChange && !entry.stopOnUserOverride);
+  if (misconfigured.length === 0) return;
+
+  const fieldKeys = misconfigured.map((e) => e.debugName ?? e.fieldKey);
+  logger.warn(
+    'Derivation - reEngageOnDependencyChange without stopOnUserOverride detected. ' +
+      'reEngageOnDependencyChange only takes effect when stopOnUserOverride is true. ' +
+      'Either add stopOnUserOverride: true or remove reEngageOnDependencyChange.',
+    fieldKeys,
+  );
 }

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-warning-tracker.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-warning-tracker.ts
@@ -1,18 +1,13 @@
 import { InjectionToken } from '@angular/core';
+import { createWarningTracker, WarningTracker } from '../../utils/warning-tracker';
 
 /**
  * Tracks fields that have already been warned about to prevent log spam.
  * Scoped to a single form instance via DI.
  *
- * This replaces the module-level Set to avoid SSR/testing issues where
- * warnings from one form instance would suppress warnings for all others.
- *
  * @public
  */
-export interface DerivationWarningTracker {
-  /** Set of field keys we've already warned about */
-  warnedFields: Set<string>;
-}
+export type DerivationWarningTracker = WarningTracker;
 
 /**
  * Injection token for the derivation warning tracker.
@@ -22,16 +17,12 @@ export interface DerivationWarningTracker {
  */
 export const DERIVATION_WARNING_TRACKER = new InjectionToken<DerivationWarningTracker>('DerivationWarningTracker', {
   providedIn: null,
-  factory: () => ({ warnedFields: new Set<string>() }),
+  factory: createWarningTracker,
 });
 
 /**
  * Creates a fresh warning tracker instance.
  *
- * @returns A new DerivationWarningTracker with an empty warnedFields Set
- *
  * @public
  */
-export function createDerivationWarningTracker(): DerivationWarningTracker {
-  return { warnedFields: new Set<string>() };
-}
+export const createDerivationWarningTracker = createWarningTracker;

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-warning-tracker.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-warning-tracker.ts
@@ -1,28 +1,14 @@
 import { InjectionToken } from '@angular/core';
-import { createWarningTracker, WarningTracker } from '../../utils/warning-tracker';
-
-/**
- * Tracks fields that have already been warned about to prevent log spam.
- * Scoped to a single form instance via DI.
- *
- * @public
- */
-export type DerivationWarningTracker = WarningTracker;
+import { createWarningTracker, type WarningTracker } from '../../utils/warning-tracker';
 
 /**
  * Injection token for the derivation warning tracker.
- * Provided at form component level for instance-scoped tracking.
+ * Provided at form component level for instance-scoped tracking of derivation warnings
+ * (keyed by field path) so the same warning fires once per form rather than every render.
  *
- * @public
+ * @internal
  */
-export const DERIVATION_WARNING_TRACKER = new InjectionToken<DerivationWarningTracker>('DerivationWarningTracker', {
+export const DERIVATION_WARNING_TRACKER = new InjectionToken<WarningTracker>('DerivationWarningTracker', {
   providedIn: null,
   factory: createWarningTracker,
 });
-
-/**
- * Creates a fresh warning tracker instance.
- *
- * @public
- */
-export const createDerivationWarningTracker = createWarningTracker;

--- a/packages/dynamic-forms/src/lib/core/derivation/field-value-utils.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/field-value-utils.ts
@@ -182,10 +182,10 @@ function setFieldValue(
 export function warnMissingField(fieldKey: string, logger?: Logger, warningTracker?: DerivationWarningTracker): void {
   // If tracker is provided, check if we've already warned about this field
   if (warningTracker) {
-    if (warningTracker.warnedFields.has(fieldKey)) {
+    if (warningTracker.warnedKeys.has(fieldKey)) {
       return;
     }
-    warningTracker.warnedFields.add(fieldKey);
+    warningTracker.warnedKeys.add(fieldKey);
   }
 
   logger?.warn(

--- a/packages/dynamic-forms/src/lib/core/derivation/field-value-utils.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/field-value-utils.ts
@@ -5,12 +5,6 @@ import { Logger } from '../../providers/features/logger/logger.interface';
 import { DerivationWarningTracker } from './derivation-warning-tracker';
 
 /**
- * Error message prefix for derivation-related errors.
- * @internal
- */
-const ERROR_PREFIX = '[Derivation]';
-
-/**
  * Navigates the form tree to resolve a field instance at the given path.
  *
  * Walks the tree following the same pattern as `setFieldValue`:
@@ -189,7 +183,7 @@ export function warnMissingField(fieldKey: string, logger?: Logger, warningTrack
   }
 
   logger?.warn(
-    `${ERROR_PREFIX} Target field '${fieldKey}' not found in form. ` +
+    `Derivation - target field '${fieldKey}' not found in form. ` +
       `Ensure the field is defined in your form configuration. ` +
       `This warning is shown once per field.`,
   );

--- a/packages/dynamic-forms/src/lib/core/derivation/field-value-utils.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/field-value-utils.ts
@@ -2,7 +2,7 @@ import { isWritableSignal, untracked } from '@angular/core';
 import type { FieldState, FieldTree } from '@angular/forms/signals';
 import type { FieldTreeRecord } from '../field-tree-utils';
 import { Logger } from '../../providers/features/logger/logger.interface';
-import { DerivationWarningTracker } from './derivation-warning-tracker';
+import type { WarningTracker } from '../../utils/warning-tracker';
 
 /**
  * Navigates the form tree to resolve a field instance at the given path.
@@ -78,7 +78,7 @@ export function applyValueToForm(
   value: unknown,
   rootForm: FieldTree<unknown>,
   logger?: Logger,
-  warningTracker?: DerivationWarningTracker,
+  warningTracker?: WarningTracker,
 ): boolean {
   // Handle simple top-level fields
   if (!targetPath.includes('.')) {
@@ -133,7 +133,7 @@ function setFieldValue(
   fieldKey: string,
   value: unknown,
   logger?: Logger,
-  warningTracker?: DerivationWarningTracker,
+  warningTracker?: WarningTracker,
 ): boolean {
   const fieldAccessor = parent[fieldKey];
 
@@ -173,7 +173,7 @@ function setFieldValue(
  *
  * @internal
  */
-export function warnMissingField(fieldKey: string, logger?: Logger, warningTracker?: DerivationWarningTracker): void {
+export function warnMissingField(fieldKey: string, logger?: Logger, warningTracker?: WarningTracker): void {
   // If tracker is provided, check if we've already warned about this field
   if (warningTracker) {
     if (warningTracker.warnedKeys.has(fieldKey)) {
@@ -183,7 +183,7 @@ export function warnMissingField(fieldKey: string, logger?: Logger, warningTrack
   }
 
   logger?.warn(
-    `Derivation - target field '${fieldKey}' not found in form. ` +
+    `Derivation: target field '${fieldKey}' not found in form. ` +
       `Ensure the field is defined in your form configuration. ` +
       `This warning is shown once per field.`,
   );

--- a/packages/dynamic-forms/src/lib/core/derivation/http-derivation-stream.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/http-derivation-stream.ts
@@ -14,7 +14,7 @@ import { resolveHttpRequest } from '../http/http-request-resolver';
 import { Logger } from '../../providers/features/logger/logger.interface';
 import { DerivationEntry } from './derivation-types';
 import { DerivationLogger } from './derivation-logger.service';
-import { DerivationWarningTracker } from './derivation-warning-tracker';
+import type { WarningTracker } from '../../utils/warning-tracker';
 import { readFieldDirty, resetFieldState, applyValueToForm } from './field-value-utils';
 import { readFieldStateInfo, createFormFieldStateMap } from './field-state-extractor';
 import type { FieldTreeRecord } from '../field-tree-utils';
@@ -47,7 +47,7 @@ export interface HttpDerivationStreamContext {
   externalData?: () => Record<string, unknown> | undefined;
 
   /** Warning tracker to suppress duplicate missing-field warnings */
-  warningTracker?: DerivationWarningTracker;
+  warningTracker?: WarningTracker;
 
   /**
    * Observable that emits when the current generation of streams should be torn down.

--- a/packages/dynamic-forms/src/lib/core/derivation/index.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/index.ts
@@ -23,8 +23,7 @@ export type { DerivationApplicatorContext } from './derivation-applicator';
 export { applyDerivations, applyDerivationsForTrigger, getDebouncedDerivationEntries } from './derivation-applicator';
 
 // Warning Tracker
-export type { DerivationWarningTracker } from './derivation-warning-tracker';
-export { DERIVATION_WARNING_TRACKER, createDerivationWarningTracker } from './derivation-warning-tracker';
+export { DERIVATION_WARNING_TRACKER } from './derivation-warning-tracker';
 
 // Constants
 export { MAX_DERIVATION_ITERATIONS, ARRAY_PLACEHOLDER, MAX_AST_CACHE_SIZE, DERIVATION_KEY_DELIMITER } from './derivation-constants';

--- a/packages/dynamic-forms/src/lib/core/expressions/async-condition-logic-function.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/async-condition-logic-function.spec.ts
@@ -10,7 +10,8 @@ import { RootFormRegistryService } from '../registry/root-form-registry.service'
 import { FormStateManager } from '../../state/form-state-manager';
 import { DynamicFormLogger } from '../../providers/features/logger/logger.token';
 import { createMockLogger, MockLogger } from '../../../../testing/src/mock-logger';
-import { createDeprecationWarningTracker, DEPRECATION_WARNING_TRACKER } from '../../utils/deprecation-warning-tracker';
+import { DEPRECATION_WARNING_TRACKER } from '../../utils/deprecation-warning-tracker';
+import { createWarningTracker } from '../../utils/warning-tracker';
 import { createAsyncConditionLogicFunction } from './async-condition-logic-function';
 import { AsyncConditionFunctionCacheService } from './async-condition-function-cache.service';
 import { LogicFunctionCacheService } from './logic-function-cache.service';
@@ -35,7 +36,7 @@ describe('createAsyncConditionLogicFunction', () => {
         { provide: RootFormRegistryService, useValue: { formValue: mockEntity, rootForm: mockFormSignal } },
         { provide: FormStateManager, useValue: { activeConfig: signal(undefined) } },
         { provide: DynamicFormLogger, useValue: mockLogger },
-        { provide: DEPRECATION_WARNING_TRACKER, useFactory: createDeprecationWarningTracker },
+        { provide: DEPRECATION_WARNING_TRACKER, useFactory: createWarningTracker },
         AsyncConditionFunctionCacheService,
         LogicFunctionCacheService,
         DynamicValueFunctionCacheService,

--- a/packages/dynamic-forms/src/lib/core/expressions/http-condition-logic-function.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/http-condition-logic-function.spec.ts
@@ -12,7 +12,8 @@ import { FormStateManager } from '../../state/form-state-manager';
 import { HTTP_CONDITION_CACHE, HttpConditionCache } from '../http/http-condition-cache';
 import { DynamicFormLogger } from '../../providers/features/logger/logger.token';
 import { createMockLogger, MockLogger } from '../../../../testing/src/mock-logger';
-import { createDeprecationWarningTracker, DEPRECATION_WARNING_TRACKER } from '../../utils/deprecation-warning-tracker';
+import { DEPRECATION_WARNING_TRACKER } from '../../utils/deprecation-warning-tracker';
+import { createWarningTracker } from '../../utils/warning-tracker';
 import { createHttpConditionLogicFunction } from './http-condition-logic-function';
 import { HttpConditionFunctionCacheService } from './http-condition-function-cache.service';
 import { LogicFunctionCacheService } from './logic-function-cache.service';
@@ -40,7 +41,7 @@ describe('createHttpConditionLogicFunction', () => {
         { provide: RootFormRegistryService, useValue: { formValue: mockEntity, rootForm: mockFormSignal } },
         { provide: FormStateManager, useValue: { activeConfig: signal(undefined) } },
         { provide: DynamicFormLogger, useValue: mockLogger },
-        { provide: DEPRECATION_WARNING_TRACKER, useFactory: createDeprecationWarningTracker },
+        { provide: DEPRECATION_WARNING_TRACKER, useFactory: createWarningTracker },
         { provide: HttpClient, useValue: httpClient },
         { provide: HTTP_CONDITION_CACHE, useValue: conditionCache },
         HttpConditionFunctionCacheService,

--- a/packages/dynamic-forms/src/lib/core/expressions/logic-function-factory.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/logic-function-factory.spec.ts
@@ -10,7 +10,8 @@ import { FormStateManager } from '../../state/form-state-manager';
 import { createLogicFunction, createDebouncedLogicFunction } from './logic-function-factory';
 import { DynamicFormLogger } from '../../providers/features/logger/logger.token';
 import { createMockLogger, MockLogger } from '../../../../testing/src/mock-logger';
-import { createDeprecationWarningTracker, DEPRECATION_WARNING_TRACKER } from '../../utils/deprecation-warning-tracker';
+import { DEPRECATION_WARNING_TRACKER } from '../../utils/deprecation-warning-tracker';
+import { createWarningTracker } from '../../utils/warning-tracker';
 import { HTTP_CONDITION_CACHE, HttpConditionCache } from '../http/http-condition-cache';
 import { LogicFunctionCacheService } from './logic-function-cache.service';
 import { HttpConditionFunctionCacheService } from './http-condition-function-cache.service';
@@ -34,7 +35,7 @@ describe('logic-function-factory', () => {
         { provide: RootFormRegistryService, useValue: { formValue: mockEntity, rootForm: mockFormSignal } },
         { provide: FormStateManager, useValue: { activeConfig: signal(undefined) } },
         { provide: DynamicFormLogger, useValue: mockLogger },
-        { provide: DEPRECATION_WARNING_TRACKER, useFactory: createDeprecationWarningTracker },
+        { provide: DEPRECATION_WARNING_TRACKER, useFactory: createWarningTracker },
         { provide: HttpClient, useValue: { request: vi.fn().mockReturnValue(of({ allowed: true })) } },
         { provide: HTTP_CONDITION_CACHE, useValue: new HttpConditionCache() },
         LogicFunctionCacheService,

--- a/packages/dynamic-forms/src/lib/core/logic/logic-applicator.ts
+++ b/packages/dynamic-forms/src/lib/core/logic/logic-applicator.ts
@@ -1,5 +1,5 @@
-import { isDevMode } from '@angular/core';
 import { disabled, hidden, readonly, required, LogicFn } from '@angular/forms/signals';
+import { DEV_MODE } from '../../utils/dev-mode';
 import type { SchemaPath, SchemaPathTree } from '@angular/forms/signals';
 import {
   LogicConfig,
@@ -45,7 +45,7 @@ export function applyLogic<TValue>(config: LogicConfig, fieldPath: SchemaPath<TV
 
   // Guard against unrecognized logic types that may be added in the future.
   if (!isStateLogicConfig(config)) {
-    if (isDevMode()) {
+    if (DEV_MODE) {
       console.warn(
         `[Dynamic Forms] Unrecognized logic config type '${(config as { type: string }).type}' in applyLogic. ` +
           'This config will be ignored. If this is a new logic type, ensure it is handled explicitly.',

--- a/packages/dynamic-forms/src/lib/core/property-derivation/apply-property-overrides.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/apply-property-overrides.ts
@@ -1,4 +1,4 @@
-import { isDevMode } from '@angular/core';
+import { DEV_MODE } from '../../utils/dev-mode';
 import { DynamicFormError } from '../../errors/dynamic-form-error';
 import { BaseValueField } from '../../definitions/base/base-value-field';
 import { FieldWithValidation } from '../../definitions/base/field-with-validation';
@@ -81,7 +81,7 @@ export function applyPropertyOverrides(inputs: Record<string, unknown>, override
     // Dev-mode check: warn only when a known standard field property is missing from inputs,
     // which likely indicates a typo. Dynamic/custom keys are intentionally skipped to avoid
     // false positives for properties added by derivations that aren't in the initial config.
-    if (isDevMode()) {
+    if (DEV_MODE) {
       const topLevelKey = dotIndex === -1 ? key : key.substring(0, dotIndex);
       if (KNOWN_FIELD_PROPERTIES.has(topLevelKey) && !(topLevelKey in inputs)) {
         console.warn(

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-applicator.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-applicator.ts
@@ -9,7 +9,7 @@ import { evaluateCondition } from '../expressions/condition-evaluator';
 import { ExpressionParser } from '../expressions/parser/expression-parser';
 import { getNestedValue } from '../expressions/value-utils';
 import { Logger } from '../../providers/features/logger/logger.interface';
-import { DerivationWarningTracker } from '../derivation/derivation-warning-tracker';
+import type { WarningTracker } from '../../utils/warning-tracker';
 import { PropertyDerivationCollection, PropertyDerivationEntry } from './property-derivation-types';
 import { PropertyOverrideStore } from './property-override-store';
 
@@ -38,7 +38,7 @@ export interface PropertyDerivationApplicatorContext {
   logger: Logger;
 
   /** Warning tracker to prevent log spam */
-  warningTracker?: DerivationWarningTracker;
+  warningTracker?: WarningTracker;
 }
 
 /**

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-collector.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-collector.spec.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { collectPropertyDerivations } from './property-derivation-collector';
 import { FieldDef } from '../../definitions/base/field-def';
 import { createMockLogger } from '../../../../testing/src/mock-logger';
-import { createDeprecationWarningTracker } from '../../utils/deprecation-warning-tracker';
+import { createWarningTracker } from '../../utils/warning-tracker';
 
 describe('property-derivation-collector', () => {
   const logger = createMockLogger();
-  const tracker = createDeprecationWarningTracker();
+  const tracker = createWarningTracker();
 
   describe('collectPropertyDerivations', () => {
     it('should return empty collection when no fields have propertyDerivation logic', () => {

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-collector.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-collector.ts
@@ -3,7 +3,7 @@ import { FieldWithValidation } from '../../definitions/base/field-with-validatio
 import { DerivationLogicConfig, isDerivationLogicConfig, hasTargetProperty } from '../../models/logic/logic-config';
 import { hasChildFields } from '../../models/types/type-guards';
 import { Logger } from '../../providers/features/logger/logger.interface';
-import { DeprecationWarningTracker } from '../../utils/deprecation-warning-tracker';
+import type { WarningTracker } from '../../utils/warning-tracker';
 import { normalizeFieldsArray } from '../../utils/object-utils';
 import { extractExpressionDependencies, extractStringDependencies } from '../cross-field/cross-field-detector';
 import { buildPropertyOverrideKey, PLACEHOLDER_INDEX } from './property-override-key';
@@ -18,7 +18,7 @@ interface CollectionContext {
   /** Current array path for resolving relative field references. */
   arrayPath?: string;
   logger: Logger;
-  tracker: DeprecationWarningTracker;
+  tracker: WarningTracker;
 }
 
 /**
@@ -38,7 +38,7 @@ interface CollectionContext {
 export function collectPropertyDerivations(
   fields: FieldDef<unknown>[],
   logger: Logger,
-  tracker: DeprecationWarningTracker,
+  tracker: WarningTracker,
 ): PropertyDerivationCollection {
   const entries: PropertyDerivationEntry[] = [];
   const context: CollectionContext = { logger, tracker };

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-orchestrator.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-orchestrator.spec.ts
@@ -8,8 +8,9 @@ import { DynamicFormLogger } from '../../providers/features/logger/logger.token'
 import { createMockLogger, MockLogger } from '../../../../testing/src/mock-logger';
 import { DEFAULT_DEBOUNCE_MS } from '../../utils/debounce/debounce';
 import { FunctionRegistryService } from '../registry/function-registry.service';
-import { createDerivationWarningTracker, DERIVATION_WARNING_TRACKER } from '../derivation/derivation-warning-tracker';
-import { createDeprecationWarningTracker, DEPRECATION_WARNING_TRACKER } from '../../utils/deprecation-warning-tracker';
+import { DERIVATION_WARNING_TRACKER } from '../derivation/derivation-warning-tracker';
+import { DEPRECATION_WARNING_TRACKER } from '../../utils/deprecation-warning-tracker';
+import { createWarningTracker } from '../../utils/warning-tracker';
 import { createPropertyOverrideStore, PropertyOverrideStore } from './property-override-store';
 import { PropertyDerivationOrchestrator, PropertyDerivationOrchestratorConfig } from './property-derivation-orchestrator';
 
@@ -93,14 +94,8 @@ describe('PropertyDerivationOrchestrator', () => {
       providers: [
         FunctionRegistryService,
         { provide: DynamicFormLogger, useValue: mockLogger },
-        {
-          provide: DERIVATION_WARNING_TRACKER,
-          useFactory: createDerivationWarningTracker,
-        },
-        {
-          provide: DEPRECATION_WARNING_TRACKER,
-          useFactory: createDeprecationWarningTracker,
-        },
+        { provide: DERIVATION_WARNING_TRACKER, useFactory: createWarningTracker },
+        { provide: DEPRECATION_WARNING_TRACKER, useFactory: createWarningTracker },
         { provide: FORM_OPTIONS, useValue: signal(undefined) },
       ],
     });

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-orchestrator.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-orchestrator.ts
@@ -1,4 +1,5 @@
-import { computed, DestroyRef, inject, InjectionToken, Injector, isDevMode, isSignal, Signal, untracked } from '@angular/core';
+import { computed, DestroyRef, inject, InjectionToken, Injector, isSignal, Signal, untracked } from '@angular/core';
+import { DEV_MODE } from '../../utils/dev-mode';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { explicitEffect } from 'ngxtension/explicit-effect';
 import {
@@ -107,7 +108,9 @@ export class PropertyDerivationOrchestrator {
         config.store.registerField(entry.fieldKey);
       }
 
-      this.warnAboutWildcardDependencies(collection.entries, fields?.length ?? 0);
+      if (DEV_MODE) {
+        this.warnAboutWildcardDependencies(collection.entries, fields?.length ?? 0);
+      }
     });
 
     this.setupOnChangeStream();
@@ -224,8 +227,6 @@ export class PropertyDerivationOrchestrator {
   }
 
   private warnAboutWildcardDependencies(entries: PropertyDerivationEntry[], fieldCount: number): void {
-    if (!isDevMode()) return;
-
     const implicitWildcards = entries.filter(
       (entry) =>
         entry.dependsOn.includes('*') &&

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-orchestrator.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-orchestrator.ts
@@ -21,6 +21,7 @@ import {
 import { FieldDef } from '../../definitions/base/field-def';
 import { FORM_OPTIONS } from '../../models/field-signal-context.token';
 import { DynamicFormLogger } from '../../providers/features/logger/logger.token';
+import { Logger } from '../../providers/features/logger/logger.interface';
 import { DEFAULT_DEBOUNCE_MS } from '../../utils/debounce/debounce';
 import { getChangedKeys } from '../../utils/object-utils';
 import { FunctionRegistryService } from '../registry';
@@ -109,7 +110,7 @@ export class PropertyDerivationOrchestrator {
       }
 
       if (DEV_MODE) {
-        this.warnAboutWildcardDependencies(collection.entries, fields?.length ?? 0);
+        warnAboutWildcardDependencies(this.logger, collection.entries, fields?.length ?? 0);
       }
     });
 
@@ -226,26 +227,6 @@ export class PropertyDerivationOrchestrator {
     return Array.from(periods);
   }
 
-  private warnAboutWildcardDependencies(entries: PropertyDerivationEntry[], fieldCount: number): void {
-    const implicitWildcards = entries.filter(
-      (entry) =>
-        entry.dependsOn.includes('*') &&
-        entry.functionName &&
-        (!entry.originalConfig?.dependsOn || entry.originalConfig.dependsOn.length === 0),
-    );
-
-    if (implicitWildcards.length > 0) {
-      const derivationDescs = implicitWildcards.map((e) => `${e.fieldKey}.${e.targetProperty} (${e.functionName})`);
-
-      this.logger.warn(
-        '[PropertyDerivation] Property derivations using custom functions without explicit dependsOn detected. ' +
-          `These run on EVERY form change, which may impact performance (form has ${fieldCount} fields). ` +
-          'Consider specifying explicit dependsOn arrays for better performance.',
-        derivationDescs,
-      );
-    }
-  }
-
   /**
    * Resolves external data signals to their current values.
    *
@@ -292,3 +273,26 @@ export function createPropertyDerivationOrchestrator(config: PropertyDerivationO
  * @public
  */
 export const PROPERTY_DERIVATION_ORCHESTRATOR = new InjectionToken<PropertyDerivationOrchestrator>('PROPERTY_DERIVATION_ORCHESTRATOR');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dev-mode diagnostics (tree-shaken in prod via DEV_MODE gate at call site)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function warnAboutWildcardDependencies(logger: Logger, entries: PropertyDerivationEntry[], fieldCount: number): void {
+  const implicitWildcards = entries.filter(
+    (entry) =>
+      entry.dependsOn.includes('*') &&
+      entry.functionName &&
+      (!entry.originalConfig?.dependsOn || entry.originalConfig.dependsOn.length === 0),
+  );
+
+  if (implicitWildcards.length > 0) {
+    const derivationDescs = implicitWildcards.map((e) => `${e.fieldKey}.${e.targetProperty} (${e.functionName})`);
+    logger.warn(
+      'PropertyDerivation - custom functions without explicit dependsOn detected. ' +
+        `These run on EVERY form change, which may impact performance (form has ${fieldCount} fields). ` +
+        'Consider specifying explicit dependsOn arrays for better performance.',
+      derivationDescs,
+    );
+  }
+}

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-orchestrator.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-orchestrator.ts
@@ -289,7 +289,7 @@ function warnAboutWildcardDependencies(logger: Logger, entries: PropertyDerivati
   if (implicitWildcards.length > 0) {
     const derivationDescs = implicitWildcards.map((e) => `${e.fieldKey}.${e.targetProperty} (${e.functionName})`);
     logger.warn(
-      'PropertyDerivation - custom functions without explicit dependsOn detected. ' +
+      'PropertyDerivation: custom functions without explicit dependsOn detected. ' +
         `These run on EVERY form change, which may impact performance (form has ${fieldCount} fields). ` +
         'Consider specifying explicit dependsOn arrays for better performance.',
       derivationDescs,

--- a/packages/dynamic-forms/src/lib/core/validation/async-http-validator.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/validation/async-http-validator.spec.ts
@@ -9,7 +9,8 @@ import { applyValidator } from './validator-factory';
 import { AsyncCustomValidator, HttpCustomValidator } from './validator-types';
 import { DynamicFormLogger } from '../../providers/features/logger/logger.token';
 import { ConsoleLogger } from '../../providers/features/logger/console-logger';
-import { createDeprecationWarningTracker, DEPRECATION_WARNING_TRACKER } from '../../utils/deprecation-warning-tracker';
+import { DEPRECATION_WARNING_TRACKER } from '../../utils/deprecation-warning-tracker';
+import { createWarningTracker } from '../../utils/warning-tracker';
 import { LogicFunctionCacheService } from '../expressions/logic-function-cache.service';
 import { HttpConditionFunctionCacheService } from '../expressions/http-condition-function-cache.service';
 import { DynamicValueFunctionCacheService } from '../values/dynamic-value-function-cache.service';
@@ -38,7 +39,7 @@ describe('Async and HTTP Validator Integration', () => {
         FieldContextRegistryService,
         // Provide ConsoleLogger to enable logging in tests
         { provide: DynamicFormLogger, useValue: new ConsoleLogger() },
-        { provide: DEPRECATION_WARNING_TRACKER, useFactory: createDeprecationWarningTracker },
+        { provide: DEPRECATION_WARNING_TRACKER, useFactory: createWarningTracker },
         LogicFunctionCacheService,
         HttpConditionFunctionCacheService,
         DynamicValueFunctionCacheService,

--- a/packages/dynamic-forms/src/lib/core/validation/validator-factory.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/validation/validator-factory.spec.ts
@@ -6,7 +6,8 @@ import { ValidatorConfig } from '../../models/validation/validator-config';
 import { RootFormRegistryService, FunctionRegistryService, FieldContextRegistryService } from '../registry';
 import { FormStateManager } from '../../state/form-state-manager';
 import { DynamicFormLogger } from '../../providers/features/logger/logger.token';
-import { DEPRECATION_WARNING_TRACKER, createDeprecationWarningTracker } from '../../utils/deprecation-warning-tracker';
+import { DEPRECATION_WARNING_TRACKER } from '../../utils/deprecation-warning-tracker';
+import { createWarningTracker } from '../../utils/warning-tracker';
 import { applyValidator, applyValidators } from './validator-factory';
 import { LogicFunctionCacheService } from '../expressions/logic-function-cache.service';
 import { HttpConditionFunctionCacheService } from '../expressions/http-condition-function-cache.service';
@@ -39,7 +40,7 @@ describe('validator-factory', () => {
         { provide: RootFormRegistryService, useValue: { formValue: mockEntity, rootForm: mockFormSignal } },
         { provide: FormStateManager, useValue: { activeConfig: signal(undefined) } },
         { provide: DynamicFormLogger, useValue: mockLogger },
-        { provide: DEPRECATION_WARNING_TRACKER, useFactory: createDeprecationWarningTracker },
+        { provide: DEPRECATION_WARNING_TRACKER, useFactory: createWarningTracker },
         FunctionRegistryService,
         FieldContextRegistryService,
         LogicFunctionCacheService,

--- a/packages/dynamic-forms/src/lib/events/event.bus.ts
+++ b/packages/dynamic-forms/src/lib/events/event.bus.ts
@@ -163,7 +163,7 @@ export class EventBus {
     try {
       this.pipeline$.next(event);
     } catch (err: unknown) {
-      this.logger.error('[Dynamic Forms] Exception in EventBus subscriber during dispatch', err);
+      this.logger.error('Exception in EventBus subscriber during dispatch', err);
     }
   }
 

--- a/packages/dynamic-forms/src/lib/models/expressions/evaluation-context.ts
+++ b/packages/dynamic-forms/src/lib/models/expressions/evaluation-context.ts
@@ -1,5 +1,5 @@
 import type { Logger } from '../../providers/features/logger/logger.interface';
-import type { DeprecationWarningTracker } from '../../utils/deprecation-warning-tracker';
+import type { WarningTracker } from '../../utils/warning-tracker';
 import type { FieldStateContext, FormFieldStateMap } from './field-state-context';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- default `any` for TFormValue ensures backward compatibility at registry boundaries
@@ -87,7 +87,7 @@ export interface EvaluationContext<TValue = unknown, TFormValue extends Record<s
    * DI-scoped tracker for deprecation warnings.
    * Used by the condition evaluator to deduplicate deprecation warnings.
    */
-  deprecationTracker?: DeprecationWarningTracker;
+  deprecationTracker?: WarningTracker;
 
   /**
    * State of the current field being evaluated.

--- a/packages/dynamic-forms/src/lib/providers/dynamic-form-di.ts
+++ b/packages/dynamic-forms/src/lib/providers/dynamic-form-di.ts
@@ -13,8 +13,9 @@ import {
   EXTERNAL_DATA,
   FORM_OPTIONS,
 } from '../models/field-signal-context.token';
-import { DERIVATION_WARNING_TRACKER, createDerivationWarningTracker } from '../core/derivation/derivation-warning-tracker';
-import { DEPRECATION_WARNING_TRACKER, createDeprecationWarningTracker } from '../utils/deprecation-warning-tracker';
+import { DERIVATION_WARNING_TRACKER } from '../core/derivation/derivation-warning-tracker';
+import { DEPRECATION_WARNING_TRACKER } from '../utils/deprecation-warning-tracker';
+import { createWarningTracker } from '../utils/warning-tracker';
 import {
   DERIVATION_ORCHESTRATOR,
   createDerivationOrchestrator,
@@ -90,8 +91,8 @@ export function provideDynamicFormDI(): Provider[] {
       useFactory: (stateManager: FormStateManager) => computed(() => stateManager.activeConfig()?.externalData),
       deps: [FormStateManager],
     },
-    { provide: DERIVATION_WARNING_TRACKER, useFactory: createDerivationWarningTracker },
-    { provide: DEPRECATION_WARNING_TRACKER, useFactory: createDeprecationWarningTracker },
+    { provide: DERIVATION_WARNING_TRACKER, useFactory: createWarningTracker },
+    { provide: DEPRECATION_WARNING_TRACKER, useFactory: createWarningTracker },
     {
       provide: DERIVATION_ORCHESTRATOR,
       useFactory: (

--- a/packages/dynamic-forms/src/lib/utils/deprecation-warning-tracker.ts
+++ b/packages/dynamic-forms/src/lib/utils/deprecation-warning-tracker.ts
@@ -1,25 +1,11 @@
 import { InjectionToken } from '@angular/core';
-import { createWarningTracker, WarningTracker } from './warning-tracker';
-
-/**
- * Tracks deprecated API usages that have already been warned about to prevent log spam.
- * Scoped to a single form instance via DI (never module-scoped — SSR-unsafe).
- *
- * @public
- */
-export type DeprecationWarningTracker = WarningTracker;
+import type { WarningTracker } from './warning-tracker';
 
 /**
  * Injection token for the deprecation warning tracker.
- * Provided at form component level for instance-scoped tracking.
+ * Provided at form component level for instance-scoped tracking of deprecated API usages
+ * (keyed by deprecation id) so the same warning fires once per form rather than every render.
  *
- * @public
+ * @internal
  */
-export const DEPRECATION_WARNING_TRACKER = new InjectionToken<DeprecationWarningTracker>('DeprecationWarningTracker');
-
-/**
- * Creates a fresh deprecation warning tracker instance.
- *
- * @public
- */
-export const createDeprecationWarningTracker = createWarningTracker;
+export const DEPRECATION_WARNING_TRACKER = new InjectionToken<WarningTracker>('DeprecationWarningTracker');

--- a/packages/dynamic-forms/src/lib/utils/deprecation-warning-tracker.ts
+++ b/packages/dynamic-forms/src/lib/utils/deprecation-warning-tracker.ts
@@ -1,18 +1,13 @@
 import { InjectionToken } from '@angular/core';
+import { createWarningTracker, WarningTracker } from './warning-tracker';
 
 /**
  * Tracks deprecated API usages that have already been warned about to prevent log spam.
- * Scoped to a single form instance via DI.
- *
- * This follows the same pattern as DerivationWarningTracker — DI-scoped rather than
- * module-scoped to avoid SSR issues where state would be shared across requests.
+ * Scoped to a single form instance via DI (never module-scoped — SSR-unsafe).
  *
  * @public
  */
-export interface DeprecationWarningTracker {
-  /** Set of deprecation keys we've already warned about */
-  warnedKeys: Set<string>;
-}
+export type DeprecationWarningTracker = WarningTracker;
 
 /**
  * Injection token for the deprecation warning tracker.
@@ -25,10 +20,6 @@ export const DEPRECATION_WARNING_TRACKER = new InjectionToken<DeprecationWarning
 /**
  * Creates a fresh deprecation warning tracker instance.
  *
- * @returns A new DeprecationWarningTracker with an empty warnedKeys Set
- *
  * @public
  */
-export function createDeprecationWarningTracker(): DeprecationWarningTracker {
-  return { warnedKeys: new Set<string>() };
-}
+export const createDeprecationWarningTracker = createWarningTracker;

--- a/packages/dynamic-forms/src/lib/utils/deprecation-warnings.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/deprecation-warnings.spec.ts
@@ -19,7 +19,7 @@ describe('deprecation-warnings', () => {
       warnDeprecated(logger, tracker, 'test-key', 'Test message');
 
       expect(logger.warn).toHaveBeenCalledOnce();
-      expect(logger.warn).toHaveBeenCalledWith('[Dynamic Forms] DEPRECATED: Test message');
+      expect(logger.warn).toHaveBeenCalledWith('DEPRECATED: Test message');
     });
 
     it('should fire only once per key (idempotent)', () => {
@@ -35,8 +35,8 @@ describe('deprecation-warnings', () => {
       warnDeprecated(logger, tracker, 'key-b', 'Message B');
 
       expect(logger.warn).toHaveBeenCalledTimes(2);
-      expect(logger.warn).toHaveBeenCalledWith('[Dynamic Forms] DEPRECATED: Message A');
-      expect(logger.warn).toHaveBeenCalledWith('[Dynamic Forms] DEPRECATED: Message B');
+      expect(logger.warn).toHaveBeenCalledWith('DEPRECATED: Message A');
+      expect(logger.warn).toHaveBeenCalledWith('DEPRECATED: Message B');
     });
 
     it('should track warned keys in the tracker', () => {

--- a/packages/dynamic-forms/src/lib/utils/deprecation-warnings.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/deprecation-warnings.spec.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import { warnDeprecated } from './deprecation-warnings';
-import { createDeprecationWarningTracker, DeprecationWarningTracker } from './deprecation-warning-tracker';
+import { createWarningTracker, type WarningTracker } from './warning-tracker';
 import { createMockLogger, MockLogger } from '../../../testing/src/mock-logger';
 
 describe('deprecation-warnings', () => {
   let logger: MockLogger;
-  let tracker: DeprecationWarningTracker;
+  let tracker: WarningTracker;
 
   beforeEach(() => {
     logger = createMockLogger();
-    tracker = createDeprecationWarningTracker();
+    tracker = createWarningTracker();
   });
 
   describe('warnDeprecated', () => {

--- a/packages/dynamic-forms/src/lib/utils/deprecation-warnings.ts
+++ b/packages/dynamic-forms/src/lib/utils/deprecation-warnings.ts
@@ -16,6 +16,6 @@ import { DEV_MODE } from './dev-mode';
 export function warnDeprecated(logger: Logger, tracker: DeprecationWarningTracker, id: string, message: string): void {
   if (DEV_MODE && !tracker.warnedKeys.has(id)) {
     tracker.warnedKeys.add(id);
-    logger.warn(`[Dynamic Forms] DEPRECATED: ${message}`);
+    logger.warn(`DEPRECATED: ${message}`);
   }
 }

--- a/packages/dynamic-forms/src/lib/utils/deprecation-warnings.ts
+++ b/packages/dynamic-forms/src/lib/utils/deprecation-warnings.ts
@@ -1,6 +1,6 @@
-import { isDevMode } from '@angular/core';
 import { Logger } from '../providers/features/logger/logger.interface';
 import { DeprecationWarningTracker } from './deprecation-warning-tracker';
+import { DEV_MODE } from './dev-mode';
 
 /**
  * Emits a deprecation warning once per unique key in dev mode only.
@@ -14,7 +14,7 @@ import { DeprecationWarningTracker } from './deprecation-warning-tracker';
  * @public
  */
 export function warnDeprecated(logger: Logger, tracker: DeprecationWarningTracker, id: string, message: string): void {
-  if (isDevMode() && !tracker.warnedKeys.has(id)) {
+  if (DEV_MODE && !tracker.warnedKeys.has(id)) {
     tracker.warnedKeys.add(id);
     logger.warn(`[Dynamic Forms] DEPRECATED: ${message}`);
   }

--- a/packages/dynamic-forms/src/lib/utils/deprecation-warnings.ts
+++ b/packages/dynamic-forms/src/lib/utils/deprecation-warnings.ts
@@ -1,5 +1,5 @@
 import { Logger } from '../providers/features/logger/logger.interface';
-import { DeprecationWarningTracker } from './deprecation-warning-tracker';
+import type { WarningTracker } from './warning-tracker';
 import { DEV_MODE } from './dev-mode';
 
 /**
@@ -11,9 +11,9 @@ import { DEV_MODE } from './dev-mode';
  * @param id - Unique identifier for this deprecation (e.g., 'type:propertyDerivation')
  * @param message - Human-readable deprecation message
  *
- * @public
+ * @internal
  */
-export function warnDeprecated(logger: Logger, tracker: DeprecationWarningTracker, id: string, message: string): void {
+export function warnDeprecated(logger: Logger, tracker: WarningTracker, id: string, message: string): void {
   if (DEV_MODE && !tracker.warnedKeys.has(id)) {
     tracker.warnedKeys.add(id);
     logger.warn(`DEPRECATED: ${message}`);

--- a/packages/dynamic-forms/src/lib/utils/dev-mode.ts
+++ b/packages/dynamic-forms/src/lib/utils/dev-mode.ts
@@ -6,5 +6,11 @@ declare const ngDevMode: boolean | undefined;
  * Angular CLI's optimizer substitutes `ngDevMode` with `false` in production builds,
  * letting terser dead-code-eliminate branches gated by this constant. Non-Angular
  * consumers fall back to `true` so warnings still fire under their bundler.
+ *
+ * Note: `DEV_MODE` is evaluated at module-load time and captured into the constant,
+ * so it does NOT reflect later runtime calls to Angular's `enableProdMode()`. For
+ * the dead-code-elimination case this is intentional (the value must be known at
+ * build time). If a runtime check is needed instead, use `isDevMode()` from
+ * `@angular/core` directly.
  */
 export const DEV_MODE: boolean = typeof ngDevMode === 'undefined' || !!ngDevMode;

--- a/packages/dynamic-forms/src/lib/utils/dev-mode.ts
+++ b/packages/dynamic-forms/src/lib/utils/dev-mode.ts
@@ -1,0 +1,10 @@
+declare const ngDevMode: boolean | undefined;
+
+/**
+ * Dev-mode guard for tree-shakeable diagnostics.
+ *
+ * Angular CLI's optimizer substitutes `ngDevMode` with `false` in production builds,
+ * letting terser dead-code-eliminate branches gated by this constant. Non-Angular
+ * consumers fall back to `true` so warnings still fire under their bundler.
+ */
+export const DEV_MODE: boolean = typeof ngDevMode === 'undefined' || !!ngDevMode;

--- a/packages/dynamic-forms/src/lib/utils/initialization-tracker/initialization-tracker.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/initialization-tracker/initialization-tracker.spec.ts
@@ -1,9 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { EventBus } from '../../events/event.bus';
 import { ComponentInitializedEvent } from '../../events/constants/component-initialized.event';
-import { createInitializationTracker, createDetailedInitializationTracker } from './initialization-tracker';
+import { createInitializationTracker } from './initialization-tracker';
 import { firstValueFrom } from 'rxjs';
-import { take, toArray } from 'rxjs/operators';
 
 describe('initialization-tracker', () => {
   describe('createInitializationTracker', () => {
@@ -95,113 +94,6 @@ describe('initialization-tracker', () => {
     });
   });
 
-  describe('createDetailedInitializationTracker', () => {
-    it('should emit detailed progress for each initialization', async () => {
-      const eventBus = new EventBus();
-      const tracker$ = createDetailedInitializationTracker(eventBus, 3);
-
-      const emissionsPromise = firstValueFrom(tracker$.pipe(take(3), toArray()));
-
-      eventBus.dispatch(ComponentInitializedEvent, 'dynamic-form', 'form1');
-      eventBus.dispatch(ComponentInitializedEvent, 'page', 'page1');
-      eventBus.dispatch(ComponentInitializedEvent, 'row', 'row1');
-
-      const emissions = await emissionsPromise;
-      expect(emissions).toEqual([
-        { currentCount: 1, expectedCount: 3, isComplete: false },
-        { currentCount: 2, expectedCount: 3, isComplete: false },
-        { currentCount: 3, expectedCount: 3, isComplete: true },
-      ]);
-    });
-
-    it('should mark as complete when count reaches expected', async () => {
-      const eventBus = new EventBus();
-      const tracker$ = createDetailedInitializationTracker(eventBus, 2);
-
-      const emissionsPromise = firstValueFrom(tracker$.pipe(take(2), toArray()));
-
-      eventBus.dispatch(ComponentInitializedEvent, 'dynamic-form', 'form1');
-      eventBus.dispatch(ComponentInitializedEvent, 'page', 'page1');
-
-      const emissions = await emissionsPromise;
-      expect(emissions[0].isComplete).toBe(false);
-      expect(emissions[1].isComplete).toBe(true);
-    });
-
-    it('should track progress for single component', async () => {
-      const eventBus = new EventBus();
-      const tracker$ = createDetailedInitializationTracker(eventBus, 1);
-
-      const promise = firstValueFrom(tracker$);
-      eventBus.dispatch(ComponentInitializedEvent, 'dynamic-form', 'form1');
-
-      const result = await promise;
-      expect(result).toEqual({
-        currentCount: 1,
-        expectedCount: 1,
-        isComplete: true,
-      });
-    });
-
-    it('should continue emitting beyond expected count', async () => {
-      const eventBus = new EventBus();
-      const tracker$ = createDetailedInitializationTracker(eventBus, 2);
-
-      const emissionsPromise = firstValueFrom(tracker$.pipe(take(3), toArray()));
-
-      eventBus.dispatch(ComponentInitializedEvent, 'dynamic-form', 'form1');
-      eventBus.dispatch(ComponentInitializedEvent, 'page', 'page1');
-      eventBus.dispatch(ComponentInitializedEvent, 'row', 'row1');
-
-      const emissions = await emissionsPromise;
-      expect(emissions[2]).toEqual({
-        currentCount: 3,
-        expectedCount: 2,
-        isComplete: true,
-      });
-    });
-
-    it('should emit for every initialization event', async () => {
-      const eventBus = new EventBus();
-      const tracker$ = createDetailedInitializationTracker(eventBus, 5);
-
-      const emissionsPromise = firstValueFrom(tracker$.pipe(take(5), toArray()));
-
-      // Dispatch 5 events
-      for (let i = 1; i <= 5; i++) {
-        eventBus.dispatch(ComponentInitializedEvent, 'component', `comp${i}`);
-      }
-
-      const emissions = await emissionsPromise;
-
-      // Verify each emission has correct count and expectedCount
-      emissions.forEach((status, index) => {
-        expect(status.currentCount).toBe(index + 1);
-        expect(status.expectedCount).toBe(5);
-      });
-
-      // Fourth emission should not be complete
-      expect(emissions[3].isComplete).toBe(false);
-      // Fifth emission should be complete
-      expect(emissions[4].isComplete).toBe(true);
-    });
-
-    it('should handle zero expected count', async () => {
-      const eventBus = new EventBus();
-      const tracker$ = createDetailedInitializationTracker(eventBus, 0);
-
-      const promise = firstValueFrom(tracker$);
-      eventBus.dispatch(ComponentInitializedEvent, 'dynamic-form', 'form1');
-
-      const result = await promise;
-      expect(result).toEqual({
-        currentCount: 1,
-        expectedCount: 0,
-        isComplete: true,
-      });
-    });
-  });
-
   describe('integration scenarios', () => {
     it('should work with typical form initialization (dynamic-form + 2 pages + row + group)', async () => {
       const eventBus = new EventBus();
@@ -218,21 +110,6 @@ describe('initialization-tracker', () => {
 
       const isComplete = await promise;
       expect(isComplete).toBe(true);
-    });
-
-    it('should handle detailed tracking for complex form', async () => {
-      const eventBus = new EventBus();
-      const tracker$ = createDetailedInitializationTracker(eventBus, 3);
-
-      const statusesPromise = firstValueFrom(tracker$.pipe(take(3), toArray()));
-
-      eventBus.dispatch(ComponentInitializedEvent, 'dynamic-form', 'mainForm');
-      eventBus.dispatch(ComponentInitializedEvent, 'page', 'personalInfo');
-      eventBus.dispatch(ComponentInitializedEvent, 'page', 'contactInfo');
-
-      const statuses = await statusesPromise;
-      expect(statuses.length).toBe(3);
-      expect(statuses[2].currentCount).toBe(3);
     });
   });
 });

--- a/packages/dynamic-forms/src/lib/utils/initialization-tracker/initialization-tracker.ts
+++ b/packages/dynamic-forms/src/lib/utils/initialization-tracker/initialization-tracker.ts
@@ -19,69 +19,15 @@ export const INITIALIZATION_TIMEOUT_MS = new InjectionToken<number>('INITIALIZAT
 /**
  * Creates an observable that tracks component initialization progress.
  *
- * This function returns an observable that emits when all expected components
- * have been initialized. It uses the scan operator to accumulate initialization
- * events and emits true when the count reaches the expected total.
- *
- * @param eventBus - The event bus instance to subscribe to
- * @param expectedCount - Total number of components expected to initialize
- * @returns Observable<boolean> that emits true when all components are initialized
- *
- * @example
- * ```typescript
- * const eventBus = inject(EventBus);
- * const totalComponents = 5; // 1 dynamic-form + 2 pages + 1 row + 1 group
- *
- * const allInitialized$ = createInitializationTracker(eventBus, totalComponents);
- *
- * allInitialized$.subscribe(isComplete => {
- *   if (isComplete) {
- *     console.log('All components are initialized!');
- *   }
- * });
- * ```
+ * Emits once with `true` when `expectedCount` component-initialized events have
+ * been seen on the bus. Used internally by {@link setupInitializationTracking}
+ * and kept as a named export for focused unit testing.
  */
 export function createInitializationTracker(eventBus: EventBus, expectedCount: number): Observable<boolean> {
   return eventBus.on<ComponentInitializedEvent>('component-initialized').pipe(
     scan((count) => count + 1, 0),
     map((currentCount) => currentCount >= expectedCount),
     filter((isComplete) => isComplete),
-  );
-}
-
-/**
- * Creates an observable that tracks component initialization progress with detailed status.
- *
- * This function returns an observable that emits the current count and completion status
- * for each initialization event, providing more granular tracking capabilities.
- *
- * @param eventBus - The event bus instance to subscribe to
- * @param expectedCount - Total number of components expected to initialize
- * @returns Observable with current count, expected count, and completion status
- *
- * @example
- * ```typescript
- * const eventBus = inject(EventBus);
- * const totalComponents = 5;
- *
- * const progress$ = createDetailedInitializationTracker(eventBus, totalComponents);
- *
- * progress$.subscribe(({ currentCount, expectedCount, isComplete }) => {
- *   console.log(`Progress: ${currentCount}/${expectedCount} (${isComplete ? 'Complete' : 'In Progress'})`);
- * });
- * ```
- */
-export function createDetailedInitializationTracker(
-  eventBus: EventBus,
-  expectedCount: number,
-): Observable<{ currentCount: number; expectedCount: number; isComplete: boolean }> {
-  return eventBus.on<ComponentInitializedEvent>('component-initialized').pipe(
-    scan((count) => count + 1, 0),
-    map((currentCount) => ({
-      currentCount,
-      expectedCount,
-      isComplete: currentCount >= expectedCount,
-    })),
   );
 }
 
@@ -105,9 +51,6 @@ export interface InitializationTrackingOptions {
  * before emitting its initialization event. On timeout, a warning is logged
  * and true is emitted as a best-effort fallback.
  *
- * @param options - Configuration options for initialization tracking
- * @returns Observable<boolean> that emits true when all components are initialized
- *
  * @example
  * ```typescript
  * const eventBus = inject(EventBus);
@@ -130,18 +73,15 @@ export function setupInitializationTracking(options: InitializationTrackingOptio
   return toObservable(totalComponentsCount, { injector }).pipe(
     take(1),
     switchMap((count) => {
-      let tracking$: Observable<boolean>;
-
-      if (count === 1) {
-        // Only dynamic-form component, emit immediately when it initializes
-        tracking$ = eventBus.on<ComponentInitializedEvent>('component-initialized').pipe(
-          filter((event) => event.componentType === 'dynamic-form' && event.componentId === componentId),
-          map(() => true),
-          take(1),
-        );
-      } else {
-        tracking$ = createInitializationTracker(eventBus, count);
-      }
+      const tracking$: Observable<boolean> =
+        count === 1
+          ? // Only dynamic-form component, emit immediately when it initializes
+            eventBus.on<ComponentInitializedEvent>('component-initialized').pipe(
+              filter((event) => event.componentType === 'dynamic-form' && event.componentId === componentId),
+              map(() => true),
+              take(1),
+            )
+          : createInitializationTracker(eventBus, count);
 
       // Timeout guard: emit best-effort true if a container throws before initializing
       return tracking$.pipe(

--- a/packages/dynamic-forms/src/lib/utils/object-utils.ts
+++ b/packages/dynamic-forms/src/lib/utils/object-utils.ts
@@ -344,22 +344,6 @@ export function getChangedKeys(
 }
 
 /**
- * Fast 32-bit FNV-1a hash for strings.
- * Used as a cache key to avoid expensive string concatenation in memoize resolvers.
- *
- * @param str - String to hash
- * @returns 32-bit integer hash
- */
-export function simpleStringHash(str: string): number {
-  let hash = 0x811c9dc5; // FNV offset basis
-  for (let i = 0; i < str.length; i++) {
-    hash ^= str.charCodeAt(i);
-    hash = (hash * 0x01000193) | 0; // FNV prime, keep as 32-bit int
-  }
-  return hash;
-}
-
-/**
  * Compile-time exhaustiveness check for discriminated unions.
  *
  * Place in the `default` branch of a `switch` over a union's discriminant.

--- a/packages/dynamic-forms/src/lib/utils/warning-tracker.ts
+++ b/packages/dynamic-forms/src/lib/utils/warning-tracker.ts
@@ -4,6 +4,8 @@
  * Used by both the derivation-warning tracker (keys are field paths) and the
  * deprecation-warning tracker (keys are deprecation IDs). The property is
  * generic so the same shape works for any string-keyed warning domain.
+ *
+ * @internal
  */
 export interface WarningTracker {
   warnedKeys: Set<string>;
@@ -12,6 +14,8 @@ export interface WarningTracker {
 /**
  * Creates a fresh warning tracker instance with an empty key set.
  * DI-scoped per form instance — never module-scoped (SSR-unsafe).
+ *
+ * @internal
  */
 export function createWarningTracker(): WarningTracker {
   return { warnedKeys: new Set<string>() };

--- a/packages/dynamic-forms/src/lib/utils/warning-tracker.ts
+++ b/packages/dynamic-forms/src/lib/utils/warning-tracker.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared shape for DI-scoped warning trackers that dedupe log output.
+ *
+ * Used by both the derivation-warning tracker (keys are field paths) and the
+ * deprecation-warning tracker (keys are deprecation IDs). The property is
+ * generic so the same shape works for any string-keyed warning domain.
+ */
+export interface WarningTracker {
+  warnedKeys: Set<string>;
+}
+
+/**
+ * Creates a fresh warning tracker instance with an empty key set.
+ * DI-scoped per form instance — never module-scoped (SSR-unsafe).
+ */
+export function createWarningTracker(): WarningTracker {
+  return { warnedKeys: new Set<string>() };
+}


### PR DESCRIPTION
## Summary
- 5 commits of internal cleanup that don't touch public API or behavior
- Consumer prod bundle drops from 49.8 → 48.4 KB gz-min (~1.4 KB, ~2.8%) when Angular CLI substitutes `ngDevMode`
- Library FESM itself shrinks marginally (49,819 → 49,750 gz-min) — the rest materializes at consumer build time

## The work

| # | Commit | Change |
|---|---|---|
| 1 | `remove dead simpleStringHash utility` | FNV hash helper with zero call sites |
| 2 | `gate dev warnings with ngDevMode for prod DCE` | Shared `DEV_MODE` constant guards warning call sites; swaps `isDevMode()` (runtime, unstrippable) for `typeof ngDevMode === 'undefined' \|\| !!ngDevMode` (build-time, DCE-able) |
| 3 | `consolidate warning trackers and prune dead init tracker` | Shared `WarningTracker` interface + factory, `warnedFields` → `warnedKeys` rename, `createDetailedInitializationTracker` deleted (0 callers outside its own spec) |
| 4 | `collapse three formValue regex patterns into one` | Dot/single-quote/double-quote alternation instead of three `matchAll` passes |
| 5 | `promote dev warnings to top-level fns for full DCE` | Class methods can't be tree-shaken; extracting the two warning fns out of the orchestrators lets terser drop them entirely. Also drops `[Dynamic Forms]` / `[Derivation]` log prefixes since the DI logger already adds them. |

## Measurement methodology
Library FESM with ng-packagr; terser with `--compress --mangle --ecma 2022 --module`; gzip -9. Consumer prod simulated by `perl -pe 's/\bngDevMode\b/false/g'` then re-running terser + gzip — this matches what Angular CLI's production optimizer does.

## What I explicitly skipped
Listed for review transparency:
- **J, K** (wrapper chain micro-opts) — already at their optimal form in source
- **L** (registry classes → InjectionTokens) — 60 call sites for ~300 bytes gz-min
- **C** (FunctionRegistryService fat) — JSDoc doesn't affect bundle; minified savings ~200 bytes
- **E** (form-state-manager redundant sync) — the sync isn't redundant during \`transitioning\` state; too risky without deeper test coverage
- **H1** (consolidate two init effects) — paged vs non-paged effects have different dep sets and timing (afterNextRender); consolidation risks init-order bugs
- **H2** (createEventOutput helper) — `outputFromObservable(...)` is already a one-liner; extracting adds indirection for ~10 bytes

## Next phases (separate PRs)
- **A** — consolidate the parallel derivation/property-derivation/cross-field collector + applicator implementations (`\$1` / `\$2` suffix functions in the FESM confirm real source duplication). Estimated 1.5–2.5 KB gz-min.
- **Phase 2** — opt-in JSON-serializable expressions
- **Phase 3** — feature-gated derivations / conditions / HTTP

## Test plan
- [ ] \`nx test dynamic-forms\` passes (2524 pass, 2 skipped — same as baseline)
- [ ] \`nx build dynamic-forms\` produces clean FESM
- [ ] E2E material/bootstrap/primeng/ionic still pass in Docker
- [ ] Manual spot-check: dev warnings still appear in dev mode (wildcard dependencies, deprecations)