### PR TITLE
ci(release): use github app token + drop redundant manual tagging step

### DIFF
--- a/.github/workflows/discord-release-notify.yml
+++ b/.github/workflows/discord-release-notify.yml
@@ -3,6 +3,12 @@ name: Discord Release Notification
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to (re)post (e.g. v0.8.0 or next/0.8.1-next.5). Used for backfill when an auto-fire was missed.'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -11,15 +17,17 @@ jobs:
   notify:
     name: Post release to Discord
     runs-on: ubuntu-latest
-    if: ${{ !github.event.release.draft }}
     steps:
       - name: Build payload and post to Discord
+        # Both triggers route through `gh release view` so the embed-building logic stays
+        # identical regardless of how we were fired. For release: published events we could
+        # use github.event.release.* directly, but going through the API also dodges subtle
+        # interpolation issues with bodies containing backticks or YAML-significant chars.
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          RELEASE_NAME: ${{ github.event.release.name || github.event.release.tag_name }}
-          RELEASE_URL: ${{ github.event.release.html_url }}
-          RELEASE_BODY: ${{ github.event.release.body }}
-          IS_PRERELEASE: ${{ github.event.release.prerelease }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag || github.event.release.tag_name }}
         run: |
           set -euo pipefail
 
@@ -28,8 +36,20 @@ jobs:
             exit 1
           fi
 
+          META=$(gh release view "${TAG}" --json name,tagName,body,isPrerelease,isDraft,url)
+
+          if [ "$(echo "$META" | jq -r '.isDraft')" = "true" ]; then
+            echo "::warning::Release ${TAG} is a draft — skipping Discord notification"
+            exit 0
+          fi
+
+          RELEASE_NAME=$(echo "$META" | jq -r '.name // .tagName')
+          RELEASE_URL=$(echo "$META" | jq -r '.url')
+          IS_PRERELEASE=$(echo "$META" | jq -r '.isPrerelease')
+          BODY=$(echo "$META" | jq -r '.body // empty')
+          BODY="${BODY:-_No release notes provided._}"
+
           # Discord embed description max is 4096 chars; trim with a notice if longer.
-          BODY="${RELEASE_BODY:-_No release notes provided._}"
           MAX=3900
           if [ "${#BODY}" -gt "$MAX" ]; then
             BODY="${BODY:0:$MAX}"$'\n\n'"… *truncated — see [full release notes](${RELEASE_URL}).*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,6 +306,17 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Generate GitHub App Token
+        # GITHUB_TOKEN cannot trigger downstream workflows (GitHub recursion safeguard),
+        # so releases created with it don't fire `release: published` — which is what
+        # discord-release-notify.yml listens for. Using a GitHub App-scoped token instead
+        # makes those events propagate normally.
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Install pnpm
         uses: pnpm/action-setup@v5
         with:
@@ -420,8 +431,8 @@ jobs:
 
       - name: Publish to npm
         # Real publish: workflow_dispatch mode=publish, workflow_dispatch mode=next, or schedule.
-        # Runs BEFORE git tag + GitHub release on the stable path (and @next tag below) so
-        # that the irreversible-first-so-reversible-second pattern holds: if npm fails, no
+        # Runs BEFORE the GitHub release/prerelease steps so that the
+        # irreversible-first-so-reversible-second pattern holds: if npm fails, no
         # stale tag/release is left behind. On re-run after a partial failure, the
         # per-package `npm view` check below skips packages already on npm so we don't 409.
         if: |
@@ -439,38 +450,22 @@ jobs:
             npm publish "dist/packages/$pkg" --access public --provenance --tag "$DIST_TAG"
           done
 
-      - name: Configure Git
-        # Git identity for the tag-creation steps below (stable and @next paths).
-        if: inputs.mode == 'publish' || github.event_name == 'schedule' || inputs.mode == 'next'
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-
-      - name: Create Git Tag (stable)
-        # Runs AFTER npm publish so a failed publish doesn't leave a stale v* tag.
-        # If the tag step itself fails after a successful publish, re-running
-        # succeeds because the idempotency check in Publish skips the already-pushed
-        # packages. Manual recovery: re-dispatch mode=publish.
-        if: inputs.mode == 'publish'
-        run: |
-          if git rev-parse "v${{ env.VERSION }}" >/dev/null 2>&1; then
-            echo "Tag v${{ env.VERSION }} already exists (likely from a retry after partial failure) — skipping create"
-          else
-            git tag -a "v${{ env.VERSION }}" -m "Release v${{ env.VERSION }}"
-            git push origin "v${{ env.VERSION }}"
-          fi
-
       - name: Create GitHub Release
+        # action-gh-release creates the v${VERSION} tag at github.sha via the GitHub API
+        # AND publishes the release in one step. Runs AFTER npm publish so a failed publish
+        # doesn't leave a stale tag/release behind. Idempotent on retry: if the release
+        # already exists, the action updates it. Manual recovery: re-dispatch mode=publish.
         if: inputs.mode == 'publish'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ env.VERSION }}
+          target_commitish: ${{ github.sha }}
           name: Release v${{ env.VERSION }}
           body_path: RELEASE_NOTES.md
           draft: false
           prerelease: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Generate Nightly Release Notes
         # Body for the @next GitHub prerelease. Reuses the gate's BASE (most recent of
@@ -514,7 +509,7 @@ jobs:
           prerelease: true
           draft: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Summary
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,20 +306,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate GitHub App Token
-        # GITHUB_TOKEN cannot trigger downstream workflows (GitHub recursion safeguard),
-        # so releases created with it don't fire `release: published` — which is what
-        # discord-release-notify.yml listens for. Using a GitHub App-scoped token instead
-        # makes those events propagate normally.
-        # Gated to the same paths that consume the token (matches the old Configure Git
-        # step's condition) so a dry-run doesn't depend on the App secrets being present.
-        if: inputs.mode == 'publish' || github.event_name == 'schedule' || inputs.mode == 'next'
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
       - name: Install pnpm
         uses: pnpm/action-setup@v5
         with:
@@ -452,6 +438,24 @@ jobs:
             fi
             npm publish "dist/packages/$pkg" --access public --provenance --tag "$DIST_TAG"
           done
+
+      - name: Generate GitHub App Token
+        # GITHUB_TOKEN cannot trigger downstream workflows (GitHub recursion safeguard),
+        # so releases created with it don't fire `release: published` — which is what
+        # discord-release-notify.yml listens for. Using a GitHub App-scoped token instead
+        # makes those events propagate normally.
+        # Generated immediately before action-gh-release (not at job start) because App
+        # installation tokens have a 1-hour lifetime; build + npm publish can eat into
+        # that window on a slow run, so we always hand action-gh-release a fresh token.
+        # Gated to the same paths that consume it so a dry-run doesn't depend on the
+        # App secrets being present. The two action-gh-release steps below are mutually
+        # exclusive (publish vs schedule|next), so a single shared token is sufficient.
+        if: inputs.mode == 'publish' || github.event_name == 'schedule' || inputs.mode == 'next'
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Create GitHub Release
         # action-gh-release creates the v${VERSION} tag at github.sha via the GitHub API

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,6 +311,9 @@ jobs:
         # so releases created with it don't fire `release: published` — which is what
         # discord-release-notify.yml listens for. Using a GitHub App-scoped token instead
         # makes those events propagate normally.
+        # Gated to the same paths that consume the token (matches the old Configure Git
+        # step's condition) so a dry-run doesn't depend on the App secrets being present.
+        if: inputs.mode == 'publish' || github.event_name == 'schedule' || inputs.mode == 'next'
         id: app-token
         uses: actions/create-github-app-token@v2
         with:


### PR DESCRIPTION
## Summary

- **Switch `softprops/action-gh-release@v3` calls** (stable + nightly) to a GitHub App-scoped token via `actions/create-github-app-token@v2`. `GITHUB_TOKEN` is silently suppressed by GitHub's recursion safeguard, which is why the v0.8.0 publish never fired `discord-release-notify.yml` even though it listens for `release: published`.
- **Drop the now-redundant manual `Configure Git` + `Create Git Tag (stable)` steps.** `action-gh-release` creates the v${VERSION} tag itself when given `target_commitish: ${{ github.sha }}` — same pattern PR #369 already adopted for the @next path. Stable and @next paths now match.
- **Add `workflow_dispatch` backfill** to `discord-release-notify.yml`. Lets you manually re-fire a Discord notification by tag (e.g. v0.8.0) when an auto-fire was missed. Both triggers now resolve release metadata via `gh release view` so the embed logic is single-source-of-truth.

## Prereqs (must be in place before merging)

- [x] GitHub App `ng-forge-release-bot` created under the org with `Contents: Read and write` permission, installed on `ng-forge/ng-forge`
- [x] Repo variable `RELEASE_APP_ID` set
- [x] Repo secret `RELEASE_APP_PRIVATE_KEY` set (full PEM contents)

## Behavioral notes

- Stable release tags are now created via the GitHub API as **lightweight tags** (matching what @next already does post-#369). Old manual flow used `git tag -a` annotated tags. No expected impact on `git describe`, npm refs, or the GitHub UI.
- The tag is created via the app token, so any future workflow listening on `push: tags:` would also propagate. None exist today.
- Idempotency on retry preserved: `action-gh-release` updates existing releases; npm step still skips already-published versions.
- Discord backfill skips drafts via an in-step API check (replaces the job-level YAML `if:`, which couldn't handle the dispatch path cleanly).

## Test plan

- [ ] Dispatch `Release` workflow with `mode=next` from this branch — verify Nightly v…-next.X release appears under Releases AND Discord receives the amber embed
- [ ] After merge, dispatch `Discord Release Notification` with `tag=v0.8.0` — should backfill the missed notification with a green stable embed
- [ ] After next stable dispatch (`mode=publish`) post-merge — verify Discord receives the green embed automatically
- [ ] Confirm v${VERSION} tag points at the correct dispatching SHA (not main HEAD)