### PR TITLE
ci(release): nightly fires only when packages/ changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,10 +161,17 @@ jobs:
           # Bump-worthy commit types per nx.json release.conventionalCommits:
           # feat, fix, perf, revert. Everything else (docs/ci/chore/test/build/style/refactor)
           # is classified semverBump:none and should not trigger a next release.
+          #
+          # Path filter `-- packages/` further restricts to commits that actually touched
+          # the published library sources. A `feat(docs): …` or `fix(examples): …` no
+          # longer triggers a nightly because it doesn't change anything that ships to
+          # npm. Only changes under `packages/**` (the seven workspaces in
+          # LIBRARY_PACKAGES) qualify.
+          #
           # Disable pipefail for this pipeline so we can distinguish grep's "no matches"
           # (exit 1, fine) from a real grep error (exit ≥2, fail loud).
           set +o pipefail
-          RELEVANT=$(git log "${BASE}..HEAD" --pretty=format:'%s' \
+          RELEVANT=$(git log "${BASE}..HEAD" --pretty=format:'%s' -- packages/ \
             | grep -cE '^(feat|fix|perf|revert)(\([^)]+\))?!?: ')
           GREP_EXIT=$?
           set -o pipefail
@@ -173,7 +180,7 @@ jobs:
             exit 1
           fi
 
-          echo "Bump-worthy commits since $BASE: $RELEVANT"
+          echo "Bump-worthy commits touching packages/ since $BASE: $RELEVANT"
 
           if [ "$RELEVANT" -eq 0 ]; then
             echo "No bump-worthy commits since last release — skipping next release"


### PR DESCRIPTION
## Summary

The nightly @next release gate (`next-gate` job in `.github/workflows/release.yml`) counted any bump-worthy conventional-commit type (`feat`/`fix`/`perf`/`revert`) on main, **regardless of which directory the commit touched**. Result: a `fix(docs): …` or `feat(examples): …` would publish a new @next prerelease of every library — even though nothing under `packages/**` had changed. Nightly noise + npm registry churn for zero substantive change.

This PR adds `-- packages/` to the `git log` so only commits whose diff touched published library sources count toward the gate.

## Diff

```diff
- RELEVANT=$(git log "${BASE}..HEAD" --pretty=format:'%s' \
+ RELEVANT=$(git log "${BASE}..HEAD" --pretty=format:'%s' -- packages/ \
    | grep -cE '^(feat|fix|perf|revert)(\([^)]+\))?!?: ')
```

Other gate logic (SHA pinning, per-package counter lookup, CI-green gate) is unchanged.

## Sanity check against current main

```
BASE = v0.8.0
v0.8.0..HEAD bump-worthy commits, all paths:    1   ← old gate would fire
v0.8.0..HEAD bump-worthy commits, packages/:    0   ← new gate skips

The single commit it counts:
  cdea41574 fix(docs): serve prerendered html on clean urls and prerender api reference
```

That commit only touches `apps/docs/**`. Old gate would have published a nightly for zero packages/ change. New gate correctly skips.

## Why packages/ specifically

Internal-only workspaces under `internal/**` are intentionally excluded. They're consumed at build time but aren't separately published, and their public-surface impact is captured whenever a real `packages/**` change ships that bundles them in.

## Test plan

- [x] Sanity-check on current main shows old gate=1 / new gate=0 (committed in commit body)
- [ ] After merge: confirm tomorrow's scheduled cron run skips publish (no recent `packages/**` commits since `v0.8.0`)
- [ ] After the next genuine `packages/**` change lands, confirm the cron does fire
- [ ] Manual `workflow_dispatch` with `mode=next` still works (same gate code path)