### PR TITLE
fix(dynamic-forms): apply property derivation overrides on warm-cache resolution

### DIFF
--- a/packages/dynamic-forms/src/lib/dynamic-form.component.spec.ts
+++ b/packages/dynamic-forms/src/lib/dynamic-form.component.spec.ts
@@ -3473,4 +3473,78 @@ describe('DynamicFormComponent', () => {
       await expect(clearPromise).resolves.toBeDefined();
     });
   });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Property derivation reactivity — sync resolution race
+  //
+  // Reproduces the navigate-back bug: when COMPONENT_CACHE (providedIn: 'root')
+  // is warm from a previous DynamicForm instance, FormStateManager takes the
+  // resolveFieldSync path, which calls mapFieldToInputs synchronously during
+  // bootstrap — before PropertyDerivationOrchestrator's explicitEffect has had
+  // a chance to register fields in PROPERTY_OVERRIDE_STORE. Before the fix the
+  // mapper consulted the store non-reactively at call time, took the fast path,
+  // and returned a static signal that never reflected overrides written later.
+  // ───────────────────────────────────────────────────────────────────────────
+  describe('Property derivation reactivity (sync resolution race)', () => {
+    it('should reflect property override on a re-created form once components are cached', async () => {
+      const configWithDerivation: TestFormConfig = {
+        fields: [
+          {
+            key: 'src',
+            type: 'input',
+            label: 'Source',
+          },
+          {
+            key: 'dest',
+            type: 'input',
+            label: 'STATIC_LABEL',
+            // type: 'derivation' with targetProperty routes to property-override store.
+            // Override 'label' from formValue.src whenever src changes.
+            logic: [
+              {
+                type: 'derivation',
+                targetProperty: 'label',
+                expression: 'formValue.src',
+                dependsOn: ['src'],
+                trigger: 'onChange',
+              },
+            ],
+          } as any,
+        ],
+      };
+
+      // First mount: cold COMPONENT_CACHE → async resolveField path. By the time
+      // mapFieldToInputs runs, the orchestrator's effect has already registered
+      // 'dest', so the mapper wraps in computed and the override applies.
+      const first = createComponent(configWithDerivation, { src: 'FROM_FIRST', dest: '' });
+      await waitForDynamicComponents(first.fixture);
+
+      const firstHarnesses = first.fixture.debugElement.queryAll(
+        (by: DebugElement) => by.componentInstance instanceof TestInputHarnessComponent,
+      );
+      const firstDest = firstHarnesses.find((h) => h.componentInstance.key() === 'dest');
+      expect(firstDest, 'dest harness should render on first mount').toBeDefined();
+      expect(firstDest!.componentInstance.label()).toBe('FROM_FIRST');
+
+      // Tear down — mimics navigation away from the form route.
+      first.fixture.destroy();
+
+      // Second mount: COMPONENT_CACHE is warm (root-scoped, survives component
+      // destruction), so FormStateManager takes resolveFieldSync. Mapper runs in
+      // the same task as the orchestrator's construction, before its effect has
+      // fired. The fix decouples the mapper's hasOverrides check from store
+      // registration timing by inspecting the FieldDef directly.
+      const second = createComponent(configWithDerivation, { src: 'FROM_SECOND', dest: '' });
+      await waitForDynamicComponents(second.fixture);
+
+      const secondHarnesses = second.fixture.debugElement.queryAll(
+        (by: DebugElement) => by.componentInstance instanceof TestInputHarnessComponent,
+      );
+      const secondDest = secondHarnesses.find((h) => h.componentInstance.key() === 'dest');
+      expect(secondDest, 'dest harness should render on second mount').toBeDefined();
+
+      // Override should propagate to the harness on the second mount too.
+      expect(secondDest!.componentInstance.label()).toBe('FROM_SECOND');
+    });
+  });
 });

--- a/packages/dynamic-forms/src/lib/utils/field-mapper/field-mapper.ts
+++ b/packages/dynamic-forms/src/lib/utils/field-mapper/field-mapper.ts
@@ -1,5 +1,6 @@
 import { computed, inject, isSignal, Signal } from '@angular/core';
 import { FieldDef } from '../../definitions/base/field-def';
+import { FieldWithValidation } from '../../definitions/base/field-with-validation';
 import { FieldMeta } from '../../definitions/base/field-meta';
 import { FieldTypeDefinition } from '../../models/field-type';
 import { ARRAY_CONTEXT } from '../../models/field-signal-context.token';
@@ -7,7 +8,25 @@ import { ArrayContext } from '../../mappers/types';
 import { baseFieldMapper } from '../../mappers/base/base-field-mapper';
 import { PROPERTY_OVERRIDE_STORE } from '../../core/property-derivation/property-override-store';
 import { applyPropertyOverrides } from '../../core/property-derivation/apply-property-overrides';
-import { buildPropertyOverrideKey, PLACEHOLDER_INDEX } from '../../core/property-derivation/property-override-key';
+import { buildPropertyOverrideKey } from '../../core/property-derivation/property-override-key';
+import { hasTargetProperty, isDerivationLogicConfig } from '../../models/logic/logic-config';
+
+/**
+ * Returns true if the field has any property-derivation logic entries
+ * (type: 'derivation' with a non-empty targetProperty). Mirrors the inclusion
+ * rule used by `collectPropertyDerivations`, so the mapper and orchestrator
+ * agree on which fields participate in property overrides — without depending
+ * on whether the orchestrator's registration effect has run yet (which it
+ * hasn't on the resolveFieldSync path with a warm COMPONENT_CACHE).
+ */
+function fieldHasPropertyDerivations(fieldDef: FieldDef<unknown>): boolean {
+  const logic = (fieldDef as FieldDef<unknown> & FieldWithValidation).logic;
+  if (!logic || logic.length === 0) return false;
+  for (const entry of logic) {
+    if (isDerivationLogicConfig(entry) && hasTargetProperty(entry)) return true;
+  }
+  return false;
+}
 
 /**
  * Merges forwarded props into meta, with meta taking precedence.
@@ -126,12 +145,13 @@ export function mapFieldToInputs(
   const indexSignal = arrayContext?.index;
   const hasArrayContext = indexSignal !== undefined && isSignal(indexSignal);
 
-  // Fast-path check for property overrides: only fields with registered derivations
-  // enter the computed() wrapper for overrides. hasField() is a non-reactive Map.has() — O(1).
-  // Uses PLACEHOLDER_INDEX to produce the wildcard format (e.g., 'items.$.endDate') matching
-  // what the collector/orchestrator registers. The computed block below uses a concrete index instead.
-  const hasOverrides =
-    store?.hasField(buildPropertyOverrideKey(arrayContext?.arrayKey, arrayContext ? PLACEHOLDER_INDEX : undefined, fieldDef.key)) ?? false;
+  // Fast-path check for property overrides: only fields whose definition declares
+  // a property-derivation enter the computed() wrapper. We inspect the FieldDef
+  // directly rather than asking the store, because the store's registration
+  // effect may not have fired yet when the mapper runs in the resolveFieldSync
+  // path (warm COMPONENT_CACHE). Both the mapper and the orchestrator's
+  // collector apply the same inclusion rule, so the answers always agree.
+  const hasOverrides = fieldHasPropertyDerivations(fieldDef);
 
   // Fast path: no transformations needed
   if (!hasPropsForwarding && !hasArrayContext && !hasOverrides) {

--- a/packages/dynamic-forms/src/lib/utils/field-mapper/field-mapper.ts
+++ b/packages/dynamic-forms/src/lib/utils/field-mapper/field-mapper.ts
@@ -20,6 +20,10 @@ import { hasTargetProperty, isDerivationLogicConfig } from '../../models/logic/l
  * hasn't on the resolveFieldSync path with a warm COMPONENT_CACHE).
  */
 function fieldHasPropertyDerivations(fieldDef: FieldDef<unknown>): boolean {
+  // Match the collector's keyless guard (property-derivation-collector.ts):
+  // keyless fields are never registered in the store, so the mapper must skip
+  // them too — otherwise getOverrides() would be called with an undefined key.
+  if (!fieldDef.key) return false;
   const logic = (fieldDef as FieldDef<unknown> & FieldWithValidation).logic;
   if (!logic || logic.length === 0) return false;
   for (const entry of logic) {


### PR DESCRIPTION
## Summary

- Property derivations (e.g. dependent dropdown `options` derived from another field) silently stop applying after navigating away from a form route and back. A hard refresh restores them.
- Root cause: when `COMPONENT_CACHE` (`providedIn: 'root'`) is warm from a prior `DynamicForm` instance, `FormStateManager` takes the `resolveFieldSync` path and calls `mapFieldToInputs` synchronously during bootstrap — before `PropertyDerivationOrchestrator`'s `explicitEffect` registers fields in `PROPERTY_OVERRIDE_STORE`. The mapper read `store.hasField()` non-reactively at call time, took the fast path, and returned a static signal that never reflected overrides written later.
- Fix: decouple the mapper's `hasOverrides` check from store-registration timing by inspecting the `FieldDef.logic` array directly using the same `isDerivationLogicConfig + hasTargetProperty` rule the orchestrator's collector uses. Both sides apply the same inclusion rule, so they always agree without depending on effect ordering. The fast-path optimization for fields without derivations is preserved.

No public API or schema change. The orchestrator and store are unchanged.

## Test plan

- [x] New TDD-style integration test in `dynamic-form.component.spec.ts`: mounts a form with a `type: 'derivation' / targetProperty: 'label'` entry (cold cache → async resolution path → override applies), tears it down, then mounts a second form with the same config (warm cache → sync resolution path) and asserts the override applies on the second instance. Test fails on `main` with `expected 'STATIC_LABEL' to be 'FROM_SECOND'` and passes after the fix.
- [x] `nx test dynamic-forms` — full suite green (2527 passed, 2 skipped, no regressions)
- [x] `nx build dynamic-forms` — green
- [x] `nx lint dynamic-forms` — green