### PR TITLE
fix(dynamic-forms): resolve leaf fieldValue and groupValue for array-item property derivations

### DIFF
--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-applicator.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-applicator.ts
@@ -20,6 +20,7 @@ import {
 } from './derivation-types';
 import type { WarningTracker } from '../../utils/warning-tracker';
 import { computeValueFromEntry } from './compute-derived-value';
+import { getParentPathInScope, resolveArrayItemScope } from './evaluation-scope';
 import { MAX_DERIVATION_ITERATIONS } from './derivation-constants';
 import { DerivationLogger } from './derivation-logger.service';
 import { readFieldStateInfo, createFormFieldStateMap } from './field-state-extractor';
@@ -523,25 +524,6 @@ function createEvaluationContext(
 }
 
 /**
- * Returns the path to the parent of the given field path, expressed in the
- * scope appropriate for the entry. Drops the last `.`-delimited segment.
- * Returns `undefined` when the field has no parent in scope (e.g., a
- * single-segment root key, or `'items.$.x'` inside the array-item scope
- * where `x` is a direct child of the item).
- *
- * For non-array entries: `'address.state'` → `'address'`, `'state'` → undefined.
- * For array entries inside `createEvaluationContext` (root scope): unused —
- * `createArrayItemEvaluationContext` handles the array-scope case.
- *
- * @internal
- */
-function getParentPathInScope(fieldKey: string): string | undefined {
-  const lastDot = fieldKey.lastIndexOf('.');
-  if (lastDot <= 0) return undefined;
-  return fieldKey.slice(0, lastDot);
-}
-
-/**
  * Creates an evaluation context scoped to a specific array item.
  *
  * For array derivations, `formValue` in the expression should reference
@@ -583,18 +565,7 @@ function createArrayItemEvaluationContext(
     }
   }
 
-  // groupValue inside an array item:
-  // - Field directly under the array item (no inner group): the array item
-  //   itself is the "nearest parent group".
-  // - Field inside an inner group within the item: the inner group's value.
-  // The relative path within the item is everything after `'.$.'`.
-  const relativePath = pathInfo.isArrayPath ? (pathInfo.relativePath ?? '') : '';
-  const innerParentPath = relativePath.includes('.') ? relativePath.slice(0, relativePath.lastIndexOf('.')) : '';
-  const groupValue = innerParentPath ? getNestedValue(arrayItem, innerParentPath) : arrayItem;
-  // Resolve fieldValue to the leaf value addressed by the entry's relative path
-  // within the array item. Without this, $self / fieldValue derivations inside
-  // arrays receive the whole array item instead of the field's own value.
-  const fieldValue = relativePath ? getNestedValue(arrayItem, relativePath) : arrayItem;
+  const { relativePath, groupValue, fieldValue } = resolveArrayItemScope(pathInfo, arrayItem);
 
   return {
     fieldValue,

--- a/packages/dynamic-forms/src/lib/core/derivation/evaluation-scope.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/evaluation-scope.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { parseArrayPath } from '../../utils/path-utils/path-utils';
+import { getParentPathInScope, resolveArrayItemScope } from './evaluation-scope';
+
+describe('getParentPathInScope', () => {
+  it('returns undefined for a single-segment root key', () => {
+    expect(getParentPathInScope('state')).toBeUndefined();
+  });
+
+  it('returns the parent for a two-segment path', () => {
+    expect(getParentPathInScope('address.state')).toBe('address');
+  });
+
+  it('returns the innermost parent for nested groups', () => {
+    expect(getParentPathInScope('org.address.state')).toBe('org.address');
+  });
+
+  it('returns undefined for an empty string', () => {
+    expect(getParentPathInScope('')).toBeUndefined();
+  });
+});
+
+describe('resolveArrayItemScope', () => {
+  it('returns the array item itself as both groupValue and fieldValue when the leaf has no relative path', () => {
+    const pathInfo = parseArrayPath('items');
+    const arrayItem = { name: 'Widget' };
+
+    const scope = resolveArrayItemScope(pathInfo, arrayItem);
+
+    expect(scope.relativePath).toBe('');
+    expect(scope.groupValue).toBe(arrayItem);
+    expect(scope.fieldValue).toBe(arrayItem);
+  });
+
+  it('resolves the leaf value for a direct child of the array item', () => {
+    const pathInfo = parseArrayPath('items.$.name');
+    const arrayItem = { name: 'Widget', quantity: 3 };
+
+    const scope = resolveArrayItemScope(pathInfo, arrayItem);
+
+    expect(scope.relativePath).toBe('name');
+    // Direct child: nearest parent is the array item itself.
+    expect(scope.groupValue).toBe(arrayItem);
+    expect(scope.fieldValue).toBe('Widget');
+  });
+
+  it('resolves groupValue to the inner group when the leaf is nested under a group inside the array item', () => {
+    const pathInfo = parseArrayPath('items.$.address.state');
+    const arrayItem = { address: { country: 'usa', state: 'NY' } };
+
+    const scope = resolveArrayItemScope(pathInfo, arrayItem);
+
+    expect(scope.relativePath).toBe('address.state');
+    expect(scope.groupValue).toEqual({ country: 'usa', state: 'NY' });
+    expect(scope.fieldValue).toBe('NY');
+  });
+
+  it('resolves multi-segment inner paths', () => {
+    const pathInfo = parseArrayPath('items.$.contact.address.zip');
+    const arrayItem = { contact: { address: { zip: '12345' } } };
+
+    const scope = resolveArrayItemScope(pathInfo, arrayItem);
+
+    expect(scope.relativePath).toBe('contact.address.zip');
+    expect(scope.groupValue).toEqual({ zip: '12345' });
+    expect(scope.fieldValue).toBe('12345');
+  });
+
+  it('returns undefined fieldValue when the leaf is missing on a fresh array item', () => {
+    const pathInfo = parseArrayPath('items.$.name');
+    const arrayItem = {} as Record<string, unknown>;
+
+    const scope = resolveArrayItemScope(pathInfo, arrayItem);
+
+    expect(scope.relativePath).toBe('name');
+    expect(scope.groupValue).toBe(arrayItem);
+    expect(scope.fieldValue).toBeUndefined();
+  });
+});

--- a/packages/dynamic-forms/src/lib/core/derivation/evaluation-scope.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/evaluation-scope.ts
@@ -1,0 +1,56 @@
+import { getNestedValue } from '../expressions/value-utils';
+import { ArrayPathInfo } from '../../utils/path-utils/path-utils';
+
+/**
+ * Returns the path to the parent of the given field path. Drops the last
+ * `.`-delimited segment. Returns `undefined` when the field has no parent
+ * in scope (single-segment root key).
+ *
+ * - `'address.state'` → `'address'`
+ * - `'org.address.state'` → `'org.address'`
+ * - `'state'` → `undefined`
+ *
+ * Used by the non-array evaluation context to populate `groupValue` from
+ * the field's parent group on `formValue`.
+ *
+ * @internal
+ */
+export function getParentPathInScope(fieldKey: string): string | undefined {
+  const lastDot = fieldKey.lastIndexOf('.');
+  if (lastDot <= 0) return undefined;
+  return fieldKey.slice(0, lastDot);
+}
+
+/**
+ * Per-array-item scope values resolved from a parsed array path.
+ *
+ * @internal
+ */
+export interface ArrayItemScope {
+  /** Path within the array item (everything after `'.$.'`); `''` for non-array entries. */
+  readonly relativePath: string;
+  /** Nearest parent of the leaf within the array item: the inner group's value when the leaf
+   *  is nested under a group, otherwise the array item itself. */
+  readonly groupValue: unknown;
+  /** Leaf value addressed by `relativePath` within the array item, or the array item itself
+   *  when the leaf has no relative path. */
+  readonly fieldValue: unknown;
+}
+
+/**
+ * Resolves the per-array-item scope shared by both derivation applicators.
+ *
+ * Both `derivation-applicator.ts` and `property-derivation-applicator.ts`
+ * need the same fan-out from `(pathInfo, arrayItem)` to `fieldValue`,
+ * `groupValue`, and `relativePath` when building an evaluation context for
+ * an array item. Centralising here keeps the two pipelines from drifting.
+ *
+ * @internal
+ */
+export function resolveArrayItemScope(pathInfo: ArrayPathInfo, arrayItem: Record<string, unknown>): ArrayItemScope {
+  const relativePath = pathInfo.isArrayPath ? pathInfo.relativePath : '';
+  const innerParentPath = relativePath.includes('.') ? relativePath.slice(0, relativePath.lastIndexOf('.')) : '';
+  const groupValue = innerParentPath ? getNestedValue(arrayItem, innerParentPath) : arrayItem;
+  const fieldValue = relativePath ? getNestedValue(arrayItem, relativePath) : arrayItem;
+  return { relativePath, groupValue, fieldValue };
+}

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-applicator.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-applicator.spec.ts
@@ -307,6 +307,133 @@ describe('applyPropertyDerivations', () => {
       expect(context.store.getOverrides('items.1.discount')()).toEqual({});
       expect(context.store.getOverrides('items.2.discount')()).toEqual({ visible: true });
     });
+
+    it('should pass the leaf field value (not the array item) as ctx.fieldValue', () => {
+      const captured: Array<{ fieldValue: unknown; fieldPath: unknown; arrayIndex: unknown; groupValue: unknown }> = [];
+      const entry = createEntry({
+        fieldKey: 'items.$.label',
+        targetProperty: 'label',
+        dependsOn: ['items'],
+        expression: undefined,
+        functionName: 'capture',
+      });
+      const collection: PropertyDerivationCollection = { entries: [entry] };
+      const context = createContext({
+        items: [{ label: 'first' }, { label: 'second' }],
+      });
+      context.derivationFunctions = {
+        capture: (evalCtx) => {
+          captured.push({
+            fieldValue: evalCtx.fieldValue,
+            fieldPath: evalCtx.fieldPath,
+            arrayIndex: evalCtx.arrayIndex,
+            groupValue: evalCtx.groupValue,
+          });
+          return evalCtx.fieldValue;
+        },
+      };
+
+      applyPropertyDerivations(collection, context);
+
+      expect(captured).toHaveLength(2);
+      expect(captured[0].fieldValue).toBe('first');
+      expect(captured[0].fieldPath).toBe('items.0.label');
+      expect(captured[0].arrayIndex).toBe(0);
+      // groupValue for a leaf direct under the array item is the item itself.
+      expect(captured[0].groupValue).toEqual({ label: 'first' });
+      expect(captured[1].fieldValue).toBe('second');
+      expect(captured[1].fieldPath).toBe('items.1.label');
+      expect(captured[1].arrayIndex).toBe(1);
+      expect(captured[1].groupValue).toEqual({ label: 'second' });
+    });
+
+    it('should resolve groupValue to the inner group when the leaf is nested under a group inside the array item', () => {
+      const captured: Array<{ fieldValue: unknown; fieldPath: unknown; groupValue: unknown }> = [];
+      const entry = createEntry({
+        fieldKey: 'items.$.address.state',
+        targetProperty: 'label',
+        dependsOn: ['items'],
+        expression: undefined,
+        functionName: 'capture',
+      });
+      const collection: PropertyDerivationCollection = { entries: [entry] };
+      const context = createContext({
+        items: [{ address: { country: 'usa', state: 'NY' } }, { address: { country: 'canada', state: 'ON' } }],
+      });
+      context.derivationFunctions = {
+        capture: (evalCtx) => {
+          captured.push({
+            fieldValue: evalCtx.fieldValue,
+            fieldPath: evalCtx.fieldPath,
+            groupValue: evalCtx.groupValue,
+          });
+          return evalCtx.fieldValue;
+        },
+      };
+
+      applyPropertyDerivations(collection, context);
+
+      expect(captured).toHaveLength(2);
+      expect(captured[0].fieldValue).toBe('NY');
+      expect(captured[0].fieldPath).toBe('items.0.address.state');
+      expect(captured[0].groupValue).toEqual({ country: 'usa', state: 'NY' });
+      expect(captured[1].fieldValue).toBe('ON');
+      expect(captured[1].fieldPath).toBe('items.1.address.state');
+      expect(captured[1].groupValue).toEqual({ country: 'canada', state: 'ON' });
+    });
+  });
+
+  describe('non-array evaluation context', () => {
+    it('should populate groupValue with the parent group object for fields nested in a group', () => {
+      const captured: Array<{ fieldValue: unknown; groupValue: unknown }> = [];
+      const entry = createEntry({
+        fieldKey: 'address.state',
+        targetProperty: 'label',
+        dependsOn: ['address'],
+        expression: undefined,
+        functionName: 'capture',
+      });
+      const collection: PropertyDerivationCollection = { entries: [entry] };
+      const context = createContext({
+        address: { country: 'usa', state: 'NY' },
+      });
+      context.derivationFunctions = {
+        capture: (evalCtx) => {
+          captured.push({ fieldValue: evalCtx.fieldValue, groupValue: evalCtx.groupValue });
+          return evalCtx.fieldValue;
+        },
+      };
+
+      applyPropertyDerivations(collection, context);
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].fieldValue).toBe('NY');
+      expect(captured[0].groupValue).toEqual({ country: 'usa', state: 'NY' });
+    });
+
+    it('should leave groupValue undefined for fields at form root', () => {
+      const captured: Array<{ groupValue: unknown }> = [];
+      const entry = createEntry({
+        fieldKey: 'rootField',
+        targetProperty: 'label',
+        dependsOn: ['rootField'],
+        expression: undefined,
+        functionName: 'capture',
+      });
+      const collection: PropertyDerivationCollection = { entries: [entry] };
+      const context = createContext({ rootField: 'foo' });
+      context.derivationFunctions = {
+        capture: (evalCtx) => {
+          captured.push({ groupValue: evalCtx.groupValue });
+          return evalCtx.fieldValue;
+        },
+      };
+
+      applyPropertyDerivations(collection, context);
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].groupValue).toBeUndefined();
+    });
   });
 });
 

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-applicator.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-applicator.ts
@@ -9,6 +9,7 @@ import { getNestedValue } from '../expressions/value-utils';
 import { Logger } from '../../providers/features/logger/logger.interface';
 import type { WarningTracker } from '../../utils/warning-tracker';
 import { computeValueFromEntry } from '../derivation/compute-derived-value';
+import { getParentPathInScope, resolveArrayItemScope } from '../derivation/evaluation-scope';
 import { PropertyDerivationCollection, PropertyDerivationEntry } from './property-derivation-types';
 import { PropertyOverrideStore } from './property-override-store';
 
@@ -252,19 +253,6 @@ function createEvaluationContext(
 }
 
 /**
- * Returns the path to the parent of the given field path. Drops the last
- * `.`-delimited segment. Returns `undefined` when the field has no parent
- * in scope (single-segment root key).
- *
- * @internal
- */
-function getParentPathInScope(fieldKey: string): string | undefined {
-  const lastDot = fieldKey.lastIndexOf('.');
-  if (lastDot <= 0) return undefined;
-  return fieldKey.slice(0, lastDot);
-}
-
-/**
  * Creates an evaluation context scoped to a specific array item.
  *
  * @internal
@@ -278,19 +266,7 @@ function createArrayItemEvaluationContext(
   context: PropertyDerivationApplicatorContext,
 ): EvaluationContext {
   const pathInfo = parseArrayPath(entry.fieldKey);
-
-  // groupValue inside an array item:
-  // - Field directly under the array item (no inner group): the array item
-  //   itself is the "nearest parent group".
-  // - Field inside an inner group within the item: the inner group's value.
-  // The relative path within the item is everything after `'.$.'`.
-  const relativePath = pathInfo.isArrayPath ? (pathInfo.relativePath ?? '') : '';
-  const innerParentPath = relativePath.includes('.') ? relativePath.slice(0, relativePath.lastIndexOf('.')) : '';
-  const groupValue = innerParentPath ? getNestedValue(arrayItem, innerParentPath) : arrayItem;
-  // Resolve fieldValue to the leaf value addressed by the entry's relative path
-  // within the array item. Without this, $self / fieldValue derivations inside
-  // arrays receive the whole array item instead of the field's own value.
-  const fieldValue = relativePath ? getNestedValue(arrayItem, relativePath) : arrayItem;
+  const { relativePath, groupValue, fieldValue } = resolveArrayItemScope(pathInfo, arrayItem);
 
   return {
     fieldValue,

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-applicator.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-applicator.ts
@@ -228,14 +228,33 @@ function createEvaluationContext(
 ): EvaluationContext {
   const fieldValue = getNestedValue(formValue, entry.fieldKey);
 
+  // Parent group value: the absolute path with the trailing field segment
+  // dropped. `undefined` when the field is at form root.
+  const parentPath = getParentPathInScope(entry.fieldKey);
+  const groupValue = parentPath ? getNestedValue(formValue, parentPath) : undefined;
+
   return {
     fieldValue,
     formValue,
     fieldPath: entry.fieldKey,
+    groupValue,
     customFunctions: context.customFunctions,
     externalData: context.externalData,
     logger: context.logger,
   };
+}
+
+/**
+ * Returns the path to the parent of the given field path. Drops the last
+ * `.`-delimited segment. Returns `undefined` when the field has no parent
+ * in scope (single-segment root key).
+ *
+ * @internal
+ */
+function getParentPathInScope(fieldKey: string): string | undefined {
+  const lastDot = fieldKey.lastIndexOf('.');
+  if (lastDot <= 0) return undefined;
+  return fieldKey.slice(0, lastDot);
 }
 
 /**
@@ -251,10 +270,26 @@ function createArrayItemEvaluationContext(
   arrayPath: string,
   context: PropertyDerivationApplicatorContext,
 ): EvaluationContext {
+  const pathInfo = parseArrayPath(entry.fieldKey);
+
+  // groupValue inside an array item:
+  // - Field directly under the array item (no inner group): the array item
+  //   itself is the "nearest parent group".
+  // - Field inside an inner group within the item: the inner group's value.
+  // The relative path within the item is everything after `'.$.'`.
+  const relativePath = pathInfo.isArrayPath ? (pathInfo.relativePath ?? '') : '';
+  const innerParentPath = relativePath.includes('.') ? relativePath.slice(0, relativePath.lastIndexOf('.')) : '';
+  const groupValue = innerParentPath ? getNestedValue(arrayItem, innerParentPath) : arrayItem;
+  // Resolve fieldValue to the leaf value addressed by the entry's relative path
+  // within the array item. Without this, $self / fieldValue derivations inside
+  // arrays receive the whole array item instead of the field's own value.
+  const fieldValue = relativePath ? getNestedValue(arrayItem, relativePath) : arrayItem;
+
   return {
-    fieldValue: arrayItem,
+    fieldValue,
     formValue: arrayItem,
-    fieldPath: `${arrayPath}.${itemIndex}`,
+    fieldPath: relativePath ? `${arrayPath}.${itemIndex}.${relativePath}` : `${arrayPath}.${itemIndex}`,
+    groupValue,
     customFunctions: context.customFunctions,
     externalData: context.externalData,
     logger: context.logger,

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-applicator.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-applicator.ts
@@ -219,6 +219,13 @@ function tryApplyArrayPropertyDerivation(entry: PropertyDerivationEntry, context
 /**
  * Creates an evaluation context for property derivation processing.
  *
+ * Note: `fieldState`/`formFieldState` are intentionally not populated here.
+ * Property derivations run against the form value signal and write to a
+ * separate override store; the applicator does not have access to the live
+ * `FieldTree` (no `rootForm` on `PropertyDerivationApplicatorContext`), so
+ * field-state snapshots cannot be read in this pipeline. Functions that need
+ * field state (e.g. `dirty()`, `touched()`) must use a regular derivation.
+ *
  * @internal
  */
 function createEvaluationContext(


### PR DESCRIPTION
## Summary

Property derivations on a field nested inside an array item received `ctx.fieldValue` set to the entire array item rather than the leaf value addressed by the entry's relative path, and `ctx.fieldPath` was the item index without the leaf segment. Functions reading `ctx.fieldValue` (for instance, to compute `targetProperty: 'minDate'` or `'disabled'`) saw the wrong shape.

`createArrayItemEvaluationContext` in the regular derivation applicator already handles this correctly. This PR brings property-derivation's `createArrayItemEvaluationContext` in line and also populates `groupValue` on the non-array `createEvaluationContext`.

### Behavior

For an entry with `fieldKey: 'items.\$.label'` and `arrayItem = { label: 'first' }` at `itemIndex: 0`:

|                | Before                       | After             |
| -------------- | ---------------------------- | ----------------- |
| `fieldValue`   | `{ label: 'first' }`         | `'first'`         |
| `fieldPath`    | `'items.0'`                  | `'items.0.label'` |
| `groupValue`   | (unset)                      | `{ label: 'first' }` (the array item — nearest parent) |

For nested shapes (`'items.\$.address.state'`), `groupValue` resolves to the inner group (`address`), matching the regular-derivation semantics.

For non-array fields nested in a group (`'address.state'`), `groupValue` is now populated with the parent group's value. Fields at form root keep `groupValue: undefined`.

## Test plan

- [x] Unit tests added in `property-derivation-applicator.spec.ts`:
  - leaf-value `fieldValue` + full `fieldPath` + array-item `groupValue` for direct array children
  - inner-group `groupValue` + full `fieldPath` for `array > group > leaf`
  - parent-group `groupValue` for non-array nested fields
  - `groupValue: undefined` for form-root fields
- [x] `nx test dynamic-forms` — 2577 passed
- [x] `nx build dynamic-forms` — clean
- [x] `nx lint dynamic-forms` — no new warnings