### PR TITLE
fix(dynamic-forms): preserve nested group defaults on partial value

### DIFF
--- a/packages/dynamic-forms/src/lib/dynamic-form.component.spec.ts
+++ b/packages/dynamic-forms/src/lib/dynamic-form.component.spec.ts
@@ -1,3 +1,4 @@
+import { vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
 import { DynamicForm } from './dynamic-form.component';
 import { delay } from '@ng-forge/utils';
@@ -1127,6 +1128,94 @@ describe('DynamicFormComponent', () => {
       expect(component.formValue()).toEqual({
         firstName: 'Jane',
         lastName: 'Smith',
+      });
+    });
+
+    // Regression: when a partial value is applied to a `group` field, the
+    // omitted sub-fields must retain their declared defaults. Pre-fix, the
+    // shallow merge in `FormStateManager.entity` replaced the full nested
+    // default object with the partial value, causing Angular Signal Forms
+    // to throw `NG01902: Orphan field` from its deep-signal validation graph.
+    describe('partial value applied to nested group field', () => {
+      const addressGroupConfig: TestFormConfig = {
+        fields: [
+          {
+            key: 'a',
+            type: 'group',
+            label: 'Address',
+            fields: [
+              { key: 'line1', type: 'input', label: 'Line 1', value: '' },
+              { key: 'line2', type: 'input', label: 'Line 2', value: '' },
+              { key: 'city', type: 'input', label: 'City', value: '' },
+              { key: 'state', type: 'input', label: 'State', value: '' },
+              { key: 'zip', type: 'input', label: 'ZIP', value: '' },
+            ],
+          },
+        ],
+      };
+
+      const partialAddressValue = {
+        a: {
+          line1: '701 Brazos St.',
+          city: 'Austin',
+          state: 'TX',
+          zip: '78701',
+          // line2 intentionally omitted
+        },
+      };
+
+      const expectedSettledValue = {
+        a: {
+          line1: '701 Brazos St.',
+          line2: '',
+          city: 'Austin',
+          state: 'TX',
+          zip: '78701',
+        },
+      };
+
+      const collectOrphanErrors = (errors: unknown[]): string[] =>
+        errors
+          .map((e) => (Array.isArray(e) ? e.map(String).join(' ') : String(e)))
+          .filter((msg) => msg.includes('NG01902') || msg.includes('Orphan field'));
+
+      it('back-fills omitted sub-field with default when partial value is set at construction', async () => {
+        const errors: unknown[] = [];
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation((...args) => errors.push(args));
+
+        const { component, fixture } = createComponent(addressGroupConfig, partialAddressValue);
+        await waitForDynamicComponents(fixture);
+
+        consoleSpy.mockRestore();
+
+        expect(component.formValue()).toEqual(expectedSettledValue);
+        expect(collectOrphanErrors(errors)).toEqual([]);
+      });
+
+      it('back-fills omitted sub-field with default when partial value is set after render', async () => {
+        const errors: unknown[] = [];
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation((...args) => errors.push(args));
+
+        const { component, fixture } = createComponent(addressGroupConfig);
+        await waitForDynamicComponents(fixture);
+
+        expect(component.formValue()).toEqual({
+          a: { line1: '', line2: '', city: '', state: '', zip: '' },
+        });
+
+        fixture.componentRef.setInput('value', partialAddressValue);
+        await waitForDynamicComponents(fixture);
+
+        // Touch every signal that depends on the validation graph — pre-fix,
+        // any of these reads would trigger NG01902.
+        void component.valid();
+        void component.errors();
+        void component.formValue();
+
+        consoleSpy.mockRestore();
+
+        expect(component.formValue()).toEqual(expectedSettledValue);
+        expect(collectOrphanErrors(errors)).toEqual([]);
       });
     });
   });

--- a/packages/dynamic-forms/src/lib/dynamic-form.component.spec.ts
+++ b/packages/dynamic-forms/src/lib/dynamic-form.component.spec.ts
@@ -1183,39 +1183,43 @@ describe('DynamicFormComponent', () => {
         const errors: unknown[] = [];
         const consoleSpy = vi.spyOn(console, 'error').mockImplementation((...args) => errors.push(args));
 
-        const { component, fixture } = createComponent(addressGroupConfig, partialAddressValue);
-        await waitForDynamicComponents(fixture);
+        try {
+          const { component, fixture } = createComponent(addressGroupConfig, partialAddressValue);
+          await waitForDynamicComponents(fixture);
 
-        consoleSpy.mockRestore();
-
-        expect(component.formValue()).toEqual(expectedSettledValue);
-        expect(collectOrphanErrors(errors)).toEqual([]);
+          expect(component.formValue()).toEqual(expectedSettledValue);
+          expect(collectOrphanErrors(errors)).toEqual([]);
+        } finally {
+          consoleSpy.mockRestore();
+        }
       });
 
       it('back-fills omitted sub-field with default when partial value is set after render', async () => {
         const errors: unknown[] = [];
         const consoleSpy = vi.spyOn(console, 'error').mockImplementation((...args) => errors.push(args));
 
-        const { component, fixture } = createComponent(addressGroupConfig);
-        await waitForDynamicComponents(fixture);
+        try {
+          const { component, fixture } = createComponent(addressGroupConfig);
+          await waitForDynamicComponents(fixture);
 
-        expect(component.formValue()).toEqual({
-          a: { line1: '', line2: '', city: '', state: '', zip: '' },
-        });
+          expect(component.formValue()).toEqual({
+            a: { line1: '', line2: '', city: '', state: '', zip: '' },
+          });
 
-        fixture.componentRef.setInput('value', partialAddressValue);
-        await waitForDynamicComponents(fixture);
+          fixture.componentRef.setInput('value', partialAddressValue);
+          await waitForDynamicComponents(fixture);
 
-        // Touch every signal that depends on the validation graph — pre-fix,
-        // any of these reads would trigger NG01902.
-        void component.valid();
-        void component.errors();
-        void component.formValue();
+          // Touch every signal that depends on the validation graph — pre-fix,
+          // any of these reads would trigger NG01902.
+          void component.valid();
+          void component.errors();
+          void component.formValue();
 
-        consoleSpy.mockRestore();
-
-        expect(component.formValue()).toEqual(expectedSettledValue);
-        expect(collectOrphanErrors(errors)).toEqual([]);
+          expect(component.formValue()).toEqual(expectedSettledValue);
+          expect(collectOrphanErrors(errors)).toEqual([]);
+        } finally {
+          consoleSpy.mockRestore();
+        }
       });
     });
   });

--- a/packages/dynamic-forms/src/lib/state/form-state-manager.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-manager.ts
@@ -39,7 +39,7 @@ import { SchemaRegistryService } from '../core/registry/schema-registry.service'
 import { createSchemaFromFields } from '../core/schema-builder';
 import { createFormLevelSchema } from '../core/form-schema-merger';
 import { collectCrossFieldEntries } from '../core/cross-field/cross-field-collector';
-import { isEqual } from '../utils/object-utils';
+import { deepMergeDefaults, isEqual } from '../utils/object-utils';
 import { CONTAINER_FIELD_PROCESSORS } from '../utils/container-utils/container-field-processors';
 import { derivedFromDeferred } from '../utils/derived-from-deferred/derived-from-deferred';
 import { reconcileFields, ResolvedField, resolveField, resolveFieldSync } from '../utils/resolve-field/resolve-field';
@@ -324,7 +324,10 @@ export class FormStateManager<
       const defaults = this.defaultValues();
       const keys = this.validKeys();
 
-      const combined = { ...defaults, ...inputValue };
+      // Deep-merge so a partial nested object in `inputValue` (e.g. a group
+      // value missing one of its declared sub-field keys) does not orphan
+      // the absent sub-field in the Signal Forms validation graph.
+      const combined = deepMergeDefaults(defaults as Record<string, unknown>, inputValue as Record<string, unknown>);
 
       if (keys) {
         const filtered: Record<string, unknown> = {};

--- a/packages/dynamic-forms/src/lib/utils/object-utils.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/object-utils.spec.ts
@@ -400,5 +400,25 @@ describe('object-utils', () => {
 
       expect(deepMergeDefaults(defaults, value)).toEqual({ a: null });
     });
+
+    it('should not be vulnerable to prototype pollution via __proto__', () => {
+      const defaults: Record<string, unknown> = { a: 1 };
+      const value = JSON.parse('{"__proto__": {"polluted": true}, "a": 2}') as Record<string, unknown>;
+
+      const result = deepMergeDefaults(defaults, value);
+
+      expect(result).toEqual({ a: 2 });
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+      expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    });
+
+    it('should not merge constructor or prototype keys', () => {
+      const defaults: Record<string, unknown> = { a: 1 };
+      const value: Record<string, unknown> = { constructor: { evil: true }, prototype: { evil: true }, a: 2 };
+
+      const result = deepMergeDefaults(defaults, value);
+
+      expect(result).toEqual({ a: 2 });
+    });
   });
 });

--- a/packages/dynamic-forms/src/lib/utils/object-utils.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/object-utils.spec.ts
@@ -1,5 +1,5 @@
 import { vi } from 'vitest';
-import { omit, keyBy, mapValues, memoize } from './object-utils';
+import { deepMergeDefaults, omit, keyBy, mapValues, memoize } from './object-utils';
 
 describe('object-utils', () => {
   describe('omit', () => {
@@ -312,6 +312,93 @@ describe('object-utils', () => {
       // 'a' was evicted, needs recompute
       memoized({ key: 'a', data: 1 });
       expect(fn).toHaveBeenCalledTimes(5);
+    });
+  });
+
+  describe('deepMergeDefaults', () => {
+    it('should preserve nested keys missing from value', () => {
+      const defaults = { a: { line1: '', line2: '', city: '' }, b: 0 };
+      const value = { a: { line1: 'X', city: 'Y' }, b: 1 };
+
+      expect(deepMergeDefaults(defaults, value)).toEqual({
+        a: { line1: 'X', line2: '', city: 'Y' },
+        b: 1,
+      });
+    });
+
+    it('should not mutate the input objects', () => {
+      const defaults = { a: { x: 1 } };
+      const value = { a: { y: 2 } };
+      const defaultsClone = JSON.parse(JSON.stringify(defaults));
+      const valueClone = JSON.parse(JSON.stringify(value));
+
+      deepMergeDefaults(defaults, value);
+
+      expect(defaults).toEqual(defaultsClone);
+      expect(value).toEqual(valueClone);
+    });
+
+    it('should return a clone of defaults when value is null or undefined', () => {
+      const defaults = { a: 1 };
+
+      expect(deepMergeDefaults(defaults, null)).toEqual(defaults);
+      expect(deepMergeDefaults(defaults, undefined)).toEqual(defaults);
+      expect(deepMergeDefaults(defaults, null)).not.toBe(defaults);
+    });
+
+    it('should replace arrays wholesale rather than merging them', () => {
+      const defaults = { tags: ['a', 'b', 'c'] };
+      const value = { tags: ['x'] };
+
+      expect(deepMergeDefaults(defaults, value)).toEqual({ tags: ['x'] });
+    });
+
+    it('should replace primitive overrides', () => {
+      const defaults = { name: 'default', count: 0, ready: false };
+      const value = { name: 'updated', count: 5, ready: true };
+
+      expect(deepMergeDefaults(defaults, value)).toEqual(value);
+    });
+
+    it('should merge multiple levels of nested plain objects', () => {
+      const defaults = {
+        outer: { inner: { a: 1, b: 2 }, sibling: 'kept' },
+      };
+      const value = {
+        outer: { inner: { a: 99 } },
+      };
+
+      expect(deepMergeDefaults(defaults, value)).toEqual({
+        outer: { inner: { a: 99, b: 2 }, sibling: 'kept' },
+      });
+    });
+
+    it('should treat Date and class instances as opaque (replace, do not merge)', () => {
+      class Box {
+        constructor(public n: number) {}
+      }
+      const date = new Date('2026-01-01T00:00:00Z');
+      const defaults = { d: new Date('2024-01-01T00:00:00Z'), b: new Box(1) };
+      const value = { d: date, b: new Box(2) };
+
+      const result = deepMergeDefaults(defaults, value);
+
+      expect(result.d).toBe(date);
+      expect((result.b as Box).n).toBe(2);
+    });
+
+    it('should accept new keys present only in value', () => {
+      const defaults = { a: 1 };
+      const value = { a: 2, b: 3 } as Record<string, unknown>;
+
+      expect(deepMergeDefaults<Record<string, unknown>>(defaults, value)).toEqual({ a: 2, b: 3 });
+    });
+
+    it('should let an explicit null override a plain-object default', () => {
+      const defaults = { a: { x: 1 } };
+      const value: Record<string, unknown> = { a: null };
+
+      expect(deepMergeDefaults(defaults, value)).toEqual({ a: null });
     });
   });
 });

--- a/packages/dynamic-forms/src/lib/utils/object-utils.ts
+++ b/packages/dynamic-forms/src/lib/utils/object-utils.ts
@@ -235,6 +235,8 @@ export function deepMergeDefaults<T extends Record<string, unknown>>(defaults: T
   const result: Record<string, unknown> = { ...defaults };
 
   for (const key of Object.keys(value)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
+
     const incoming = value[key];
     const existing = result[key];
 

--- a/packages/dynamic-forms/src/lib/utils/object-utils.ts
+++ b/packages/dynamic-forms/src/lib/utils/object-utils.ts
@@ -211,6 +211,56 @@ export function mapValues<T, U>(obj: Record<string, T>, fn: (value: T, key: stri
 }
 
 /**
+ * Deep-merges `value` into `defaults`, producing a new object that contains every
+ * key from `defaults` plus any overrides from `value`. Plain-object values at
+ * matching keys are merged recursively; arrays, dates, and primitives in `value`
+ * replace the corresponding default wholesale.
+ *
+ * Used by `FormStateManager.entity` so a partial input value (e.g. a nested
+ * group object missing one of its declared sub-fields) does not orphan the
+ * absent sub-field in Angular Signal Forms' validation graph.
+ *
+ * @example
+ * ```typescript
+ * deepMergeDefaults(
+ *   { a: { line1: '', line2: '', city: '' }, b: 0 },
+ *   { a: { line1: 'X', city: 'Y' }, b: 1 },
+ * );
+ * // { a: { line1: 'X', line2: '', city: 'Y' }, b: 1 }
+ * ```
+ */
+export function deepMergeDefaults<T extends Record<string, unknown>>(defaults: T, value: Record<string, unknown> | null | undefined): T {
+  if (value == null) return { ...defaults };
+
+  const result: Record<string, unknown> = { ...defaults };
+
+  for (const key of Object.keys(value)) {
+    const incoming = value[key];
+    const existing = result[key];
+
+    if (isPlainObject(existing) && isPlainObject(incoming)) {
+      result[key] = deepMergeDefaults(existing, incoming);
+    } else {
+      result[key] = incoming;
+    }
+  }
+
+  return result as T;
+}
+
+/**
+ * @internal
+ * Returns true for objects that should be deep-merged (plain objects produced
+ * by literals or `Object.create(null)`); false for arrays, Dates, RegExps,
+ * Maps, Sets, class instances, and primitives.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === null || proto === Object.prototype;
+}
+
+/**
  * Options for memoize function
  */
 /** Default maximum cache size for memoized functions */


### PR DESCRIPTION
# Pull Request

## Description

Was finally able to reproduce this issue, where setting the formValue with an equivalent Partial would cause the form to basically crash and Angular Signals to throw "NG01902: Orphan field".

<img width="741" height="657" alt="Screenshot 2026-05-04 at 2 18 21 PM" src="https://github.com/user-attachments/assets/3f28041c-2bbc-4ec4-b96f-8cd58393cb34" />

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Code style update (formatting, renaming)
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build/tooling update

## Related Issues

<!-- Link to related issues. Use "Fixes #123" to auto-close issues when PR is merged -->

Fixes #
Related to #

## Changes Made

<!-- Provide a detailed list of changes -->

- Replace the shallow merge in FormStateManager.entity with deepMergeDefaults so a partial nested object in the input value (e.g. a group missing one of its declared sub-field keys) no longer triggers NG01902: Orphan field from the Signal Forms validation graph.

## Testing

- [x] Unit tests added/updated
- [x] All tests pass locally
- [ ] Tested manually
- [ ] Tested edge cases

<!-- If applicable, describe manual testing or include test configuration -->

## Screenshots / Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

## Documentation

- [ ] Documentation updated (if needed)
- [ ] API documentation (TSDoc) added/updated
- [ ] Examples updated (if needed)

## Checklist

<!-- Ensure all items are checked before requesting review -->

- [ ] Code follows the [coding standards](../CODING_STANDARDS.md)
- [ ] No linting errors (`pnpm lint`)
- [ ] Code is formatted (`pnpm lint:fix`)
- [ ] Build succeeds (`pnpm build:libs`)
- [ ] Commits follow [conventional commit format](https://www.conventionalcommits.org/)
- [ ] Self-review completed
- [ ] No commented-out code or console.log() statements
- [ ] Type safety maintained (no `any` types)

## Additional Notes

<!-- Any additional information that reviewers should know -->
