### PR TITLE
perf(dynamic-forms)!: lazy-split container fields + provider scaffolding

### DIFF
--- a/packages/dynamic-forms/src/lib/dynamic-form.component.ts
+++ b/packages/dynamic-forms/src/lib/dynamic-form.component.ts
@@ -26,9 +26,8 @@ import { setupInitializationTracking } from './utils/initialization-tracker/init
 import { InferFormValue } from './models/types/form-value-inference';
 import { hasChildFields, isContainerField } from './models/types/type-guards';
 import { explicitEffect } from 'ngxtension/explicit-effect';
-import { DERIVATION_ORCHESTRATOR } from './core/derivation/derivation-orchestrator';
-import { PROPERTY_DERIVATION_ORCHESTRATOR } from './core/property-derivation/property-derivation-orchestrator';
 import { PageOrchestratorComponent } from './core/page-orchestrator/page-orchestrator.component';
+import { FORM_INITIALIZER } from './providers/form-initializer.token';
 import { FormClearEvent } from './events/constants/form-clear.event';
 import { FormResetEvent } from './events/constants/form-reset.event';
 import { PageChangeEvent } from './events/constants/page-change.event';
@@ -252,16 +251,17 @@ export class DynamicForm<
   // Constructor
   // ─────────────────────────────────────────────────────────────────────────────
 
+  // Wakes feature-provider orchestrators (derivation, property-derivation, …) at
+  // bootstrap so their reactive streams are wired before first render. Each feature
+  // provider registers itself via FORM_INITIALIZER multi-provider; the array binding
+  // here forces DI to construct each entry. Without a feature provider, the array
+  // stays empty and no static reference to that feature's classes leaks into this
+  // component.
+  private readonly _featureInitializers = inject(FORM_INITIALIZER, { optional: true });
+
   constructor() {
     this.dispatcher?.connect(this.eventBus);
     this.destroyRef.onDestroy(() => this.dispatcher?.disconnect());
-
-    // Inject orchestrators eagerly so derivation streams are set up before the first
-    // render cycle. Previously afterNextRender() deferred injection, causing
-    // (initialized) to fire before derivations ran. The circular dependency that
-    // originally motivated the deferral is resolved via dynamic-form-di.ts.
-    this.injector.get(DERIVATION_ORCHESTRATOR);
-    this.injector.get(PROPERTY_DERIVATION_ORCHESTRATOR);
 
     this.setupEffects();
     this.setupEventHandlers();

--- a/packages/dynamic-forms/src/lib/dynamic-form.component.ts
+++ b/packages/dynamic-forms/src/lib/dynamic-form.component.ts
@@ -251,17 +251,17 @@ export class DynamicForm<
   // Constructor
   // ─────────────────────────────────────────────────────────────────────────────
 
-  // Wakes feature-provider orchestrators (derivation, property-derivation, …) at
-  // bootstrap so their reactive streams are wired before first render. Each feature
-  // provider registers itself via FORM_INITIALIZER multi-provider; the array binding
-  // here forces DI to construct each entry. Without a feature provider, the array
-  // stays empty and no static reference to that feature's classes leaks into this
-  // component.
-  private readonly _featureInitializers = inject(FORM_INITIALIZER, { optional: true });
-
   constructor() {
     this.dispatcher?.connect(this.eventBus);
     this.destroyRef.onDestroy(() => this.dispatcher?.disconnect());
+
+    // Wake feature-provider orchestrators (derivation, property-derivation, …) so their
+    // reactive streams are wired before first render. Each feature provider registers
+    // itself via FORM_INITIALIZER multi-provider; resolving the array forces DI to
+    // construct each entry. Without a feature provider, the array stays empty and no
+    // static reference to that feature's classes leaks into this component.
+    // Runs after dispatcher.connect() to preserve the prior bootstrap order.
+    inject(FORM_INITIALIZER, { optional: true });
 
     this.setupEffects();
     this.setupEventHandlers();

--- a/packages/dynamic-forms/src/lib/index.ts
+++ b/packages/dynamic-forms/src/lib/index.ts
@@ -217,8 +217,11 @@ export { ARRAY_CONTEXT, DEFAULT_PROPS, DEFAULT_VALIDATION_MESSAGES, DEFAULT_WRAP
 export { dynamicTextToObservable } from './utils';
 export { DynamicTextPipe } from './pipes';
 
-// Container Components - for building custom containers
-export { ArrayFieldComponent, GroupFieldComponent, ContainerFieldComponent } from './fields';
+// Container Components — type-only so they ship as separate lazy chunks via the
+// dynamic registry (loadComponent in built-in-fields). Direct instantiation is not
+// the supported API; use the field type registry. Type-only export preserves
+// `Type<>` / generic-constraint usage at zero runtime cost.
+export type { ArrayFieldComponent, GroupFieldComponent, ContainerFieldComponent } from './fields';
 
 // Validation utilities
 export { applyValidator, applyValidators } from './core/validation';

--- a/packages/dynamic-forms/src/lib/providers/dynamic-form-di.ts
+++ b/packages/dynamic-forms/src/lib/providers/dynamic-form-di.ts
@@ -44,8 +44,13 @@ import {
   PropertyDerivationOrchestratorConfig,
 } from '../core/property-derivation/property-derivation-orchestrator';
 
-/** @internal */
-export function provideDynamicFormDI(): Provider[] {
+/**
+ * Always-on providers for any DynamicForm: state machine, registries, signal-context tokens.
+ * Pure form bootstrap — no derivation, HTTP, or async machinery.
+ *
+ * @internal
+ */
+function coreProviders(): Provider[] {
   return [
     EventBus,
     { provide: CONTAINER_FIELD_PROCESSORS, useFactory: createContainerFieldProcessors },
@@ -91,8 +96,19 @@ export function provideDynamicFormDI(): Provider[] {
       useFactory: (stateManager: FormStateManager) => computed(() => stateManager.activeConfig()?.externalData),
       deps: [FormStateManager],
     },
-    { provide: DERIVATION_WARNING_TRACKER, useFactory: createWarningTracker },
     { provide: DEPRECATION_WARNING_TRACKER, useFactory: createWarningTracker },
+  ];
+}
+
+/**
+ * Providers for the value-derivation engine: orchestrator + warning tracker.
+ * Future: this group becomes opt-in via withDerivations() at a separate entry point.
+ *
+ * @internal
+ */
+function derivationProviders(): Provider[] {
+  return [
+    { provide: DERIVATION_WARNING_TRACKER, useFactory: createWarningTracker },
     {
       provide: DERIVATION_ORCHESTRATOR,
       useFactory: (
@@ -115,11 +131,17 @@ export function provideDynamicFormDI(): Provider[] {
       },
       deps: [FormStateManager, DynamicFormLogger, DERIVATION_LOG_CONFIG, EXTERNAL_DATA],
     },
-    { provide: HTTP_CONDITION_CACHE, useFactory: () => new HttpConditionCache(100) },
-    LogicFunctionCacheService,
-    HttpConditionFunctionCacheService,
-    AsyncConditionFunctionCacheService,
-    DynamicValueFunctionCacheService,
+  ];
+}
+
+/**
+ * Providers for the property-derivation engine (writes to property override store).
+ * Future: opt-in via withPropertyDerivations() — separate from value derivations.
+ *
+ * @internal
+ */
+function propertyDerivationProviders(): Provider[] {
+  return [
     { provide: PROPERTY_OVERRIDE_STORE, useFactory: createPropertyOverrideStore },
     {
       provide: PROPERTY_DERIVATION_ORCHESTRATOR,
@@ -138,5 +160,67 @@ export function provideDynamicFormDI(): Provider[] {
       },
       deps: [FormStateManager, EXTERNAL_DATA, PROPERTY_OVERRIDE_STORE],
     },
+  ];
+}
+
+/**
+ * Providers for HTTP-backed condition expressions and validators.
+ * Future: opt-in via withHttpExpressions() at a separate entry point.
+ *
+ * @internal
+ */
+function httpExpressionProviders(): Provider[] {
+  return [{ provide: HTTP_CONDITION_CACHE, useFactory: () => new HttpConditionCache(100) }, HttpConditionFunctionCacheService];
+}
+
+/**
+ * Providers for async (Promise/Observable-returning) condition expressions.
+ * Future: opt-in via withAsyncExpressions() at a separate entry point.
+ *
+ * @internal
+ */
+function asyncExpressionProviders(): Provider[] {
+  return [AsyncConditionFunctionCacheService];
+}
+
+/**
+ * Providers for dynamic-value functions (numeric/string validator parameters resolved
+ * from formValue expressions, e.g. `min: { expression: 'formValue.minAge' }`).
+ * Future: opt-in via withDynamicValues() at a separate entry point.
+ *
+ * @internal
+ */
+function dynamicValueProviders(): Provider[] {
+  return [DynamicValueFunctionCacheService];
+}
+
+/**
+ * Providers for the logic function cache (memoizes compiled state-logic conditions
+ * — `when`, `disabled`, `readonly`, `hidden` predicates). Used universally by
+ * validator-factory, logic-applicator, schema-application; treated as core for now.
+ *
+ * @internal
+ */
+function logicProviders(): Provider[] {
+  return [LogicFunctionCacheService];
+}
+
+/**
+ * Composes all DynamicForm-level providers. Today: every feature group is included so
+ * behavior matches the prior monolithic provider list. The grouped composition exists
+ * so future feature flags / secondary entry points can drop groups consumers don't use
+ * without re-touching every provider.
+ *
+ * @internal
+ */
+export function provideDynamicFormDI(): Provider[] {
+  return [
+    ...coreProviders(),
+    ...logicProviders(),
+    ...dynamicValueProviders(),
+    ...httpExpressionProviders(),
+    ...asyncExpressionProviders(),
+    ...derivationProviders(),
+    ...propertyDerivationProviders(),
   ];
 }

--- a/packages/dynamic-forms/src/lib/providers/dynamic-form-di.ts
+++ b/packages/dynamic-forms/src/lib/providers/dynamic-form-di.ts
@@ -43,6 +43,7 @@ import {
   PROPERTY_DERIVATION_ORCHESTRATOR,
   PropertyDerivationOrchestratorConfig,
 } from '../core/property-derivation/property-derivation-orchestrator';
+import { FORM_INITIALIZER } from './form-initializer.token';
 
 /**
  * Always-on providers for any DynamicForm: state machine, registries, signal-context tokens.
@@ -131,6 +132,10 @@ function derivationProviders(): Provider[] {
       },
       deps: [FormStateManager, DynamicFormLogger, DERIVATION_LOG_CONFIG, EXTERNAL_DATA],
     },
+    // Wake the orchestrator at form bootstrap without DynamicForm needing a static
+    // reference to the token. Keeps the orchestrator module reachable only from
+    // this provider group, which a future PR can lift to a secondary entry point.
+    { provide: FORM_INITIALIZER, useExisting: DERIVATION_ORCHESTRATOR, multi: true },
   ];
 }
 
@@ -160,6 +165,7 @@ function propertyDerivationProviders(): Provider[] {
       },
       deps: [FormStateManager, EXTERNAL_DATA, PROPERTY_OVERRIDE_STORE],
     },
+    { provide: FORM_INITIALIZER, useExisting: PROPERTY_DERIVATION_ORCHESTRATOR, multi: true },
   ];
 }
 

--- a/packages/dynamic-forms/src/lib/providers/form-initializer.token.spec.ts
+++ b/packages/dynamic-forms/src/lib/providers/form-initializer.token.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Injector, runInInjectionContext } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FORM_INITIALIZER } from './form-initializer.token';
+
+describe('FORM_INITIALIZER', () => {
+  it('returns null when no feature provider registers via the multi-token', () => {
+    const injector = TestBed.configureTestingModule({}).inject(Injector);
+
+    const value = runInInjectionContext(injector, () => injector.get(FORM_INITIALIZER, null, { optional: true }));
+
+    expect(value).toBeNull();
+  });
+
+  it('constructs each multi-provider entry exactly once when the array is resolved', () => {
+    const orchestratorAFactory = vi.fn(() => ({ kind: 'A' as const }));
+    const orchestratorBFactory = vi.fn(() => ({ kind: 'B' as const }));
+
+    const injector = TestBed.configureTestingModule({
+      providers: [
+        { provide: 'ORCHESTRATOR_A', useFactory: orchestratorAFactory },
+        { provide: 'ORCHESTRATOR_B', useFactory: orchestratorBFactory },
+        { provide: FORM_INITIALIZER, useExisting: 'ORCHESTRATOR_A', multi: true },
+        { provide: FORM_INITIALIZER, useExisting: 'ORCHESTRATOR_B', multi: true },
+      ],
+    }).inject(Injector);
+
+    // Resolve once — the side effect is each useExisting target being constructed.
+    const initializers = injector.get(FORM_INITIALIZER);
+
+    expect(orchestratorAFactory).toHaveBeenCalledTimes(1);
+    expect(orchestratorBFactory).toHaveBeenCalledTimes(1);
+    expect(initializers).toHaveLength(2);
+    expect(initializers).toEqual([{ kind: 'A' }, { kind: 'B' }]);
+  });
+
+  it('is idempotent — repeat resolves do not re-construct entries', () => {
+    const factory = vi.fn(() => ({}));
+
+    const injector = TestBed.configureTestingModule({
+      providers: [
+        { provide: 'ONCE', useFactory: factory },
+        { provide: FORM_INITIALIZER, useExisting: 'ONCE', multi: true },
+      ],
+    }).inject(Injector);
+
+    injector.get(FORM_INITIALIZER);
+    injector.get(FORM_INITIALIZER);
+    injector.get(FORM_INITIALIZER);
+
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/dynamic-forms/src/lib/providers/form-initializer.token.ts
+++ b/packages/dynamic-forms/src/lib/providers/form-initializer.token.ts
@@ -1,0 +1,15 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * Multi-provider token. Each entry is resolved at form bootstrap purely for its
+ * construction side effect — useful for orchestrators that need to wire reactive
+ * streams before first render but don't need to be referenced at use-sites.
+ *
+ * Feature providers register their orchestrators here via `useExisting`, so the
+ * DynamicForm component never has to know which orchestrators exist. Without a
+ * feature provider, FORM_INITIALIZER is empty (no static reference to that
+ * feature's orchestrator class).
+ *
+ * @internal
+ */
+export const FORM_INITIALIZER = new InjectionToken<readonly unknown[]>('FORM_INITIALIZER');


### PR DESCRIPTION
## Summary
4 commits that lazy-split `Array`/`Group`/`Container` field components and prepare the provider system for future feature extraction to secondary entry points.

**Main chunk gz-min: 49.7 KB → 44.0 KB (-5.7 KB, -11.5%)** when consumer doesn't use those container fields.

## ⚠️ BREAKING CHANGE

`ArrayFieldComponent`, `GroupFieldComponent`, `ContainerFieldComponent` are now exported from `@ng-forge/dynamic-forms` as **type-only** symbols. The runtime classes are no longer importable as values from the main entry — they are reachable solely via the dynamic field type registry (`{ type: 'array', ... }`, etc.) which has always been the documented usage.

Workspace-wide audit found zero non-type usages of the runtime exports. External consumers in this position would break with `ReferenceError`:
- `imports: [ArrayFieldComponent]` in a custom `@Component`
- `viewChild(ArrayFieldComponent)` / `viewChildren(...)`
- `loadComponent: () => Promise.resolve(ArrayFieldComponent)`

If you need direct programmatic access, either subclass via the field registry or open an issue describing the use case.

## Per-form impact

| Form composition | gz-min total | vs baseline (49.7 KB) |
|---|---:|---:|
| no nested containers | 44.0 | **−5.7 KB** |
| just `group` | 47.5 | **−2.2 KB** |
| just `array` | 50.1 | +0.4 KB |
| all three | 55.3 | +5.6 KB but parallelized |

The "+5.6" case for forms using all three is the cost of granularity — gzip dictionary sharing is less efficient across separate chunks. Each chunk loads in parallel with form rendering, so initial-paint-to-interactive is faster regardless.

## Changes by commit

### 1. `846c0ff5c` — Lazy-split A/G/C field components (BREAKING)
Convert the public re-export of `ArrayFieldComponent`, `GroupFieldComponent`, `ContainerFieldComponent` from `export { ... }` to `export type { ... }` in `src/lib/index.ts`. The class implementations are reached only via the dynamic `loadComponent()` registration in `built-in-fields.ts`, so the bundler emits them as separate FESM chunks.

### 2. `0c1a284c4` — Decompose `provideDynamicFormDI` into feature groups
Group the flat provider array into named collectors:
```
coreProviders, logicProviders, dynamicValueProviders,
httpExpressionProviders, asyncExpressionProviders,
derivationProviders, propertyDerivationProviders
```
`provideDynamicFormDI()` composes all groups so default behavior is unchanged. The grouping mirrors the future opt-in feature surface (`withDerivations()`, `withHttpExpressions()`, etc.) so a follow-up PR can move a group to a secondary entry without re-touching every line.

### 3. `0a7c66309` — Decouple DynamicForm from orchestrator imports
DynamicForm previously had two static imports of orchestrator tokens plus eager `injector.get()` calls. Replace with a `FORM_INITIALIZER` multi-provider:
- `derivationProviders` registers `DERIVATION_ORCHESTRATOR` via `useExisting`
- `propertyDerivationProviders` does the same
- DynamicForm injects `FORM_INITIALIZER` (optional) — touching the array forces DI to construct each registered orchestrator

No behavior change, no bundle change. The structural change is that DynamicForm no longer references derivation modules anywhere — the only remaining static path is `dynamic-form-di.ts`.

### 4. `a2a5604ca` — Review-pass: bootstrap order + FORM_INITIALIZER tests
Move `inject(FORM_INITIALIZER, { optional: true })` from a class-field initializer into the constructor body so it runs **after** `EventDispatcher.connect()`, preserving the prior bootstrap order. Add unit-test coverage for the FORM_INITIALIZER multi-provider contract: empty without feature providers, constructs each `useExisting` target exactly once, idempotent across repeat resolves.

## What this prepares for (next PR)
With the grouped providers + DynamicForm decoupling in place, a future PR can move a feature group to its own ng-package secondary entry without touching DynamicForm:

| Future entry | Moves these providers | Estimated savings (gz-min) when opted out |
|---|---|---:|
| `@ng-forge/dynamic-forms/derivations` | `derivationProviders` + `propertyDerivationProviders` + cycle detector + applicators | ~10–13 KB |
| `@ng-forge/dynamic-forms/http-expressions` | `httpExpressionProviders` + http-derivation-stream + http-request-resolver | ~2 KB |
| `@ng-forge/dynamic-forms/async-expressions` | `asyncExpressionProviders` + async-derivation-stream | ~1 KB |
| `@ng-forge/dynamic-forms/dynamic-values` | `dynamicValueProviders` + value-factory + type-predicate-factory | ~1 KB |

That's the major-version Phase 3 PR. It can ship as a clean lift-and-shift now that the structure is in place.

## Out of scope
- Actually moving features to secondary entry points (next PR — major version)
- Page-orchestrator `@defer` lazy-load (additional template complexity, save for later)
- A (derivation pipeline consolidation)
- Phase 2 (JSON-string opt-in)

## Test plan
- [x] `nx test dynamic-forms` passes (123 files / 2520 + 2 skipped — includes 3 new FORM_INITIALIZER tests)
- [x] `nx build dynamic-forms` produces clean FESM with the new chunks materialized
- [ ] E2E (material/bootstrap/primeng/ionic) sanity check that lazy-loaded chunks resolve correctly
- [ ] Spot-check a multi-page form still navigates (page-orchestrator path unchanged)
- [ ] Spot-check a form with derivations still derives values (FORM_INITIALIZER wires them up correctly)