### PR TITLE
fix(dynamic-forms): prefix group keys on derivation paths

### DIFF
--- a/apps/e2e/core/src/app/testing/container-nesting/container-nesting.routes.ts
+++ b/apps/e2e/core/src/app/testing/container-nesting/container-nesting.routes.ts
@@ -33,6 +33,16 @@ const routes: Routes = [
     data: { scenario: getContainerNestingScenario('container-inside-row') },
   },
   {
+    path: 'container-inside-group',
+    loadComponent: () => import('../shared/test-scenario.component').then((m) => m.TestScenarioComponent),
+    data: { scenario: getContainerNestingScenario('container-inside-group') },
+  },
+  {
+    path: 'container-inside-group-self',
+    loadComponent: () => import('../shared/test-scenario.component').then((m) => m.TestScenarioComponent),
+    data: { scenario: getContainerNestingScenario('container-inside-group-self') },
+  },
+  {
     path: 'deeply-nested',
     loadComponent: () => import('../shared/test-scenario.component').then((m) => m.TestScenarioComponent),
     data: { scenario: getContainerNestingScenario('deeply-nested') },

--- a/apps/e2e/core/src/app/testing/container-nesting/container-nesting.routes.ts
+++ b/apps/e2e/core/src/app/testing/container-nesting/container-nesting.routes.ts
@@ -43,6 +43,11 @@ const routes: Routes = [
     data: { scenario: getContainerNestingScenario('container-inside-group-self') },
   },
   {
+    path: 'container-inside-group-parent',
+    loadComponent: () => import('../shared/test-scenario.component').then((m) => m.TestScenarioComponent),
+    data: { scenario: getContainerNestingScenario('container-inside-group-parent') },
+  },
+  {
     path: 'deeply-nested',
     loadComponent: () => import('../shared/test-scenario.component').then((m) => m.TestScenarioComponent),
     data: { scenario: getContainerNestingScenario('deeply-nested') },

--- a/apps/e2e/core/src/app/testing/container-nesting/container-nesting.spec.ts
+++ b/apps/e2e/core/src/app/testing/container-nesting/container-nesting.spec.ts
@@ -1,5 +1,6 @@
 import type { Locator } from '@playwright/test';
 import { expect, setupConsoleCheck, setupTestLogging, test } from '../shared/fixtures';
+import { fillInput } from '../shared/test-utils';
 
 setupTestLogging();
 setupConsoleCheck();
@@ -149,6 +150,45 @@ test.describe('Container Nesting E2E Tests', () => {
       expect(data['firstName']).toBe('Ada');
       expect(data['nickname']).toBe('Lovelace');
       expect(data['pronouns']).toBe('she/her');
+    });
+  });
+
+  test.describe('Container Inside Group', () => {
+    test('should fire derivation for an input nested as group > container > input', async ({ page, helpers }) => {
+      await page.goto('/#/test/container-nesting/container-inside-group');
+      await page.waitForLoadState('networkidle');
+      const scenario = helpers.getScenario('container-inside-group');
+      await expect(scenario).toBeVisible({ timeout: 10000 });
+
+      const stateInput = scenario.locator('#state input');
+      await expect(stateInput).toBeVisible({ timeout: 5000 });
+      await fillInput(stateInput, 'tx');
+
+      // Derivation should self-transform the value to uppercase.
+      await expect(stateInput).toHaveValue('TX', { timeout: 5000 });
+
+      const data = await helpers.submitFormAndCapture(scenario);
+      // Container is layout-only — `state` lives under the `address` group boundary.
+      const address = data['address'] as Record<string, unknown>;
+      expect(address['state']).toBe('TX');
+    });
+
+    test('should resolve $self in dependsOn for an input nested as group > container > input', async ({ page, helpers }) => {
+      await page.goto('/#/test/container-nesting/container-inside-group-self');
+      await page.waitForLoadState('networkidle');
+      const scenario = helpers.getScenario('container-inside-group-self');
+      await expect(scenario).toBeVisible({ timeout: 10000 });
+
+      const stateInput = scenario.locator('#state input');
+      await expect(stateInput).toBeVisible({ timeout: 5000 });
+      await fillInput(stateInput, 'tx');
+
+      // $self resolves to `address.state` so the derivation fires and writes back.
+      await expect(stateInput).toHaveValue('TX', { timeout: 5000 });
+
+      const data = await helpers.submitFormAndCapture(scenario);
+      const address = data['address'] as Record<string, unknown>;
+      expect(address['state']).toBe('TX');
     });
   });
 

--- a/apps/e2e/core/src/app/testing/container-nesting/container-nesting.spec.ts
+++ b/apps/e2e/core/src/app/testing/container-nesting/container-nesting.spec.ts
@@ -190,6 +190,29 @@ test.describe('Container Nesting E2E Tests', () => {
       const address = data['address'] as Record<string, unknown>;
       expect(address['state']).toBe('TX');
     });
+
+    test('should fire derivation when any sibling in the parent group changes via $group', async ({ page, helpers }) => {
+      await page.goto('/#/test/container-nesting/container-inside-group-parent');
+      await page.waitForLoadState('networkidle');
+      const scenario = helpers.getScenario('container-inside-group-parent');
+      await expect(scenario).toBeVisible({ timeout: 10000 });
+
+      const countryInput = scenario.locator('#country input');
+      const stateInput = scenario.locator('#state input');
+      await expect(countryInput).toBeVisible({ timeout: 5000 });
+
+      // $group resolves to 'address' — fires the derivation on any sibling change.
+      await fillInput(countryInput, 'usa');
+      await expect(stateInput).toHaveValue('NY', { timeout: 5000 });
+
+      await fillInput(countryInput, 'canada');
+      await expect(stateInput).toHaveValue('ON', { timeout: 5000 });
+
+      const data = await helpers.submitFormAndCapture(scenario);
+      const address = data['address'] as Record<string, unknown>;
+      expect(address['country']).toBe('canada');
+      expect(address['state']).toBe('ON');
+    });
   });
 
   // Deeply nested (group > row > array > group) is a known library limitation.

--- a/apps/e2e/core/src/app/testing/container-nesting/container-nesting.suite.ts
+++ b/apps/e2e/core/src/app/testing/container-nesting/container-nesting.suite.ts
@@ -6,6 +6,7 @@ import { rowInsideContainerScenario } from './scenarios/row-inside-container.sce
 import { containerInsideRowScenario } from './scenarios/container-inside-row.scenario';
 import { containerInsideGroupScenario } from './scenarios/container-inside-group.scenario';
 import { containerInsideGroupSelfScenario } from './scenarios/container-inside-group-self.scenario';
+import { containerInsideGroupParentScenario } from './scenarios/container-inside-group-parent.scenario';
 import { deeplyNestedScenario } from './scenarios/deeply-nested.scenario';
 
 /**
@@ -27,6 +28,7 @@ export const containerNestingSuite: TestSuite = {
     containerInsideRowScenario,
     containerInsideGroupScenario,
     containerInsideGroupSelfScenario,
+    containerInsideGroupParentScenario,
     deeplyNestedScenario,
   ],
 };

--- a/apps/e2e/core/src/app/testing/container-nesting/container-nesting.suite.ts
+++ b/apps/e2e/core/src/app/testing/container-nesting/container-nesting.suite.ts
@@ -4,6 +4,8 @@ import { groupInsideArrayScenario } from './scenarios/group-inside-array.scenari
 import { rowInsideArrayScenario } from './scenarios/row-inside-array.scenario';
 import { rowInsideContainerScenario } from './scenarios/row-inside-container.scenario';
 import { containerInsideRowScenario } from './scenarios/container-inside-row.scenario';
+import { containerInsideGroupScenario } from './scenarios/container-inside-group.scenario';
+import { containerInsideGroupSelfScenario } from './scenarios/container-inside-group-self.scenario';
 import { deeplyNestedScenario } from './scenarios/deeply-nested.scenario';
 
 /**
@@ -23,6 +25,8 @@ export const containerNestingSuite: TestSuite = {
     rowInsideArrayScenario,
     rowInsideContainerScenario,
     containerInsideRowScenario,
+    containerInsideGroupScenario,
+    containerInsideGroupSelfScenario,
     deeplyNestedScenario,
   ],
 };

--- a/apps/e2e/core/src/app/testing/container-nesting/scenarios/container-inside-group-parent.scenario.ts
+++ b/apps/e2e/core/src/app/testing/container-nesting/scenarios/container-inside-group-parent.scenario.ts
@@ -1,0 +1,79 @@
+import { EvaluationContext, FormConfig } from '@ng-forge/dynamic-forms';
+import { TestScenario } from '../../shared/types';
+
+/**
+ * Variant of `container-inside-group` that exercises the `$group` dependency
+ * token. `dependsOn: ['$group']` resolves at collection time to the field's
+ * nearest parent container path (`address` here), so the derivation fires
+ * whenever any sibling in the same group changes — without enumerating each
+ * sibling explicitly.
+ *
+ * Shape: `group(address) > container > input(state) + input(country)` where
+ * `state` has a derivation that picks a value from `country`.
+ */
+const config = {
+  fields: [
+    {
+      key: 'address',
+      type: 'group',
+      fields: [
+        {
+          key: 'addressContainer',
+          type: 'container',
+          wrappers: [{ type: 'css', cssClasses: 'test-container' }],
+          fields: [
+            {
+              key: 'country',
+              type: 'input',
+              label: 'Country',
+              value: '',
+            },
+            {
+              key: 'state',
+              type: 'input',
+              label: 'State',
+              value: '',
+              logic: [
+                {
+                  type: 'derivation',
+                  functionName: 'deriveStateFromCountry',
+                  // $group resolves to 'address' — the derivation fires on
+                  // any change inside the address group.
+                  dependsOn: ['$group'],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      key: 'submit',
+      type: 'submit',
+      label: 'Submit',
+      props: { type: 'submit', color: 'primary' },
+      col: 12,
+    },
+  ],
+} as const satisfies FormConfig;
+
+export const containerInsideGroupParentScenario: TestScenario = {
+  testId: 'container-inside-group-parent',
+  title: 'Container Inside Group ($group)',
+  description: 'Verify $group in dependsOn resolves to the nearest parent container path',
+  config,
+  customFnConfig: {
+    derivations: {
+      deriveStateFromCountry: (context: EvaluationContext) => {
+        // `groupValue` is the address group's value — no need to know
+        // the parent group's key. Mirrors the `'$group'` token's
+        // path-resolution semantic in dependsOn.
+        const group = (context.groupValue ?? {}) as Record<string, unknown>;
+        const country = String(group['country'] ?? '').toLowerCase();
+        if (country === 'usa') return 'NY';
+        if (country === 'canada') return 'ON';
+        return '';
+      },
+    },
+  },
+};

--- a/apps/e2e/core/src/app/testing/container-nesting/scenarios/container-inside-group-self.scenario.ts
+++ b/apps/e2e/core/src/app/testing/container-nesting/scenarios/container-inside-group-self.scenario.ts
@@ -1,0 +1,61 @@
+import { EvaluationContext, FormConfig } from '@ng-forge/dynamic-forms';
+import { TestScenario } from '../../shared/types';
+
+/**
+ * Variant of `container-inside-group` that exercises the `$self` dependency
+ * token. `dependsOn: ['$self']` resolves at collection time to the field's
+ * own absolute path (`address.state`), so factory authors don't need to know
+ * the ancestor group keys when wiring self-derivations.
+ *
+ * Same shape: `group(address) > container > input(state)` with a
+ * self-transforming derivation that uppercases the value.
+ */
+const config = {
+  fields: [
+    {
+      key: 'address',
+      type: 'group',
+      fields: [
+        {
+          key: 'addressContainer',
+          type: 'container',
+          wrappers: [{ type: 'css', cssClasses: 'test-container' }],
+          fields: [
+            {
+              key: 'state',
+              type: 'input',
+              label: 'State',
+              value: '',
+              logic: [
+                {
+                  type: 'derivation',
+                  functionName: 'uppercaseState',
+                  dependsOn: ['$self'],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      key: 'submit',
+      type: 'submit',
+      label: 'Submit',
+      props: { type: 'submit', color: 'primary' },
+      col: 12,
+    },
+  ],
+} as const satisfies FormConfig;
+
+export const containerInsideGroupSelfScenario: TestScenario = {
+  testId: 'container-inside-group-self',
+  title: 'Container Inside Group ($self)',
+  description: "Verify $self in dependsOn resolves to the field's absolute path under a group",
+  config,
+  customFnConfig: {
+    derivations: {
+      uppercaseState: (context: EvaluationContext) => String(context.fieldValue ?? '').toUpperCase(),
+    },
+  },
+};

--- a/apps/e2e/core/src/app/testing/container-nesting/scenarios/container-inside-group.scenario.ts
+++ b/apps/e2e/core/src/app/testing/container-nesting/scenarios/container-inside-group.scenario.ts
@@ -1,0 +1,72 @@
+import { EvaluationContext, FormConfig } from '@ng-forge/dynamic-forms';
+import { TestScenario } from '../../shared/types';
+
+/**
+ * Reproduces a bug found via @dereekb/dbx-form: a derivation attached to a
+ * value field does not fire when the field lives inside a `group` whose
+ * children include a layout-only `container` (no key) that holds the value
+ * field. The same derivation works when the value field is at the root.
+ *
+ * Shape under test: `group(address) > container > input(state)` with a
+ * self-transforming derivation on `state` (uppercases its own value).
+ *
+ * `dependsOn` uses the convention-correct absolute path `'address.state'`
+ * (rooted at the form). The bug is that the collector still computes the
+ * derivation's writeback target as the bare `'state'` rather than
+ * `'address.state'`, so writeback fails silently regardless of the
+ * `dependsOn` form.
+ *
+ * Expected: typing `tx` into `address.state` results in `address.state === 'TX'`
+ * after the derivation fires.
+ */
+const config = {
+  fields: [
+    {
+      key: 'address',
+      type: 'group',
+      fields: [
+        {
+          type: 'container',
+          key: 'container',
+          wrappers: [{ type: 'css', cssClasses: 'test-container' }],
+          fields: [
+            {
+              key: 'state',
+              type: 'input',
+              label: 'State',
+              value: '',
+              logic: [
+                {
+                  type: 'derivation',
+                  functionName: 'uppercaseState',
+                  // Convention: dependsOn paths are absolute (rooted at form).
+                  // The field's actual form path is `address.state`.
+                  dependsOn: ['address.state'],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      key: 'submit',
+      type: 'submit',
+      label: 'Submit',
+      props: { type: 'submit', color: 'primary' },
+      col: 12,
+    },
+  ],
+} as const satisfies FormConfig;
+
+export const containerInsideGroupScenario: TestScenario = {
+  testId: 'container-inside-group',
+  title: 'Container Inside Group',
+  description: 'Verify a derivation fires for a value field nested as group > container > input',
+  config,
+  customFnConfig: {
+    derivations: {
+      uppercaseState: (context: EvaluationContext) => String(context.fieldValue ?? '').toUpperCase(),
+    },
+  },
+};

--- a/apps/e2e/core/src/app/testing/derivation-logic/derivation-logic.routes.ts
+++ b/apps/e2e/core/src/app/testing/derivation-logic/derivation-logic.routes.ts
@@ -53,6 +53,18 @@ const routes: Routes = [
     data: { scenario: getDerivationLogicScenario('array-field-self-derivation-test') },
   },
   {
+    path: 'array-container-field-self-derivation',
+    loadComponent: () =>
+      import('./scenarios/array-container-field-self-derivation.component').then((m) => m.ArrayContainerFieldSelfDerivationComponent),
+  },
+  {
+    path: 'array-double-container-field-self-derivation',
+    loadComponent: () =>
+      import('./scenarios/array-double-container-field-self-derivation.component').then(
+        (m) => m.ArrayDoubleContainerFieldSelfDerivationComponent,
+      ),
+  },
+  {
     path: 'bidirectional-float',
     loadComponent: () => import('../shared/test-scenario.component').then((m) => m.TestScenarioComponent),
     data: { scenario: getDerivationLogicScenario('bidirectional-float-test') },

--- a/apps/e2e/core/src/app/testing/derivation-logic/derivation-logic.routes.ts
+++ b/apps/e2e/core/src/app/testing/derivation-logic/derivation-logic.routes.ts
@@ -48,6 +48,11 @@ const routes: Routes = [
     data: { scenario: getDerivationLogicScenario('array-field-derivation-test') },
   },
   {
+    path: 'array-field-self-derivation',
+    loadComponent: () => import('../shared/test-scenario.component').then((m) => m.TestScenarioComponent),
+    data: { scenario: getDerivationLogicScenario('array-field-self-derivation-test') },
+  },
+  {
     path: 'bidirectional-float',
     loadComponent: () => import('../shared/test-scenario.component').then((m) => m.TestScenarioComponent),
     data: { scenario: getDerivationLogicScenario('bidirectional-float-test') },

--- a/apps/e2e/core/src/app/testing/derivation-logic/derivation-logic.spec.ts
+++ b/apps/e2e/core/src/app/testing/derivation-logic/derivation-logic.spec.ts
@@ -681,6 +681,70 @@ test.describe('Value Derivation Logic Tests', () => {
     });
   });
 
+  test.describe('Array Field $self Derivation (No Row Wrapper)', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(testUrl('/test/derivation-logic/array-field-self-derivation'));
+      await page.waitForLoadState('networkidle');
+    });
+
+    test('should fire $self-resolved derivation on each array item independently from initial values', async ({ page, helpers }) => {
+      const scenario = helpers.getScenario('array-field-self-derivation-test');
+      await expect(scenario).toBeVisible();
+
+      const nameInputs = scenario.locator('[id^="name"] input');
+      await expect(nameInputs).toHaveCount(2);
+
+      // Initial values 'first' / 'second' should be uppercased by the derivation
+      // resolved from `dependsOn: ['$self']` against `items.$.name`.
+      await expect(nameInputs.nth(0)).toHaveValue('FIRST');
+      await expect(nameInputs.nth(1)).toHaveValue('SECOND');
+    });
+
+    test('should fire $self derivation when user edits an array item field', async ({ page, helpers }) => {
+      const scenario = helpers.getScenario('array-field-self-derivation-test');
+      await expect(scenario).toBeVisible();
+
+      const nameInputs = scenario.locator('[id^="name"] input');
+      const firstName = nameInputs.nth(0);
+      const secondName = nameInputs.nth(1);
+
+      await expect(firstName).toHaveValue('FIRST');
+
+      // Edit first item — derivation should uppercase the new value
+      await helpers.clearAndFill(firstName, 'hello');
+      await page.waitForTimeout(500);
+      await expect(firstName).toHaveValue('HELLO');
+
+      // Second item should be unaffected
+      await expect(secondName).toHaveValue('SECOND');
+
+      // Edit second item — derivation should fire independently for that item
+      await helpers.clearAndFill(secondName, 'world');
+      await page.waitForTimeout(500);
+      await expect(secondName).toHaveValue('WORLD');
+      await expect(firstName).toHaveValue('HELLO');
+    });
+
+    test('should fire $self derivation on a newly added array item', async ({ page, helpers }) => {
+      const scenario = helpers.getScenario('array-field-self-derivation-test');
+      await expect(scenario).toBeVisible();
+
+      const nameInputs = scenario.locator('[id^="name"] input');
+      const addButton = scenario.locator('#addItem button');
+
+      await expect(nameInputs).toHaveCount(2);
+
+      await addButton.click();
+      await page.waitForTimeout(500);
+      await expect(nameInputs).toHaveCount(3);
+
+      const newName = nameInputs.nth(2);
+      await helpers.clearAndFill(newName, 'fresh');
+      await page.waitForTimeout(500);
+      await expect(newName).toHaveValue('FRESH');
+    });
+  });
+
   test.describe('Derivation in Group', () => {
     test.skip(true, 'Library limitation: derivation expressions inside group containers do not evaluate correctly');
     test('should derive fullName from firstName and lastName inside a group', async ({ page, helpers }) => {

--- a/apps/e2e/core/src/app/testing/derivation-logic/derivation-logic.spec.ts
+++ b/apps/e2e/core/src/app/testing/derivation-logic/derivation-logic.spec.ts
@@ -745,6 +745,155 @@ test.describe('Value Derivation Logic Tests', () => {
     });
   });
 
+  test.describe('Array → Container → Field $self Derivation (Post-Init Value)', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(testUrl('/test/derivation-logic/array-container-field-self-derivation'));
+      await page.waitForLoadState('networkidle');
+    });
+
+    test('should fire $self-resolved derivation when array value is set programmatically AFTER form init', async ({ page, helpers }) => {
+      const scenario = helpers.getScenario('array-container-field-self-derivation-test');
+      await expect(scenario).toBeVisible();
+
+      // The array's inline fields template renders one empty item by default.
+      const firstInputs = scenario.locator('[id^="first"] input');
+      await expect(firstInputs).toHaveCount(1);
+      await expect(firstInputs.nth(0)).toHaveValue('');
+
+      // Click the button that programmatically sets formValue to { array: [{ first: 'hi' }] }
+      // AFTER the form has been initialized.
+      await page.locator('[data-testid="load-value"]').click();
+      await page.waitForTimeout(500);
+
+      // The $self derivation should have fired and uppercased 'hi' → 'HI'
+      // even though the leaf is buried under a container in the array item.
+      await expect(firstInputs.nth(0)).toHaveValue('HI');
+    });
+
+    test('should fire $self derivation when user edits the container-wrapped array item field after post-init load', async ({
+      page,
+      helpers,
+    }) => {
+      const scenario = helpers.getScenario('array-container-field-self-derivation-test');
+      await expect(scenario).toBeVisible();
+
+      await page.locator('[data-testid="load-value"]').click();
+      await page.waitForTimeout(500);
+
+      const firstInput = scenario.locator('[id^="first"] input').nth(0);
+      await expect(firstInput).toHaveValue('HI');
+
+      await helpers.clearAndFill(firstInput, 'hello');
+      await page.waitForTimeout(500);
+      await expect(firstInput).toHaveValue('HELLO');
+    });
+
+    test('should fire $self derivation when array value is REPLACED after the form already has a value', async ({ page, helpers }) => {
+      const scenario = helpers.getScenario('array-container-field-self-derivation-test');
+      await expect(scenario).toBeVisible();
+
+      // First load
+      await page.locator('[data-testid="load-value"]').click();
+      await page.waitForTimeout(500);
+
+      const firstInput = scenario.locator('[id^="first"] input').nth(0);
+      await expect(firstInput).toHaveValue('HI');
+
+      // Replace with a new value programmatically — derivation should re-fire on the new value
+      await page.locator('[data-testid="update-value"]').click();
+      await page.waitForTimeout(500);
+
+      await expect(firstInput).toHaveValue('WORLD');
+    });
+
+    test('should fire $self derivation on a newly added container-wrapped array item after post-init load', async ({ page, helpers }) => {
+      const scenario = helpers.getScenario('array-container-field-self-derivation-test');
+      await expect(scenario).toBeVisible();
+
+      await page.locator('[data-testid="load-value"]').click();
+      await page.waitForTimeout(500);
+
+      const firstInputs = scenario.locator('[id^="first"] input');
+      const addButton = scenario.locator('#addItem button');
+
+      await expect(firstInputs).toHaveCount(1);
+
+      await addButton.click();
+      await page.waitForTimeout(500);
+      await expect(firstInputs).toHaveCount(2);
+
+      const newInput = firstInputs.nth(1);
+      await helpers.clearAndFill(newInput, 'fresh');
+      await page.waitForTimeout(500);
+      await expect(newInput).toHaveValue('FRESH');
+    });
+  });
+
+  test.describe('Array → Container → Container → Field $self Derivation (Post-Init Value)', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(testUrl('/test/derivation-logic/array-double-container-field-self-derivation'));
+      await page.waitForLoadState('networkidle');
+    });
+
+    test('should fire $self-resolved derivation when array value is set programmatically AFTER form init (double container, template-only array)', async ({
+      page,
+      helpers,
+    }) => {
+      const scenario = helpers.getScenario('array-double-container-field-self-derivation-test');
+      await expect(scenario).toBeVisible();
+
+      // Array uses `template` only — no inline items render before a value is set.
+      const firstInputs = scenario.locator('[id^="first"] input');
+      await expect(firstInputs).toHaveCount(0);
+
+      await page.locator('[data-testid="load-value"]').click();
+      await page.waitForTimeout(500);
+
+      await expect(firstInputs).toHaveCount(1);
+
+      // The $self derivation should fire and uppercase 'hi' → 'HI' even when
+      // the leaf is buried under TWO nested containers in the array item.
+      await expect(firstInputs.nth(0)).toHaveValue('HI');
+    });
+
+    test('should fire $self derivation when user edits the doubly-container-wrapped array item field after post-init load', async ({
+      page,
+      helpers,
+    }) => {
+      const scenario = helpers.getScenario('array-double-container-field-self-derivation-test');
+      await expect(scenario).toBeVisible();
+
+      await page.locator('[data-testid="load-value"]').click();
+      await page.waitForTimeout(500);
+
+      const firstInput = scenario.locator('[id^="first"] input').nth(0);
+      await expect(firstInput).toHaveValue('HI');
+
+      await helpers.clearAndFill(firstInput, 'hello');
+      await page.waitForTimeout(500);
+      await expect(firstInput).toHaveValue('HELLO');
+    });
+
+    test('should fire $self derivation when array value is REPLACED after the form already has a value (double container)', async ({
+      page,
+      helpers,
+    }) => {
+      const scenario = helpers.getScenario('array-double-container-field-self-derivation-test');
+      await expect(scenario).toBeVisible();
+
+      await page.locator('[data-testid="load-value"]').click();
+      await page.waitForTimeout(500);
+
+      const firstInput = scenario.locator('[id^="first"] input').nth(0);
+      await expect(firstInput).toHaveValue('HI');
+
+      await page.locator('[data-testid="update-value"]').click();
+      await page.waitForTimeout(500);
+
+      await expect(firstInput).toHaveValue('WORLD');
+    });
+  });
+
   test.describe('Derivation in Group', () => {
     test.skip(true, 'Library limitation: derivation expressions inside group containers do not evaluate correctly');
     test('should derive fullName from firstName and lastName inside a group', async ({ page, helpers }) => {

--- a/apps/e2e/core/src/app/testing/derivation-logic/derivation-logic.suite.ts
+++ b/apps/e2e/core/src/app/testing/derivation-logic/derivation-logic.suite.ts
@@ -8,6 +8,8 @@ import { chainDerivationScenario } from './scenarios/chain-derivation.scenario';
 import { shorthandDerivationScenario } from './scenarios/shorthand-derivation.scenario';
 import { arrayFieldDerivationScenario } from './scenarios/array-field-derivation.scenario';
 import { arrayFieldSelfDerivationScenario } from './scenarios/array-field-self-derivation.scenario';
+import { arrayContainerFieldSelfDerivationScenario } from './scenarios/array-container-field-self-derivation.scenario';
+import { arrayDoubleContainerFieldSelfDerivationScenario } from './scenarios/array-double-container-field-self-derivation.scenario';
 import { bidirectionalFloatScenario } from './scenarios/bidirectional-float.scenario';
 import { derivationInGroupScenario } from './scenarios/derivation-in-group.scenario';
 import { stopOnUserOverrideScenario } from './scenarios/stop-on-user-override.scenario';
@@ -41,6 +43,8 @@ export const derivationLogicSuite: TestSuite = {
     shorthandDerivationScenario,
     arrayFieldDerivationScenario,
     arrayFieldSelfDerivationScenario,
+    arrayContainerFieldSelfDerivationScenario,
+    arrayDoubleContainerFieldSelfDerivationScenario,
     bidirectionalFloatScenario,
     derivationInGroupScenario,
     stopOnUserOverrideScenario,

--- a/apps/e2e/core/src/app/testing/derivation-logic/derivation-logic.suite.ts
+++ b/apps/e2e/core/src/app/testing/derivation-logic/derivation-logic.suite.ts
@@ -7,6 +7,7 @@ import { selfTransformScenario } from './scenarios/self-transform.scenario';
 import { chainDerivationScenario } from './scenarios/chain-derivation.scenario';
 import { shorthandDerivationScenario } from './scenarios/shorthand-derivation.scenario';
 import { arrayFieldDerivationScenario } from './scenarios/array-field-derivation.scenario';
+import { arrayFieldSelfDerivationScenario } from './scenarios/array-field-self-derivation.scenario';
 import { bidirectionalFloatScenario } from './scenarios/bidirectional-float.scenario';
 import { derivationInGroupScenario } from './scenarios/derivation-in-group.scenario';
 import { stopOnUserOverrideScenario } from './scenarios/stop-on-user-override.scenario';
@@ -39,6 +40,7 @@ export const derivationLogicSuite: TestSuite = {
     chainDerivationScenario,
     shorthandDerivationScenario,
     arrayFieldDerivationScenario,
+    arrayFieldSelfDerivationScenario,
     bidirectionalFloatScenario,
     derivationInGroupScenario,
     stopOnUserOverrideScenario,

--- a/apps/e2e/core/src/app/testing/derivation-logic/scenarios/array-container-field-self-derivation.component.ts
+++ b/apps/e2e/core/src/app/testing/derivation-logic/scenarios/array-container-field-self-derivation.component.ts
@@ -1,0 +1,88 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { JsonPipe } from '@angular/common';
+import { DynamicForm, FormConfig } from '@ng-forge/dynamic-forms';
+import {
+  arrayContainerFieldSelfDerivationConfig,
+  arrayContainerFieldSelfDerivationCustomFns,
+  arrayContainerFieldSelfDerivationScenario,
+} from './array-container-field-self-derivation.scenario';
+
+/**
+ * Route component for `array-container-field-self-derivation`.
+ *
+ * Crucially, the form value is NOT supplied via initialValue. Instead, buttons
+ * programmatically set the [(value)] signal AFTER form initialization to verify
+ * that `dependsOn: ['$self']` derivations fire for leaves buried under a
+ * container inside an array when the value arrives post-init.
+ */
+@Component({
+  selector: 'example-array-container-field-self-derivation',
+  imports: [DynamicForm, JsonPipe],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="test-page">
+      <h1>{{ scenario.title }}</h1>
+
+      <section class="test-scenario" [attr.data-testid]="scenario.testId">
+        <h2>{{ scenario.title }}</h2>
+        <p class="scenario-description">{{ scenario.description }}</p>
+
+        <div class="value-controls">
+          <button type="button" data-testid="load-value" (click)="loadValue()">Load array with first='hi'</button>
+          <button type="button" data-testid="update-value" (click)="updateValue()">Update first to 'world'</button>
+          <button type="button" data-testid="clear-value" (click)="clearValue()">Clear Value</button>
+        </div>
+
+        <form [dynamic-form]="config" [(value)]="formValue"></form>
+
+        <details class="debug-output" open>
+          <summary>Debug Output</summary>
+          <pre [attr.data-testid]="'form-value-' + scenario.testId">{{ formValue() | json }}</pre>
+        </details>
+      </section>
+    </div>
+  `,
+  styleUrl: '../../test-styles.scss',
+  styles: [
+    `
+      .value-controls {
+        display: flex;
+        gap: 0.5rem;
+        margin-bottom: 1rem;
+        flex-wrap: wrap;
+      }
+      .value-controls button {
+        padding: 0.5rem 1rem;
+        border: 1px solid #ccc;
+        background: #f5f5f5;
+        cursor: pointer;
+        border-radius: 4px;
+      }
+      .value-controls button:hover {
+        background: #e0e0e0;
+      }
+    `,
+  ],
+})
+export class ArrayContainerFieldSelfDerivationComponent {
+  readonly scenario = arrayContainerFieldSelfDerivationScenario;
+
+  readonly config: FormConfig = {
+    ...arrayContainerFieldSelfDerivationConfig,
+    customFnConfig: arrayContainerFieldSelfDerivationCustomFns,
+  };
+
+  readonly formValue = signal<Record<string, unknown>>({});
+
+  loadValue(): void {
+    this.formValue.set({ array: [{ first: 'hi' }] });
+  }
+
+  updateValue(): void {
+    this.formValue.set({ array: [{ first: 'world' }] });
+  }
+
+  clearValue(): void {
+    this.formValue.set({});
+  }
+}

--- a/apps/e2e/core/src/app/testing/derivation-logic/scenarios/array-container-field-self-derivation.scenario.ts
+++ b/apps/e2e/core/src/app/testing/derivation-logic/scenarios/array-container-field-self-derivation.scenario.ts
@@ -1,0 +1,104 @@
+import { EvaluationContext, FormConfig } from '@ng-forge/dynamic-forms';
+import { TestScenario } from '../../shared/types';
+
+/**
+ * Variant of `array-field-self-derivation.scenario.ts` that wraps the input
+ * inside a `container` field, exercising the array → container → leaf path.
+ *
+ * Reproduces a regression where `dependsOn: ['$self']` derivations do not fire
+ * for fields buried under a layout container in array items when the form
+ * value (e.g. `{ array: [{ first: 'hi' }] }`) is supplied via the form value
+ * binding rather than baked into the field config — including the case where
+ * the value is set programmatically AFTER the form has been initialized.
+ */
+export const arrayContainerFieldSelfDerivationConfig = {
+  fields: [
+    {
+      key: 'array',
+      type: 'array',
+      fields: [
+        [
+          {
+            key: 'wrapBox',
+            type: 'container',
+            wrappers: [{ type: 'css', cssClasses: 'test-container' }],
+            fields: [
+              {
+                key: 'first',
+                type: 'input',
+                label: 'First',
+                logic: [
+                  {
+                    type: 'derivation',
+                    functionName: 'uppercase',
+                    dependsOn: ['$self'],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      ],
+    },
+    {
+      key: 'addItem',
+      type: 'addArrayItem',
+      arrayKey: 'array',
+      label: 'Add Item',
+      props: { color: 'primary' },
+      template: [
+        {
+          key: 'wrapBox',
+          type: 'container',
+          wrappers: [{ type: 'css', cssClasses: 'test-container' }],
+          fields: [
+            {
+              key: 'first',
+              type: 'input',
+              label: 'First',
+              logic: [
+                {
+                  type: 'derivation',
+                  functionName: 'uppercase',
+                  dependsOn: ['$self'],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      key: 'removeItem',
+      type: 'removeArrayItem',
+      arrayKey: 'array',
+      label: 'Remove Last Item',
+      props: { color: 'warn' },
+    },
+    {
+      key: 'submit',
+      type: 'submit',
+      label: 'Submit',
+      props: { type: 'submit', color: 'primary' },
+      col: 12,
+    },
+  ],
+} as const satisfies FormConfig;
+
+export const arrayContainerFieldSelfDerivationCustomFns = {
+  derivations: {
+    uppercase: (ctx: EvaluationContext) => {
+      const value = String(ctx.fieldValue ?? '');
+      return value.toUpperCase();
+    },
+  },
+};
+
+export const arrayContainerFieldSelfDerivationScenario: TestScenario = {
+  testId: 'array-container-field-self-derivation-test',
+  title: 'Array → Container → Field $self Derivation (Post-Init Value)',
+  description:
+    'Tests dependsOn:["$self"] derivation on a field wrapped in a container inside an array. The form value is supplied programmatically AFTER initialization via a button — verifies the derivation fires even when the leaf is buried under a layout container.',
+  config: arrayContainerFieldSelfDerivationConfig,
+  customFnConfig: arrayContainerFieldSelfDerivationCustomFns,
+};

--- a/apps/e2e/core/src/app/testing/derivation-logic/scenarios/array-double-container-field-self-derivation.component.ts
+++ b/apps/e2e/core/src/app/testing/derivation-logic/scenarios/array-double-container-field-self-derivation.component.ts
@@ -1,0 +1,87 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { JsonPipe } from '@angular/common';
+import { DynamicForm, FormConfig } from '@ng-forge/dynamic-forms';
+import {
+  arrayDoubleContainerFieldSelfDerivationConfig,
+  arrayDoubleContainerFieldSelfDerivationCustomFns,
+  arrayDoubleContainerFieldSelfDerivationScenario,
+} from './array-double-container-field-self-derivation.scenario';
+
+/**
+ * Route component for `array-double-container-field-self-derivation`.
+ *
+ * Buttons programmatically set the [(value)] signal AFTER form initialization
+ * to verify that `dependsOn: ['$self']` derivations fire for leaves buried
+ * under TWO nested containers inside an array when the value arrives post-init.
+ */
+@Component({
+  selector: 'example-array-double-container-field-self-derivation',
+  imports: [DynamicForm, JsonPipe],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="test-page">
+      <h1>{{ scenario.title }}</h1>
+
+      <section class="test-scenario" [attr.data-testid]="scenario.testId">
+        <h2>{{ scenario.title }}</h2>
+        <p class="scenario-description">{{ scenario.description }}</p>
+
+        <div class="value-controls">
+          <button type="button" data-testid="load-value" (click)="loadValue()">Load array with first='hi'</button>
+          <button type="button" data-testid="update-value" (click)="updateValue()">Update first to 'world'</button>
+          <button type="button" data-testid="clear-value" (click)="clearValue()">Clear Value</button>
+        </div>
+
+        <form [dynamic-form]="config" [(value)]="formValue"></form>
+
+        <details class="debug-output" open>
+          <summary>Debug Output</summary>
+          <pre [attr.data-testid]="'form-value-' + scenario.testId">{{ formValue() | json }}</pre>
+        </details>
+      </section>
+    </div>
+  `,
+  styleUrl: '../../test-styles.scss',
+  styles: [
+    `
+      .value-controls {
+        display: flex;
+        gap: 0.5rem;
+        margin-bottom: 1rem;
+        flex-wrap: wrap;
+      }
+      .value-controls button {
+        padding: 0.5rem 1rem;
+        border: 1px solid #ccc;
+        background: #f5f5f5;
+        cursor: pointer;
+        border-radius: 4px;
+      }
+      .value-controls button:hover {
+        background: #e0e0e0;
+      }
+    `,
+  ],
+})
+export class ArrayDoubleContainerFieldSelfDerivationComponent {
+  readonly scenario = arrayDoubleContainerFieldSelfDerivationScenario;
+
+  readonly config: FormConfig = {
+    ...arrayDoubleContainerFieldSelfDerivationConfig,
+    customFnConfig: arrayDoubleContainerFieldSelfDerivationCustomFns,
+  };
+
+  readonly formValue = signal<Record<string, unknown>>({});
+
+  loadValue(): void {
+    this.formValue.set({ array: [{ first: 'hi' }] });
+  }
+
+  updateValue(): void {
+    this.formValue.set({ array: [{ first: 'world' }] });
+  }
+
+  clearValue(): void {
+    this.formValue.set({});
+  }
+}

--- a/apps/e2e/core/src/app/testing/derivation-logic/scenarios/array-double-container-field-self-derivation.scenario.ts
+++ b/apps/e2e/core/src/app/testing/derivation-logic/scenarios/array-double-container-field-self-derivation.scenario.ts
@@ -1,0 +1,67 @@
+import { EvaluationContext, FormConfig } from '@ng-forge/dynamic-forms';
+import { TestScenario } from '../../shared/types';
+
+/**
+ * Variant of `array-container-field-self-derivation.scenario.ts` that nests
+ * the leaf input under TWO containers, exercising the
+ * array → container → container → leaf path.
+ *
+ * Reproduces the case where `dependsOn: ['$self']` derivations must still
+ * fire for fields buried under more than one layout container in array items
+ * when the form value is supplied programmatically AFTER initialization.
+ */
+export const arrayDoubleContainerFieldSelfDerivationConfig = {
+  fields: [
+    {
+      key: 'array',
+      type: 'array',
+      template: [
+        {
+          key: 'outerBox',
+          type: 'container',
+          wrappers: [{ type: 'css', cssClasses: 'test-container' }],
+          fields: [
+            {
+              key: 'innerBox',
+              type: 'container',
+              wrappers: [{ type: 'css', cssClasses: 'test-container' }],
+              fields: [
+                {
+                  key: 'first',
+                  type: 'input',
+                  label: 'First',
+                  logic: [
+                    {
+                      type: 'derivation',
+                      trigger: 'onChange',
+                      functionName: 'uppercase',
+                      dependsOn: ['$self'],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+} as const satisfies FormConfig;
+
+export const arrayDoubleContainerFieldSelfDerivationCustomFns = {
+  derivations: {
+    uppercase: (ctx: EvaluationContext) => {
+      const value = String(ctx.fieldValue ?? '');
+      return value.toUpperCase();
+    },
+  },
+};
+
+export const arrayDoubleContainerFieldSelfDerivationScenario: TestScenario = {
+  testId: 'array-double-container-field-self-derivation-test',
+  title: 'Array → Container → Container → Field $self Derivation (Post-Init Value)',
+  description:
+    'Tests dependsOn:["$self"] derivation on a field wrapped in two nested containers inside an array. The form value is supplied programmatically AFTER initialization via a button — verifies the derivation fires even when the leaf is buried under multiple layout containers.',
+  config: arrayDoubleContainerFieldSelfDerivationConfig,
+  customFnConfig: arrayDoubleContainerFieldSelfDerivationCustomFns,
+};

--- a/apps/e2e/core/src/app/testing/derivation-logic/scenarios/array-field-self-derivation.scenario.ts
+++ b/apps/e2e/core/src/app/testing/derivation-logic/scenarios/array-field-self-derivation.scenario.ts
@@ -1,0 +1,104 @@
+import { EvaluationContext, FormConfig } from '@ng-forge/dynamic-forms';
+import { TestScenario } from '../../shared/types';
+
+/**
+ * Mirrors the "should resolve $self to the array placeholder path inside arrays"
+ * unit test from `derivation-collector.spec.ts`, but at runtime. The field is
+ * placed directly inside the array (no row wrapper) so the derivation lives
+ * exactly one container hop below the array boundary.
+ *
+ * Validates that a `dependsOn: ['$self']` derivation actually fires for fields
+ * inside array items — the unit test confirms collection produces the correct
+ * `items.$.name` path; this scenario confirms the orchestrator applies it.
+ */
+const config = {
+  fields: [
+    {
+      key: 'items',
+      type: 'array',
+      fields: [
+        [
+          {
+            key: 'name',
+            type: 'input',
+            label: 'Name',
+            value: 'first',
+            logic: [
+              {
+                type: 'derivation',
+                functionName: 'uppercase',
+                dependsOn: ['$self'],
+              },
+            ],
+          },
+        ],
+        [
+          {
+            key: 'name',
+            type: 'input',
+            label: 'Name',
+            value: 'second',
+            logic: [
+              {
+                type: 'derivation',
+                functionName: 'uppercase',
+                dependsOn: ['$self'],
+              },
+            ],
+          },
+        ],
+      ],
+    },
+    {
+      key: 'addItem',
+      type: 'addArrayItem',
+      arrayKey: 'items',
+      label: 'Add Item',
+      props: { color: 'primary' },
+      template: [
+        {
+          key: 'name',
+          type: 'input',
+          label: 'Name',
+          logic: [
+            {
+              type: 'derivation',
+              functionName: 'uppercase',
+              dependsOn: ['$self'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      key: 'removeItem',
+      type: 'removeArrayItem',
+      arrayKey: 'items',
+      label: 'Remove Last Item',
+      props: { color: 'warn' },
+    },
+    {
+      key: 'submit',
+      type: 'submit',
+      label: 'Submit',
+      props: { type: 'submit', color: 'primary' },
+      col: 12,
+    },
+  ],
+} as const satisfies FormConfig;
+
+export const arrayFieldSelfDerivationScenario: TestScenario = {
+  testId: 'array-field-self-derivation-test',
+  title: 'Array Field $self Derivation (No Row Wrapper)',
+  description:
+    'Tests dependsOn:["$self"] derivation on a field placed directly inside an array — the derivation function should fire per array item and produce the uppercase value.',
+  config,
+  customFnConfig: {
+    derivations: {
+      uppercase: (ctx: EvaluationContext) => {
+        const value = String(ctx.fieldValue ?? '');
+        return value.toUpperCase();
+      },
+    },
+  },
+};

--- a/packages/dynamic-form-mcp/src/tools/data/lookup-topics.ts
+++ b/packages/dynamic-form-mcp/src/tools/data/lookup-topics.ts
@@ -780,8 +780,12 @@ logic: [{ type: 'derivation', expression: '...', stopOnUserOverride: true, reEng
 
 // HTTP derivation (server-driven values)
 logic: [{ type: 'derivation', source: 'http', http: { url: '/api/rate', queryParams: { from: 'formValue.currency' } }, responseExpression: 'response.rate', dependsOn: ['currency'] }]
+
+// Self-dependency token: $self resolves to the field's own absolute path at collection time
+logic: [{ type: 'derivation', functionName: 'uppercase', dependsOn: ['$self'] }]
 \`\`\`
 Derivation is always defined ON the field that receives the computed value (self-targeting).
+\`dependsOn\` paths are absolute from the form root (e.g. \`'address.state'\`). Use \`'$self'\` to refer to the field's own absolute path without hard-coding ancestor group keys.
 **Variables:** \`formValue\`, \`fieldValue\`, \`fieldState\`, \`formFieldState\`, \`externalData\` (see topic: expression-variables)
 **For deriving component properties** (minDate, options, label): use \`targetProperty\` (see topic \`property-derivation\`)`,
 
@@ -845,6 +849,44 @@ Derivations are always defined ON the field that receives the computed value (se
   }]
 }
 \`\`\`
+
+## \`dependsOn\` Path Resolution
+
+\`dependsOn\` paths are **absolute from the form root**, dotted notation. A field nested under a group has the group's key in its path:
+
+\`\`\`typescript
+{
+  type: 'group', key: 'address',
+  fields: [
+    { key: 'state', type: 'input', logic: [{
+      type: 'derivation',
+      functionName: 'uppercaseState',
+      dependsOn: ['address.state']  // absolute path from root
+    }]}
+  ]
+}
+\`\`\`
+
+Layout containers (\`page\`, \`row\`, \`container\`) do **not** contribute to the path — only \`group\` fields do. Array fields use the \`'arrayKey.$.fieldKey'\` placeholder convention.
+
+### \`$self\` token
+
+Use \`'$self'\` in \`dependsOn\` to refer to the field's own absolute path. Useful for self-derivations on fields built by factory helpers, where the ancestor group keys aren't known at config-authoring time:
+
+\`\`\`typescript
+{
+  type: 'group', key: 'address',
+  fields: [
+    { key: 'state', type: 'input', logic: [{
+      type: 'derivation',
+      functionName: 'uppercaseState',
+      dependsOn: ['$self']  // resolves to 'address.state' at collection time
+    }]}
+  ]
+}
+\`\`\`
+
+\`$self\` works alongside other absolute deps and inside arrays (resolves to the array placeholder form, e.g. \`'items.$.name'\`).
 
 ## HTTP Derivation (Server-Driven Values)
 

--- a/packages/dynamic-form-mcp/src/tools/data/lookup-topics.ts
+++ b/packages/dynamic-form-mcp/src/tools/data/lookup-topics.ts
@@ -783,9 +783,12 @@ logic: [{ type: 'derivation', source: 'http', http: { url: '/api/rate', queryPar
 
 // Self-dependency token: $self resolves to the field's own absolute path at collection time
 logic: [{ type: 'derivation', functionName: 'uppercase', dependsOn: ['$self'] }]
+
+// Parent-container token: $group resolves to the field's nearest parent group/array path
+logic: [{ type: 'derivation', functionName: 'computeFromGroup', dependsOn: ['$group'] }]
 \`\`\`
 Derivation is always defined ON the field that receives the computed value (self-targeting).
-\`dependsOn\` paths are absolute from the form root (e.g. \`'address.state'\`). Use \`'$self'\` to refer to the field's own absolute path without hard-coding ancestor group keys.
+\`dependsOn\` paths are absolute from the form root (e.g. \`'address.state'\`). Use \`'$self'\` for the field's own absolute path and \`'$group'\` for its nearest parent group/array — both useful in factory-built fields where ancestor keys aren't known at config time.
 **Variables:** \`formValue\`, \`fieldValue\`, \`fieldState\`, \`formFieldState\`, \`externalData\` (see topic: expression-variables)
 **For deriving component properties** (minDate, options, label): use \`targetProperty\` (see topic \`property-derivation\`)`,
 
@@ -887,6 +890,60 @@ Use \`'$self'\` in \`dependsOn\` to refer to the field's own absolute path. Usef
 \`\`\`
 
 \`$self\` works alongside other absolute deps and inside arrays (resolves to the array placeholder form, e.g. \`'items.$.name'\`).
+
+### \`$group\` token
+
+Use \`'$group'\` in \`dependsOn\` to refer to the field's **nearest parent container** (group or array). The derivation fires whenever any sibling under the same parent changes — handy when you don't want to enumerate each sibling explicitly:
+
+\`\`\`typescript
+{
+  type: 'group', key: 'address',
+  fields: [
+    { key: 'country', type: 'input' },
+    { key: 'state', type: 'input', logic: [{
+      type: 'derivation',
+      functionName: 'pickStateFromCountry',
+      dependsOn: ['$group']  // resolves to 'address' at collection time
+    }]}
+  ]
+}
+\`\`\`
+
+Resolution rules:
+- Inside group(s) only → the dotted ancestor group path (\`'address'\` or \`'org.address'\`).
+- Directly inside an array → the array key (\`'items'\`). Fires on any item change.
+- Inside group(s) inside an array → \`'items.$.address'\` form.
+- At form root → throws \`DynamicFormError\` (no parent container exists).
+
+### Token prefix substitution
+
+Both \`$self\` and \`$group\` accept a dotted suffix that is appended to the resolved path:
+
+\`\`\`typescript
+dependsOn: ['$group.country']  // resolves to 'address.country' inside group 'address'
+dependsOn: ['$group.contact.email']  // multi-segment suffix supported
+dependsOn: ['$self.flag']  // resolves to '<fieldKey>.flag' (object-valued fields)
+\`\`\`
+
+Use this to target a specific sibling without naming the parent group key — handy in factory-built field shapes.
+
+### \`groupValue\` in evaluation context
+
+Custom derivation functions and expressions receive a \`groupValue\` on the \`EvaluationContext\` that mirrors the \`$group\` token at evaluation time:
+
+\`\`\`typescript
+deriveStateFromCountry: (ctx) => {
+  const country = ctx.groupValue?.country;  // no need to know the parent key
+  return country === 'usa' ? 'NY' : '';
+}
+\`\`\`
+
+Population rules:
+- Inside a group: the parent group's value object.
+- Inside nested groups: the innermost parent group's value.
+- Directly inside an array item (no inner group): the array item itself (same as \`formValue\` in array context).
+- Inside a group inside an array item: the inner group's value within the item.
+- Field at form root: \`undefined\`.
 
 ## HTTP Derivation (Server-Driven Values)
 

--- a/packages/dynamic-forms/src/lib/core/derivation/compute-derived-value.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/compute-derived-value.ts
@@ -1,0 +1,64 @@
+import { DynamicFormError } from '../../errors/dynamic-form-error';
+import { EvaluationContext } from '../../models/expressions/evaluation-context';
+import { CustomFunction } from '../expressions/custom-function-types';
+import { ExpressionParser } from '../expressions/parser/expression-parser';
+import { BaseDerivationEntry } from './derivation-entry-base';
+
+/**
+ * Inputs accepted by {@link computeValueFromEntry}.
+ *
+ * @internal
+ */
+export interface ComputeValueOptions {
+  /**
+   * Registered derivation functions, used when the entry has `functionName`.
+   */
+  derivationFunctions?: Record<string, CustomFunction>;
+
+  /**
+   * Subject label used in the "no value source" error message — typically the
+   * resolved field key (e.g. `'items.0.lineTotal'`) or `${fieldKey}.${targetProperty}`
+   * for property derivations.
+   */
+  subject: string;
+
+  /**
+   * Optional descriptor (e.g., `'Property derivation function'`) used in the
+   * "function not found" error. Defaults to `'Derivation function'`.
+   */
+  functionKind?: string;
+}
+
+/**
+ * Single dispatch over `value` / `expression` / `functionName` shared by both
+ * the value-derivation and property-derivation applicators.
+ *
+ * Throws {@link DynamicFormError} on missing function or missing value source
+ * so both pipelines surface the library's standard error type.
+ *
+ * @internal
+ */
+export function computeValueFromEntry(
+  entry: Pick<BaseDerivationEntry, 'value' | 'expression' | 'functionName'>,
+  evalContext: EvaluationContext,
+  options: ComputeValueOptions,
+): unknown {
+  if (entry.value !== undefined) {
+    return entry.value;
+  }
+
+  if (entry.expression) {
+    return ExpressionParser.evaluate(entry.expression, evalContext);
+  }
+
+  if (entry.functionName) {
+    const fn = options.derivationFunctions?.[entry.functionName];
+    if (!fn) {
+      const kind = options.functionKind ?? 'Derivation function';
+      throw new DynamicFormError(`${kind} '${entry.functionName}' not found in customFnConfig.derivations`);
+    }
+    return fn(evalContext);
+  }
+
+  throw new DynamicFormError(`Derivation for ${options.subject} has no value source. Specify 'value', 'expression', or 'functionName'.`);
+}

--- a/packages/dynamic-forms/src/lib/core/derivation/debounce-period-utils.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/debounce-period-utils.ts
@@ -1,0 +1,32 @@
+import { DEFAULT_DEBOUNCE_MS } from '../../utils/debounce/debounce';
+import { BaseDerivationEntry } from './derivation-entry-base';
+
+/**
+ * Returns the unique set of debounce periods declared by `entries` whose
+ * `trigger === 'debounced'`. Entries without an explicit `debounceMs` use
+ * {@link DEFAULT_DEBOUNCE_MS}.
+ *
+ * @internal
+ */
+export function getDebouncePeriods(entries: ReadonlyArray<Pick<BaseDerivationEntry, 'trigger' | 'debounceMs'>>): number[] {
+  const periods = new Set<number>();
+  for (const entry of entries) {
+    if (entry.trigger === 'debounced') {
+      periods.add(entry.debounceMs ?? DEFAULT_DEBOUNCE_MS);
+    }
+  }
+  return Array.from(periods);
+}
+
+/**
+ * Filters `entries` down to those whose `trigger === 'debounced'` and whose
+ * effective `debounceMs` (defaulting to {@link DEFAULT_DEBOUNCE_MS}) equals `period`.
+ *
+ * @internal
+ */
+export function filterEntriesByDebouncePeriod<TEntry extends Pick<BaseDerivationEntry, 'trigger' | 'debounceMs'>>(
+  entries: ReadonlyArray<TEntry>,
+  period: number,
+): TEntry[] {
+  return entries.filter((entry) => entry.trigger === 'debounced' && (entry.debounceMs ?? DEFAULT_DEBOUNCE_MS) === period);
+}

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-applicator.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-applicator.spec.ts
@@ -1670,4 +1670,92 @@ describe('derivation-applicator', () => {
       expect(values.middleName).toBe(null);
     });
   });
+
+  describe('groupValue in evaluation context', () => {
+    let logger: Logger;
+    let formValueSignal: WritableSignal<Record<string, unknown>>;
+
+    beforeEach(() => {
+      logger = createMockLogger();
+      formValueSignal = signal({});
+    });
+
+    it('should populate groupValue with the parent group object for fields nested in a group', () => {
+      const { form } = createMockForm({ note: '' });
+      formValueSignal.set({ address: { country: 'usa', state: '' } });
+
+      let captured: unknown;
+      const captureFn = vi.fn().mockImplementation((ctx: { groupValue?: unknown }) => {
+        captured = ctx.groupValue;
+        return ctx.groupValue ? 'CAPTURED' : '';
+      });
+
+      const collection = createCollection([createEntry('address.state', { functionName: 'capture', dependsOn: ['*'] })]);
+
+      const context: DerivationApplicatorContext = {
+        formValue: formValueSignal,
+        rootForm: form as unknown as import('@angular/forms/signals').FieldTree<unknown>,
+        derivationFunctions: { capture: captureFn },
+        logger,
+        derivationLogger: createMockDerivationLogger(),
+      };
+
+      applyDerivations(collection, context);
+
+      expect(captureFn).toHaveBeenCalled();
+      expect(captured).toEqual({ country: 'usa', state: '' });
+    });
+
+    it('should populate groupValue with the innermost parent group for nested groups', () => {
+      const { form } = createMockForm({ note: '' });
+      formValueSignal.set({ org: { address: { country: 'usa', state: '' } } });
+
+      let captured: unknown;
+      const captureFn = vi.fn().mockImplementation((ctx: { groupValue?: unknown }) => {
+        captured = ctx.groupValue;
+        return '';
+      });
+
+      const collection = createCollection([createEntry('org.address.state', { functionName: 'capture', dependsOn: ['*'] })]);
+
+      const context: DerivationApplicatorContext = {
+        formValue: formValueSignal,
+        rootForm: form as unknown as import('@angular/forms/signals').FieldTree<unknown>,
+        derivationFunctions: { capture: captureFn },
+        logger,
+        derivationLogger: createMockDerivationLogger(),
+      };
+
+      applyDerivations(collection, context);
+
+      // Innermost parent is `address`, not `org`.
+      expect(captured).toEqual({ country: 'usa', state: '' });
+    });
+
+    it('should leave groupValue as undefined for fields at form root', () => {
+      const { form } = createMockForm({ rootField: '' });
+      formValueSignal.set({ rootField: 'foo' });
+
+      let captured: unknown = 'sentinel';
+      const captureFn = vi.fn().mockImplementation((ctx: { groupValue?: unknown }) => {
+        captured = ctx.groupValue;
+        return '';
+      });
+
+      const collection = createCollection([createEntry('rootField', { functionName: 'capture', dependsOn: ['*'] })]);
+
+      const context: DerivationApplicatorContext = {
+        formValue: formValueSignal,
+        rootForm: form as unknown as import('@angular/forms/signals').FieldTree<unknown>,
+        derivationFunctions: { capture: captureFn },
+        logger,
+        derivationLogger: createMockDerivationLogger(),
+      };
+
+      applyDerivations(collection, context);
+
+      expect(captureFn).toHaveBeenCalled();
+      expect(captured).toBeUndefined();
+    });
+  });
 });

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-applicator.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-applicator.spec.ts
@@ -807,6 +807,65 @@ describe('derivation-applicator', () => {
       expect(values.items[0].lineTotal).toBe(20); // 2 * 10
       expect(itemDirtyStates[0]['lineTotal']()).toBe(false);
     });
+
+    // Regression coverage for the array-item evaluation context: $self / fieldValue
+    // derivations must receive the leaf value at the entry's relative path inside
+    // the array item, not the entire item object. Previously fieldValue was set
+    // to `arrayItem`, so a function reading ctx.fieldValue saw `{quantity, unitPrice, lineTotal}`
+    // instead of the field's own value.
+    it('should pass the leaf field value (not the array item) as ctx.fieldValue inside array items', () => {
+      const { form, values } = createMockArrayForm({
+        items: [
+          { quantity: 2, unitPrice: 10, lineTotal: 7 },
+          { quantity: 3, unitPrice: 20, lineTotal: 13 },
+        ],
+        globalDiscount: 0,
+      });
+
+      const formValueSignal = signal({
+        items: values.items,
+        globalDiscount: 0,
+      });
+
+      const captured: Array<{ fieldValue: unknown; fieldPath: unknown; arrayIndex: unknown }> = [];
+
+      const collection = createCollection([
+        createEntry('items.$.lineTotal', {
+          functionName: 'captureLeafValue',
+          dependsOn: ['$self'],
+        }),
+      ]);
+
+      const context: DerivationApplicatorContext = {
+        formValue: formValueSignal,
+        rootForm: form as unknown as import('@angular/forms/signals').FieldTree<unknown>,
+        logger,
+        derivationLogger: createMockDerivationLogger(),
+        derivationFunctions: {
+          captureLeafValue: (ctx) => {
+            const c = ctx as unknown as Record<string, unknown>;
+            captured.push({
+              fieldValue: c['fieldValue'],
+              fieldPath: c['fieldPath'],
+              arrayIndex: c['arrayIndex'],
+            });
+            // Return value already present so we don't actually mutate
+            return c['fieldValue'];
+          },
+        },
+      };
+
+      applyDerivations(collection, context);
+
+      // One invocation per item, each receiving the leaf lineTotal value (not the item object)
+      expect(captured.length).toBe(2);
+      expect(captured[0].fieldValue).toBe(7);
+      expect(captured[0].fieldPath).toBe('items.0.lineTotal');
+      expect(captured[0].arrayIndex).toBe(0);
+      expect(captured[1].fieldValue).toBe(13);
+      expect(captured[1].fieldPath).toBe('items.1.lineTotal');
+      expect(captured[1].arrayIndex).toBe(1);
+    });
   });
 
   describe('external data in derivations', () => {

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-applicator.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-applicator.ts
@@ -591,11 +591,15 @@ function createArrayItemEvaluationContext(
   const relativePath = pathInfo.isArrayPath ? (pathInfo.relativePath ?? '') : '';
   const innerParentPath = relativePath.includes('.') ? relativePath.slice(0, relativePath.lastIndexOf('.')) : '';
   const groupValue = innerParentPath ? getNestedValue(arrayItem, innerParentPath) : arrayItem;
+  // Resolve fieldValue to the leaf value addressed by the entry's relative path
+  // within the array item. Without this, $self / fieldValue derivations inside
+  // arrays receive the whole array item instead of the field's own value.
+  const fieldValue = relativePath ? getNestedValue(arrayItem, relativePath) : arrayItem;
 
   return {
-    fieldValue: arrayItem,
+    fieldValue,
     formValue: arrayItem,
-    fieldPath: `${arrayPath}.${itemIndex}`,
+    fieldPath: relativePath ? `${arrayPath}.${itemIndex}.${relativePath}` : `${arrayPath}.${itemIndex}`,
     groupValue,
     customFunctions: context.customFunctions,
     externalData: context.externalData,

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-applicator.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-applicator.ts
@@ -504,16 +504,41 @@ function createEvaluationContext(
   const fieldAccessor = (context.rootForm as FieldTreeRecord)[entry.fieldKey];
   const fieldState = fieldAccessor ? readFieldStateInfo(fieldAccessor, false) : undefined;
 
+  // Parent group value: the absolute path with the trailing field segment
+  // dropped. `undefined` when the field is at form root.
+  const parentPath = getParentPathInScope(entry.fieldKey);
+  const groupValue = parentPath ? getNestedValue(formValue, parentPath) : undefined;
+
   return {
     fieldValue,
     formValue,
     fieldPath: entry.fieldKey,
+    groupValue,
     customFunctions: context.customFunctions,
     externalData: context.externalData,
     logger: context.logger,
     fieldState,
     formFieldState: chainContext.formFieldState,
   };
+}
+
+/**
+ * Returns the path to the parent of the given field path, expressed in the
+ * scope appropriate for the entry. Drops the last `.`-delimited segment.
+ * Returns `undefined` when the field has no parent in scope (e.g., a
+ * single-segment root key, or `'items.$.x'` inside the array-item scope
+ * where `x` is a direct child of the item).
+ *
+ * For non-array entries: `'address.state'` → `'address'`, `'state'` → undefined.
+ * For array entries inside `createEvaluationContext` (root scope): unused —
+ * `createArrayItemEvaluationContext` handles the array-scope case.
+ *
+ * @internal
+ */
+function getParentPathInScope(fieldKey: string): string | undefined {
+  const lastDot = fieldKey.lastIndexOf('.');
+  if (lastDot <= 0) return undefined;
+  return fieldKey.slice(0, lastDot);
 }
 
 /**
@@ -558,10 +583,20 @@ function createArrayItemEvaluationContext(
     }
   }
 
+  // groupValue inside an array item:
+  // - Field directly under the array item (no inner group): the array item
+  //   itself is the "nearest parent group".
+  // - Field inside an inner group within the item: the inner group's value.
+  // The relative path within the item is everything after `'.$.'`.
+  const relativePath = pathInfo.isArrayPath ? (pathInfo.relativePath ?? '') : '';
+  const innerParentPath = relativePath.includes('.') ? relativePath.slice(0, relativePath.lastIndexOf('.')) : '';
+  const groupValue = innerParentPath ? getNestedValue(arrayItem, innerParentPath) : arrayItem;
+
   return {
     fieldValue: arrayItem,
     formValue: arrayItem,
     fieldPath: `${arrayPath}.${itemIndex}`,
+    groupValue,
     customFunctions: context.customFunctions,
     externalData: context.externalData,
     logger: context.logger,

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-applicator.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-applicator.ts
@@ -8,7 +8,6 @@ import { isEqual } from '../../utils/object-utils';
 import { parseArrayPath, resolveArrayPath, isArrayPlaceholderPath } from '../../utils/path-utils/path-utils';
 import { CustomFunction } from '../expressions/custom-function-types';
 import { evaluateCondition } from '../expressions/condition-evaluator';
-import { ExpressionParser } from '../expressions/parser/expression-parser';
 import { getNestedValue } from '../expressions/value-utils';
 import { Logger } from '../../providers/features/logger/logger.interface';
 import {
@@ -20,6 +19,7 @@ import {
   DerivationProcessingResult,
 } from './derivation-types';
 import type { WarningTracker } from '../../utils/warning-tracker';
+import { computeValueFromEntry } from './compute-derived-value';
 import { MAX_DERIVATION_ITERATIONS } from './derivation-constants';
 import { DerivationLogger } from './derivation-logger.service';
 import { readFieldStateInfo, createFormFieldStateMap } from './field-state-extractor';
@@ -636,27 +636,10 @@ function computeDerivedValue(
   evalContext: EvaluationContext,
   applicatorContext: DerivationApplicatorContext,
 ): unknown {
-  // Static value
-  if (entry.value !== undefined) {
-    return entry.value;
-  }
-
-  // Expression
-  if (entry.expression) {
-    return ExpressionParser.evaluate(entry.expression, evalContext);
-  }
-
-  // Custom function
-  if (entry.functionName) {
-    const fn = applicatorContext.derivationFunctions?.[entry.functionName];
-    if (!fn) {
-      throw new Error(`Derivation function '${entry.functionName}' not found in customFnConfig.derivations`);
-    }
-    return fn(evalContext);
-  }
-
-  // No value source specified
-  throw new Error(`Derivation for ${entry.fieldKey} has no value source. ` + `Specify 'value', 'expression', or 'functionName'.`);
+  return computeValueFromEntry(entry, evalContext, {
+    derivationFunctions: applicatorContext.derivationFunctions,
+    subject: entry.fieldKey,
+  });
 }
 
 /**

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.spec.ts
@@ -162,7 +162,7 @@ describe('derivation-collector', () => {
     });
 
     describe('nested container fields', () => {
-      it('should collect derivations from group fields', () => {
+      it('should collect derivations from group fields with the group key prefixed onto the field path', () => {
         const fields: FieldDef<unknown>[] = [
           {
             key: 'address',
@@ -184,7 +184,100 @@ describe('derivation-collector', () => {
         const collection = collectDerivations(fields);
 
         expect(collection.entries.length).toBe(1);
-        expect(collection.entries[0].fieldKey).toBe('fullAddress');
+        // Field's actual form path is `address.fullAddress` — entry must
+        // match so the applicator can write back correctly.
+        expect(collection.entries[0].fieldKey).toBe('address.fullAddress');
+      });
+
+      it('should prefix nested group keys (group > group > input)', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'org',
+            type: 'group',
+            fields: [
+              {
+                key: 'address',
+                type: 'group',
+                fields: [
+                  {
+                    key: 'state',
+                    type: 'text',
+                    derivation: 'formValue.org.address.country',
+                  } as TextFieldDef,
+                ],
+              } as GroupFieldDef,
+            ],
+          } as GroupFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].fieldKey).toBe('org.address.state');
+      });
+
+      it('should pass through layout containers without affecting groupPath (group > container > input)', () => {
+        // Container is a layout-only field. Casts mirror existing test
+        // patterns in this file — we only care about the shape the
+        // collector receives at runtime.
+        const fields = [
+          {
+            key: 'address',
+            type: 'group',
+            fields: [
+              {
+                key: 'addressContainer',
+                type: 'container',
+                fields: [
+                  {
+                    key: 'state',
+                    type: 'text',
+                    logic: [
+                      {
+                        type: 'derivation',
+                        functionName: 'uppercaseState',
+                        dependsOn: ['address.state'],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ] as unknown as FieldDef<unknown>[];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].fieldKey).toBe('address.state');
+      });
+
+      it('should reset groupPath at array boundaries (array preserves array.$.fieldKey form)', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'org',
+            type: 'group',
+            fields: [
+              {
+                key: 'items',
+                type: 'array',
+                fields: [
+                  {
+                    key: 'name',
+                    type: 'text',
+                    derivation: 'formValue.foo',
+                  } as TextFieldDef,
+                ],
+              } as ArrayFieldDef,
+            ],
+          } as GroupFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        // Array boundary resets groupPath; entry uses array placeholder form.
+        expect(collection.entries[0].fieldKey).toBe('items.$.name');
       });
 
       it('should collect derivations from array fields with array path', () => {
@@ -476,6 +569,226 @@ describe('derivation-collector', () => {
         expect(collection.entries.length).toBe(2);
         // Both target the same field (field1) but with different conditions
         expect(collection.entries.every((e) => e.fieldKey === 'field1')).toBe(true);
+      });
+    });
+
+    describe('$self dependency token', () => {
+      it('should resolve $self to the field key at form root', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'state',
+            type: 'text',
+            logic: [
+              {
+                type: 'derivation',
+                functionName: 'uppercase',
+                dependsOn: ['$self'],
+              },
+            ],
+          } as TextFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].fieldKey).toBe('state');
+        expect(collection.entries[0].dependsOn).toEqual(['state']);
+      });
+
+      it('should resolve $self to the absolute path inside a group', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'address',
+            type: 'group',
+            fields: [
+              {
+                key: 'state',
+                type: 'text',
+                logic: [
+                  {
+                    type: 'derivation',
+                    functionName: 'uppercase',
+                    dependsOn: ['$self'],
+                  },
+                ],
+              } as TextFieldDef,
+            ],
+          } as GroupFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].fieldKey).toBe('address.state');
+        expect(collection.entries[0].dependsOn).toEqual(['address.state']);
+      });
+
+      it('should preserve other dependencies when $self is mixed with absolute paths', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'address',
+            type: 'group',
+            fields: [
+              {
+                key: 'state',
+                type: 'text',
+                logic: [
+                  {
+                    type: 'derivation',
+                    functionName: 'compute',
+                    dependsOn: ['$self', 'address.country'],
+                  },
+                ],
+              } as TextFieldDef,
+            ],
+          } as GroupFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].dependsOn).toEqual(['address.state', 'address.country']);
+      });
+
+      it('should resolve $self to the array placeholder path inside arrays', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'items',
+            type: 'array',
+            fields: [
+              {
+                key: 'name',
+                type: 'text',
+                logic: [
+                  {
+                    type: 'derivation',
+                    functionName: 'uppercase',
+                    dependsOn: ['$self'],
+                  },
+                ],
+              } as TextFieldDef,
+            ],
+          } as ArrayFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].fieldKey).toBe('items.$.name');
+        expect(collection.entries[0].dependsOn).toEqual(['items.$.name']);
+      });
+
+      it('should resolve $self to the deeply nested absolute path (group > group > input)', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'org',
+            type: 'group',
+            fields: [
+              {
+                key: 'address',
+                type: 'group',
+                fields: [
+                  {
+                    key: 'state',
+                    type: 'text',
+                    logic: [
+                      {
+                        type: 'derivation',
+                        functionName: 'uppercase',
+                        dependsOn: ['$self'],
+                      },
+                    ],
+                  } as TextFieldDef,
+                ],
+              } as GroupFieldDef,
+            ],
+          } as GroupFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].fieldKey).toBe('org.address.state');
+        expect(collection.entries[0].dependsOn).toEqual(['org.address.state']);
+      });
+
+      it('should resolve $self for HTTP derivations (passes the dependsOn validity guards)', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'address',
+            type: 'group',
+            fields: [
+              {
+                key: 'state',
+                type: 'text',
+                logic: [
+                  {
+                    type: 'derivation',
+                    source: 'http',
+                    http: { url: '/api/state-info' },
+                    responseExpression: 'response.normalized',
+                    dependsOn: ['$self'],
+                  },
+                ],
+              } as TextFieldDef,
+            ],
+          } as GroupFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].fieldKey).toBe('address.state');
+        expect(collection.entries[0].dependsOn).toEqual(['address.state']);
+      });
+
+      it('should resolve $self for async function derivations (passes the dependsOn validity guards)', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'address',
+            type: 'group',
+            fields: [
+              {
+                key: 'state',
+                type: 'text',
+                logic: [
+                  {
+                    type: 'derivation',
+                    source: 'asyncFunction',
+                    asyncFunctionName: 'normalizeStateAsync',
+                    dependsOn: ['$self'],
+                  },
+                ],
+              } as TextFieldDef,
+            ],
+          } as GroupFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].fieldKey).toBe('address.state');
+        expect(collection.entries[0].dependsOn).toEqual(['address.state']);
+      });
+
+      it('should NOT extract a literal $self from a shorthand expression — token is dependsOn-only', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'note',
+            type: 'text',
+            // Defensive: a `$self` literal sitting in expression text must
+            // not be picked up by `extractStringDependencies`. Token is
+            // only meaningful when listed explicitly in `dependsOn`.
+            derivation: 'formValue.foo + "$self"',
+          } as TextFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].dependsOn).toEqual(['foo']);
+        expect(collection.entries[0].dependsOn).not.toContain('$self');
+        expect(collection.entries[0].dependsOn).not.toContain('note');
       });
     });
   });

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.spec.ts
@@ -252,7 +252,7 @@ describe('derivation-collector', () => {
         expect(collection.entries[0].fieldKey).toBe('address.state');
       });
 
-      it('should reset groupPath at array boundaries (array preserves array.$.fieldKey form)', () => {
+      it('should reset ancestor groupPath at array boundaries (array preserves array.$.fieldKey form)', () => {
         const fields: FieldDef<unknown>[] = [
           {
             key: 'org',
@@ -276,8 +276,38 @@ describe('derivation-collector', () => {
         const collection = collectDerivations(fields);
 
         expect(collection.entries.length).toBe(1);
-        // Array boundary resets groupPath; entry uses array placeholder form.
+        // Ancestor `org` is dropped at the array boundary; the entry uses
+        // the array placeholder form for descendants of the array item.
         expect(collection.entries[0].fieldKey).toBe('items.$.name');
+      });
+
+      it('should combine arrayPath and inner groupPath (array > group > input)', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'items',
+            type: 'array',
+            fields: [
+              {
+                key: 'address',
+                type: 'group',
+                fields: [
+                  {
+                    key: 'state',
+                    type: 'text',
+                    derivation: 'formValue.foo',
+                  } as TextFieldDef,
+                ],
+              } as GroupFieldDef,
+            ],
+          } as ArrayFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        // Group inside an array contributes to the entry path so writeback
+        // hits the actual schema location: items[i].address.state.
+        expect(collection.entries[0].fieldKey).toBe('items.$.address.state');
       });
 
       it('should collect derivations from array fields with array path', () => {
@@ -789,6 +819,397 @@ describe('derivation-collector', () => {
         expect(collection.entries[0].dependsOn).toEqual(['foo']);
         expect(collection.entries[0].dependsOn).not.toContain('$self');
         expect(collection.entries[0].dependsOn).not.toContain('note');
+      });
+    });
+
+    describe('$group dependency token', () => {
+      it('should resolve $group to the immediate parent group path', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'address',
+            type: 'group',
+            fields: [
+              {
+                key: 'state',
+                type: 'text',
+                logic: [
+                  {
+                    type: 'derivation',
+                    functionName: 'computeFromGroup',
+                    dependsOn: ['$group'],
+                  },
+                ],
+              } as TextFieldDef,
+            ],
+          } as GroupFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].fieldKey).toBe('address.state');
+        expect(collection.entries[0].dependsOn).toEqual(['address']);
+      });
+
+      it('should resolve $group to the nearest parent group fully qualified (group > group > input)', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'org',
+            type: 'group',
+            fields: [
+              {
+                key: 'address',
+                type: 'group',
+                fields: [
+                  {
+                    key: 'state',
+                    type: 'text',
+                    logic: [
+                      {
+                        type: 'derivation',
+                        functionName: 'computeFromGroup',
+                        dependsOn: ['$group'],
+                      },
+                    ],
+                  } as TextFieldDef,
+                ],
+              } as GroupFieldDef,
+            ],
+          } as GroupFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].fieldKey).toBe('org.address.state');
+        expect(collection.entries[0].dependsOn).toEqual(['org.address']);
+      });
+
+      it('should resolve $group to the array key when directly inside an array', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'items',
+            type: 'array',
+            fields: [
+              {
+                key: 'name',
+                type: 'text',
+                logic: [
+                  {
+                    type: 'derivation',
+                    functionName: 'computeFromArray',
+                    dependsOn: ['$group'],
+                  },
+                ],
+              } as TextFieldDef,
+            ],
+          } as ArrayFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].fieldKey).toBe('items.$.name');
+        expect(collection.entries[0].dependsOn).toEqual(['items']);
+      });
+
+      it('should resolve $group to the combined array+group path (array > group > input)', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'items',
+            type: 'array',
+            fields: [
+              {
+                key: 'address',
+                type: 'group',
+                fields: [
+                  {
+                    key: 'state',
+                    type: 'text',
+                    logic: [
+                      {
+                        type: 'derivation',
+                        functionName: 'computeFromAddressGroup',
+                        dependsOn: ['$group'],
+                      },
+                    ],
+                  } as TextFieldDef,
+                ],
+              } as GroupFieldDef,
+            ],
+          } as ArrayFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].fieldKey).toBe('items.$.address.state');
+        expect(collection.entries[0].dependsOn).toEqual(['items.$.address']);
+      });
+
+      it('should preserve other dependencies when $group is mixed with $self and absolute paths', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'address',
+            type: 'group',
+            fields: [
+              {
+                key: 'state',
+                type: 'text',
+                logic: [
+                  {
+                    type: 'derivation',
+                    functionName: 'compute',
+                    dependsOn: ['$group', '$self', 'externalKey'],
+                  },
+                ],
+              } as TextFieldDef,
+            ],
+          } as GroupFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].dependsOn).toEqual(['address', 'address.state', 'externalKey']);
+      });
+
+      it('should throw DynamicFormError when $group is used at form root', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'state',
+            type: 'text',
+            logic: [
+              {
+                type: 'derivation',
+                functionName: 'compute',
+                dependsOn: ['$group'],
+              },
+            ],
+          } as TextFieldDef,
+        ];
+
+        expect(() => collectDerivations(fields)).toThrow(/has no parent group or array/);
+      });
+
+      it('should resolve $group for HTTP derivations (passes the dependsOn validity guards)', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'address',
+            type: 'group',
+            fields: [
+              {
+                key: 'state',
+                type: 'text',
+                logic: [
+                  {
+                    type: 'derivation',
+                    source: 'http',
+                    http: { url: '/api/lookup' },
+                    responseExpression: 'response.value',
+                    dependsOn: ['$group'],
+                  },
+                ],
+              } as TextFieldDef,
+            ],
+          } as GroupFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].dependsOn).toEqual(['address']);
+      });
+
+      it('should NOT extract a literal $group from a shorthand expression — token is dependsOn-only', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'address',
+            type: 'group',
+            fields: [
+              {
+                key: 'note',
+                type: 'text',
+                derivation: 'formValue.foo + "$group"',
+              } as TextFieldDef,
+            ],
+          } as GroupFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        // Shorthand deps come from extractStringDependencies(expression)
+        // — it only matches `formValue.X`, so `$group` literal is ignored.
+        expect(collection.entries[0].dependsOn).toEqual(['foo']);
+        expect(collection.entries[0].dependsOn).not.toContain('$group');
+        expect(collection.entries[0].dependsOn).not.toContain('address');
+      });
+    });
+
+    describe('token prefix substitution ($group.sibling and $self.X)', () => {
+      it('should resolve $group.sibling to <parentPath>.sibling inside a group', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'address',
+            type: 'group',
+            fields: [
+              {
+                key: 'state',
+                type: 'text',
+                logic: [
+                  {
+                    type: 'derivation',
+                    functionName: 'pickFromCountry',
+                    dependsOn: ['$group.country'],
+                  },
+                ],
+              } as TextFieldDef,
+            ],
+          } as GroupFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].fieldKey).toBe('address.state');
+        expect(collection.entries[0].dependsOn).toEqual(['address.country']);
+      });
+
+      it('should resolve $group.sibling for nested groups (joining the fully qualified parent)', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'org',
+            type: 'group',
+            fields: [
+              {
+                key: 'address',
+                type: 'group',
+                fields: [
+                  {
+                    key: 'state',
+                    type: 'text',
+                    logic: [
+                      {
+                        type: 'derivation',
+                        functionName: 'pickFromCountry',
+                        dependsOn: ['$group.country'],
+                      },
+                    ],
+                  } as TextFieldDef,
+                ],
+              } as GroupFieldDef,
+            ],
+          } as GroupFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].dependsOn).toEqual(['org.address.country']);
+      });
+
+      it('should resolve $group.sibling inside arrays (joining the array placeholder path)', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'items',
+            type: 'array',
+            fields: [
+              {
+                key: 'address',
+                type: 'group',
+                fields: [
+                  {
+                    key: 'state',
+                    type: 'text',
+                    logic: [
+                      {
+                        type: 'derivation',
+                        functionName: 'pickFromCountry',
+                        dependsOn: ['$group.country'],
+                      },
+                    ],
+                  } as TextFieldDef,
+                ],
+              } as GroupFieldDef,
+            ],
+          } as ArrayFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].dependsOn).toEqual(['items.$.address.country']);
+      });
+
+      it('should resolve multi-segment $group prefixes ($group.foo.bar)', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'address',
+            type: 'group',
+            fields: [
+              {
+                key: 'state',
+                type: 'text',
+                logic: [
+                  {
+                    type: 'derivation',
+                    functionName: 'compute',
+                    dependsOn: ['$group.contact.email'],
+                  },
+                ],
+              } as TextFieldDef,
+            ],
+          } as GroupFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries[0].dependsOn).toEqual(['address.contact.email']);
+      });
+
+      it('should resolve $self.subProperty to <fieldKey>.subProperty', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'address',
+            type: 'group',
+            fields: [
+              {
+                key: 'meta',
+                type: 'text',
+                logic: [
+                  {
+                    type: 'derivation',
+                    functionName: 'compute',
+                    dependsOn: ['$self.flag'],
+                  },
+                ],
+              } as TextFieldDef,
+            ],
+          } as GroupFieldDef,
+        ];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries[0].dependsOn).toEqual(['address.meta.flag']);
+      });
+
+      it('should throw DynamicFormError when $group.sibling is used at form root', () => {
+        const fields: FieldDef<unknown>[] = [
+          {
+            key: 'state',
+            type: 'text',
+            logic: [
+              {
+                type: 'derivation',
+                functionName: 'compute',
+                dependsOn: ['$group.country'],
+              },
+            ],
+          } as TextFieldDef,
+        ];
+
+        expect(() => collectDerivations(fields)).toThrow(/has no parent group or array/);
       });
     });
   });

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.spec.ts
@@ -708,6 +708,132 @@ describe('derivation-collector', () => {
         expect(collection.entries[0].dependsOn).toEqual(['items.$.name']);
       });
 
+      it('should resolve $self through layout containers inside arrays (array > container > input)', () => {
+        // Mirror of the `group > container > input` case: layout containers
+        // must pass through arrayPath unchanged, so $self for an input two
+        // hops below an array still resolves to the array placeholder path.
+        // Repros downstream addressList finding where array > itemContainer
+        // > input fields lost their $self → arrayPath.$.fieldKey resolution.
+        const fields = [
+          {
+            key: 'addresses',
+            type: 'array',
+            fields: [
+              {
+                key: 'addressItemContainer',
+                type: 'container',
+                fields: [
+                  {
+                    key: 'state',
+                    type: 'text',
+                    logic: [
+                      {
+                        type: 'derivation',
+                        functionName: 'uppercase',
+                        dependsOn: ['$self'],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ] as unknown as FieldDef<unknown>[];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].fieldKey).toBe('addresses.$.state');
+        expect(collection.entries[0].dependsOn).toEqual(['addresses.$.state']);
+      });
+
+      it('should resolve $self through nested layout containers inside arrays (array > container > container > input)', () => {
+        // Reproduces the downstream dbxForgeAddressListField nesting:
+        // array > itemContainer > container(flex) > input(state).
+        // $self must resolve to the array placeholder path even when two
+        // layout containers sit between the array and the input.
+        const fields = [
+          {
+            key: 'addresses',
+            type: 'array',
+            fields: [
+              {
+                key: 'addressItemContainer',
+                type: 'container',
+                fields: [
+                  {
+                    key: 'flexContainer',
+                    type: 'container',
+                    fields: [
+                      {
+                        key: 'state',
+                        type: 'text',
+                        logic: [
+                          {
+                            type: 'derivation',
+                            functionName: 'uppercase',
+                            dependsOn: ['$self'],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ] as unknown as FieldDef<unknown>[];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].fieldKey).toBe('addresses.$.state');
+        expect(collection.entries[0].dependsOn).toEqual(['addresses.$.state']);
+      });
+
+      it('should resolve $self through layout containers and an inner group inside arrays (array > container > group > input)', () => {
+        // Containers between the array and an inner group should not break
+        // the array.$.group.field path — the group key is appended to the
+        // array placeholder path, layout containers contribute nothing.
+        const fields = [
+          {
+            key: 'addresses',
+            type: 'array',
+            fields: [
+              {
+                key: 'addressItemContainer',
+                type: 'container',
+                fields: [
+                  {
+                    key: 'address',
+                    type: 'group',
+                    fields: [
+                      {
+                        key: 'state',
+                        type: 'text',
+                        logic: [
+                          {
+                            type: 'derivation',
+                            functionName: 'uppercase',
+                            dependsOn: ['$self'],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ] as unknown as FieldDef<unknown>[];
+
+        const collection = collectDerivations(fields);
+
+        expect(collection.entries.length).toBe(1);
+        expect(collection.entries[0].fieldKey).toBe('addresses.$.address.state');
+        expect(collection.entries[0].dependsOn).toEqual(['addresses.$.address.state']);
+      });
+
       it('should resolve $self to the deeply nested absolute path (group > group > input)', () => {
         const fields: FieldDef<unknown>[] = [
           {

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.ts
@@ -9,7 +9,18 @@ import { topologicalSort } from './derivation-sorter';
 import { DerivationCollection, DerivationEntry } from './derivation-types';
 
 /**
- * Context for collecting derivations, tracking the current array path for relative references.
+ * Token in `dependsOn` arrays that resolves to the current field's own
+ * absolute path at collection time. Useful for self-derivations on fields
+ * nested under groups, where the absolute path depends on ancestor keys
+ * the config author may not know (e.g. factory-built field shapes).
+ *
+ * @public
+ */
+export const SELF_DEPENDENCY_TOKEN = '$self';
+
+/**
+ * Context for collecting derivations, tracking the current array and group
+ * paths so absolute field paths can be reconstructed for entries.
  *
  * @internal
  */
@@ -21,6 +32,14 @@ interface CollectionContext {
    * (e.g., 'items[0]' or 'orders[1].lineItems[2]').
    */
   arrayPath?: string;
+
+  /**
+   * Dot-joined ancestor group keys for fields nested inside one or more
+   * groups (e.g., 'address' or 'org.address'). Layout containers
+   * (page, row, container) do not contribute to this path. Reset at
+   * array boundaries — the array placeholder path takes over.
+   */
+  groupPath?: string;
 }
 
 /**
@@ -81,13 +100,16 @@ function traverseFields(fields: FieldDef<unknown>[], entries: DerivationEntry[],
   for (const field of fields) {
     collectFromField(field, entries, context);
 
-    // Recursively process container fields (page, row, group, array)
+    // Recursively process container fields (page, row, group, array, container)
     if (hasChildFields(field)) {
-      const childContext = { ...context };
+      const childContext: CollectionContext = { ...context };
 
-      // Update array path context if this is an array field
       if (field.type === 'array') {
+        // Array boundary: the array placeholder path takes over and any
+        // ancestor groupPath is reset for descendants (entries inside
+        // array items use `arrayPath.$.fieldKey` form).
         childContext.arrayPath = field.key;
+        childContext.groupPath = undefined;
 
         // Array fields have items that can be either FieldDef (primitive) or FieldDef[] (object).
         // Normalize all items to arrays and flatten for traversal.
@@ -106,10 +128,49 @@ function traverseFields(fields: FieldDef<unknown>[], entries: DerivationEntry[],
 
         traverseFields(normalizedChildren, entries, childContext);
       } else {
+        if (field.type === 'group' && field.key) {
+          // Group establishes a model boundary; descend with the field's
+          // key appended to the ancestor groupPath.
+          childContext.groupPath = context.groupPath ? `${context.groupPath}.${field.key}` : field.key;
+        }
+        // Layout containers (page, row, container) leave context unchanged.
+
         traverseFields(normalizeFieldsArray(field.fields) as FieldDef<unknown>[], entries, childContext);
       }
     }
   }
+}
+
+/**
+ * Builds the absolute field path for a derivation entry from the field's
+ * key and the current collection context.
+ *
+ * - Inside an array, returns `${arrayPath}.$.${fieldKey}` (the placeholder
+ *   form already used by the rest of the system). `groupPath` is reset at
+ *   array boundaries, so this branch never combines them.
+ * - Inside one or more groups, returns `${groupPath}.${fieldKey}`.
+ * - Otherwise returns `fieldKey` unchanged.
+ *
+ * @internal
+ */
+function buildEffectiveFieldKey(fieldKey: string, context: CollectionContext): string {
+  if (context.arrayPath) {
+    return `${context.arrayPath}.$.${fieldKey}`;
+  }
+  if (context.groupPath) {
+    return `${context.groupPath}.${fieldKey}`;
+  }
+  return fieldKey;
+}
+
+/**
+ * Replaces occurrences of `SELF_DEPENDENCY_TOKEN` in a `dependsOn` array
+ * with the field's own resolved absolute path.
+ *
+ * @internal
+ */
+function resolveSelfDependencies(deps: string[], effectiveFieldKey: string): string[] {
+  return deps.map((dep) => (dep === SELF_DEPENDENCY_TOKEN ? effectiveFieldKey : dep));
 }
 
 /**
@@ -152,8 +213,7 @@ function collectFromField(field: FieldDef<unknown>, entries: DerivationEntry[], 
  * @internal
  */
 function createShorthandEntry(fieldKey: string, expression: string, context: CollectionContext): DerivationEntry {
-  // Build the effective field key, including array path if in array context
-  const effectiveFieldKey = context.arrayPath ? `${context.arrayPath}.$.${fieldKey}` : fieldKey;
+  const effectiveFieldKey = buildEffectiveFieldKey(fieldKey, context);
 
   return {
     fieldKey: effectiveFieldKey,
@@ -181,8 +241,7 @@ function createShorthandEntry(fieldKey: string, expression: string, context: Col
  * @internal
  */
 function createLogicEntry(fieldKey: string, config: DerivationLogicConfig, context: CollectionContext): DerivationEntry {
-  // Build the effective field key, including array path if in array context
-  const effectiveFieldKey = context.arrayPath ? `${context.arrayPath}.$.${fieldKey}` : fieldKey;
+  const effectiveFieldKey = buildEffectiveFieldKey(fieldKey, context);
 
   // Runtime guards for HTTP and async derivations.
   // Mutual exclusivity and required fields are now enforced by TypeScript (via `source` discriminant).
@@ -217,7 +276,7 @@ function createLogicEntry(fieldKey: string, config: DerivationLogicConfig, conte
     }
   }
 
-  const dependsOn = extractDependencies(config);
+  const dependsOn = resolveSelfDependencies(extractDependencies(config), effectiveFieldKey);
   const condition = config.condition ?? true;
   const trigger = config.trigger ?? 'onChange';
 

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.ts
@@ -4,6 +4,7 @@ import { DynamicFormError } from '../../errors/dynamic-form-error';
 import { DerivationLogicConfig, hasTargetProperty, isDerivationLogicConfig } from '../../models/logic/logic-config';
 import { hasChildFields } from '../../models/types/type-guards';
 import { normalizeFieldsArray } from '../../utils/object-utils';
+import { getNormalizedArrayMetadata } from '../../utils/array-field/normalized-array-metadata';
 import { extractExpressionDependencies, extractStringDependencies } from '../cross-field/cross-field-detector';
 import { topologicalSort } from './derivation-sorter';
 import { DerivationCollection, DerivationEntry } from './derivation-types';
@@ -134,7 +135,24 @@ function traverseFields(fields: FieldDef<unknown>[], entries: DerivationEntry[],
 
         // Array fields have items that can be either FieldDef (primitive) or FieldDef[] (object).
         // Normalize all items to arrays and flatten for traversal.
-        const arrayItems = normalizeFieldsArray(field.fields) as (FieldDef<unknown> | FieldDef<unknown>[])[];
+        let arrayItems = normalizeFieldsArray(field.fields) as (FieldDef<unknown> | FieldDef<unknown>[])[];
+
+        // Simplified arrays expose their item shape only via Symbol metadata
+        // when initialized without a starting `value` — `fields` is empty in
+        // that case. Fall back to the metadata template so derivations declared
+        // inside it are still collected; the resulting placeholder entry path
+        // ('array.$.x') applies to every item materialized at runtime.
+        if (arrayItems.length === 0) {
+          const metadataTemplate = getNormalizedArrayMetadata(field)?.template;
+          if (metadataTemplate) {
+            arrayItems = [
+              Array.isArray(metadataTemplate)
+                ? [...(metadataTemplate as readonly FieldDef<unknown>[])]
+                : (metadataTemplate as FieldDef<unknown>),
+            ];
+          }
+        }
+
         const normalizedChildren: FieldDef<unknown>[] = [];
 
         for (const item of arrayItems) {

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.ts
@@ -19,6 +19,27 @@ import { DerivationCollection, DerivationEntry } from './derivation-types';
 export const SELF_DEPENDENCY_TOKEN = '$self';
 
 /**
+ * Token in `dependsOn` arrays that resolves to the absolute path of the
+ * field's nearest parent container (group or array) at collection time.
+ *
+ * Useful when a derivation should fire whenever any sibling under the
+ * same parent container changes (e.g. "compute when anything in the
+ * address group is edited") without enumerating each sibling explicitly.
+ *
+ * Resolution rules:
+ * - Inside group(s) only: resolves to the dotted ancestor group path
+ *   (e.g. `'address'` or `'org.address'`).
+ * - Inside an array (no group between): resolves to the array key
+ *   (e.g. `'items'`). Fires whenever any item changes.
+ * - Inside group(s) inside an array: resolves to the array placeholder
+ *   form including the inner groups (e.g. `'items.$.address'`).
+ * - At form root: throws `DynamicFormError` (no parent to target).
+ *
+ * @public
+ */
+export const GROUP_DEPENDENCY_TOKEN = '$group';
+
+/**
  * Context for collecting derivations, tracking the current array and group
  * paths so absolute field paths can be reconstructed for entries.
  *
@@ -145,15 +166,23 @@ function traverseFields(fields: FieldDef<unknown>[], entries: DerivationEntry[],
  * Builds the absolute field path for a derivation entry from the field's
  * key and the current collection context.
  *
- * - Inside an array, returns `${arrayPath}.$.${fieldKey}` (the placeholder
- *   form already used by the rest of the system). `groupPath` is reset at
- *   array boundaries, so this branch never combines them.
- * - Inside one or more groups, returns `${groupPath}.${fieldKey}`.
+ * - Inside an array AND inside one or more groups (groups nested under
+ *   the array item): combines both as `${arrayPath}.$.${groupPath}.${fieldKey}`.
+ * - Inside an array only: returns `${arrayPath}.$.${fieldKey}`.
+ * - Inside one or more groups: returns `${groupPath}.${fieldKey}`.
  * - Otherwise returns `fieldKey` unchanged.
+ *
+ * `groupPath` is reset when entering an array (each array item is its own
+ * model root); ancestor groups OUTSIDE the array are not part of the
+ * entry path. Groups INSIDE the array are tracked via `groupPath` and
+ * combined here.
  *
  * @internal
  */
 function buildEffectiveFieldKey(fieldKey: string, context: CollectionContext): string {
+  if (context.arrayPath && context.groupPath) {
+    return `${context.arrayPath}.$.${context.groupPath}.${fieldKey}`;
+  }
   if (context.arrayPath) {
     return `${context.arrayPath}.$.${fieldKey}`;
   }
@@ -164,13 +193,56 @@ function buildEffectiveFieldKey(fieldKey: string, context: CollectionContext): s
 }
 
 /**
- * Replaces occurrences of `SELF_DEPENDENCY_TOKEN` in a `dependsOn` array
- * with the field's own resolved absolute path.
+ * Resolves the absolute path of the field's nearest parent container
+ * (group or array). Returns `undefined` when the field is at the form
+ * root with no parent container.
  *
  * @internal
  */
-function resolveSelfDependencies(deps: string[], effectiveFieldKey: string): string[] {
-  return deps.map((dep) => (dep === SELF_DEPENDENCY_TOKEN ? effectiveFieldKey : dep));
+function buildNearestGroupPath(context: CollectionContext): string | undefined {
+  if (context.arrayPath && context.groupPath) {
+    return `${context.arrayPath}.$.${context.groupPath}`;
+  }
+  return context.arrayPath ?? context.groupPath;
+}
+
+/**
+ * Substitutes special tokens in a `dependsOn` array with their resolved
+ * absolute paths. Currently supports:
+ *
+ * - `SELF_DEPENDENCY_TOKEN` ('$self') → the field's own absolute path
+ * - `'$self.X'` → the field's own path joined with `.X` (e.g. for object-valued
+ *   fields where you want to depend on a sub-property)
+ * - `GROUP_DEPENDENCY_TOKEN` ('$group') → the field's nearest parent
+ *   container path; throws if the field has no parent group/array.
+ * - `'$group.sibling'` → the parent path joined with `.sibling`, useful to
+ *   target a specific sibling without naming the parent group key.
+ *
+ * Non-token strings are passed through unchanged.
+ *
+ * @internal
+ */
+function resolveTokenDependencies(deps: string[], effectiveFieldKey: string, context: CollectionContext): string[] {
+  return deps.map((dep) => {
+    if (dep === SELF_DEPENDENCY_TOKEN) {
+      return effectiveFieldKey;
+    }
+    if (dep.startsWith(`${SELF_DEPENDENCY_TOKEN}.`)) {
+      return effectiveFieldKey + dep.slice(SELF_DEPENDENCY_TOKEN.length);
+    }
+    if (dep === GROUP_DEPENDENCY_TOKEN || dep.startsWith(`${GROUP_DEPENDENCY_TOKEN}.`)) {
+      const groupPath = buildNearestGroupPath(context);
+      if (!groupPath) {
+        throw new DynamicFormError(
+          `Derivation for '${effectiveFieldKey}' uses '${dep}' but the field has no parent group or array. ` +
+            `'${GROUP_DEPENDENCY_TOKEN}' is only valid for fields nested inside a group or array container.`,
+        );
+      }
+      if (dep === GROUP_DEPENDENCY_TOKEN) return groupPath;
+      return groupPath + dep.slice(GROUP_DEPENDENCY_TOKEN.length);
+    }
+    return dep;
+  });
 }
 
 /**
@@ -276,7 +348,7 @@ function createLogicEntry(fieldKey: string, config: DerivationLogicConfig, conte
     }
   }
 
-  const dependsOn = resolveSelfDependencies(extractDependencies(config), effectiveFieldKey);
+  const dependsOn = resolveTokenDependencies(extractDependencies(config), effectiveFieldKey, context);
   const condition = config.condition ?? true;
   const trigger = config.trigger ?? 'onChange';
 

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.ts
@@ -2,12 +2,11 @@ import { FieldDef } from '../../definitions/base/field-def';
 import { FieldWithValidation } from '../../definitions/base/field-with-validation';
 import { DynamicFormError } from '../../errors/dynamic-form-error';
 import { DerivationLogicConfig, hasTargetProperty, isDerivationLogicConfig } from '../../models/logic/logic-config';
-import { hasChildFields } from '../../models/types/type-guards';
-import { normalizeFieldsArray } from '../../utils/object-utils';
-import { getNormalizedArrayMetadata } from '../../utils/array-field/normalized-array-metadata';
-import { extractExpressionDependencies, extractStringDependencies } from '../cross-field/cross-field-detector';
+import { extractStringDependencies } from '../cross-field/cross-field-detector';
 import { topologicalSort } from './derivation-sorter';
 import { DerivationCollection, DerivationEntry } from './derivation-types';
+import { extractDependenciesFromConfig } from './extract-dependencies';
+import { traverseFieldsWithContext } from './field-traversal';
 
 /**
  * Token in `dependsOn` arrays that resolves to the current field's own
@@ -101,9 +100,21 @@ interface CollectionContext {
  */
 export function collectDerivations(fields: FieldDef<unknown>[]): DerivationCollection {
   const entries: DerivationEntry[] = [];
-  const context: CollectionContext = {};
 
-  traverseFields(fields, entries, context);
+  traverseFieldsWithContext<CollectionContext>(fields, {}, (field, context) => collectFromField(field, entries, context), {
+    // Array boundary: the array placeholder path takes over and any
+    // ancestor groupPath is reset for descendants (entries inside
+    // array items use `arrayPath.$.fieldKey` form).
+    onArrayChild: (_, field) => ({ arrayPath: field.key, groupPath: undefined }),
+    onGroupChild: (parent, field) => {
+      // Group establishes a model boundary; descend with the field's
+      // key appended to the ancestor groupPath. Groups without a key
+      // (rare) act like layout containers — leave context unchanged.
+      if (!field.key) return {};
+      return { groupPath: parent.groupPath ? `${parent.groupPath}.${field.key}` : field.key };
+    },
+    // Layout containers (page, row, container) leave context unchanged.
+  });
 
   // Sort entries in topological order for efficient processing.
   // This ensures derivations are processed in dependency order,
@@ -111,73 +122,6 @@ export function collectDerivations(fields: FieldDef<unknown>[]): DerivationColle
   const sortedEntries = topologicalSort(entries);
 
   return { entries: sortedEntries };
-}
-
-/**
- * Recursively traverses field definitions to collect derivations.
- *
- * @internal
- */
-function traverseFields(fields: FieldDef<unknown>[], entries: DerivationEntry[], context: CollectionContext): void {
-  for (const field of fields) {
-    collectFromField(field, entries, context);
-
-    // Recursively process container fields (page, row, group, array, container)
-    if (hasChildFields(field)) {
-      const childContext: CollectionContext = { ...context };
-
-      if (field.type === 'array') {
-        // Array boundary: the array placeholder path takes over and any
-        // ancestor groupPath is reset for descendants (entries inside
-        // array items use `arrayPath.$.fieldKey` form).
-        childContext.arrayPath = field.key;
-        childContext.groupPath = undefined;
-
-        // Array fields have items that can be either FieldDef (primitive) or FieldDef[] (object).
-        // Normalize all items to arrays and flatten for traversal.
-        let arrayItems = normalizeFieldsArray(field.fields) as (FieldDef<unknown> | FieldDef<unknown>[])[];
-
-        // Simplified arrays expose their item shape only via Symbol metadata
-        // when initialized without a starting `value` — `fields` is empty in
-        // that case. Fall back to the metadata template so derivations declared
-        // inside it are still collected; the resulting placeholder entry path
-        // ('array.$.x') applies to every item materialized at runtime.
-        if (arrayItems.length === 0) {
-          const metadataTemplate = getNormalizedArrayMetadata(field)?.template;
-          if (metadataTemplate) {
-            arrayItems = [
-              Array.isArray(metadataTemplate)
-                ? [...(metadataTemplate as readonly FieldDef<unknown>[])]
-                : (metadataTemplate as FieldDef<unknown>),
-            ];
-          }
-        }
-
-        const normalizedChildren: FieldDef<unknown>[] = [];
-
-        for (const item of arrayItems) {
-          if (Array.isArray(item)) {
-            // Object item: FieldDef[] - add each field
-            normalizedChildren.push(...item);
-          } else {
-            // Primitive item: single FieldDef - add directly
-            normalizedChildren.push(item);
-          }
-        }
-
-        traverseFields(normalizedChildren, entries, childContext);
-      } else {
-        if (field.type === 'group' && field.key) {
-          // Group establishes a model boundary; descend with the field's
-          // key appended to the ancestor groupPath.
-          childContext.groupPath = context.groupPath ? `${context.groupPath}.${field.key}` : field.key;
-        }
-        // Layout containers (page, row, container) leave context unchanged.
-
-        traverseFields(normalizeFieldsArray(field.fields) as FieldDef<unknown>[], entries, childContext);
-      }
-    }
-  }
 }
 
 /**
@@ -372,7 +316,7 @@ function createLogicEntry(fieldKey: string, config: DerivationLogicConfig, conte
     }
   }
 
-  const dependsOn = resolveTokenDependencies(extractDependencies(config), effectiveFieldKey, context);
+  const dependsOn = resolveTokenDependencies(extractDependenciesFromConfig(config), effectiveFieldKey, context);
   const condition = config.condition ?? true;
   const trigger = config.trigger ?? 'onChange';
 
@@ -398,45 +342,4 @@ function createLogicEntry(fieldKey: string, config: DerivationLogicConfig, conte
     stopOnUserOverride: config.stopOnUserOverride,
     reEngageOnDependencyChange: config.reEngageOnDependencyChange,
   };
-}
-
-/**
- * Extracts all field dependencies from a derivation config.
- *
- * Combines dependencies from:
- * - Explicit `dependsOn` array (if provided, takes precedence)
- * - Condition expression
- * - Value expression
- * - Function name (defaults to '*' if no explicit dependsOn)
- *
- * @internal
- */
-function extractDependencies(config: DerivationLogicConfig): string[] {
-  const deps = new Set<string>();
-
-  // If explicit dependsOn is provided, use it as the primary source
-  // This allows users to override automatic detection and control
-  // when derivations are triggered
-  if (config.dependsOn && config.dependsOn.length > 0) {
-    config.dependsOn.forEach((dep) => deps.add(dep));
-  } else {
-    // Extract from expression (automatic dependency detection)
-    if (config.expression) {
-      const exprDeps = extractStringDependencies(config.expression);
-      exprDeps.forEach((dep) => deps.add(dep));
-    }
-
-    // Custom functions assume full form access if no explicit dependsOn
-    if (config.functionName) {
-      deps.add('*');
-    }
-  }
-
-  // Always extract from condition (these are additional runtime guards)
-  if (config.condition && config.condition !== true) {
-    const conditionDeps = extractExpressionDependencies(config.condition);
-    conditionDeps.forEach((dep) => deps.add(dep));
-  }
-
-  return Array.from(deps);
 }

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.ts
@@ -318,6 +318,12 @@ function createLogicEntry(fieldKey: string, config: DerivationLogicConfig, conte
   // Runtime guards for HTTP and async derivations.
   // Mutual exclusivity and required fields are now enforced by TypeScript (via `source` discriminant).
   // The wildcard and empty-array checks below are not expressible in the type system.
+  //
+  // Note: `$group` / `$group.X` tokens are intentionally allowed for HTTP and async sources even
+  // though they resolve to the parent path and therefore fire on any sibling change inside that
+  // group/array. Unlike `*`, the token is structurally scoped (collection throws if the field has
+  // no parent container) and an explicit opt-in. Consumers that want to bound request frequency
+  // can use `trigger: 'debounced'` here, or rely on debouncing inside their async function.
   if (config.source === 'http') {
     if (config.dependsOn.length === 0) {
       throw new DynamicFormError(

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-entry-base.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-entry-base.ts
@@ -1,0 +1,78 @@
+import { ConditionalExpression } from '../../models/expressions/conditional-expression';
+import { DerivationLogicConfig, LogicTrigger } from '../../models/logic/logic-config';
+
+/**
+ * Common shape shared by `DerivationEntry` and `PropertyDerivationEntry`.
+ *
+ * Both entry types are produced by collecting `type: 'derivation'` logic from
+ * field definitions; they diverge only in their write target (form value vs.
+ * property override store) and a few specialized fields. Shared utilities
+ * (`computeValueFromEntry`, `getDebouncePeriods`, etc.) operate on this shape
+ * so they can be reused across both pipelines without casts.
+ *
+ * @public
+ */
+export interface BaseDerivationEntry {
+  /**
+   * The key of the field where this derivation is defined and targets.
+   *
+   * For array fields, this may include a placeholder path like 'items.$.x'
+   * which is resolved to actual indices at runtime.
+   */
+  fieldKey: string;
+
+  /**
+   * Field keys that this derivation depends on.
+   *
+   * Extracted from explicit `dependsOn`, expressions, and conditions.
+   */
+  dependsOn: string[];
+
+  /**
+   * Condition that determines when this derivation applies.
+   *
+   * Defaults to `true` (always apply) if not specified in the config.
+   */
+  condition: ConditionalExpression | boolean;
+
+  /**
+   * Static value. Mutually exclusive with `expression` and `functionName`.
+   */
+  value?: unknown;
+
+  /**
+   * JavaScript expression to evaluate for the derived value.
+   * Mutually exclusive with `value` and `functionName`.
+   */
+  expression?: string;
+
+  /**
+   * Name of a registered custom derivation function.
+   * Mutually exclusive with `value` and `expression`.
+   */
+  functionName?: string;
+
+  /**
+   * When to evaluate the derivation.
+   *
+   * @default 'onChange'
+   */
+  trigger: LogicTrigger;
+
+  /**
+   * Debounce duration in milliseconds. Only used when `trigger` is 'debounced'.
+   *
+   * @default 500
+   */
+  debounceMs?: number;
+
+  /**
+   * Optional debug name for easier identification in logs.
+   */
+  debugName?: string;
+
+  /**
+   * The original logic config if this entry was created from a full logic config.
+   */
+  originalConfig?: DerivationLogicConfig;
+}

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-orchestrator.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-orchestrator.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { computed, DestroyRef, inject, InjectionToken, Injector, isSignal, Signal, untracked } from '@angular/core';
+import { computed, DestroyRef, inject, InjectionToken, Injector, Signal, untracked } from '@angular/core';
 import { DEV_MODE } from '../../utils/dev-mode';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { FieldTree } from '@angular/forms/signals';
@@ -35,6 +35,8 @@ import { DerivationLogger } from './derivation-logger.service';
 import { DERIVATION_WARNING_TRACKER } from './derivation-warning-tracker';
 import { createHttpDerivationStream, createStreamGuard, HttpDerivationStreamContext } from './http-derivation-stream';
 import { createAsyncDerivationStream } from './async-derivation-stream';
+import { getDebouncePeriods } from './debounce-period-utils';
+import { resolveExternalData } from './external-data-resolver';
 
 /**
  * Minimal configuration for creating a DerivationOrchestrator.
@@ -211,7 +213,7 @@ export class DerivationOrchestrator {
           if (!collection || !formAccessor) return of(null);
 
           // Get unique debounce periods from entries with trigger 'debounced'
-          const debouncePeriods = this.getDebouncePeriods(collection.entries);
+          const debouncePeriods = getDebouncePeriods(collection.entries);
           if (debouncePeriods.length === 0) return of(null);
 
           // merge: Process multiple debounce periods concurrently.
@@ -263,7 +265,7 @@ export class DerivationOrchestrator {
       rootForm: formAccessor,
       derivationFunctions: this.functionRegistry.getDerivationFunctions(),
       customFunctions: this.functionRegistry.getCustomFunctions(),
-      externalData: this.resolveExternalData(),
+      externalData: resolveExternalData(this.config.externalData),
       logger: this.logger,
       warningTracker: this.warningTracker,
       derivationLogger: untracked(() => this.config.derivationLogger()),
@@ -306,7 +308,7 @@ export class DerivationOrchestrator {
       rootForm: formAccessor,
       derivationFunctions: this.functionRegistry.getDerivationFunctions(),
       customFunctions: this.functionRegistry.getCustomFunctions(),
-      externalData: this.resolveExternalData(),
+      externalData: resolveExternalData(this.config.externalData),
       logger: this.logger,
       warningTracker: this.warningTracker,
       derivationLogger: untracked(() => this.config.derivationLogger()),
@@ -369,7 +371,7 @@ export class DerivationOrchestrator {
             logger: this.logger,
             derivationLogger: this.config.derivationLogger,
             customFunctions: () => this.functionRegistry.getCustomFunctions(),
-            externalData: () => this.resolveExternalData(),
+            externalData: () => resolveExternalData(this.config.externalData),
             warningTracker: this.warningTracker,
             guard$: this.streamGuard.guard$,
           };
@@ -454,7 +456,7 @@ export class DerivationOrchestrator {
             derivationLogger: this.config.derivationLogger,
             customFunctions: () => this.functionRegistry.getCustomFunctions(),
             asyncDerivationFunctions: () => this.functionRegistry.getAsyncDerivationFunctions(),
-            externalData: () => this.resolveExternalData(),
+            externalData: () => resolveExternalData(this.config.externalData),
             warningTracker: this.warningTracker,
           };
 
@@ -496,46 +498,6 @@ export class DerivationOrchestrator {
         return `${entry.fieldKey}:${JSON.stringify(config, Object.keys(config).sort())}`;
       }),
     );
-  }
-
-  /**
-   * Gets all unique debounce periods from entries with trigger 'debounced'.
-   */
-  private getDebouncePeriods(entries: DerivationEntry[]): number[] {
-    const periods = new Set<number>();
-    for (const entry of entries) {
-      if (entry.trigger === 'debounced') {
-        periods.add(entry.debounceMs ?? DEFAULT_DEBOUNCE_MS);
-      }
-    }
-    return Array.from(periods);
-  }
-
-  /**
-   * Resolves external data signals to their current values without creating dependencies.
-   *
-   * Uses `untracked()` to read signals without establishing reactive dependencies,
-   * which is important for derivations that shouldn't re-trigger on every external data change.
-   *
-   * @returns Record of resolved external data values, or undefined if no external data.
-   */
-  private resolveExternalData(): Record<string, unknown> | undefined {
-    const externalDataRecord = untracked(() => this.config.externalData?.());
-
-    if (!externalDataRecord) {
-      return undefined;
-    }
-
-    const resolved: Record<string, unknown> = {};
-    for (const [key, signal] of Object.entries(externalDataRecord)) {
-      if (isSignal(signal)) {
-        resolved[key] = untracked(() => signal());
-      } else {
-        resolved[key] = signal;
-      }
-    }
-
-    return resolved;
   }
 }
 

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-types.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-types.ts
@@ -1,7 +1,6 @@
-import { ConditionalExpression } from '../../models/expressions/conditional-expression';
 import type { FormFieldStateMap } from '../../models/expressions/field-state-context';
 import { HttpRequestConfig } from '../../models/http/http-request-config';
-import { DerivationLogicConfig, LogicTrigger } from '../../models/logic/logic-config';
+import { BaseDerivationEntry } from './derivation-entry-base';
 
 /**
  * Entry representing a collected derivation from field definitions.
@@ -12,57 +11,12 @@ import { DerivationLogicConfig, LogicTrigger } from '../../models/logic/logic-co
  * All derivations are self-targeting: the `fieldKey` is both where the
  * derivation is defined AND where the computed value will be set.
  *
+ * Extends {@link BaseDerivationEntry} with derivation-pipeline specific fields
+ * (HTTP/async sources, shorthand flag, user-override controls).
+ *
  * @public
  */
-export interface DerivationEntry {
-  /**
-   * The key of the field where this derivation is defined and targets.
-   *
-   * Derivations always target the field they are defined on (self-targeting).
-   * For array fields, this may include a placeholder path like 'items.$.lineTotal'
-   * which is resolved to actual indices at runtime.
-   */
-  fieldKey: string;
-
-  /**
-   * Field keys that this derivation depends on.
-   *
-   * Extracted from conditions and expressions.
-   * Used for:
-   * - Cycle detection
-   * - Reactive dependency tracking
-   * - Determining evaluation order
-   */
-  dependsOn: string[];
-
-  /**
-   * Condition that determines when this derivation applies.
-   *
-   * Defaults to `true` (always apply) if not specified.
-   */
-  condition: ConditionalExpression | boolean;
-
-  /**
-   * Static value to set on this field.
-   *
-   * Mutually exclusive with `expression` and `functionName`.
-   */
-  value?: unknown;
-
-  /**
-   * JavaScript expression to evaluate for the derived value.
-   *
-   * Mutually exclusive with `value` and `functionName`.
-   */
-  expression?: string;
-
-  /**
-   * Name of a registered custom derivation function.
-   *
-   * Mutually exclusive with `value`, `expression`, and `http`.
-   */
-  functionName?: string;
-
+export interface DerivationEntry extends BaseDerivationEntry {
   /**
    * HTTP request configuration for server-driven derivations.
    *
@@ -87,42 +41,11 @@ export interface DerivationEntry {
   responseExpression?: string;
 
   /**
-   * When to evaluate the derivation.
-   *
-   * - `onChange`: Evaluate immediately when dependencies change (default)
-   * - `debounced`: Evaluate after value has stabilized for debounceMs
-   *
-   * @default 'onChange'
-   */
-  trigger: LogicTrigger;
-
-  /**
-   * Debounce duration in milliseconds.
-   *
-   * Only used when `trigger` is 'debounced'.
-   * @default 500
-   */
-  debounceMs?: number;
-
-  /**
    * Whether this derivation was created from the shorthand `derivation` property.
    *
    * Shorthand derivations use a string expression directly on the field.
    */
   isShorthand: boolean;
-
-  /**
-   * The original logic config if this entry was created from a full logic config.
-   */
-  originalConfig?: DerivationLogicConfig;
-
-  /**
-   * Optional debug name for easier identification in logs.
-   *
-   * Copied from the originalConfig if provided. When set, this name
-   * appears in verbose derivation logs instead of the field key.
-   */
-  debugName?: string;
 
   /**
    * When true, the derivation stops running after the user manually

--- a/packages/dynamic-forms/src/lib/core/derivation/external-data-resolver.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/external-data-resolver.ts
@@ -1,0 +1,30 @@
+import { isSignal, Signal, untracked } from '@angular/core';
+
+/**
+ * Resolves a record of external-data signals to their current values without
+ * establishing reactive dependencies.
+ *
+ * The orchestrators read external data per derivation cycle; using `untracked`
+ * here ensures the orchestrator's own computed/effect graph isn't tied to the
+ * external-data signal identities.
+ *
+ * @internal
+ */
+export function resolveExternalData(
+  externalDataSignal: Signal<Record<string, Signal<unknown>> | undefined> | undefined,
+): Record<string, unknown> | undefined {
+  const externalDataRecord = untracked(() => externalDataSignal?.());
+
+  if (!externalDataRecord) return undefined;
+
+  const resolved: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(externalDataRecord)) {
+    if (isSignal(value)) {
+      resolved[key] = untracked(() => value());
+    } else {
+      resolved[key] = value;
+    }
+  }
+
+  return resolved;
+}

--- a/packages/dynamic-forms/src/lib/core/derivation/extract-dependencies.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/extract-dependencies.ts
@@ -1,0 +1,34 @@
+import { DerivationLogicConfig } from '../../models/logic/logic-config';
+import { extractExpressionDependencies, extractStringDependencies } from '../cross-field/cross-field-detector';
+
+/**
+ * Extracts the union of field dependencies declared by a derivation config.
+ *
+ * Combines:
+ * - Explicit `dependsOn` (when provided, it takes precedence over auto-detection)
+ * - Expression-detected dependencies (only used when `dependsOn` is empty)
+ * - `'*'` wildcard for `functionName` (only when `dependsOn` is empty)
+ * - Condition expression dependencies (always included)
+ *
+ * @internal
+ */
+export function extractDependenciesFromConfig(config: DerivationLogicConfig): string[] {
+  const deps = new Set<string>();
+
+  if (config.dependsOn && config.dependsOn.length > 0) {
+    config.dependsOn.forEach((dep) => deps.add(dep));
+  } else {
+    if (config.expression) {
+      extractStringDependencies(config.expression).forEach((dep) => deps.add(dep));
+    }
+    if (config.functionName) {
+      deps.add('*');
+    }
+  }
+
+  if (config.condition && config.condition !== true) {
+    extractExpressionDependencies(config.condition).forEach((dep) => deps.add(dep));
+  }
+
+  return Array.from(deps);
+}

--- a/packages/dynamic-forms/src/lib/core/derivation/field-traversal.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/field-traversal.ts
@@ -1,0 +1,111 @@
+import { FieldDef } from '../../definitions/base/field-def';
+import { hasChildFields } from '../../models/types/type-guards';
+import { getNormalizedArrayMetadata } from '../../utils/array-field/normalized-array-metadata';
+import { normalizeFieldsArray } from '../../utils/object-utils';
+
+/**
+ * Visitor invoked for every field encountered during traversal.
+ *
+ * @internal
+ */
+export type FieldVisitor<TContext> = (field: FieldDef<unknown>, context: TContext) => void;
+
+/**
+ * Hooks for mutating the traversal context when crossing container boundaries.
+ *
+ * Both hooks receive the parent context and the container field; they return
+ * a partial object that is merged into a copy of the parent context to form
+ * the child context. Layout containers (page, row, container) call
+ * `onLayoutChild` and by default leave context unchanged.
+ *
+ * @internal
+ */
+export interface FieldTraversalHooks<TContext> {
+  /** Called when descending into an `array` field. */
+  onArrayChild?: (parent: TContext, field: FieldDef<unknown>) => Partial<TContext>;
+  /** Called when descending into a `group` field. */
+  onGroupChild?: (parent: TContext, field: FieldDef<unknown>) => Partial<TContext>;
+  /** Called when descending into a layout container (page, row, container). */
+  onLayoutChild?: (parent: TContext, field: FieldDef<unknown>) => Partial<TContext>;
+}
+
+/**
+ * Recursively walks a field-definition tree, invoking `visitor` for each field.
+ *
+ * Owns the subtleties shared across derivation collectors:
+ * - Detects container fields via `hasChildFields`.
+ * - Falls back to the simplified-array Symbol-metadata template when an array
+ *   field has empty `fields` (the case for arrays initialized without a
+ *   starting `value` — only the metadata template carries their item shape).
+ * - Flattens primitive (FieldDef) and object (FieldDef[]) array items into a
+ *   single child list before recursing.
+ *
+ * Callers customize per-boundary context via {@link FieldTraversalHooks}: e.g.,
+ * the value-derivation collector tracks an array path AND a group path (with
+ * the group path reset at array boundaries), while the property-derivation
+ * collector tracks only the array path.
+ *
+ * @internal
+ */
+export function traverseFieldsWithContext<TContext>(
+  fields: FieldDef<unknown>[],
+  context: TContext,
+  visitor: FieldVisitor<TContext>,
+  hooks?: FieldTraversalHooks<TContext>,
+): void {
+  for (const field of fields) {
+    visitor(field, context);
+
+    if (!hasChildFields(field)) continue;
+
+    if (field.type === 'array') {
+      const childContext = mergeContext(context, hooks?.onArrayChild?.(context, field));
+      const arrayChildren = collectArrayChildren(field);
+      traverseFieldsWithContext(arrayChildren, childContext, visitor, hooks);
+      continue;
+    }
+
+    const overrides = field.type === 'group' ? hooks?.onGroupChild?.(context, field) : hooks?.onLayoutChild?.(context, field);
+    const childContext = mergeContext(context, overrides);
+    traverseFieldsWithContext(normalizeFieldsArray(field.fields) as FieldDef<unknown>[], childContext, visitor, hooks);
+  }
+}
+
+/**
+ * Returns the flattened list of children for an array field, falling back
+ * to the Symbol metadata template when `fields` is empty.
+ *
+ * Caller must ensure `field` is a container (passes `hasChildFields`); this
+ * function reads `field.fields` directly and would error otherwise.
+ *
+ * @internal
+ */
+function collectArrayChildren(
+  field: FieldDef<unknown> & { fields: FieldDef<unknown>[] | Record<string, FieldDef<unknown>> },
+): FieldDef<unknown>[] {
+  let arrayItems = normalizeFieldsArray(field.fields) as (FieldDef<unknown> | FieldDef<unknown>[])[];
+
+  if (arrayItems.length === 0) {
+    const metadataTemplate = getNormalizedArrayMetadata(field)?.template;
+    if (metadataTemplate) {
+      arrayItems = [
+        Array.isArray(metadataTemplate) ? [...(metadataTemplate as readonly FieldDef<unknown>[])] : (metadataTemplate as FieldDef<unknown>),
+      ];
+    }
+  }
+
+  const flattened: FieldDef<unknown>[] = [];
+  for (const item of arrayItems) {
+    if (Array.isArray(item)) {
+      flattened.push(...item);
+    } else {
+      flattened.push(item);
+    }
+  }
+  return flattened;
+}
+
+/** @internal */
+function mergeContext<TContext>(base: TContext, overrides: Partial<TContext> | undefined): TContext {
+  return overrides ? { ...base, ...overrides } : { ...base };
+}

--- a/packages/dynamic-forms/src/lib/core/derivation/index.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/index.ts
@@ -9,6 +9,18 @@ export type {
 
 export { createEmptyDerivationCollection, createDerivationChainContext, createDerivationKey, parseDerivationKey } from './derivation-types';
 
+// Shared base entry shape (extended by both DerivationEntry and PropertyDerivationEntry)
+export type { BaseDerivationEntry } from './derivation-entry-base';
+
+// Shared collection / applicator helpers — used by both derivation and property-derivation pipelines
+export { traverseFieldsWithContext } from './field-traversal';
+export type { FieldTraversalHooks, FieldVisitor } from './field-traversal';
+export { extractDependenciesFromConfig } from './extract-dependencies';
+export { computeValueFromEntry } from './compute-derived-value';
+export type { ComputeValueOptions } from './compute-derived-value';
+export { getDebouncePeriods, filterEntriesByDebouncePeriod } from './debounce-period-utils';
+export { resolveExternalData } from './external-data-resolver';
+
 // Collector
 export { collectDerivations, SELF_DEPENDENCY_TOKEN, GROUP_DEPENDENCY_TOKEN } from './derivation-collector';
 

--- a/packages/dynamic-forms/src/lib/core/derivation/index.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/index.ts
@@ -10,7 +10,7 @@ export type {
 export { createEmptyDerivationCollection, createDerivationChainContext, createDerivationKey, parseDerivationKey } from './derivation-types';
 
 // Collector
-export { collectDerivations, SELF_DEPENDENCY_TOKEN } from './derivation-collector';
+export { collectDerivations, SELF_DEPENDENCY_TOKEN, GROUP_DEPENDENCY_TOKEN } from './derivation-collector';
 
 // Cycle detection
 export { detectCycles, validateNoCycles } from './cycle-detector';

--- a/packages/dynamic-forms/src/lib/core/derivation/index.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/index.ts
@@ -10,7 +10,7 @@ export type {
 export { createEmptyDerivationCollection, createDerivationChainContext, createDerivationKey, parseDerivationKey } from './derivation-types';
 
 // Collector
-export { collectDerivations } from './derivation-collector';
+export { collectDerivations, SELF_DEPENDENCY_TOKEN } from './derivation-collector';
 
 // Cycle detection
 export { detectCycles, validateNoCycles } from './cycle-detector';

--- a/packages/dynamic-forms/src/lib/core/form-mapping.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/form-mapping.spec.ts
@@ -826,6 +826,182 @@ describe('form-mapping', () => {
       });
     });
 
+    describe('array item layout containers', () => {
+      // Locks in the downstream dbxForgeAddressListField fix: a value-bearing
+      // input nested under one or more layout containers (page/row/container)
+      // inside an array item must still receive its schema mapping. Without
+      // this, validators/logic/derivations against the leaf path do nothing.
+      // `mapContainerChildren` flattens layout containers into the parent
+      // path, so any depth of layout-container nesting reaches the leaf.
+      it('should apply required validator to an input nested under a container inside an array item', () => {
+        runInInjectionContext(injector, () => {
+          const formValue = signal({ addresses: [{ state: '' }] });
+          const arrayField = {
+            key: 'addresses',
+            type: 'array',
+            fields: [
+              {
+                type: 'container',
+                fields: [{ key: 'state', type: 'input', required: true }],
+                wrappers: [],
+              },
+            ],
+          } as unknown as FieldDef;
+
+          const formInstance = form(
+            formValue,
+            schema<typeof formValue>((path) => {
+              mapFieldToForm(arrayField, path.addresses as any);
+            }),
+          );
+          mockFormSignal.set(formInstance);
+
+          expect(formInstance().valid()).toBe(false);
+        });
+      });
+
+      it('should apply required validator to an input nested under TWO containers inside an array item', () => {
+        // Mirrors the deepest downstream nesting: array > itemContainer >
+        // container(flex) > input(state).
+        runInInjectionContext(injector, () => {
+          const formValue = signal({ addresses: [{ state: '' }] });
+          const arrayField = {
+            key: 'addresses',
+            type: 'array',
+            fields: [
+              {
+                type: 'container',
+                fields: [
+                  {
+                    type: 'container',
+                    fields: [{ key: 'state', type: 'input', required: true }],
+                    wrappers: [],
+                  },
+                ],
+                wrappers: [],
+              },
+            ],
+          } as unknown as FieldDef;
+
+          const formInstance = form(
+            formValue,
+            schema<typeof formValue>((path) => {
+              mapFieldToForm(arrayField, path.addresses as any);
+            }),
+          );
+          mockFormSignal.set(formInstance);
+
+          expect(formInstance().valid()).toBe(false);
+        });
+      });
+
+      it('should apply required validator to a leaf inside a group nested under a container in an array item', () => {
+        // array > container > group > input — the inner group still consumes
+        // its key (address), the layout container flattens into the item path.
+        runInInjectionContext(injector, () => {
+          const formValue = signal({ addresses: [{ address: { state: '' } }] });
+          const arrayField = {
+            key: 'addresses',
+            type: 'array',
+            fields: [
+              {
+                type: 'container',
+                fields: [
+                  {
+                    key: 'address',
+                    type: 'group',
+                    fields: [{ key: 'state', type: 'input', required: true }],
+                  },
+                ],
+                wrappers: [],
+              },
+            ],
+          } as unknown as FieldDef;
+
+          const formInstance = form(
+            formValue,
+            schema<typeof formValue>((path) => {
+              mapFieldToForm(arrayField, path.addresses as any);
+            }),
+          );
+          mockFormSignal.set(formInstance);
+
+          expect(formInstance().valid()).toBe(false);
+        });
+      });
+
+      it('should apply required validator to an input nested under all three layout container types in an array item', () => {
+        // array > row > page > container > input — exercises every layout
+        // container type in one chain.
+        runInInjectionContext(injector, () => {
+          const formValue = signal({ addresses: [{ state: '' }] });
+          const arrayField = {
+            key: 'addresses',
+            type: 'array',
+            fields: [
+              {
+                type: 'row',
+                fields: [
+                  {
+                    type: 'page',
+                    fields: [
+                      {
+                        type: 'container',
+                        wrappers: [],
+                        fields: [{ key: 'state', type: 'input', required: true }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          } as unknown as FieldDef;
+
+          const formInstance = form(
+            formValue,
+            schema<typeof formValue>((path) => {
+              mapFieldToForm(arrayField, path.addresses as any);
+            }),
+          );
+          mockFormSignal.set(formInstance);
+
+          expect(formInstance().valid()).toBe(false);
+        });
+      });
+    });
+
+    describe('group with layout container child', () => {
+      // The same fix in `mapContainerChildren` also repairs the group case:
+      // an input nested under a layout container inside a group at form root
+      // was previously skipped for the same reason as the array case.
+      it('should apply required validator to an input nested under a container inside a group at form root', () => {
+        runInInjectionContext(injector, () => {
+          const formValue = signal({ address: { state: '' } });
+          const groupField = {
+            key: 'address',
+            type: 'group',
+            fields: [
+              {
+                type: 'container',
+                fields: [{ key: 'state', type: 'input', required: true }],
+                wrappers: [],
+              },
+            ],
+          } as unknown as FieldDef;
+
+          const formInstance = form(
+            formValue,
+            schema<typeof formValue>((path) => {
+              mapFieldToForm(groupField, path.address as any);
+            }),
+          );
+          mockFormSignal.set(formInstance);
+
+          expect(formInstance().valid()).toBe(false);
+        });
+      });
+    });
+
     describe('nullable + required interaction', () => {
       // Documents that `nullable` and `required` describe different layers: nullable
       // widens the accepted value shape; required validates that a value is present.

--- a/packages/dynamic-forms/src/lib/core/form-mapping.ts
+++ b/packages/dynamic-forms/src/lib/core/form-mapping.ts
@@ -23,6 +23,7 @@ import { isArrayField } from '../definitions/default/array-field';
 import { isPageField } from '../definitions/default/page-field';
 import { isRowField } from '../definitions/default/row-field';
 import { isContainerTypedField } from '../definitions/default/container-field';
+import { getNormalizedArrayMetadata } from '../utils/array-field/normalized-array-metadata';
 import { DynamicFormError } from '../errors/dynamic-form-error';
 
 // Type alias for schema path parameters
@@ -281,10 +282,23 @@ function mapArrayFieldToForm(arrayField: FieldDef<unknown>, fieldPath: AnySchema
   }
 
   // Fields can be either FieldDef (primitive) or FieldDef[] (object)
-  const itemDefinitions = arrayField.fields as readonly (FieldDef<unknown> | readonly FieldDef<unknown>[])[];
+  let itemDefinitions = arrayField.fields as readonly (FieldDef<unknown> | readonly FieldDef<unknown>[])[];
 
-  // Empty array is valid - items will be added via buttons with their own templates
-  // Create a minimal schema that just accepts any value
+  // Simplified arrays initialized without `value` have empty `fields`; their
+  // item shape only lives in Symbol metadata. Fall back to that template so
+  // validators and logic declared inside it still apply when items are
+  // materialized from a programmatically-set form value.
+  if (!itemDefinitions || itemDefinitions.length === 0) {
+    const metadataTemplate = getNormalizedArrayMetadata(arrayField)?.template;
+    if (metadataTemplate) {
+      itemDefinitions = [
+        Array.isArray(metadataTemplate) ? [...(metadataTemplate as readonly FieldDef<unknown>[])] : (metadataTemplate as FieldDef<unknown>),
+      ];
+    }
+  }
+
+  // Empty array with no template metadata - items will be added via buttons with
+  // their own templates. Create a minimal schema that just accepts any value.
   if (!itemDefinitions || itemDefinitions.length === 0) {
     const emptyItemSchema = schema<unknown>(() => {
       // No fields to map - items will be added dynamically via buttons

--- a/packages/dynamic-forms/src/lib/core/form-mapping.ts
+++ b/packages/dynamic-forms/src/lib/core/form-mapping.ts
@@ -153,6 +153,12 @@ export function mapFieldToForm(fieldDef: FieldDef<unknown>, fieldPath: AnySchema
 
 /**
  * Maps children of a container field (page, row, group) to the form schema.
+ *
+ * Layout containers (page/row/container) flatten into `parentPath` and are
+ * recursed through without consuming a key — same contract as `mapFieldToForm`'s
+ * top-level layout branch, so any depth of layout-container nesting reaches its
+ * leaf descendants. Group/array fields consume their key and look up their own
+ * child path on `parentPath`.
  */
 function mapContainerChildren(fields: readonly FieldDef<unknown>[] | undefined, parentPath: AnySchemaPath): void {
   if (!fields) return;
@@ -160,6 +166,11 @@ function mapContainerChildren(fields: readonly FieldDef<unknown>[] | undefined, 
   const pathRecord = parentPath as Record<string, AnySchemaPath>;
 
   for (const field of fields) {
+    if (isPageField(field) || isRowField(field) || isContainerTypedField(field)) {
+      mapContainerChildren(field.fields as readonly FieldDef<unknown>[] | undefined, parentPath);
+      continue;
+    }
+
     if (!field.key) continue;
 
     const childPath = pathRecord[field.key];
@@ -287,12 +298,21 @@ function mapArrayFieldToForm(arrayField: FieldDef<unknown>, fieldPath: AnySchema
   const allObjectFields: FieldDef<unknown>[] = [];
 
   for (const itemDef of itemDefinitions) {
-    if (!Array.isArray(itemDef)) {
-      // Primitive item: single FieldDef
-      hasPrimitiveItems = true;
-    } else {
+    if (Array.isArray(itemDef)) {
       // Object item: collect fields for superset schema
       collectFieldsFromObjectItem(itemDef as readonly FieldDef<unknown>[], allObjectFields);
+    } else if (
+      isPageField(itemDef as FieldDef<unknown>) ||
+      isRowField(itemDef as FieldDef<unknown>) ||
+      isContainerTypedField(itemDef as FieldDef<unknown>)
+    ) {
+      // Layout container as a single-template item: its descendants describe
+      // the item's object shape. Hand it to the object-item collector wrapped
+      // as a 1-element array so the structured-item mapping path runs.
+      collectFieldsFromObjectItem([itemDef as FieldDef<unknown>], allObjectFields);
+    } else {
+      // Primitive item: single FieldDef
+      hasPrimitiveItems = true;
     }
   }
 

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-applicator.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-applicator.ts
@@ -2,14 +2,13 @@ import { Signal, untracked } from '@angular/core';
 import { EvaluationContext } from '../../models/expressions/evaluation-context';
 import { ConditionalExpression } from '../../models/expressions/conditional-expression';
 
-import { DynamicFormError } from '../../errors/dynamic-form-error';
 import { parseArrayPath, resolveArrayPath, isArrayPlaceholderPath } from '../../utils/path-utils/path-utils';
 import { CustomFunction } from '../expressions/custom-function-types';
 import { evaluateCondition } from '../expressions/condition-evaluator';
-import { ExpressionParser } from '../expressions/parser/expression-parser';
 import { getNestedValue } from '../expressions/value-utils';
 import { Logger } from '../../providers/features/logger/logger.interface';
 import type { WarningTracker } from '../../utils/warning-tracker';
+import { computeValueFromEntry } from '../derivation/compute-derived-value';
 import { PropertyDerivationCollection, PropertyDerivationEntry } from './property-derivation-types';
 import { PropertyOverrideStore } from './property-override-store';
 
@@ -287,27 +286,9 @@ function computePropertyValue(
   evalContext: EvaluationContext,
   applicatorContext: PropertyDerivationApplicatorContext,
 ): unknown {
-  // Static value
-  if (entry.value !== undefined) {
-    return entry.value;
-  }
-
-  // Expression
-  if (entry.expression) {
-    return ExpressionParser.evaluate(entry.expression, evalContext);
-  }
-
-  // Custom function
-  if (entry.functionName) {
-    const fn = applicatorContext.derivationFunctions?.[entry.functionName];
-    if (!fn) {
-      throw new DynamicFormError(`Property derivation function '${entry.functionName}' not found in customFnConfig.derivations`);
-    }
-    return fn(evalContext);
-  }
-
-  throw new DynamicFormError(
-    `Property derivation for ${entry.fieldKey}.${entry.targetProperty} has no value source. ` +
-      `Specify 'value', 'expression', or 'functionName'.`,
-  );
+  return computeValueFromEntry(entry, evalContext, {
+    derivationFunctions: applicatorContext.derivationFunctions,
+    subject: `${entry.fieldKey}.${entry.targetProperty}`,
+    functionKind: 'Property derivation function',
+  });
 }

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-collector.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-collector.ts
@@ -5,6 +5,7 @@ import { hasChildFields } from '../../models/types/type-guards';
 import { Logger } from '../../providers/features/logger/logger.interface';
 import type { WarningTracker } from '../../utils/warning-tracker';
 import { normalizeFieldsArray } from '../../utils/object-utils';
+import { getNormalizedArrayMetadata } from '../../utils/array-field/normalized-array-metadata';
 import { extractExpressionDependencies, extractStringDependencies } from '../cross-field/cross-field-detector';
 import { buildPropertyOverrideKey, PLACEHOLDER_INDEX } from './property-override-key';
 import { PropertyDerivationCollection, PropertyDerivationEntry } from './property-derivation-types';
@@ -64,7 +65,22 @@ function traverseFields(fields: FieldDef<unknown>[], entries: PropertyDerivation
       if (field.type === 'array') {
         childContext.arrayPath = field.key;
 
-        const arrayItems = normalizeFieldsArray(field.fields) as (FieldDef<unknown> | FieldDef<unknown>[])[];
+        let arrayItems = normalizeFieldsArray(field.fields) as (FieldDef<unknown> | FieldDef<unknown>[])[];
+
+        // Simplified arrays initialized without `value` have empty `fields`;
+        // their item shape only lives in Symbol metadata. Fall back to that
+        // template so property derivations inside it are still collected.
+        if (arrayItems.length === 0) {
+          const metadataTemplate = getNormalizedArrayMetadata(field)?.template;
+          if (metadataTemplate) {
+            arrayItems = [
+              Array.isArray(metadataTemplate)
+                ? [...(metadataTemplate as readonly FieldDef<unknown>[])]
+                : (metadataTemplate as FieldDef<unknown>),
+            ];
+          }
+        }
+
         const normalizedChildren: FieldDef<unknown>[] = [];
 
         for (const item of arrayItems) {

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-collector.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-collector.ts
@@ -1,12 +1,10 @@
 import { FieldDef } from '../../definitions/base/field-def';
 import { FieldWithValidation } from '../../definitions/base/field-with-validation';
 import { DerivationLogicConfig, isDerivationLogicConfig, hasTargetProperty } from '../../models/logic/logic-config';
-import { hasChildFields } from '../../models/types/type-guards';
 import { Logger } from '../../providers/features/logger/logger.interface';
 import type { WarningTracker } from '../../utils/warning-tracker';
-import { normalizeFieldsArray } from '../../utils/object-utils';
-import { getNormalizedArrayMetadata } from '../../utils/array-field/normalized-array-metadata';
-import { extractExpressionDependencies, extractStringDependencies } from '../cross-field/cross-field-detector';
+import { extractDependenciesFromConfig } from '../derivation/extract-dependencies';
+import { traverseFieldsWithContext } from '../derivation/field-traversal';
 import { buildPropertyOverrideKey, PLACEHOLDER_INDEX } from './property-override-key';
 import { PropertyDerivationCollection, PropertyDerivationEntry } from './property-derivation-types';
 
@@ -44,59 +42,12 @@ export function collectPropertyDerivations(
   const entries: PropertyDerivationEntry[] = [];
   const context: CollectionContext = { logger, tracker };
 
-  traverseFields(fields, entries, context);
+  traverseFieldsWithContext<CollectionContext>(fields, context, (field, ctx) => collectFromField(field, entries, ctx), {
+    onArrayChild: (_, field) => ({ arrayPath: field.key }),
+    // Group and layout containers do not affect property-derivation paths.
+  });
 
   return { entries };
-}
-
-/**
- * Recursively traverses field definitions to collect property derivations.
- *
- * @internal
- */
-function traverseFields(fields: FieldDef<unknown>[], entries: PropertyDerivationEntry[], context: CollectionContext): void {
-  for (const field of fields) {
-    collectFromField(field, entries, context);
-
-    // Recursively process container fields (page, row, group, array)
-    if (hasChildFields(field)) {
-      const childContext = { ...context };
-
-      if (field.type === 'array') {
-        childContext.arrayPath = field.key;
-
-        let arrayItems = normalizeFieldsArray(field.fields) as (FieldDef<unknown> | FieldDef<unknown>[])[];
-
-        // Simplified arrays initialized without `value` have empty `fields`;
-        // their item shape only lives in Symbol metadata. Fall back to that
-        // template so property derivations inside it are still collected.
-        if (arrayItems.length === 0) {
-          const metadataTemplate = getNormalizedArrayMetadata(field)?.template;
-          if (metadataTemplate) {
-            arrayItems = [
-              Array.isArray(metadataTemplate)
-                ? [...(metadataTemplate as readonly FieldDef<unknown>[])]
-                : (metadataTemplate as FieldDef<unknown>),
-            ];
-          }
-        }
-
-        const normalizedChildren: FieldDef<unknown>[] = [];
-
-        for (const item of arrayItems) {
-          if (Array.isArray(item)) {
-            normalizedChildren.push(...item);
-          } else {
-            normalizedChildren.push(item);
-          }
-        }
-
-        traverseFields(normalizedChildren, entries, childContext);
-      } else {
-        traverseFields(normalizeFieldsArray(field.fields) as FieldDef<unknown>[], entries, childContext);
-      }
-    }
-  }
 }
 
 /**
@@ -134,7 +85,7 @@ function createPropertyDerivationEntryFromDerivation(
   context: CollectionContext,
 ): PropertyDerivationEntry {
   const effectiveFieldKey = buildPropertyOverrideKey(context.arrayPath, context.arrayPath ? PLACEHOLDER_INDEX : undefined, fieldKey);
-  const dependsOn = extractDependencies(config);
+  const dependsOn = extractDependenciesFromConfig(config);
   const condition = config.condition ?? true;
   const trigger = config.trigger ?? 'onChange';
   const debounceMs = trigger === 'debounced' ? (config as { debounceMs?: number }).debounceMs : undefined;
@@ -152,34 +103,4 @@ function createPropertyDerivationEntryFromDerivation(
     debugName: config.debugName,
     originalConfig: config,
   };
-}
-
-/**
- * Extracts all field dependencies from a property derivation config.
- *
- * @internal
- */
-function extractDependencies(config: DerivationLogicConfig): string[] {
-  const deps = new Set<string>();
-
-  if (config.dependsOn && config.dependsOn.length > 0) {
-    config.dependsOn.forEach((dep) => deps.add(dep));
-  } else {
-    if (config.expression) {
-      const exprDeps = extractStringDependencies(config.expression);
-      exprDeps.forEach((dep) => deps.add(dep));
-    }
-
-    if (config.functionName) {
-      deps.add('*');
-    }
-  }
-
-  // Always extract from condition
-  if (config.condition && config.condition !== true) {
-    const conditionDeps = extractExpressionDependencies(config.condition);
-    conditionDeps.forEach((dep) => deps.add(dep));
-  }
-
-  return Array.from(deps);
 }

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-orchestrator.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-orchestrator.ts
@@ -1,4 +1,4 @@
-import { computed, DestroyRef, inject, InjectionToken, Injector, isSignal, Signal, untracked } from '@angular/core';
+import { computed, DestroyRef, inject, InjectionToken, Injector, Signal, untracked } from '@angular/core';
 import { DEV_MODE } from '../../utils/dev-mode';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { explicitEffect } from 'ngxtension/explicit-effect';
@@ -26,6 +26,8 @@ import { DEFAULT_DEBOUNCE_MS } from '../../utils/debounce/debounce';
 import { getChangedKeys } from '../../utils/object-utils';
 import { FunctionRegistryService } from '../registry';
 import { DERIVATION_WARNING_TRACKER } from '../derivation/derivation-warning-tracker';
+import { getDebouncePeriods } from '../derivation/debounce-period-utils';
+import { resolveExternalData } from '../derivation/external-data-resolver';
 import { DEPRECATION_WARNING_TRACKER } from '../../utils/deprecation-warning-tracker';
 import { applyPropertyDerivationsForTrigger } from './property-derivation-applicator';
 import { collectPropertyDerivations } from './property-derivation-collector';
@@ -154,7 +156,7 @@ export class PropertyDerivationOrchestrator {
           const collection = untracked(() => this.propertyDerivationCollection());
           if (!collection) return of(null);
 
-          const debouncePeriods = this.getDebouncePeriods(collection.entries);
+          const debouncePeriods = getDebouncePeriods(collection.entries);
           if (debouncePeriods.length === 0) return of(null);
 
           const periodStreams = debouncePeriods.map((debounceMs) => this.createPeriodStream(debounceMs, collection, changedFields));
@@ -187,7 +189,7 @@ export class PropertyDerivationOrchestrator {
       store: this.config.store,
       derivationFunctions: this.functionRegistry.getDerivationFunctions(),
       customFunctions: this.functionRegistry.getCustomFunctions(),
-      externalData: this.resolveExternalData(),
+      externalData: resolveExternalData(this.config.externalData),
       logger: this.logger,
       warningTracker: this.warningTracker,
     };
@@ -209,48 +211,12 @@ export class PropertyDerivationOrchestrator {
       store: this.config.store,
       derivationFunctions: this.functionRegistry.getDerivationFunctions(),
       customFunctions: this.functionRegistry.getCustomFunctions(),
-      externalData: this.resolveExternalData(),
+      externalData: resolveExternalData(this.config.externalData),
       logger: this.logger,
       warningTracker: this.warningTracker,
     };
 
     applyPropertyDerivationsForTrigger(filteredCollection, 'debounced', applicatorContext, changedFields);
-  }
-
-  private getDebouncePeriods(entries: PropertyDerivationEntry[]): number[] {
-    const periods = new Set<number>();
-    for (const entry of entries) {
-      if (entry.trigger === 'debounced') {
-        periods.add(entry.debounceMs ?? DEFAULT_DEBOUNCE_MS);
-      }
-    }
-    return Array.from(periods);
-  }
-
-  /**
-   * Resolves external data signals to their current values.
-   *
-   * Called on every onChange and debounced application. Each call iterates all
-   * external data entries and resolves signals via untracked(). For forms with
-   * many external data entries, this could be optimized by caching the resolved
-   * record and only invalidating when external data signal values change.
-   * In practice, external data entries are few, so the linear scan is acceptable.
-   */
-  private resolveExternalData(): Record<string, unknown> | undefined {
-    const externalDataRecord = untracked(() => this.config.externalData?.());
-
-    if (!externalDataRecord) return undefined;
-
-    const resolved: Record<string, unknown> = {};
-    for (const [key, signalValue] of Object.entries(externalDataRecord)) {
-      if (isSignal(signalValue)) {
-        resolved[key] = untracked(() => signalValue());
-      } else {
-        resolved[key] = signalValue;
-      }
-    }
-
-    return resolved;
   }
 }
 

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-types.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-types.ts
@@ -1,5 +1,4 @@
-import { ConditionalExpression } from '../../models/expressions/conditional-expression';
-import { DerivationLogicConfig, LogicTrigger } from '../../models/logic/logic-config';
+import { BaseDerivationEntry } from '../derivation/derivation-entry-base';
 
 /**
  * Entry representing a collected property derivation from field definitions.
@@ -8,92 +7,18 @@ import { DerivationLogicConfig, LogicTrigger } from '../../models/logic/logic-co
  * to collect all `type: 'derivation'` logic entries with `targetProperty`.
  *
  * All property derivations are self-targeting: the `fieldKey` is both where the
- * derivation is defined AND where the derived property will be set.
+ * derivation is defined AND where the derived property will be set. Extends
+ * {@link BaseDerivationEntry} with the property-pipeline specific `targetProperty`.
  *
  * @public
  */
-export interface PropertyDerivationEntry {
-  /**
-   * The key of the field where this property derivation is defined and targets.
-   *
-   * For array fields, this may include a placeholder path like 'items.$.endDate'
-   * which is resolved to actual indices at runtime.
-   */
-  fieldKey: string;
-
+export interface PropertyDerivationEntry extends BaseDerivationEntry {
   /**
    * The target property to set on the field component.
    *
    * Supports dot-notation for nested properties (max 2 levels).
    */
   targetProperty: string;
-
-  /**
-   * Field keys that this property derivation depends on.
-   *
-   * Extracted from conditions and expressions. Used for reactive
-   * dependency tracking and determining which entries to re-evaluate.
-   */
-  dependsOn: string[];
-
-  /**
-   * Condition that determines when this property derivation applies.
-   *
-   * Defaults to `true` (always apply) if not specified in the config.
-   *
-   * Note: This default behavior is consistent with `DerivationLogicConfig` (where
-   * `condition` is also optional and defaults to `true`) but differs from
-   * `StateLogicConfig` where `condition` is **required**. This is intentional:
-   * state logic always needs a condition to evaluate, whereas derivations and
-   * property derivations make sense as unconditional by default (always compute).
-   */
-  condition: ConditionalExpression | boolean;
-
-  /**
-   * Static value to set on the target property.
-   *
-   * Mutually exclusive with `expression` and `functionName`.
-   */
-  value?: unknown;
-
-  /**
-   * JavaScript expression to evaluate for the derived property value.
-   *
-   * Mutually exclusive with `value` and `functionName`.
-   */
-  expression?: string;
-
-  /**
-   * Name of a registered custom property derivation function.
-   *
-   * Mutually exclusive with `value` and `expression`.
-   */
-  functionName?: string;
-
-  /**
-   * When to evaluate the property derivation.
-   *
-   * @default 'onChange'
-   */
-  trigger: LogicTrigger;
-
-  /**
-   * Debounce duration in milliseconds.
-   *
-   * Only used when `trigger` is 'debounced'.
-   * @default 500
-   */
-  debounceMs?: number;
-
-  /**
-   * Optional debug name for easier identification in logs.
-   */
-  debugName?: string;
-
-  /**
-   * The original logic config if this entry was created from a full logic config.
-   */
-  originalConfig?: DerivationLogicConfig;
 }
 
 /**

--- a/packages/dynamic-forms/src/lib/definitions/default/container-field.ts
+++ b/packages/dynamic-forms/src/lib/definitions/default/container-field.ts
@@ -84,11 +84,22 @@ export interface ContainerField<
 }
 
 /**
- * Type guard for ContainerField with proper type narrowing
+ * Type guard for ContainerField with proper type narrowing.
+ *
+ * `wrappers` is part of the type but optional in practice — many configs use
+ * containers purely as flex/layout wrappers without any wrapper components.
+ * Match on `type === 'container'` and the `fields` shape only, mirroring
+ * `isPageField` / `isRowField`.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Type guard must accept any field type
 export function isContainerTypedField(field: FieldDef<any>): field is ContainerField {
-  return field.type === 'container' && 'fields' in field && 'wrappers' in field;
+  return (
+    field.type === 'container' &&
+    'wrappers' in field &&
+    'fields' in field &&
+    Array.isArray((field as ContainerField).wrappers) &&
+    Array.isArray((field as ContainerField).fields)
+  );
 }
 
 export type ContainerComponent = FieldComponent<ContainerField<ContainerAllowedChildren[]>>;

--- a/packages/dynamic-forms/src/lib/definitions/default/page-field.ts
+++ b/packages/dynamic-forms/src/lib/definitions/default/page-field.ts
@@ -2,6 +2,7 @@ import { FieldDef } from '../base/field-def';
 import { PageAllowedChildren } from '../../models/types/nesting-constraints';
 import { isRowField } from './row-field';
 import { isGroupField } from './group-field';
+import { isContainerTypedField } from './container-field';
 import { ContainerLogicConfig } from '../base/container-logic-config';
 
 /**
@@ -74,7 +75,11 @@ export function validatePageNesting(pageField: PageField): boolean {
  * Type guard to check if a field is a container with fields property
  */
 function isContainerWithFields(field: FieldDef<unknown>): field is FieldDef<unknown> & { readonly fields: readonly FieldDef<unknown>[] } {
-  return (isRowField(field) || isGroupField(field)) && 'fields' in field && Array.isArray((field as { fields: unknown }).fields);
+  return (
+    (isRowField(field) || isGroupField(field) || isContainerTypedField(field)) &&
+    'fields' in field &&
+    Array.isArray((field as { fields: unknown }).fields)
+  );
 }
 
 /**

--- a/packages/dynamic-forms/src/lib/fields/page/page-field.component.spec.ts
+++ b/packages/dynamic-forms/src/lib/fields/page/page-field.component.spec.ts
@@ -165,5 +165,88 @@ describe('PageField validation functions', () => {
 
       expect(validatePageNesting(pageField)).toBe(false);
     });
+
+    it('should return false for page with nested page inside container', () => {
+      const pageField: PageField<any> = {
+        key: 'invalid-page',
+        type: 'page',
+        fields: [
+          {
+            key: 'container1',
+            type: 'container',
+            wrappers: [],
+            fields: [{ key: 'nested-page', type: 'page', fields: [] }],
+          },
+        ],
+      };
+
+      expect(validatePageNesting(pageField)).toBe(false);
+    });
+
+    it('should return false for nested page inside container wrapping a row', () => {
+      const pageField: PageField<any> = {
+        key: 'invalid-page',
+        type: 'page',
+        fields: [
+          {
+            key: 'container1',
+            type: 'container',
+            wrappers: [],
+            fields: [
+              {
+                key: 'row1',
+                type: 'row',
+                fields: [{ key: 'nested-page', type: 'page', fields: [] }],
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(validatePageNesting(pageField)).toBe(false);
+    });
+
+    it('should return false for nested page inside row wrapping a container', () => {
+      const pageField: PageField<any> = {
+        key: 'invalid-page',
+        type: 'page',
+        fields: [
+          {
+            key: 'row1',
+            type: 'row',
+            fields: [
+              {
+                key: 'container1',
+                type: 'container',
+                wrappers: [],
+                fields: [{ key: 'nested-page', type: 'page', fields: [] }],
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(validatePageNesting(pageField)).toBe(false);
+    });
+
+    it('should return true for page with container holding only leaf fields', () => {
+      const pageField: PageField<any> = {
+        key: 'valid-page',
+        type: 'page',
+        fields: [
+          {
+            key: 'container1',
+            type: 'container',
+            wrappers: [],
+            fields: [
+              { key: 'input1', type: 'input' },
+              { key: 'input2', type: 'input' },
+            ],
+          },
+        ],
+      };
+
+      expect(validatePageNesting(pageField)).toBe(true);
+    });
   });
 });

--- a/packages/dynamic-forms/src/lib/models/expressions/evaluation-context.ts
+++ b/packages/dynamic-forms/src/lib/models/expressions/evaluation-context.ts
@@ -26,6 +26,36 @@ export interface EvaluationContext<TValue = unknown, TFormValue extends Record<s
   logger: Logger;
 
   /**
+   * Value of the field's nearest parent **group** (or array item, when the
+   * field has no inner group above the array boundary).
+   *
+   * Complements `formValue` and `fieldValue` for derivations on fields nested
+   * inside groups built by factory helpers, where the parent group's key
+   * isn't known at config-authoring time. Mirrors the runtime semantics of
+   * the `'$group'` token used in `dependsOn`.
+   *
+   * Resolution at evaluation time:
+   * - Inside a group at form root: the parent group's value object (e.g.,
+   *   for `address.state`, `groupValue === formValue.address`).
+   * - Inside nested groups: the innermost parent group's value object.
+   * - Directly inside an array item (no inner group): the array item itself
+   *   (same shape as `formValue` in array context).
+   * - Inside a group inside an array item: the inner group's value object
+   *   within the current item.
+   * - Field at form root with no parent container: `undefined`.
+   *
+   * @example
+   * ```typescript
+   * // Field 'state' inside group 'address':
+   * deriveStateFromCountry: (ctx) => {
+   *   const country = ctx.groupValue?.country;  // no need to know parent key
+   *   return country === 'usa' ? 'NY' : '';
+   * }
+   * ```
+   */
+  groupValue?: unknown;
+
+  /**
    * Root form value when inside an array context.
    *
    * This provides access to values outside the current array item.

--- a/packages/dynamic-forms/src/lib/models/logic/logic-config.ts
+++ b/packages/dynamic-forms/src/lib/models/logic/logic-config.ts
@@ -383,6 +383,11 @@ interface HttpDerivationBase extends SharedDerivationFields {
   /**
    * Explicit field dependencies. Required for HTTP derivations to prevent
    * wildcard triggering on every keystroke.
+   *
+   * The wildcard token `'*'` is rejected. The structural token `'$group'`
+   * (and `'$group.X'`) is allowed and resolves to the field's parent container
+   * path — be aware this fires whenever any sibling under that group changes,
+   * so the caller owns the request frequency (consider `trigger: 'debounced'`).
    */
   dependsOn: string[];
   /**
@@ -440,6 +445,12 @@ interface AsyncFunctionDerivationBase extends SharedDerivationFields {
   /**
    * Explicit field dependencies. Required for async derivations to prevent
    * wildcard triggering on every form change.
+   *
+   * The wildcard token `'*'` is rejected. The structural token `'$group'`
+   * (and `'$group.X'`) is allowed and resolves to the field's parent container
+   * path — be aware this fires whenever any sibling under that group changes,
+   * so the caller owns the invocation frequency (handle this via
+   * `trigger: 'debounced'` or via debouncing inside the async function).
    */
   dependsOn: string[];
   // Mutual exclusivity: other sources are not allowed

--- a/packages/dynamic-forms/src/lib/models/types/form-mode.ts
+++ b/packages/dynamic-forms/src/lib/models/types/form-mode.ts
@@ -130,7 +130,7 @@ function hasAnyPageFields(fields: FieldDef<unknown>[]): boolean {
     }
 
     // Check nested fields in container types
-    if (isContainerWithFields(field) && (field.type === 'row' || field.type === 'group')) {
+    if (!isPageField(field) && isContainerWithFields(field)) {
       if (hasAnyPageFields(field.fields)) {
         return true;
       }
@@ -155,7 +155,7 @@ function hasNestedPageFields(fields: FieldDef<unknown>[]): boolean {
     }
 
     // Check other container types for nested pages
-    if (isContainerWithFields(field) && (field.type === 'row' || field.type === 'group')) {
+    if (!isPageField(field) && isContainerWithFields(field)) {
       if (hasNestedPageFields(field.fields)) {
         return true;
       }

--- a/packages/dynamic-forms/src/lib/utils/form-validation/form-mode-validator.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/form-validation/form-mode-validator.spec.ts
@@ -153,6 +153,81 @@ describe('form-mode-validator', () => {
         expect(result.isValid).toBe(false);
         expect(result.errors.length).toBeGreaterThan(0);
       });
+
+      it('should detect nested page errors when wrapped in a container', () => {
+        const fields = [
+          {
+            type: 'page',
+            key: 'page1',
+            fields: [
+              {
+                type: 'container',
+                key: 'container1',
+                wrappers: [],
+                fields: [{ type: 'page', key: 'nested', fields: [] }],
+              },
+            ],
+          },
+        ];
+
+        const result = FormModeValidator.validateFormConfiguration(fields as any);
+
+        expect(result.isValid).toBe(false);
+        expect(result.errors.length).toBeGreaterThan(0);
+      });
+
+      it('should detect nested page errors when buried under container > row', () => {
+        const fields = [
+          {
+            type: 'page',
+            key: 'page1',
+            fields: [
+              {
+                type: 'container',
+                key: 'container1',
+                wrappers: [],
+                fields: [
+                  {
+                    type: 'row',
+                    key: 'row1',
+                    fields: [{ type: 'page', key: 'nested', fields: [] }],
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+
+        const result = FormModeValidator.validateFormConfiguration(fields as any);
+
+        expect(result.isValid).toBe(false);
+        expect(result.errors.length).toBeGreaterThan(0);
+      });
+
+      it('should validate paged form with container holding leaf fields', () => {
+        const fields = [
+          {
+            type: 'page',
+            key: 'page1',
+            fields: [
+              {
+                type: 'container',
+                key: 'container1',
+                wrappers: [],
+                fields: [
+                  { type: 'input', key: 'name' },
+                  { type: 'input', key: 'email' },
+                ],
+              },
+            ],
+          },
+        ];
+
+        const result = FormModeValidator.validateFormConfiguration(fields as any);
+
+        expect(result.isValid).toBe(true);
+        expect(result.mode).toBe('paged');
+      });
     });
 
     // Mixed mode no longer exists in current codebase


### PR DESCRIPTION
# Pull Request

## Description

Derivations attached to a value field nested inside a group (or under any number of groups, with optional layout containers in between) silently failed: the entry was registered with a bare fieldKey while the field's actual form path was group-prefixed, so the applicator's writeback target pointed at the form root and never landed. 

This PR fixes that. It also adds a $self and $group token so factory-built field shapes can self-target and group-target without knowing their ancestor group keys.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] 🎨 Code style update (formatting, renaming)
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build/tooling update

## Related Issues

<!-- Link to related issues. Use "Fixes #123" to auto-close issues when PR is merged -->

Fixes #
Related to #

## Changes Made

- SELF_DEPENDENCY_TOKEN = '$self' exported from derivation/index.ts.
- resolveSelfDependencies() substitutes '$self' in dependsOn arrays with the field's resolved absolute path at collection time. Token is dependsOn-only — extractStringDependencies is unchanged, and a literal "$self" inside an expression string is not treated as a dependency.
- Works for shorthand and full-logic derivations, alongside other absolute deps, in nested groups, and inside arrays (resolves to the array placeholder form 'items.$.name').
- Added GROUP_DEPENDENCY_TOKEN = '$group' next to $self, exported from derivation/index.ts                                                                                                                                                                   
- buildEffectiveFieldKey now combines arrayPath + groupPath (fixes latent array > group > input bug — the form schema nests under the group, but the entry was using 'items.$.field' ignoring the group)                                                   
- New buildNearestGroupPath helper used by token resolution                                                                                                                                                                                                  
- resolveTokenDependencies (renamed from resolveSelfDependencies) substitutes both tokens AND their dotted prefix forms ($group.sibling, $self.X)
- Throws DynamicFormError when $group is used at form root
- Added groupValue?: unknown to EvaluationContext                                                                                                                                                                                                            
- createEvaluationContext populates it from the entry's parent path against formValue                                                                                                                                                                        
- createArrayItemEvaluationContext populates it from the array item's inner group path, falling back to the array item itself when the field is a direct child of the array          

- Fixes a latent bug in the collector where a derivation on a field nested
as `array > group > input` produced an entry path of `'items.$.field'`
(group ignored) instead of `'items.$.group.field'`. The form schema
correctly nests under the group, so writeback was silently failing the
same way the original group bug did, just inside an array. The collector
now combines arrayPath and inner groupPath into the entry path.

<!--
## Breaking Changes (if applicable)

**Before:**
```typescript
// Old usage
```

**After:**
```typescript
// New usage
```

**Migration guide:**
-
-->

## Testing

- [x] Unit tests added/updated
- [x] All tests pass locally
- [ ] Tested manually
- [ ] Tested edge cases
                                                                                                                                                                                                                                             
- Updated the existing collector test that asserted the buggy behavior (fullAddress → address.fullAddress).                                                                                                                                                  
- Added 4 collector tests for groupPath: prefixed groups, nested groups, group-with-container pass-through, and array boundary reset.
- Added 7 collector tests for $self: root, inside group, mixed with absolute paths, deeply nested, inside array, with HTTP derivation, with async function derivation, plus a defensive expression-extraction test.                                          
- Added two e2e scenarios container-inside-group and container-inside-group-self (apps/e2e/core/src/app/testing/container-nesting/) covering the group > container > input shape with absolute-path and $self variants.
                     
## Screenshots / Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

## Documentation

- [ ] Documentation updated (if needed)
- [ ] API documentation (TSDoc) added/updated
- [ ] Examples updated (if needed)

## Checklist

<!-- Ensure all items are checked before requesting review -->

- [x] Code follows the [coding standards](../CODING_STANDARDS.md)
- [x] No linting errors (`pnpm lint`)
- [x] Code is formatted (`pnpm lint:fix`)
- [x] Build succeeds (`pnpm build:libs`)
- [ ] Commits follow [conventional commit format](https://www.conventionalcommits.org/)
- [ ] Self-review completed
- [ ] No commented-out code or console.log() statements
- [ ] Type safety maintained (no `any` types)

## Additional Notes

<!-- Any additional information that reviewers should know -->
