### PR TITLE
ci(release): raise node heap to 8GB for vercel build step

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -95,6 +95,8 @@ jobs:
         run: vercel pull --yes --environment=${{ inputs.environment }} --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build Project
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
         run: vercel build ${{ inputs.environment == 'production' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy to Vercel


### PR DESCRIPTION
## Summary
- Today's `Deploy to Vercel` run [25116277376](https://github.com/ng-forge/ng-forge/actions/runs/25116277376) failed with `FATAL ERROR: Ineffective mark-compacts near heap limit — Allocation failed - JavaScript heap out of memory` during the `Build Project` step (`vercel build` → `pnpm run deploy:prep` → `nx build docs:production`).
- Root cause: the runner uses Node's default ~4 GB heap and the Analog/Vite SSR pre-render now exceeds it. `ci.yml` and `pr-check.yml` already set `NODE_OPTIONS=--max-old-space-size=8192` for their docs-build steps; only `deploy-vercel.yml` was missing it.
- Adds `NODE_OPTIONS: --max-old-space-size=8192` to the `Build Project` step so production/staging deploys match CI.

## Test plan
- [ ] Manually trigger the `Deploy to Vercel` workflow against this branch (preview env) and confirm `Build Project` completes without OOM.
- [ ] After merge, re-run the production deploy and confirm the smoke test on `https://ng-forge.com/dynamic-forms/` passes.