### PR TITLE
fix(docs): prevent double adapter prefix on routerLink-resolved hrefs

### DIFF
--- a/apps/docs/src/app/pages/doc-page/doc-page.component.ts
+++ b/apps/docs/src/app/pages/doc-page/doc-page.component.ts
@@ -680,6 +680,13 @@ export class DocPageComponent {
         if (el) el.scrollIntoView({ behavior: 'smooth' });
         return;
       }
+      // Skip links whose resolved href already contains the adapter prefix.
+      // Custom components embedded in markdown (e.g. feature-overview nav cards
+      // and pitfall links) use routerLink, which Angular resolves to an absolute
+      // href that already starts with /{adapter}/. Prefixing again would
+      // produce a double-prefixed URL (e.g. /material/material/getting-started).
+      const adapterPrefix = `/${this.adapter.adapter()}/`;
+      if (href.startsWith(adapterPrefix)) return;
       // Root-relative paths — add adapter prefix for SPA navigation
       if (href.startsWith('/') && !href.startsWith('//')) {
         event.preventDefault();


### PR DESCRIPTION
## Description

Custom markdown-embedded components (feature-overview nav cards, pitfall links) use `routerLink`, which Angular resolves to an absolute href that already includes the adapter prefix (e.g. `/material/getting-started`). The click handler in `DocPageComponent` was unconditionally prepending the adapter prefix again, producing broken URLs like `/material/material/getting-started`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Related to #

## Changes Made

- Added an early-return guard in `DocPageComponent`'s link-click handler that skips adapter-prefix injection when the resolved `href` already starts with `/{adapter}/`

## Testing

- [x] Tested manually

## Checklist

- [x] Code follows the [coding standards](../CODING_STANDARDS.md)
- [x] No linting errors (`pnpm lint`)
- [x] Code is formatted (`pnpm lint:fix`)
- [x] Build succeeds (`pnpm build:libs`)
- [x] Commits follow [conventional commit format](https://www.conventionalcommits.org/)
- [x] Self-review completed
- [x] No commented-out code or console.log() statements
- [x] Type safety maintained (no `any` types)