### PR TITLE
ci(release): raise node heap to 8GB for staging vercel build step

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -51,6 +51,8 @@ jobs:
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build Project
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy to Vercel


### PR DESCRIPTION
## Summary
- Follow-up to #372 — `deploy-staging.yml` has the same `vercel build` step on a GitHub Actions runner with no `NODE_OPTIONS` override, so auto-staging deploys from `main` were OOM-ing for the same reason (4 GB Node heap default vs. ~8 GB headroom on Vercel's own builders).
- Two staging runs earlier today (deployments `4525137484` and `4524845536`) failed with the same `Allocation failed - JavaScript heap out of memory` as the production run that #372 fixed.
- Mirrors the fix from #372 onto `deploy-staging.yml`.

## Test plan
- [ ] Next push to `main` (or manual re-run of the failed staging deploy) completes the `Build Project` step without OOM and aliases successfully to `staging.ng-forge.com`.