### PR TITLE
fix(dynamic-forms): refresh field props on same-key config changes

### DIFF
--- a/packages/dynamic-forms/src/lib/dynamic-form.component.spec.ts
+++ b/packages/dynamic-forms/src/lib/dynamic-form.component.spec.ts
@@ -5,8 +5,9 @@ import { delay } from '@ng-forge/utils';
 import { SimpleTestUtils } from '../../testing/src/simple-test-utils';
 import TestInputHarnessComponent from '../../testing/src/harnesses/test-input.harness';
 import TestCheckboxHarnessComponent from '../../testing/src/harnesses/test-checkbox.harness';
+import TestSelectHarnessComponent from '../../testing/src/harnesses/test-select.harness';
 import { FIELD_REGISTRY, FieldTypeDefinition } from './models/field-type';
-import { checkboxFieldMapper, valueFieldMapper } from '@ng-forge/dynamic-forms/integration';
+import { checkboxFieldMapper, optionsFieldMapper, valueFieldMapper } from '@ng-forge/dynamic-forms/integration';
 import { BUILT_IN_FIELDS, BUILT_IN_WRAPPERS } from './providers/built-in-fields';
 import { FieldWrapperContract, WRAPPER_REGISTRY, WrapperTypeDefinition } from './models/wrapper-type';
 import { ARRAY_CONTEXT } from './models/field-signal-context.token';
@@ -26,6 +27,7 @@ type TestFormConfig = {
   fields: Array<
     | (BaseValueField<any, any> & { type: 'input' })
     | (BaseCheckedField<any> & { type: 'checkbox' })
+    | (BaseValueField<any, any> & { type: 'select'; options: Array<{ value: any; label: string }> })
     | { type: 'row'; key: string; label: string; fields: any[] }
     | { type: 'group'; key: string; label: string; fields: any[] }
     | { type: 'page'; key: string; label?: string; fields: any[] }
@@ -85,6 +87,11 @@ const TEST_FIELD_TYPES: FieldTypeDefinition[] = [
     loadComponent: () => import('../../testing/src/harnesses/test-checkbox.harness').then((m) => m.default),
     mapper: checkboxFieldMapper,
   },
+  {
+    name: 'select',
+    loadComponent: () => import('../../testing/src/harnesses/test-select.harness').then((m) => m.default),
+    mapper: optionsFieldMapper as FieldTypeDefinition['mapper'],
+  },
 ];
 
 describe('DynamicFormComponent', () => {
@@ -114,6 +121,7 @@ describe('DynamicFormComponent', () => {
         DynamicForm,
         TestInputHarnessComponent,
         TestCheckboxHarnessComponent,
+        TestSelectHarnessComponent,
         TestParentWrapperComponent,
         TestChildWrapperComponent,
         TestArrayContextWrapperComponent,
@@ -737,6 +745,76 @@ describe('DynamicFormComponent', () => {
         firstName: 'John',
         lastName: 'Smith',
       });
+    });
+
+    it('should refresh select options when config changes for a field with the same key', async () => {
+      // Initial config: select field with empty options array.
+      const initialConfig: TestFormConfig = {
+        fields: [
+          {
+            key: 'country',
+            type: 'select',
+            label: 'Country',
+            options: [],
+          },
+        ],
+      };
+
+      const { fixture } = createComponent(initialConfig);
+      await waitForDynamicComponents(fixture);
+
+      // Sanity: the select harness rendered with no options.
+      let selectDe = fixture.debugElement.query((de: DebugElement) => de.componentInstance instanceof TestSelectHarnessComponent);
+      expect(selectDe).not.toBeNull();
+      let selectInstance = selectDe.componentInstance as TestSelectHarnessComponent;
+      expect(selectInstance.options()).toEqual([]);
+
+      // Swap config quickly: same key, same type, but now with options populated.
+      // This mimics a real-world flow where async data fills the options after the
+      // form has already been rendered with an empty list.
+      const newConfig: TestFormConfig = {
+        fields: [
+          {
+            key: 'country',
+            type: 'select',
+            label: 'Country',
+            options: [
+              { value: 'us', label: 'United States' },
+              { value: 'ca', label: 'Canada' },
+            ],
+          },
+        ],
+      };
+
+      fixture.componentRef.setInput('dynamic-form', newConfig);
+      // Config transitions go through multiple phases (config-change -> teardown ->
+      // applying -> restoring -> ready); allow each tick for the pipeline to settle.
+      await delay(10);
+      fixture.detectChanges();
+      TestBed.flushEffects();
+      await delay(10);
+      fixture.detectChanges();
+      TestBed.flushEffects();
+      await delay(10);
+      fixture.detectChanges();
+
+      // The harness's options input should reflect the new options.
+      // BUG: reconcileFields preserves the prior ResolvedField when key+component+injector
+      // match, so the stale `inputs` signal (whose options were captured by closure in
+      // optionsFieldMapper from the initial fieldDef) is reused and the harness still
+      // sees an empty options array.
+      selectDe = fixture.debugElement.query((de: DebugElement) => de.componentInstance instanceof TestSelectHarnessComponent);
+      selectInstance = selectDe.componentInstance as TestSelectHarnessComponent;
+      expect(selectInstance.options()).toEqual([
+        { value: 'us', label: 'United States' },
+        { value: 'ca', label: 'Canada' },
+      ]);
+
+      // And the rendered DOM should reflect the new options too.
+      const renderedOptionLabels = Array.from(selectDe.nativeElement.querySelectorAll('option'))
+        .map((opt: Element) => opt.textContent?.trim())
+        .filter((label: string | undefined) => label && label !== 'Select...');
+      expect(renderedOptionLabels).toEqual(['United States', 'Canada']);
     });
   });
 

--- a/packages/dynamic-forms/src/lib/dynamic-form.component.spec.ts
+++ b/packages/dynamic-forms/src/lib/dynamic-form.component.spec.ts
@@ -799,10 +799,11 @@ describe('DynamicFormComponent', () => {
       fixture.detectChanges();
 
       // The harness's options input should reflect the new options.
-      // BUG: reconcileFields preserves the prior ResolvedField when key+component+injector
-      // match, so the stale `inputs` signal (whose options were captured by closure in
-      // optionsFieldMapper from the initial fieldDef) is reused and the harness still
-      // sees an empty options array.
+      // Regression test for prior bug: reconcileFields preserved the prior ResolvedField when
+      // key+component+injector matched, reusing a stale `inputs` signal whose options were
+      // captured by closure in optionsFieldMapper from the initial fieldDef — so the harness
+      // saw an empty options array. This assertion verifies the fix: selectInstance.options()
+      // must now reflect the new options after a same-key config change.
       selectDe = fixture.debugElement.query((de: DebugElement) => de.componentInstance instanceof TestSelectHarnessComponent);
       selectInstance = selectDe.componentInstance as TestSelectHarnessComponent;
       expect(selectInstance.options()).toEqual([

--- a/packages/dynamic-forms/src/lib/state/form-state-manager.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-manager.ts
@@ -502,7 +502,12 @@ export class FormStateManager<
   /**
    * Phase-aware field source that coordinates component lifecycle with form updates.
    * Teardown/Applying → intersection of old/new fields; Restoring → all new fields.
-   * Uses key+type equality to avoid spurious emissions during rapid transitions.
+   *
+   * Uses per-field reference equality to suppress spurious emissions when the same
+   * field definitions are returned (e.g. memoized intersections during transitions)
+   * while still triggering re-resolution when the underlying field definition
+   * references change (e.g. a config swap that updates options/props for a
+   * same-keyed field).
    */
   private readonly fieldsSource = computed(
     () => {
@@ -528,7 +533,7 @@ export class FormStateManager<
       equal: (a, b) => {
         if (a === b) return true;
         if (a.length !== b.length) return false;
-        return a.every((field, i) => field.key === b[i].key && field.type === b[i].type);
+        return a.every((field, i) => field === b[i]);
       },
     },
   );

--- a/packages/dynamic-forms/src/lib/utils/container-utils/container-field-processors.ts
+++ b/packages/dynamic-forms/src/lib/utils/container-utils/container-field-processors.ts
@@ -3,7 +3,7 @@ import { FieldDef } from '../../definitions/base/field-def';
 import { FieldTypeDefinition } from '../../models/field-type';
 import { flattenFields } from '../flattener/field-flattener';
 import { getFieldDefaultValue } from '../default-value/default-value';
-import { keyBy, memoize, mapValues } from '../object-utils';
+import { keyBy, mapValues } from '../object-utils';
 
 /**
  * Creates memoized field processing functions shared across container components.
@@ -11,66 +11,63 @@ import { keyBy, memoize, mapValues } from '../object-utils';
  * These functions are used by both `FormStateManager` and `GroupFieldComponent`
  * to compute flattened fields, field lookups, and default values from field definitions.
  *
+ * Caches are keyed on the input array's reference identity (via WeakMap) rather than
+ * a derived content key. Different array instances — even ones with the same field
+ * keys/types — must produce fresh results so per-field content changes (e.g. updated
+ * select options) propagate through the form pipeline.
+ *
  * @returns Object containing memoized processing functions
  */
 export function createContainerFieldProcessors() {
-  const createFieldsResolver =
-    (preserveRows = false) =>
-    (fields: readonly FieldDef<unknown>[], registry: Map<string, FieldTypeDefinition>) => {
-      let key = '';
-      for (const f of fields) {
-        key += (f.key ?? '') + ':' + (f.type ?? '') + '|';
-      }
-      return key + registry.size + '|' + preserveRows;
-    };
+  const flattenCache = new WeakMap<readonly FieldDef<unknown>[], FieldDef<unknown>[]>();
+  const memoizedFlattenFields = (fields: readonly FieldDef<unknown>[], registry: Map<string, FieldTypeDefinition>): FieldDef<unknown>[] => {
+    const cached = flattenCache.get(fields);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const result = flattenFields([...fields], registry);
+    flattenCache.set(fields, result);
+    return result;
+  };
 
-  const memoizedFlattenFields = memoize(
-    (fields: readonly FieldDef<unknown>[], registry: Map<string, FieldTypeDefinition>) => flattenFields([...fields], registry),
-    {
-      // registry.size is a valid cache key proxy because the field registry is populated
-      // once at bootstrap and never mutated at runtime. If the registry were mutable,
-      // we would need a content-based hash instead.
-      resolver: createFieldsResolver(),
-      maxSize: 10,
-    },
-  );
+  const flattenForRenderingCache = new WeakMap<readonly FieldDef<unknown>[], FieldDef<unknown>[]>();
+  const memoizedFlattenFieldsForRendering = (
+    fields: readonly FieldDef<unknown>[],
+    registry: Map<string, FieldTypeDefinition>,
+  ): FieldDef<unknown>[] => {
+    const cached = flattenForRenderingCache.get(fields);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const result = flattenFields([...fields], registry, { preserveRows: true });
+    flattenForRenderingCache.set(fields, result);
+    return result;
+  };
 
-  const memoizedFlattenFieldsForRendering = memoize(
-    (fields: readonly FieldDef<unknown>[], registry: Map<string, FieldTypeDefinition>) =>
-      flattenFields([...fields], registry, { preserveRows: true }),
-    {
-      // registry.size is a valid cache key proxy because the field registry is populated
-      // once at bootstrap and never mutated at runtime. If the registry were mutable,
-      // we would need a content-based hash instead.
-      resolver: createFieldsResolver(true),
-      maxSize: 10,
-    },
-  );
+  const keyByCache = new WeakMap<object[], Record<string, unknown>>();
+  const memoizedKeyBy = <T extends { key: string }>(fields: T[]): Record<string, T> => {
+    const cached = keyByCache.get(fields);
+    if (cached !== undefined) {
+      return cached as Record<string, T>;
+    }
+    const result = keyBy(fields, 'key');
+    keyByCache.set(fields, result);
+    return result;
+  };
 
-  const memoizedKeyBy = memoize(<T extends { key: string }>(fields: T[]) => keyBy(fields, 'key'), {
-    resolver: (fields) => {
-      let key = '';
-      for (const f of fields) {
-        key += f.key + '|';
-      }
-      return key;
-    },
-    maxSize: 10,
-  });
-
-  const memoizedDefaultValues = memoize(
-    <T extends FieldDef<unknown>>(fieldsById: Record<string, T>, registry: Map<string, FieldTypeDefinition>) =>
-      mapValues(fieldsById, (field) => getFieldDefaultValue(field, registry)),
-    {
-      // registry.size is a valid cache key proxy because the field registry is populated
-      // once at bootstrap and never mutated at runtime.
-      resolver: (fieldsById, registry) => {
-        const keys = Object.keys(fieldsById).sort();
-        return keys.join('|') + '|' + registry.size;
-      },
-      maxSize: 10,
-    },
-  );
+  const defaultValuesCache = new WeakMap<object, Record<string, unknown>>();
+  const memoizedDefaultValues = <T extends FieldDef<unknown>>(
+    fieldsById: Record<string, T>,
+    registry: Map<string, FieldTypeDefinition>,
+  ): Record<string, unknown> => {
+    const cached = defaultValuesCache.get(fieldsById);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const result = mapValues(fieldsById, (field) => getFieldDefaultValue(field, registry));
+    defaultValuesCache.set(fieldsById, result);
+    return result;
+  };
 
   return { memoizedFlattenFields, memoizedFlattenFieldsForRendering, memoizedKeyBy, memoizedDefaultValues };
 }

--- a/packages/dynamic-forms/src/lib/utils/resolve-field/resolve-field.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/resolve-field/resolve-field.spec.ts
@@ -336,6 +336,84 @@ describe('resolve-field', () => {
       expect(result[0].inputs).toBe(newInputs);
     });
 
+    it('should swap inputs and fieldDef when component/injector match but fieldDef changes', () => {
+      const oldFieldDef: FieldDef<unknown> = { type: 'select', key: 'country', options: [] } as FieldDef<unknown>;
+      const newFieldDef: FieldDef<unknown> = {
+        type: 'select',
+        key: 'country',
+        options: [{ value: 'us', label: 'US' }],
+      } as FieldDef<unknown>;
+      const oldInputs = computed(() => ({ options: [] }));
+      const newInputs = computed(() => ({ options: [{ value: 'us', label: 'US' }] }));
+      const oldRenderReady = computed(() => true);
+      const newRenderReady = computed(() => true);
+
+      const prev: ResolvedField[] = [
+        {
+          key: 'country',
+          fieldDef: oldFieldDef,
+          component: componentA,
+          injector: injector1,
+          inputs: oldInputs,
+          renderReady: oldRenderReady,
+        },
+      ];
+      const curr: ResolvedField[] = [
+        {
+          key: 'country',
+          fieldDef: newFieldDef,
+          component: componentA,
+          injector: injector1,
+          inputs: newInputs,
+          renderReady: newRenderReady,
+        },
+      ];
+
+      const result = reconcileFields(prev, curr);
+
+      expect(result).toHaveLength(1);
+      // Component and injector are preserved (same instance kept)
+      expect(result[0].component).toBe(componentA);
+      expect(result[0].injector).toBe(injector1);
+      // But the fieldDef, inputs, and renderReady signals come from the new resolution
+      expect(result[0].fieldDef).toBe(newFieldDef);
+      expect(result[0].inputs).toBe(newInputs);
+      expect(result[0].renderReady).toBe(newRenderReady);
+      // The returned object is NOT the previous one (since inputs were swapped)
+      expect(result[0]).not.toBe(prev[0]);
+    });
+
+    it('should preserve previous object identity when fieldDef reference is identical', () => {
+      const sharedFieldDef: FieldDef<unknown> = { type: 'input', key: 'name' };
+      const inputs = computed(() => ({}));
+      const renderReady = computed(() => true);
+
+      const prev: ResolvedField[] = [
+        {
+          key: 'name',
+          fieldDef: sharedFieldDef,
+          component: componentA,
+          injector: injector1,
+          inputs,
+          renderReady,
+        },
+      ];
+      const curr: ResolvedField[] = [
+        {
+          key: 'name',
+          fieldDef: sharedFieldDef,
+          component: componentA,
+          injector: injector1,
+          inputs: computed(() => ({})),
+          renderReady: computed(() => true),
+        },
+      ];
+
+      const result = reconcileFields(prev, curr);
+
+      expect(result[0]).toBe(prev[0]);
+    });
+
     it('should handle multiple fields with mixed scenarios', () => {
       const componentC = class ComponentC {} as Type<unknown>;
 

--- a/packages/dynamic-forms/src/lib/utils/resolve-field/resolve-field.ts
+++ b/packages/dynamic-forms/src/lib/utils/resolve-field/resolve-field.ts
@@ -156,6 +156,11 @@ export function resolveFieldSync(fieldDef: FieldDef<unknown>, context: SyncResol
  * Reconciles previous and current resolved fields to preserve injector instances
  * for fields that haven't changed type, preventing unnecessary component recreation.
  *
+ * When a field's key, component, and injector all match the previous render but the
+ * underlying `fieldDef` has changed (e.g. updated options/props), the existing
+ * component/injector are preserved while the new `inputs` and `renderReady` signals
+ * are adopted so prop updates flow through to the rendered component.
+ *
  * @param prev - Previous resolved fields array
  * @param curr - Current resolved fields array
  * @returns Reconciled fields with preserved injectors where applicable
@@ -167,8 +172,21 @@ export function reconcileFields(prev: ResolvedField[], curr: ResolvedField[]): R
     const existing = prevMap.get(field.key);
 
     if (existing && existing.component === field.component && existing.injector === field.injector) {
-      // Truly unchanged - preserve object identity for signal stability
-      return existing;
+      if (existing.fieldDef === field.fieldDef) {
+        // Truly unchanged - preserve object identity for signal stability
+        return existing;
+      }
+
+      // Same component instance + injector, but the field definition changed.
+      // Preserve component identity (so ngComponentOutlet keeps the same instance)
+      // while swapping in the freshly-mapped inputs/renderReady signals so prop
+      // updates (e.g. select options) reach the component.
+      return {
+        ...existing,
+        fieldDef: field.fieldDef,
+        inputs: field.inputs,
+        renderReady: field.renderReady,
+      };
     }
 
     // New field, type changed, or context changed (new injector) - use new field


### PR DESCRIPTION

# Pull Request

## Description

Ran into an issue where when the form config was changed but the fields were the same/similar the FieldDefs that had the same keys did not pass the new props.

In the screenshot below, the Redirect URI is updated to have options but the new options do not appear in the form.

<img width="1758" height="561" alt="Screenshot 2026-05-06 at 11 09 49 PM" src="https://github.com/user-attachments/assets/db04e1a2-9fa6-4010-8507-a4421ea26348" />

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Code style update (formatting, renaming)
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build/tooling update

## Related Issues

<!-- Link to related issues. Use "Fixes #123" to auto-close issues when PR is merged -->

Fixes #
Related to #

## Changes Made

<!-- Provide a detailed list of changes -->

- Switch container-field-processors to WeakMap caches keyed on input array identity so different config snapshots invalidate correctly.
- Tighten fieldsSource equality from key+type to per-element reference equality.
- In reconcileFields, when a same-keyed field has a new fieldDef, preserve the component/injector but adopt the fresh inputs/renderReady signals.

<!--
## Breaking Changes (if applicable)

**Before:**
```typescript
// Old usage
```

**After:**
```typescript
// New usage
```

**Migration guide:**
-
-->

## Testing

- [x] Unit tests added/updated
- [x] All tests pass locally
- [ ] Tested manually
- [ ] Tested edge cases

<!-- If applicable, describe manual testing or include test configuration -->

## Screenshots / Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->

## Documentation

- [ ] Documentation updated (if needed)
- [ ] API documentation (TSDoc) added/updated
- [ ] Examples updated (if needed)

## Checklist

<!-- Ensure all items are checked before requesting review -->

- [x] Code follows the [coding standards](../CODING_STANDARDS.md)
- [x] No linting errors (`pnpm lint`)
- [x] Code is formatted (`pnpm lint:fix`)
- [x] Build succeeds (`pnpm build:libs`)
- [x] Commits follow [conventional commit format](https://www.conventionalcommits.org/)
- [x] Self-review completed
- [x] No commented-out code or console.log() statements
- [x] Type safety maintained (no `any` types)

## Additional Notes

<!-- Any additional information that reviewers should know -->
