### PR TITLE
ci(release): make nightly publish self-correcting

### DIFF
--- a/.github/workflows/discord-release-notify.yml
+++ b/.github/workflows/discord-release-notify.yml
@@ -3,6 +3,12 @@ name: Discord Release Notification
 on:
   release:
     types: [published]
+  workflow_run:
+    # Fires whenever release.yml finishes; the notify-failure job below filters to failures.
+    # Runs from main's copy of this file (workflow_run always uses the default branch),
+    # so changes here only take effect after merge.
+    workflows: ['Release']
+    types: [completed]
   workflow_dispatch:
     inputs:
       tag:
@@ -16,6 +22,9 @@ permissions:
 jobs:
   notify:
     name: Post release to Discord
+    # workflow_run firings are handled by notify-failure below; this job only handles
+    # the "release published" embed path.
+    if: github.event_name != 'workflow_run'
     runs-on: ubuntu-latest
     steps:
       - name: Build payload and post to Discord
@@ -91,6 +100,55 @@ jobs:
           fi
 
           # --fail makes curl exit non-zero on any 4xx/5xx so the step actually fails on bad webhook responses.
+          curl --fail --silent --show-error \
+            -H "Content-Type: application/json" \
+            -X POST \
+            -d "$PAYLOAD" \
+            "$DISCORD_WEBHOOK_URL"
+
+  notify-failure:
+    name: Post release-workflow failure to Discord
+    # Catches the "nightly silently failed for N days" class of incident: a run that
+    # broke late (e.g. token-step misconfig) ships to npm but skips tag-write, so the
+    # gate keeps re-publishing every night. Without an alert, all 8 prior failures sat
+    # in the Actions tab unread for a week. Fires on any release.yml failure regardless
+    # of trigger — schedule, workflow_dispatch, push — so manual dispatches get the
+    # ping too.
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post failure to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_EVENT: ${{ github.event.workflow_run.event }}
+          RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_TITLE: ${{ github.event.workflow_run.display_title }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${DISCORD_WEBHOOK_URL}" ]; then
+            echo "::error::DISCORD_WEBHOOK_URL secret is not set"
+            exit 1
+          fi
+
+          PAYLOAD=$(jq -n \
+            --arg url "$RUN_URL" \
+            --arg event "$RUN_EVENT" \
+            --arg branch "$RUN_BRANCH" \
+            --arg sha "${RUN_SHA:0:7}" \
+            --arg title "$RUN_TITLE" \
+            '{
+              embeds: [{
+                title: "❌ Release workflow failed",
+                url: $url,
+                description: ($title + "\n\nTrigger: `" + $event + "` on `" + $branch + "` (`" + $sha + "`)\n\n[Open run](" + $url + ")"),
+                color: 15158332,
+                timestamp: now | todateiso8601
+              }]
+            }')
+
           curl --fail --silent --show-error \
             -H "Content-Type: application/json" \
             -X POST \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -461,7 +461,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,6 +348,25 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "📦 Releasing $VERSION (dist-tag: $DIST_TAG)"
 
+      - name: Generate GitHub App Token
+        # Generated up-front so the job fails before any irreversible action if App config
+        # is broken (missing/expired secret, App uninstalled, GH outage). Earlier placement
+        # after npm publish let broken-token runs ship to npm but skip the tag-write below,
+        # leaving the gate stuck on a stale BASE and re-publishing every night.
+        # GITHUB_TOKEN cannot trigger downstream workflows (GitHub recursion safeguard), so
+        # releases created with it don't fire `release: published` — which is what
+        # discord-release-notify.yml listens for. App-scoped tokens propagate normally.
+        # The 1-hour token lifetime comfortably covers build (~3 min) + npm publish (~2 min).
+        # Gated to the same paths that consume it so a dry-run doesn't depend on App secrets.
+        # The two action-gh-release steps below are mutually exclusive (publish vs
+        # schedule|next), so a single shared token is sufficient.
+        if: inputs.mode == 'publish' || github.event_name == 'schedule' || inputs.mode == 'next'
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Build libraries
         # Build BEFORE bumping. Some packages (e.g. openapi-generator) declare
         # `manifestRootsToUpdate: ['{projectRoot}', 'dist/{projectRoot}']`, so
@@ -445,24 +464,6 @@ jobs:
             fi
             npm publish "dist/packages/$pkg" --access public --provenance --tag "$DIST_TAG"
           done
-
-      - name: Generate GitHub App Token
-        # GITHUB_TOKEN cannot trigger downstream workflows (GitHub recursion safeguard),
-        # so releases created with it don't fire `release: published` — which is what
-        # discord-release-notify.yml listens for. Using a GitHub App-scoped token instead
-        # makes those events propagate normally.
-        # Generated immediately before action-gh-release (not at job start) because App
-        # installation tokens have a 1-hour lifetime; build + npm publish can eat into
-        # that window on a slow run, so we always hand action-gh-release a fresh token.
-        # Gated to the same paths that consume it so a dry-run doesn't depend on the
-        # App secrets being present. The two action-gh-release steps below are mutually
-        # exclusive (publish vs schedule|next), so a single shared token is sufficient.
-        if: inputs.mode == 'publish' || github.event_name == 'schedule' || inputs.mode == 'next'
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Create GitHub Release
         # action-gh-release creates the v${VERSION} tag at github.sha via the GitHub API


### PR DESCRIPTION
## Summary

Three related changes so the next "release workflow has been red for a week" incident catches itself.

**1. Read `RELEASE_APP_ID` from `secrets`, not `vars`** (`release.yml:464`).
The repo has it provisioned as a secret, but the workflow read `${{ vars.RELEASE_APP_ID }}` — empty string. Every nightly since #374 failed at `Generate GitHub App Token` with `'client-id' input must be set to a non-empty string`. npm publish ran *before* that step and succeeded; the `Create GitHub Prerelease (@next)` step that writes the `next/<version>` tag never ran. Without the tag, `next-gate` kept `BASE = v0.8.0` and re-counted the same 4 bump-worthy commits (#387, #389, #392, #393) every night, producing a fresh `0.9.0-next.N` on npm daily.

**2. Move the App token step before npm publish.**
Even with (1), the prior ordering was fragile: any future App-config breakage (rotated key, App uninstalled, GH API hiccup) would publish to npm and skip the tag — same loop. Generating up-front fails the job before any irreversible action. The 1-hour token lifetime comfortably covers build (~3 min) + publish (~2 min); the freshness concern in the original comment was overstated.

**3. Discord alert when `release.yml` fails.**
The 8-day incident wasn't caught because all 8 runs sat red in the Actions tab unread. New `notify-failure` job in `discord-release-notify.yml`, triggered via `workflow_run` + `conclusion: failure`, posts to the same webhook. Existing `notify` job is gated to non-`workflow_run` events so the two paths coexist.

The already-broken nightly chain has been anchored manually by tagging `next/0.9.0-next.8` at `1d829c296` (SHA confirmed via npm `gitHead`), so the cron after this lands will skip cleanly.

## Test plan

- [ ] After merge, manually dispatch `Release` with `mode=next` on `main` → confirm token step runs early, `Create GitHub Prerelease (@next)` writes the tag, `discord-release-notify` fires the success embed
- [ ] Subsequent scheduled cron skips publish (gate sees `BASE = next/<latest>` and zero new bump-worthy commits under `packages/`)
- [ ] (Negative test, optional) Temporarily break the App config and confirm the job fails *before* `Publish to npm`, AND the Discord failure embed posts