### PR TITLE
fix(dynamic-forms): stop excludeValueIfHidden from leaking defaults into bound value

### DIFF
--- a/apps/docs/public/content/recipes/value-exclusion.md
+++ b/apps/docs/public/content/recipes/value-exclusion.md
@@ -10,7 +10,7 @@ Value exclusion controls which field values are included in the form submission 
 
 By default, field values are **excluded** from the `(submitted)` output when the field is hidden, disabled, or readonly. This prevents stale or irrelevant data from being sent to the server.
 
-**Key point:** Value exclusion only affects the submission output. Internal form controls retain their values so they can be restored when a field becomes visible, enabled, or editable again. Two-way binding via `[value]` / `[(value)]` is **not affected**.
+**Key point:** Value exclusion always applies to the submission output. It also applies to the two-way bound model (`[value]` / `[(value)]`) **only when you opt in explicitly** at the field or form level — the global defaults configured via `withValueExclusionDefaults()` are intentionally not applied to the bound model, so the host's view of the form remains predictable. Internal form controls retain their values so they can be restored when an explicitly excluded field becomes visible, enabled, or editable again.
 
 ## Default Behavior
 
@@ -126,13 +126,13 @@ Value exclusion applies to the `hidden` **property** on regular fields (e.g., `{
 
 ## What's Excluded vs Retained
 
-| Aspect                     | Affected by exclusion? | Details                                  |
-| -------------------------- | ---------------------- | ---------------------------------------- |
-| `(submitted)` output       | Yes                    | Excluded fields are omitted              |
-| `filteredFormValue` signal | Yes                    | Same filtering as submission             |
-| `formValue` signal         | No                     | Always contains all values               |
-| `[(value)]` binding        | No                     | Two-way binding retains all values       |
-| Internal form controls     | No                     | Fields keep their values for restoration |
+| Aspect                     | Affected by exclusion?  | Details                                                                              |
+| -------------------------- | ----------------------- | ------------------------------------------------------------------------------------ |
+| `(submitted)` output       | Yes                     | Excluded fields are omitted (full Field > Form > Global hierarchy applies)           |
+| `filteredFormValue` signal | Yes                     | Same filtering as submission                                                         |
+| `formValue` signal         | No                      | Always contains all values                                                           |
+| `[(value)]` binding        | Only on explicit opt-in | Field- or form-level `excludeValueIf*: true` filters the bound model; global doesn't |
+| Internal form controls     | No                      | Fields keep their values for restoration                                             |
 
 ## Migration from Previous Versions
 

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -12657,7 +12657,7 @@ Value exclusion controls which field values are included in the form submission 
 
 By default, field values are **excluded** from the `(submitted)` output when the field is hidden, disabled, or readonly. This prevents stale or irrelevant data from being sent to the server.
 
-**Key point:** Value exclusion only affects the submission output. Internal form controls retain their values so they can be restored when a field becomes visible, enabled, or editable again. Two-way binding via `[value]` / `[(value)]` is **not affected**.
+**Key point:** Value exclusion always applies to the submission output. It also applies to the two-way bound model (`[value]` / `[(value)]`) **only when you opt in explicitly** at the field or form level — the global defaults configured via `withValueExclusionDefaults()` are intentionally not applied to the bound model, so the host's view of the form remains predictable. Internal form controls retain their values so they can be restored when an explicitly excluded field becomes visible, enabled, or editable again.
 
 ## Default Behavior
 
@@ -12773,13 +12773,13 @@ Value exclusion applies to the `hidden` **property** on regular fields (e.g., `{
 
 ## What's Excluded vs Retained
 
-| Aspect                     | Affected by exclusion? | Details                                  |
-| -------------------------- | ---------------------- | ---------------------------------------- |
-| `(submitted)` output       | Yes                    | Excluded fields are omitted              |
-| `filteredFormValue` signal | Yes                    | Same filtering as submission             |
-| `formValue` signal         | No                     | Always contains all values               |
-| `[(value)]` binding        | No                     | Two-way binding retains all values       |
-| Internal form controls     | No                     | Fields keep their values for restoration |
+| Aspect                     | Affected by exclusion?  | Details                                                                              |
+| -------------------------- | ----------------------- | ------------------------------------------------------------------------------------ |
+| `(submitted)` output       | Yes                     | Excluded fields are omitted (full Field > Form > Global hierarchy applies)           |
+| `filteredFormValue` signal | Yes                     | Same filtering as submission                                                         |
+| `formValue` signal         | No                      | Always contains all values                                                           |
+| `[(value)]` binding        | Only on explicit opt-in | Field- or form-level `excludeValueIf*: true` filters the bound model; global doesn't |
+| Internal form controls     | No                      | Fields keep their values for restoration                                             |
 
 ## Migration from Previous Versions
 

--- a/packages/dynamic-forms/src/lib/core/form-mapping.ts
+++ b/packages/dynamic-forms/src/lib/core/form-mapping.ts
@@ -176,12 +176,9 @@ export function mapFieldToForm(
   // and conflict with our own `validateWhenHidden` mechanism. Static state on groups is
   // detected by reading the field def directly (see value-filter).
   if (isGroupField(fieldDef)) {
-    const groupLogic = (fieldDef as { logic?: readonly LogicConfig[] }).logic;
-    if (groupLogic) {
-      for (const config of groupLogic) {
-        if (!isValidationStateLogic(config)) {
-          applyLogic(config, fieldPath);
-        }
+    if (fieldDef.logic) {
+      for (const config of fieldDef.logic) {
+        applyLogic(config, fieldPath);
       }
     }
     const descendantContext = resolveDescendantContext(fieldDef, ownContext);

--- a/packages/dynamic-forms/src/lib/core/form-mapping.ts
+++ b/packages/dynamic-forms/src/lib/core/form-mapping.ts
@@ -170,11 +170,20 @@ export function mapFieldToForm(
     return;
   }
 
-  // Group fields - map children under the group's path. Groups have a schema path,
-  // so Angular Signal Forms can propagate `hidden(path, ...)` calls to descendants —
-  // but groups don't currently apply their own hidden state, so we still propagate
-  // through the cascade as a belt-and-suspenders fallback.
+  // Group fields - apply state logic (hidden/disabled/readonly) so dynamic visibility
+  // can be detected by callers (e.g. value filtering). Static `hidden: true` is intentionally
+  // NOT applied here — that would propagate through Angular Signal Forms' descendant cascade
+  // and conflict with our own `validateWhenHidden` mechanism. Static state on groups is
+  // detected by reading the field def directly (see value-filter).
   if (isGroupField(fieldDef)) {
+    const groupLogic = (fieldDef as { logic?: readonly LogicConfig[] }).logic;
+    if (groupLogic) {
+      for (const config of groupLogic) {
+        if (!isValidationStateLogic(config)) {
+          applyLogic(config, fieldPath);
+        }
+      }
+    }
     const descendantContext = resolveDescendantContext(fieldDef, ownContext);
     mapContainerChildren(fieldDef.fields, fieldPath, descendantContext);
     return;

--- a/packages/dynamic-forms/src/lib/core/form-mapping.ts
+++ b/packages/dynamic-forms/src/lib/core/form-mapping.ts
@@ -170,12 +170,15 @@ export function mapFieldToForm(
     return;
   }
 
-  // Group fields - apply state logic (hidden/disabled/readonly) so dynamic visibility
+  // Group fields - apply static disabled/readonly + any state logic so visibility/state
   // can be detected by callers (e.g. value filtering). Static `hidden: true` is intentionally
-  // NOT applied here — that would propagate through Angular Signal Forms' descendant cascade
-  // and conflict with our own `validateWhenHidden` mechanism. Static state on groups is
-  // detected by reading the field def directly (see value-filter).
+  // NOT applied — that would propagate through Angular Signal Forms' descendant cascade and
+  // conflict with our `validateWhenHidden` mechanism. Static hidden on groups is detected
+  // by reading the field def directly in value-filter.
   if (isGroupField(fieldDef)) {
+    const path = fieldPath as SchemaPath<unknown>;
+    if (fieldDef.disabled) disabled(path);
+    if (fieldDef.readonly) readonly(path);
     if (fieldDef.logic) {
       for (const config of fieldDef.logic) {
         applyLogic(config, fieldPath);

--- a/packages/dynamic-forms/src/lib/core/form-mapping.ts
+++ b/packages/dynamic-forms/src/lib/core/form-mapping.ts
@@ -170,20 +170,11 @@ export function mapFieldToForm(
     return;
   }
 
-  // Group fields - apply static disabled/readonly + any state logic so visibility/state
-  // can be detected by callers (e.g. value filtering). Static `hidden: true` is intentionally
-  // NOT applied — that would propagate through Angular Signal Forms' descendant cascade and
-  // conflict with our `validateWhenHidden` mechanism. Static hidden on groups is detected
-  // by reading the field def directly in value-filter.
+  // Group fields - map children under the group's path. Groups have a schema path,
+  // so Angular Signal Forms can propagate `hidden(path, ...)` calls to descendants —
+  // but groups don't currently apply their own hidden state, so we still propagate
+  // through the cascade as a belt-and-suspenders fallback.
   if (isGroupField(fieldDef)) {
-    const path = fieldPath as SchemaPath<unknown>;
-    if (fieldDef.disabled) disabled(path);
-    if (fieldDef.readonly) readonly(path);
-    if (fieldDef.logic) {
-      for (const config of fieldDef.logic) {
-        applyLogic(config, fieldPath);
-      }
-    }
     const descendantContext = resolveDescendantContext(fieldDef, ownContext);
     mapContainerChildren(fieldDef.fields, fieldPath, descendantContext);
     return;

--- a/packages/dynamic-forms/src/lib/state/form-state-manager.spec.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-manager.spec.ts
@@ -1138,6 +1138,58 @@ describe('FormStateManager', () => {
         const synced = valueSignal() as Record<string, unknown>;
         expect(synced.address).toEqual({ street: '123 Main', city: 'Springfield' });
       });
+
+      it('should preserve a nested field value when only that child field toggles hidden inside a visible group', () => {
+        const valueSignal = signal<Partial<TestModel> | undefined>({
+          trigger: 'show',
+          address: { street: '123 Main', city: 'Springfield' },
+        });
+        initManager(
+          {
+            fields: [
+              { type: 'input', key: 'trigger', label: 'Trigger' },
+              {
+                type: 'group',
+                key: 'address',
+                fields: [
+                  {
+                    type: 'input',
+                    key: 'street',
+                    label: 'Street',
+                    excludeValueIfHidden: true,
+                    logic: [
+                      {
+                        type: 'hidden',
+                        condition: { type: 'fieldValue', fieldPath: 'trigger', operator: 'equals', value: 'hide' },
+                      },
+                    ],
+                  },
+                  { type: 'input', key: 'city', label: 'City' },
+                ],
+              },
+            ],
+          } as TestFormConfig,
+          { value: valueSignal },
+        );
+        TestBed.flushEffects();
+
+        // Initially visible
+        expect((valueSignal() as Record<string, Record<string, unknown>>).address.street).toBe('123 Main');
+
+        // Hide street (group stays visible)
+        valueSignal.set({ trigger: 'hide', address: { street: '123 Main', city: 'Springfield' } });
+        TestBed.flushEffects();
+        const hiddenSynced = (valueSignal() as Record<string, Record<string, unknown>>).address;
+        expect(hiddenSynced).not.toHaveProperty('street');
+        expect(hiddenSynced.city).toBe('Springfield');
+
+        // Show again — street's previous value should be restored
+        valueSignal.set({ trigger: 'show', address: { city: 'Springfield' } });
+        TestBed.flushEffects();
+        const restored = (valueSignal() as Record<string, Record<string, unknown>>).address;
+        expect(restored.street).toBe('123 Main');
+        expect(restored.city).toBe('Springfield');
+      });
     });
   });
 });

--- a/packages/dynamic-forms/src/lib/state/form-state-manager.spec.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-manager.spec.ts
@@ -996,6 +996,120 @@ describe('FormStateManager', () => {
         expect(valueSignal()).toHaveProperty('myNum', 7);
       });
 
+      it('should restore the previously entered value when an excluded-when-disabled field becomes enabled again', () => {
+        const valueSignal = signal<Partial<TestModel> | undefined>({ trigger: 'enabled', myNum: 42 });
+        initManager(
+          {
+            fields: [
+              { type: 'input', key: 'trigger', label: 'Trigger' },
+              {
+                type: 'input',
+                key: 'myNum',
+                label: 'Num',
+                props: { type: 'number' },
+                excludeValueIfDisabled: true,
+                logic: [
+                  {
+                    type: 'disabled',
+                    condition: { type: 'fieldValue', fieldPath: 'trigger', operator: 'equals', value: 'disable' },
+                  },
+                ],
+              },
+            ],
+          } as TestFormConfig,
+          { value: valueSignal },
+        );
+        TestBed.flushEffects();
+
+        valueSignal.set({ trigger: 'disable', myNum: 42 });
+        TestBed.flushEffects();
+        expect(valueSignal()).not.toHaveProperty('myNum');
+
+        valueSignal.set({ trigger: 'enabled' });
+        TestBed.flushEffects();
+        expect(valueSignal()).toHaveProperty('myNum', 42);
+      });
+
+      it('should restore the previously entered value when an excluded-when-readonly field becomes editable again', () => {
+        const valueSignal = signal<Partial<TestModel> | undefined>({ trigger: 'editable', myNum: 99 });
+        initManager(
+          {
+            fields: [
+              { type: 'input', key: 'trigger', label: 'Trigger' },
+              {
+                type: 'input',
+                key: 'myNum',
+                label: 'Num',
+                props: { type: 'number' },
+                excludeValueIfReadonly: true,
+                logic: [
+                  {
+                    type: 'readonly',
+                    condition: { type: 'fieldValue', fieldPath: 'trigger', operator: 'equals', value: 'readonly' },
+                  },
+                ],
+              },
+            ],
+          } as TestFormConfig,
+          { value: valueSignal },
+        );
+        TestBed.flushEffects();
+
+        valueSignal.set({ trigger: 'readonly', myNum: 99 });
+        TestBed.flushEffects();
+        expect(valueSignal()).not.toHaveProperty('myNum');
+
+        valueSignal.set({ trigger: 'editable' });
+        TestBed.flushEffects();
+        expect(valueSignal()).toHaveProperty('myNum', 99);
+      });
+
+      it('should preserve the saved value across overlapping axis transitions (hide then disable then re-show)', () => {
+        const valueSignal = signal<Partial<TestModel> | undefined>({ visibility: 'show', enabled: true, myNum: 5 });
+        initManager(
+          {
+            fields: [
+              { type: 'input', key: 'visibility', label: 'Visibility' },
+              { type: 'checkbox', key: 'enabled', label: 'Enabled' },
+              {
+                type: 'input',
+                key: 'myNum',
+                label: 'Num',
+                props: { type: 'number' },
+                excludeValueIfHidden: true,
+                excludeValueIfDisabled: true,
+                logic: [
+                  {
+                    type: 'hidden',
+                    condition: { type: 'fieldValue', fieldPath: 'visibility', operator: 'equals', value: 'hide' },
+                  },
+                  {
+                    type: 'disabled',
+                    condition: { type: 'fieldValue', fieldPath: 'enabled', operator: 'equals', value: false },
+                  },
+                ],
+              },
+            ],
+          } as TestFormConfig,
+          { value: valueSignal },
+        );
+        TestBed.flushEffects();
+
+        // Hide → captured.
+        valueSignal.set({ visibility: 'hide', enabled: true, myNum: 5 });
+        TestBed.flushEffects();
+        // Pile on disabled while still hidden → already-excluded, no re-save.
+        valueSignal.set({ visibility: 'hide', enabled: false, myNum: 5 });
+        TestBed.flushEffects();
+        // Drop hidden but stay disabled → still excluded, still no re-save.
+        valueSignal.set({ visibility: 'show', enabled: false, myNum: 5 });
+        TestBed.flushEffects();
+        // Re-enable → re-included, value restored from store.
+        valueSignal.set({ visibility: 'show', enabled: true });
+        TestBed.flushEffects();
+        expect(valueSignal()).toHaveProperty('myNum', 5);
+      });
+
       it('should hide one field independently without affecting other fields', () => {
         const valueSignal = signal<Partial<TestModel> | undefined>({
           trigger: 'show',

--- a/packages/dynamic-forms/src/lib/state/form-state-manager.spec.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-manager.spec.ts
@@ -946,12 +946,10 @@ describe('FormStateManager', () => {
         );
         TestBed.flushEffects();
 
-        // Hide the field
         valueSignal.set({ trigger: 'hide', myNum: 5 });
         TestBed.flushEffects();
         expect(valueSignal()).not.toHaveProperty('myNum');
 
-        // Show it again — last entered value should come back
         valueSignal.set({ trigger: 'show' });
         TestBed.flushEffects();
         expect(valueSignal()).toHaveProperty('myNum', 5);
@@ -982,18 +980,14 @@ describe('FormStateManager', () => {
         );
         TestBed.flushEffects();
 
-        // Cycle 1: hide → show
         valueSignal.set({ trigger: 'hide', myNum: 5 });
         TestBed.flushEffects();
         valueSignal.set({ trigger: 'show' });
         TestBed.flushEffects();
         expect(valueSignal()).toHaveProperty('myNum', 5);
 
-        // Update value while visible
         valueSignal.set({ trigger: 'show', myNum: 7 });
         TestBed.flushEffects();
-
-        // Cycle 2: hide → show — should restore the latest value (7)
         valueSignal.set({ trigger: 'hide', myNum: 7 });
         TestBed.flushEffects();
         expect(valueSignal()).not.toHaveProperty('myNum');
@@ -1111,51 +1105,6 @@ describe('FormStateManager', () => {
         expect(synced).not.toHaveProperty('address');
       });
 
-      it('should restore nested group values across hide/show cycles', () => {
-        const valueSignal = signal<Partial<TestModel> | undefined>({
-          trigger: 'show',
-          address: { street: '123 Main', city: 'Springfield' },
-        });
-        initManager(
-          {
-            fields: [
-              { type: 'input', key: 'trigger', label: 'Trigger' },
-              {
-                type: 'group',
-                key: 'address',
-                excludeValueIfHidden: true,
-                logic: [
-                  {
-                    type: 'hidden',
-                    condition: { type: 'fieldValue', fieldPath: 'trigger', operator: 'equals', value: 'hide' },
-                  },
-                ],
-                fields: [
-                  { type: 'input', key: 'street', label: 'Street' },
-                  { type: 'input', key: 'city', label: 'City' },
-                ],
-              },
-            ],
-          } as TestFormConfig,
-          { value: valueSignal },
-        );
-        TestBed.flushEffects();
-
-        // Visible initially
-        expect(valueSignal()).toHaveProperty('address');
-
-        // Hide the group
-        valueSignal.set({ trigger: 'hide', address: { street: '123 Main', city: 'Springfield' } });
-        TestBed.flushEffects();
-        expect(valueSignal()).not.toHaveProperty('address');
-
-        // Show again — nested values should be restored
-        valueSignal.set({ trigger: 'show' });
-        TestBed.flushEffects();
-        const synced = valueSignal() as Record<string, unknown>;
-        expect(synced.address).toEqual({ street: '123 Main', city: 'Springfield' });
-      });
-
       it('should preserve a nested field value when only that child field toggles hidden inside a visible group', () => {
         const valueSignal = signal<Partial<TestModel> | undefined>({
           trigger: 'show',
@@ -1190,17 +1139,14 @@ describe('FormStateManager', () => {
         );
         TestBed.flushEffects();
 
-        // Initially visible
         expect((valueSignal() as Record<string, Record<string, unknown>>).address.street).toBe('123 Main');
 
-        // Hide street (group stays visible)
         valueSignal.set({ trigger: 'hide', address: { street: '123 Main', city: 'Springfield' } });
         TestBed.flushEffects();
         const hiddenSynced = (valueSignal() as Record<string, Record<string, unknown>>).address;
         expect(hiddenSynced).not.toHaveProperty('street');
         expect(hiddenSynced.city).toBe('Springfield');
 
-        // Show again — street's previous value should be restored
         valueSignal.set({ trigger: 'show', address: { city: 'Springfield' } });
         TestBed.flushEffects();
         const restored = (valueSignal() as Record<string, Record<string, unknown>>).address;

--- a/packages/dynamic-forms/src/lib/state/form-state-manager.spec.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-manager.spec.ts
@@ -835,6 +835,23 @@ describe('FormStateManager', () => {
         expect(synced).not.toHaveProperty('myNum');
       });
 
+      it('should exclude a componentless field type (no FieldTree) when statically hidden + excludeValueIfHidden', () => {
+        const valueSignal = signal<Partial<TestModel> | undefined>({ hiddenField: 'secret' });
+        initManager(
+          {
+            fields: [
+              // The 'hidden' field type is componentless — schema-builder doesn't allocate a FieldTree
+              // path for it, so the value-filter's no-FieldTree fallback would otherwise leak the value.
+              { type: 'hidden', key: 'hiddenField', value: 'secret', hidden: true, excludeValueIfHidden: true },
+            ],
+          } as unknown as TestFormConfig,
+          { value: valueSignal },
+        );
+        TestBed.flushEffects();
+
+        expect(valueSignal()).not.toHaveProperty('hiddenField');
+      });
+
       it('should still emit hidden-field value when excludeValueIfHidden is explicitly false', () => {
         const valueSignal = signal<Partial<TestModel> | undefined>(undefined);
         initManager(

--- a/packages/dynamic-forms/src/lib/state/form-state-manager.spec.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-manager.spec.ts
@@ -1073,9 +1073,10 @@ describe('FormStateManager', () => {
         valueSignal.set({ trigger: 'show' });
         TestBed.flushEffects();
 
-        const synced = valueSignal() ?? {};
-        // After reset, myNum should either be absent or its default (NaN), but NOT 5
-        expect((synced as Record<string, unknown>).myNum).not.toBe(5);
+        // After reset, the field's default applies — for a number input, that's NaN, not the
+        // previously-saved 5. (Restored values would prove the store wasn't cleared.)
+        const myNum = (valueSignal() as Record<string, unknown> | undefined)?.['myNum'];
+        expect(Number.isNaN(myNum)).toBe(true);
       });
     });
 

--- a/packages/dynamic-forms/src/lib/state/form-state-manager.spec.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-manager.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { signal, Signal, WritableSignal } from '@angular/core';
+import { computed, signal, Signal, WritableSignal } from '@angular/core';
+import { FieldTree } from '@angular/forms/signals';
 
 import { FormStateManager, FORM_STATE_DEPS, FormStateDeps } from './form-state-manager';
 import { FormConfig, FormOptions } from '../models/form-config';
@@ -9,6 +10,10 @@ import { EventBus } from '../events/event.bus';
 import { RootFormRegistryService } from '../core/registry/root-form-registry.service';
 import { SchemaRegistryService } from '../core/registry/schema-registry.service';
 import { FunctionRegistryService } from '../core/registry/function-registry.service';
+import { FieldContextRegistryService } from '../core/registry/field-context-registry.service';
+import { LogicFunctionCacheService } from '../core/expressions/logic-function-cache.service';
+import { HttpConditionFunctionCacheService } from '../core/expressions/http-condition-function-cache.service';
+import { DynamicValueFunctionCacheService } from '../core/values/dynamic-value-function-cache.service';
 import { DynamicFormLogger } from '../providers/features/logger/logger.token';
 import { createMockLogger, MockLogger } from '../../../testing/src/mock-logger';
 
@@ -42,20 +47,33 @@ function initManager(
   mockLogger = createMockLogger();
   const deps = createFormStateDeps(config, overrides);
 
+  // Lazy wiring: RootFormRegistryService gets signals that defer reading FormStateManager
+  // until they're actually evaluated, breaking the construction-time cycle.
+  const stateManagerRef: { current: FormStateManager<TestFields, TestModel> | null } = { current: null };
+  const formValueSig = computed<Record<string, unknown>>(() => (stateManagerRef.current?.formValue() as Record<string, unknown>) ?? {});
+  const formSig = computed<FieldTree<Record<string, unknown>> | undefined>(
+    () => stateManagerRef.current?.form() as FieldTree<Record<string, unknown>> | undefined,
+  );
+
   TestBed.resetTestingModule();
   TestBed.configureTestingModule({
     providers: [
       { provide: FORM_STATE_DEPS, useValue: deps },
       FormStateManager,
       EventBus,
-      { provide: RootFormRegistryService, useValue: new RootFormRegistryService(signal({}), signal(undefined)) },
+      { provide: RootFormRegistryService, useValue: new RootFormRegistryService(formValueSig, formSig) },
       SchemaRegistryService,
       FunctionRegistryService,
+      FieldContextRegistryService,
+      LogicFunctionCacheService,
+      HttpConditionFunctionCacheService,
+      DynamicValueFunctionCacheService,
       { provide: DynamicFormLogger, useValue: mockLogger },
     ],
   });
 
   const stateManager = TestBed.inject(FormStateManager) as FormStateManager<TestFields, TestModel>;
+  stateManagerRef.current = stateManager;
   TestBed.flushEffects();
 
   return { stateManager, deps, mockLogger };
@@ -754,6 +772,372 @@ describe('FormStateManager', () => {
       } as TestFormConfig);
 
       expect(stateManager.resolvedFields()).toEqual([]);
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // excludeValueIfHidden + outward value sync (issue #394)
+  // ─────────────────────────────────────────────────────────────────────
+  //
+  // Bug: when a field is hidden AND excludeValueIfHidden is true, the
+  // field's internal default (e.g. NaN for number inputs) still leaks
+  // into the host's two-way bound `deps.value`. The exclusion only filters
+  // the submission output (`filteredFormValue`) — it should also filter
+  // the outward sync from `entity` → `deps.value`.
+  //
+  // Acceptance: when a field is hidden+excluded, its key must be absent
+  // from `deps.value`. When the field becomes visible again, its previously
+  // entered value must be restored (not reset to its default).
+  // ─────────────────────────────────────────────────────────────────────
+
+  describe('excludeValueIfHidden + outward value sync', () => {
+    describe('static hidden fields', () => {
+      it('should not emit NaN for a hidden number field with field-level excludeValueIfHidden', () => {
+        const valueSignal = signal<Partial<TestModel> | undefined>(undefined);
+        initManager(
+          {
+            fields: [{ type: 'input', key: 'myNum', label: 'Num', props: { type: 'number' }, hidden: true, excludeValueIfHidden: true }],
+          } as TestFormConfig,
+          { value: valueSignal },
+        );
+        TestBed.flushEffects();
+
+        const synced = valueSignal();
+        expect(synced).not.toHaveProperty('myNum');
+      });
+
+      it('should omit a hidden input string field from deps.value when excludeValueIfHidden is true', () => {
+        const valueSignal = signal<Partial<TestModel> | undefined>(undefined);
+        initManager(
+          {
+            fields: [{ type: 'input', key: 'name', label: 'Name', value: 'hello', hidden: true, excludeValueIfHidden: true }],
+          } as TestFormConfig,
+          { value: valueSignal },
+        );
+        TestBed.flushEffects();
+
+        const synced = valueSignal();
+        expect(synced).not.toHaveProperty('name');
+      });
+
+      it('should respect form-level excludeValueIfHidden when field-level is unset', () => {
+        const valueSignal = signal<Partial<TestModel> | undefined>(undefined);
+        const formOptions = signal({ excludeValueIfHidden: true } as FormOptions | undefined);
+        initManager(
+          {
+            fields: [{ type: 'input', key: 'myNum', label: 'Num', props: { type: 'number' }, hidden: true }],
+          } as TestFormConfig,
+          { value: valueSignal, formOptions },
+        );
+        TestBed.flushEffects();
+
+        const synced = valueSignal();
+        expect(synced).not.toHaveProperty('myNum');
+      });
+
+      it('should still emit hidden-field value when excludeValueIfHidden is explicitly false', () => {
+        const valueSignal = signal<Partial<TestModel> | undefined>(undefined);
+        initManager(
+          {
+            fields: [{ type: 'input', key: 'myNum', label: 'Num', props: { type: 'number' }, hidden: true, excludeValueIfHidden: false }],
+          } as TestFormConfig,
+          { value: valueSignal },
+        );
+        TestBed.flushEffects();
+
+        // Field-level opt-out → key present even though hidden.
+        expect(valueSignal()).toHaveProperty('myNum');
+      });
+
+      it('should leave non-hidden sibling fields untouched in deps.value', () => {
+        const valueSignal = signal<Partial<TestModel> | undefined>({ visible: 'keep' });
+        initManager(
+          {
+            fields: [
+              { type: 'input', key: 'visible', label: 'Visible' },
+              { type: 'input', key: 'hiddenOne', label: 'Hidden', hidden: true, excludeValueIfHidden: true },
+            ],
+          } as TestFormConfig,
+          { value: valueSignal },
+        );
+        TestBed.flushEffects();
+
+        const synced = valueSignal();
+        expect(synced).toHaveProperty('visible', 'keep');
+        expect(synced).not.toHaveProperty('hiddenOne');
+      });
+    });
+
+    describe('dynamic hidden fields (logic-driven)', () => {
+      it('should remove the key from deps.value when the field transitions visible → hidden', () => {
+        const valueSignal = signal<Partial<TestModel> | undefined>({ trigger: 'show', myNum: 5 });
+        initManager(
+          {
+            fields: [
+              { type: 'input', key: 'trigger', label: 'Trigger' },
+              {
+                type: 'input',
+                key: 'myNum',
+                label: 'Num',
+                props: { type: 'number' },
+                excludeValueIfHidden: true,
+                logic: [
+                  {
+                    type: 'hidden',
+                    condition: { type: 'fieldValue', fieldPath: 'trigger', operator: 'equals', value: 'hide' },
+                  },
+                ],
+              },
+            ],
+          } as TestFormConfig,
+          { value: valueSignal },
+        );
+        TestBed.flushEffects();
+
+        // Field initially visible → value present
+        expect(valueSignal()).toHaveProperty('myNum', 5);
+
+        // Toggle trigger to hide myNum
+        valueSignal.set({ trigger: 'hide', myNum: 5 });
+        TestBed.flushEffects();
+
+        expect(valueSignal()).not.toHaveProperty('myNum');
+      });
+
+      it('should restore the previously entered value when the field becomes visible again', () => {
+        const valueSignal = signal<Partial<TestModel> | undefined>({ trigger: 'show', myNum: 5 });
+        initManager(
+          {
+            fields: [
+              { type: 'input', key: 'trigger', label: 'Trigger' },
+              {
+                type: 'input',
+                key: 'myNum',
+                label: 'Num',
+                props: { type: 'number' },
+                excludeValueIfHidden: true,
+                logic: [
+                  {
+                    type: 'hidden',
+                    condition: { type: 'fieldValue', fieldPath: 'trigger', operator: 'equals', value: 'hide' },
+                  },
+                ],
+              },
+            ],
+          } as TestFormConfig,
+          { value: valueSignal },
+        );
+        TestBed.flushEffects();
+
+        // Hide the field
+        valueSignal.set({ trigger: 'hide', myNum: 5 });
+        TestBed.flushEffects();
+        expect(valueSignal()).not.toHaveProperty('myNum');
+
+        // Show it again — last entered value should come back
+        valueSignal.set({ trigger: 'show' });
+        TestBed.flushEffects();
+        expect(valueSignal()).toHaveProperty('myNum', 5);
+      });
+
+      it('should preserve the last value across multiple hide/show cycles', () => {
+        const valueSignal = signal<Partial<TestModel> | undefined>({ trigger: 'show', myNum: 5 });
+        initManager(
+          {
+            fields: [
+              { type: 'input', key: 'trigger', label: 'Trigger' },
+              {
+                type: 'input',
+                key: 'myNum',
+                label: 'Num',
+                props: { type: 'number' },
+                excludeValueIfHidden: true,
+                logic: [
+                  {
+                    type: 'hidden',
+                    condition: { type: 'fieldValue', fieldPath: 'trigger', operator: 'equals', value: 'hide' },
+                  },
+                ],
+              },
+            ],
+          } as TestFormConfig,
+          { value: valueSignal },
+        );
+        TestBed.flushEffects();
+
+        // Cycle 1: hide → show
+        valueSignal.set({ trigger: 'hide', myNum: 5 });
+        TestBed.flushEffects();
+        valueSignal.set({ trigger: 'show' });
+        TestBed.flushEffects();
+        expect(valueSignal()).toHaveProperty('myNum', 5);
+
+        // Update value while visible
+        valueSignal.set({ trigger: 'show', myNum: 7 });
+        TestBed.flushEffects();
+
+        // Cycle 2: hide → show — should restore the latest value (7)
+        valueSignal.set({ trigger: 'hide', myNum: 7 });
+        TestBed.flushEffects();
+        expect(valueSignal()).not.toHaveProperty('myNum');
+        valueSignal.set({ trigger: 'show' });
+        TestBed.flushEffects();
+        expect(valueSignal()).toHaveProperty('myNum', 7);
+      });
+
+      it('should hide one field independently without affecting other fields', () => {
+        const valueSignal = signal<Partial<TestModel> | undefined>({
+          trigger: 'show',
+          numA: 1,
+          numB: 2,
+        });
+        initManager(
+          {
+            fields: [
+              { type: 'input', key: 'trigger', label: 'Trigger' },
+              {
+                type: 'input',
+                key: 'numA',
+                label: 'NumA',
+                props: { type: 'number' },
+                excludeValueIfHidden: true,
+                logic: [
+                  {
+                    type: 'hidden',
+                    condition: { type: 'fieldValue', fieldPath: 'trigger', operator: 'equals', value: 'hide' },
+                  },
+                ],
+              },
+              { type: 'input', key: 'numB', label: 'NumB', props: { type: 'number' } },
+            ],
+          } as TestFormConfig,
+          { value: valueSignal },
+        );
+        TestBed.flushEffects();
+
+        valueSignal.set({ trigger: 'hide', numA: 1, numB: 2 });
+        TestBed.flushEffects();
+
+        const synced = valueSignal();
+        expect(synced).not.toHaveProperty('numA');
+        expect(synced).toHaveProperty('numB', 2);
+      });
+    });
+
+    describe('form reset clears saved hidden values', () => {
+      it('should not restore previously saved values after form reset', () => {
+        const valueSignal = signal<Partial<TestModel> | undefined>({ trigger: 'show', myNum: 5 });
+        const { stateManager } = initManager(
+          {
+            fields: [
+              { type: 'input', key: 'trigger', label: 'Trigger' },
+              {
+                type: 'input',
+                key: 'myNum',
+                label: 'Num',
+                props: { type: 'number' },
+                excludeValueIfHidden: true,
+                logic: [
+                  {
+                    type: 'hidden',
+                    condition: { type: 'fieldValue', fieldPath: 'trigger', operator: 'equals', value: 'hide' },
+                  },
+                ],
+              },
+            ],
+          } as TestFormConfig,
+          { value: valueSignal },
+        );
+        TestBed.flushEffects();
+
+        // Hide while value present → store should capture 5
+        valueSignal.set({ trigger: 'hide', myNum: 5 });
+        TestBed.flushEffects();
+
+        // Reset — should clear the saved store
+        stateManager.reset();
+        TestBed.flushEffects();
+
+        // Show again — value should NOT be restored from the saved store
+        valueSignal.set({ trigger: 'show' });
+        TestBed.flushEffects();
+
+        const synced = valueSignal() ?? {};
+        // After reset, myNum should either be absent or its default (NaN), but NOT 5
+        expect((synced as Record<string, unknown>).myNum).not.toBe(5);
+      });
+    });
+
+    describe('group fields', () => {
+      it('should omit a hidden + excluded group from deps.value', () => {
+        const valueSignal = signal<Partial<TestModel> | undefined>(undefined);
+        initManager(
+          {
+            fields: [
+              {
+                type: 'group',
+                key: 'address',
+                hidden: true,
+                excludeValueIfHidden: true,
+                fields: [
+                  { type: 'input', key: 'street', label: 'Street' },
+                  { type: 'input', key: 'city', label: 'City' },
+                ],
+              },
+            ],
+          } as TestFormConfig,
+          { value: valueSignal },
+        );
+        TestBed.flushEffects();
+
+        const synced = valueSignal();
+        expect(synced).not.toHaveProperty('address');
+      });
+
+      it('should restore nested group values across hide/show cycles', () => {
+        const valueSignal = signal<Partial<TestModel> | undefined>({
+          trigger: 'show',
+          address: { street: '123 Main', city: 'Springfield' },
+        });
+        initManager(
+          {
+            fields: [
+              { type: 'input', key: 'trigger', label: 'Trigger' },
+              {
+                type: 'group',
+                key: 'address',
+                excludeValueIfHidden: true,
+                logic: [
+                  {
+                    type: 'hidden',
+                    condition: { type: 'fieldValue', fieldPath: 'trigger', operator: 'equals', value: 'hide' },
+                  },
+                ],
+                fields: [
+                  { type: 'input', key: 'street', label: 'Street' },
+                  { type: 'input', key: 'city', label: 'City' },
+                ],
+              },
+            ],
+          } as TestFormConfig,
+          { value: valueSignal },
+        );
+        TestBed.flushEffects();
+
+        // Visible initially
+        expect(valueSignal()).toHaveProperty('address');
+
+        // Hide the group
+        valueSignal.set({ trigger: 'hide', address: { street: '123 Main', city: 'Springfield' } });
+        TestBed.flushEffects();
+        expect(valueSignal()).not.toHaveProperty('address');
+
+        // Show again — nested values should be restored
+        valueSignal.set({ trigger: 'show' });
+        TestBed.flushEffects();
+        const synced = valueSignal() as Record<string, unknown>;
+        expect(synced.address).toEqual({ street: '123 Main', city: 'Springfield' });
+      });
     });
   });
 });

--- a/packages/dynamic-forms/src/lib/state/form-state-manager.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-manager.ts
@@ -96,16 +96,28 @@ const BOUND_VALUE_EXCLUSION_BASELINE = {
   excludeValueIfReadonly: false,
 } as const;
 
+/** Per-field axes that can drive value exclusion. */
+interface FieldExclusionAxes {
+  readonly hidden: boolean;
+  readonly disabled: boolean;
+  readonly readonly: boolean;
+}
+
+/** True when any of the three exclusion axes is asserted (i.e. the field could be filtered out of the bound model). */
+function isFieldExcluded(axes: FieldExclusionAxes | undefined): boolean {
+  return !!axes && (axes.hidden || axes.disabled || axes.readonly);
+}
+
 /**
- * Recursively populates `out` with `dottedPath → hidden` for every keyed field reachable
+ * Recursively populates `out` with `dottedPath → exclusion axes` for every keyed field reachable
  * from `fields`, walking into groups so nested-leaf transitions can be detected. Arrays are
  * treated as leaves (whole-array filtering only — see value-filter v1 limitation).
  */
-function collectVisibilitySnapshot(
+function collectFieldStateSnapshot(
   fields: readonly FieldDef<unknown>[],
   treeRecord: Record<string, FieldTree<unknown>>,
   pathParts: readonly string[],
-  out: Record<string, boolean>,
+  out: Record<string, FieldExclusionAxes>,
 ): void {
   for (const field of fields) {
     const key = field.key;
@@ -113,11 +125,12 @@ function collectVisibilitySnapshot(
     const subtree = treeRecord[key];
     if (!subtree || typeof subtree !== 'function') continue;
 
+    const state = subtree();
     const path = [...pathParts, key];
-    out[path.join('.')] = subtree().hidden();
+    out[path.join('.')] = { hidden: state.hidden(), disabled: state.disabled(), readonly: state.readonly() };
 
     if (isGroupField(field) && field.fields) {
-      collectVisibilitySnapshot(field.fields as readonly FieldDef<unknown>[], asFieldTreeRecord(subtree), path, out);
+      collectFieldStateSnapshot(field.fields as readonly FieldDef<unknown>[], asFieldTreeRecord(subtree), path, out);
     }
   }
 }
@@ -373,29 +386,30 @@ export class FormStateManager<
   });
 
   /**
-   * Per-field hidden state keyed by dotted path. Drives the save-on-hide effect's
-   * transition detection. Walks recursively into groups so nested-leaf transitions
-   * are captured. Arrays are treated as leaves (whole-array preservation only).
+   * Per-field exclusion-axis state (hidden/disabled/readonly) keyed by dotted path. Drives the
+   * save-on-exclude effect's transition detection. Walks recursively into groups so nested-leaf
+   * transitions are captured. Arrays are treated as leaves (whole-array preservation only).
    */
-  private readonly fieldVisibilitySnapshot = computed((): Record<string, boolean> => {
+  private readonly fieldStateSnapshot = computed((): Record<string, FieldExclusionAxes> => {
     const setup = this.formSetup();
     if (!setup.schemaFields || setup.schemaFields.length === 0) return {};
 
-    const snapshot: Record<string, boolean> = {};
-    collectVisibilitySnapshot(setup.schemaFields, asFieldTreeRecord(this.form()), [], snapshot);
+    const snapshot: Record<string, FieldExclusionAxes> = {};
+    collectFieldStateSnapshot(setup.schemaFields, asFieldTreeRecord(this.form()), [], snapshot);
     return snapshot;
   });
 
   /**
-   * Captured values for fields actively excluded from the bound model (i.e. they have
-   * explicit `excludeValueIfHidden` and are currently hidden). Restored when the field
-   * becomes visible again. The save effect only writes here when the field is being
-   * filtered out by `boundFormValue` — fields without explicit opt-in never enter the store.
+   * Captured values for fields actively excluded from the bound model — either via
+   * `excludeValueIfHidden`, `excludeValueIfDisabled`, or `excludeValueIfReadonly`. Restored when
+   * the field becomes re-included (visible/enabled/editable). The save effect only writes here
+   * when the field is being filtered out by `boundFormValue` — fields without explicit opt-in
+   * never enter the store.
    */
-  private readonly hiddenValueStore = signal<Record<string, unknown>>({});
+  private readonly excludedValueStore = signal<Record<string, unknown>>({});
 
-  /** Tracks per-path hidden state across save-effect runs to detect visible→hidden transitions. */
-  private readonly prevVisibilitySnapshot = signal<Record<string, boolean>>({});
+  /** Tracks per-path exclusion state across save-effect runs to detect newly-excluded fields. */
+  private readonly prevFieldStateSnapshot = signal<Record<string, FieldExclusionAxes>>({});
 
   // ─────────────────────────────────────────────────────────────────────────────
   // Computed Signals - Entity & Form
@@ -422,12 +436,12 @@ export class FormStateManager<
       const inputValue = this.deps.value();
       const defaults = this.defaultValues();
       const keys = this.validKeys();
-      const saved = this.hiddenValueStore();
+      const saved = this.excludedValueStore();
 
       // Deep-merge so a partial nested object in `inputValue` (e.g. a group
       // value missing one of its declared sub-field keys) does not orphan
       // the absent sub-field in the Signal Forms validation graph.
-      // Layer order: defaults < saved (hidden+excluded restorations) < inputValue.
+      // Layer order: defaults < saved (excluded-field restorations) < inputValue.
       const withSaved = deepMergeDefaults(defaults as Record<string, unknown>, saved);
       const combined = deepMergeDefaults(withSaved, inputValue as Record<string, unknown>);
 
@@ -906,7 +920,7 @@ export class FormStateManager<
    * Resets the form to default values.
    */
   reset(): void {
-    this.hiddenValueStore.set({});
+    this.excludedValueStore.set({});
     const defaults = this.defaultValues();
     (this.form()().value as WritableSignal<TModel>).set(defaults);
     this.deps.value.set(defaults as Partial<TModel>);
@@ -916,7 +930,7 @@ export class FormStateManager<
    * Clears the form to empty state.
    */
   clear(): void {
-    this.hiddenValueStore.set({});
+    this.excludedValueStore.set({});
     const emptyValue = {} as TModel;
     (this.form()().value as WritableSignal<TModel>).set(emptyValue);
     this.deps.value.set(emptyValue);
@@ -945,22 +959,23 @@ export class FormStateManager<
       }
     });
 
-    // Save-on-hide: capture entity values for fields that boundFormValue is actively filtering
-    // out (i.e. fields with explicit excludeValueIfHidden where hidden is true), so they can be
-    // restored when the field becomes visible again. Comparing entity vs bound at the path
-    // limits the store to fields that are actually being filtered — fields without explicit
-    // opt-in never enter the store and never participate in the entity merge.
-    // NaN values are skipped: they're the number-input default and would defeat the bug fix
-    // by restoring NaN to the bound model when the field becomes visible again.
-    explicitEffect([this.fieldVisibilitySnapshot], ([snapshot]) => {
-      const currentSaved = this.hiddenValueStore();
+    // Save-on-exclude: capture entity values for fields that boundFormValue is actively
+    // filtering out via any of the three axes (hidden / disabled / readonly), so they can be
+    // restored when the field becomes re-included. The transition fires once per "no axis
+    // asserted → at least one axis asserted" edge; subsequent axis changes while still excluded
+    // are no-ops. Comparing entity vs bound at the path limits the store to fields that are
+    // actually being filtered — fields without explicit opt-in never enter the store and never
+    // participate in the entity merge. `NaN` values are skipped: they're the number-input default
+    // and would re-leak via the merge once the field becomes re-included.
+    explicitEffect([this.fieldStateSnapshot], ([snapshot]) => {
+      const currentSaved = this.excludedValueStore();
       const currentEntity = this.entity() as Record<string, unknown>;
       const boundValue = this.boundFormValue() as Record<string, unknown>;
-      const prev = this.prevVisibilitySnapshot();
+      const prev = this.prevFieldStateSnapshot();
       let newSaved = currentSaved;
 
-      for (const [path, isHidden] of Object.entries(snapshot)) {
-        if (isHidden && !prev[path]) {
+      for (const [path, axes] of Object.entries(snapshot)) {
+        if (isFieldExcluded(axes) && !isFieldExcluded(prev[path])) {
           const segments = path.split('.');
           const inEntity = getValueAtPath(currentEntity, segments);
           const inBound = getValueAtPath(boundValue, segments);
@@ -969,19 +984,19 @@ export class FormStateManager<
           }
         }
       }
-      this.prevVisibilitySnapshot.set({ ...snapshot });
+      this.prevFieldStateSnapshot.set({ ...snapshot });
 
       if (newSaved !== currentSaved && !isEqual(newSaved, currentSaved)) {
-        this.hiddenValueStore.set(newSaved);
+        this.excludedValueStore.set(newSaved);
       }
     });
 
     // Schema change resets the saved store + transition tracker so values from a stale schema
     // can't leak into the new one.
     explicitEffect([this.formSetup], () => {
-      this.prevVisibilitySnapshot.set({});
-      if (Object.keys(this.hiddenValueStore()).length > 0) {
-        this.hiddenValueStore.set({});
+      this.prevFieldStateSnapshot.set({});
+      if (Object.keys(this.excludedValueStore()).length > 0) {
+        this.excludedValueStore.set({});
       }
     });
 

--- a/packages/dynamic-forms/src/lib/state/form-state-manager.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-manager.ts
@@ -21,6 +21,7 @@ import { explicitEffect } from 'ngxtension/explicit-effect';
 import { FieldDef } from '../definitions/base/field-def';
 import { normalizeSimplifiedArrays } from '../utils/array-field/normalize-simplified-arrays';
 import { DynamicFormError } from '../errors/dynamic-form-error';
+import { isGroupField } from '../definitions/default/group-field';
 import { isPageField, PageField } from '../definitions/default/page-field';
 import { EventBus } from '../events/event.bus';
 import { FormClearEvent } from '../events/constants/form-clear.event';
@@ -86,6 +87,63 @@ export const FORM_STATE_DEPS = new InjectionToken<FormStateDeps>('FORM_STATE_DEP
  */
 function asFieldTreeRecord(tree: FieldTree<unknown>): Record<string, FieldTree<unknown>> {
   return tree as unknown as Record<string, FieldTree<unknown>>;
+}
+
+/**
+ * Recursively populates `out` with `dottedPath → hidden` for every keyed field reachable
+ * from `fields`, walking into groups so nested transitions can be detected. Arrays are
+ * treated as leaves (whole-array filtering only — see value-filter v1 limitation).
+ */
+function collectVisibilitySnapshot(
+  fields: readonly FieldDef<unknown>[],
+  treeRecord: Record<string, FieldTree<unknown>>,
+  pathParts: readonly string[],
+  out: Record<string, boolean>,
+): void {
+  for (const field of fields) {
+    const key = field.key;
+    if (!key) continue;
+    const subtree = treeRecord[key];
+    if (!subtree || typeof subtree !== 'function') continue;
+
+    const path = [...pathParts, key];
+    out[path.join('.')] = subtree().hidden();
+
+    if (isGroupField(field) && field.fields) {
+      collectVisibilitySnapshot(field.fields as readonly FieldDef<unknown>[], asFieldTreeRecord(subtree), path, out);
+    }
+  }
+}
+
+/**
+ * Reads a value from a nested object by dotted-path segments. Returns undefined
+ * if any intermediate segment is missing or non-object.
+ */
+function getValueAtPath(source: Record<string, unknown>, segments: readonly string[]): unknown {
+  let current: unknown = source;
+  for (const segment of segments) {
+    if (current === null || typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+/**
+ * Returns a new object with `value` set at the path described by `segments`.
+ * Intermediate objects are cloned shallowly to preserve immutability of `target`.
+ */
+function setValueAtPath(target: Record<string, unknown>, segments: readonly string[], value: unknown): Record<string, unknown> {
+  if (segments.length === 0) return target;
+  const [head, ...rest] = segments;
+  const next = { ...target };
+  if (rest.length === 0) {
+    next[head] = value;
+  } else {
+    const child = target[head];
+    const childObj = child !== null && typeof child === 'object' ? (child as Record<string, unknown>) : {};
+    next[head] = setValueAtPath(childObj, rest, value);
+  }
+  return next;
 }
 
 /**
@@ -298,27 +356,25 @@ export class FormStateManager<
     return new Set(schemaFields.map((f) => f.key).filter((key): key is string => key !== undefined));
   });
 
-  /** Per-top-level-field hidden state, used to detect visible→hidden transitions. */
+  /**
+   * Per-field hidden state keyed by dotted path, used to detect visible→hidden transitions.
+   * Walks recursively into group fields so nested-leaf transitions are captured. Arrays are
+   * treated as leaves (whole-array preservation only) per the existing v1 filtering design.
+   */
   private readonly fieldVisibilitySnapshot = computed((): Record<string, boolean> => {
     const setup = this.formSetup();
     if (!setup.schemaFields || setup.schemaFields.length === 0) return {};
 
-    const fieldTreeRecord = asFieldTreeRecord(this.form());
     const snapshot: Record<string, boolean> = {};
-
-    for (const field of setup.schemaFields) {
-      const key = field.key;
-      if (!key) continue;
-      const subtree = fieldTreeRecord[key];
-      if (!subtree || typeof subtree !== 'function') continue;
-      snapshot[key] = subtree().hidden();
-    }
-
+    collectVisibilitySnapshot(setup.schemaFields, asFieldTreeRecord(this.form()), [], snapshot);
     return snapshot;
   });
 
   /** Captured values for fields currently hidden+excluded. Restored when they become visible again. */
   private readonly hiddenValueStore = signal<Record<string, unknown>>({});
+
+  /** Tracks per-path hidden state across save-effect runs to detect visible→hidden transitions. */
+  private prevVisibilitySnapshot: Record<string, boolean> = {};
 
   // ─────────────────────────────────────────────────────────────────────────────
   // Computed Signals - Entity & Form
@@ -829,23 +885,35 @@ export class FormStateManager<
     });
 
     // Save-on-hide: capture entity values right before write-back filters them out, so
-    // they can be restored when the field becomes visible again.
-    let prevVisibilitySnapshot: Record<string, boolean> = {};
+    // they can be restored when the field becomes visible again. Snapshot keys are dotted
+    // paths so nested-leaf transitions inside groups are also captured.
     explicitEffect([this.fieldVisibilitySnapshot], ([snapshot]) => {
-      const currentSaved = untracked(() => this.hiddenValueStore());
-      const currentEntity = untracked(() => this.entity()) as Record<string, unknown>;
-      const newSaved = { ...currentSaved };
+      const currentSaved = this.hiddenValueStore();
+      const currentEntity = this.entity() as Record<string, unknown>;
+      let newSaved = currentSaved;
 
-      for (const [key, isHidden] of Object.entries(snapshot)) {
-        if (isHidden && !prevVisibilitySnapshot[key]) {
-          const value = currentEntity[key];
-          if (value !== undefined) newSaved[key] = value;
+      for (const [path, isHidden] of Object.entries(snapshot)) {
+        if (isHidden && !this.prevVisibilitySnapshot[path]) {
+          const segments = path.split('.');
+          const value = getValueAtPath(currentEntity, segments);
+          if (value !== undefined) {
+            newSaved = setValueAtPath(newSaved, segments, value);
+          }
         }
       }
-      prevVisibilitySnapshot = { ...snapshot };
+      this.prevVisibilitySnapshot = { ...snapshot };
 
-      if (!isEqual(newSaved, currentSaved)) {
+      if (newSaved !== currentSaved && !isEqual(newSaved, currentSaved)) {
         this.hiddenValueStore.set(newSaved);
+      }
+    });
+
+    // Schema change (config swap, teardown/restore) resets the saved store + transition tracker
+    // so values from a stale schema can't leak into the new one.
+    explicitEffect([this.formSetup], () => {
+      this.prevVisibilitySnapshot = {};
+      if (Object.keys(this.hiddenValueStore()).length > 0) {
+        this.hiddenValueStore.set({});
       }
     });
 

--- a/packages/dynamic-forms/src/lib/state/form-state-manager.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-manager.ts
@@ -136,6 +136,15 @@ function getValueAtPath(source: Record<string, unknown>, segments: readonly stri
 }
 
 /**
+ * Whether a value is worth capturing into the saved-hidden-value store. `NaN` (the number-input
+ * default) is excluded — restoring it would re-leak the default into the bound model when the
+ * field becomes visible again, defeating the bug fix.
+ */
+function isRestoreRelevant(value: unknown): boolean {
+  return !(typeof value === 'number' && Number.isNaN(value));
+}
+
+/**
  * Returns a new object with `value` set at the path described by `segments`.
  * Intermediate objects are cloned shallowly to preserve immutability of `target`.
  */
@@ -386,7 +395,7 @@ export class FormStateManager<
   private readonly hiddenValueStore = signal<Record<string, unknown>>({});
 
   /** Tracks per-path hidden state across save-effect runs to detect visible→hidden transitions. */
-  private prevVisibilitySnapshot: Record<string, boolean> = {};
+  private readonly prevVisibilitySnapshot = signal<Record<string, boolean>>({});
 
   // ─────────────────────────────────────────────────────────────────────────────
   // Computed Signals - Entity & Form
@@ -941,23 +950,26 @@ export class FormStateManager<
     // restored when the field becomes visible again. Comparing entity vs bound at the path
     // limits the store to fields that are actually being filtered — fields without explicit
     // opt-in never enter the store and never participate in the entity merge.
+    // NaN values are skipped: they're the number-input default and would defeat the bug fix
+    // by restoring NaN to the bound model when the field becomes visible again.
     explicitEffect([this.fieldVisibilitySnapshot], ([snapshot]) => {
       const currentSaved = this.hiddenValueStore();
       const currentEntity = this.entity() as Record<string, unknown>;
       const boundValue = this.boundFormValue() as Record<string, unknown>;
+      const prev = this.prevVisibilitySnapshot();
       let newSaved = currentSaved;
 
       for (const [path, isHidden] of Object.entries(snapshot)) {
-        if (isHidden && !this.prevVisibilitySnapshot[path]) {
+        if (isHidden && !prev[path]) {
           const segments = path.split('.');
           const inEntity = getValueAtPath(currentEntity, segments);
           const inBound = getValueAtPath(boundValue, segments);
-          if (inEntity !== undefined && inBound === undefined) {
+          if (inEntity !== undefined && inBound === undefined && isRestoreRelevant(inEntity)) {
             newSaved = setValueAtPath(newSaved, segments, inEntity);
           }
         }
       }
-      this.prevVisibilitySnapshot = { ...snapshot };
+      this.prevVisibilitySnapshot.set({ ...snapshot });
 
       if (newSaved !== currentSaved && !isEqual(newSaved, currentSaved)) {
         this.hiddenValueStore.set(newSaved);
@@ -967,7 +979,7 @@ export class FormStateManager<
     // Schema change resets the saved store + transition tracker so values from a stale schema
     // can't leak into the new one.
     explicitEffect([this.formSetup], () => {
-      this.prevVisibilitySnapshot = {};
+      this.prevVisibilitySnapshot.set({});
       if (Object.keys(this.hiddenValueStore()).length > 0) {
         this.hiddenValueStore.set({});
       }

--- a/packages/dynamic-forms/src/lib/state/form-state-manager.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-manager.ts
@@ -298,6 +298,28 @@ export class FormStateManager<
     return new Set(schemaFields.map((f) => f.key).filter((key): key is string => key !== undefined));
   });
 
+  /** Per-top-level-field hidden state, used to detect visible→hidden transitions. */
+  private readonly fieldVisibilitySnapshot = computed((): Record<string, boolean> => {
+    const setup = this.formSetup();
+    if (!setup.schemaFields || setup.schemaFields.length === 0) return {};
+
+    const fieldTreeRecord = asFieldTreeRecord(this.form());
+    const snapshot: Record<string, boolean> = {};
+
+    for (const field of setup.schemaFields) {
+      const key = field.key;
+      if (!key) continue;
+      const subtree = fieldTreeRecord[key];
+      if (!subtree || typeof subtree !== 'function') continue;
+      snapshot[key] = subtree().hidden();
+    }
+
+    return snapshot;
+  });
+
+  /** Captured values for fields currently hidden+excluded. Restored when they become visible again. */
+  private readonly hiddenValueStore = signal<Record<string, unknown>>({});
+
   // ─────────────────────────────────────────────────────────────────────────────
   // Computed Signals - Entity & Form
   // ─────────────────────────────────────────────────────────────────────────────
@@ -323,11 +345,14 @@ export class FormStateManager<
       const inputValue = this.deps.value();
       const defaults = this.defaultValues();
       const keys = this.validKeys();
+      const saved = this.hiddenValueStore();
 
       // Deep-merge so a partial nested object in `inputValue` (e.g. a group
       // value missing one of its declared sub-field keys) does not orphan
       // the absent sub-field in the Signal Forms validation graph.
-      const combined = deepMergeDefaults(defaults as Record<string, unknown>, inputValue as Record<string, unknown>);
+      // Layer order: defaults < saved (hidden+excluded restorations) < inputValue.
+      const withSaved = deepMergeDefaults(defaults as Record<string, unknown>, saved);
+      const combined = deepMergeDefaults(withSaved, inputValue as Record<string, unknown>);
 
       if (keys) {
         const filtered: Record<string, unknown> = {};
@@ -764,6 +789,7 @@ export class FormStateManager<
    * Resets the form to default values.
    */
   reset(): void {
+    this.hiddenValueStore.set({});
     const defaults = this.defaultValues();
     (this.form()().value as WritableSignal<TModel>).set(defaults);
     this.deps.value.set(defaults as Partial<TModel>);
@@ -773,6 +799,7 @@ export class FormStateManager<
    * Clears the form to empty state.
    */
   clear(): void {
+    this.hiddenValueStore.set({});
     const emptyValue = {} as TModel;
     (this.form()().value as WritableSignal<TModel>).set(emptyValue);
     this.deps.value.set(emptyValue);
@@ -801,12 +828,32 @@ export class FormStateManager<
       }
     });
 
-    // Outward sync: write entity changes back to deps.value (see entity JSDoc for full explanation).
-    // The isEqual guard prevents infinite ping-pong between this effect and the linkedSignal source.
-    explicitEffect([this.entity], ([currentEntity]) => {
+    // Save-on-hide: capture entity values right before write-back filters them out, so
+    // they can be restored when the field becomes visible again.
+    let prevVisibilitySnapshot: Record<string, boolean> = {};
+    explicitEffect([this.fieldVisibilitySnapshot], ([snapshot]) => {
+      const currentSaved = untracked(() => this.hiddenValueStore());
+      const currentEntity = untracked(() => this.entity()) as Record<string, unknown>;
+      const newSaved = { ...currentSaved };
+
+      for (const [key, isHidden] of Object.entries(snapshot)) {
+        if (isHidden && !prevVisibilitySnapshot[key]) {
+          const value = currentEntity[key];
+          if (value !== undefined) newSaved[key] = value;
+        }
+      }
+      prevVisibilitySnapshot = { ...snapshot };
+
+      if (!isEqual(newSaved, currentSaved)) {
+        this.hiddenValueStore.set(newSaved);
+      }
+    });
+
+    // Outward sync uses filteredFormValue (not entity) so excluded fields don't leak their defaults.
+    explicitEffect([this.filteredFormValue], ([currentFiltered]) => {
       const currentValue = this.deps.value();
-      if (!isEqual(currentEntity, currentValue)) {
-        this.deps.value.set(currentEntity);
+      if (!isEqual(currentFiltered, currentValue)) {
+        this.deps.value.set(currentFiltered as TModel);
       }
     });
 

--- a/packages/dynamic-forms/src/lib/state/form-state-manager.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-manager.ts
@@ -89,9 +89,16 @@ function asFieldTreeRecord(tree: FieldTree<unknown>): Record<string, FieldTree<u
   return tree as unknown as Record<string, FieldTree<unknown>>;
 }
 
+/** All-false baseline for the outward two-way binding filter — see `boundFormValue`. */
+const BOUND_VALUE_EXCLUSION_BASELINE = {
+  excludeValueIfHidden: false,
+  excludeValueIfDisabled: false,
+  excludeValueIfReadonly: false,
+} as const;
+
 /**
  * Recursively populates `out` with `dottedPath → hidden` for every keyed field reachable
- * from `fields`, walking into groups so nested transitions can be detected. Arrays are
+ * from `fields`, walking into groups so nested-leaf transitions can be detected. Arrays are
  * treated as leaves (whole-array filtering only — see value-filter v1 limitation).
  */
 function collectVisibilitySnapshot(
@@ -357,9 +364,9 @@ export class FormStateManager<
   });
 
   /**
-   * Per-field hidden state keyed by dotted path, used to detect visible→hidden transitions.
-   * Walks recursively into group fields so nested-leaf transitions are captured. Arrays are
-   * treated as leaves (whole-array preservation only) per the existing v1 filtering design.
+   * Per-field hidden state keyed by dotted path. Drives the save-on-hide effect's
+   * transition detection. Walks recursively into groups so nested-leaf transitions
+   * are captured. Arrays are treated as leaves (whole-array preservation only).
    */
   private readonly fieldVisibilitySnapshot = computed((): Record<string, boolean> => {
     const setup = this.formSetup();
@@ -370,7 +377,12 @@ export class FormStateManager<
     return snapshot;
   });
 
-  /** Captured values for fields currently hidden+excluded. Restored when they become visible again. */
+  /**
+   * Captured values for fields actively excluded from the bound model (i.e. they have
+   * explicit `excludeValueIfHidden` and are currently hidden). Restored when the field
+   * becomes visible again. The save effect only writes here when the field is being
+   * filtered out by `boundFormValue` — fields without explicit opt-in never enter the store.
+   */
   private readonly hiddenValueStore = signal<Record<string, unknown>>({});
 
   /** Tracks per-path hidden state across save-effect runs to detect visible→hidden transitions. */
@@ -547,6 +559,46 @@ export class FormStateManager<
       fieldTreeRecord,
       setup.registry,
       this.valueExclusionDefaults,
+      formOptions,
+    );
+  });
+
+  /**
+   * Form value used for the outward two-way binding sync.
+   *
+   * Only honors *explicit* form-level and field-level `excludeValueIf*` settings — global
+   * defaults (`VALUE_EXCLUSION_DEFAULTS`) are intentionally ignored here. Rationale:
+   * - Original V1 behavior: the bound model carries all values regardless of visibility.
+   * - Bug fix: when a user explicitly sets `excludeValueIfHidden: true` on a field/form,
+   *   they expect that value to disappear from the bound model when hidden (e.g. NaN for
+   *   number inputs, see issue #394).
+   * - Without explicit opt-in, the bound model keeps the V1 contract.
+   * `filteredFormValue` (above) still applies the full Field > Form > Global hierarchy
+   * for the submission output.
+   */
+  private readonly boundFormValue = computed(() => {
+    const rawValue = this.formValue();
+    const setup = this.formSetup();
+    const options = this.effectiveFormOptions();
+
+    if (!setup.schemaFields || setup.schemaFields.length === 0) {
+      return rawValue;
+    }
+
+    const formTree = this.form();
+    const formOptions: ValueExclusionConfig = {
+      excludeValueIfHidden: options.excludeValueIfHidden,
+      excludeValueIfDisabled: options.excludeValueIfDisabled,
+      excludeValueIfReadonly: options.excludeValueIfReadonly,
+    };
+    const fieldTreeRecord = asFieldTreeRecord(formTree);
+
+    return filterFormValue(
+      rawValue as Record<string, unknown>,
+      setup.schemaFields,
+      fieldTreeRecord,
+      setup.registry,
+      BOUND_VALUE_EXCLUSION_BASELINE,
       formOptions,
     );
   });
@@ -884,20 +936,24 @@ export class FormStateManager<
       }
     });
 
-    // Save-on-hide: capture entity values right before write-back filters them out, so
-    // they can be restored when the field becomes visible again. Snapshot keys are dotted
-    // paths so nested-leaf transitions inside groups are also captured.
+    // Save-on-hide: capture entity values for fields that boundFormValue is actively filtering
+    // out (i.e. fields with explicit excludeValueIfHidden where hidden is true), so they can be
+    // restored when the field becomes visible again. Comparing entity vs bound at the path
+    // limits the store to fields that are actually being filtered — fields without explicit
+    // opt-in never enter the store and never participate in the entity merge.
     explicitEffect([this.fieldVisibilitySnapshot], ([snapshot]) => {
       const currentSaved = this.hiddenValueStore();
       const currentEntity = this.entity() as Record<string, unknown>;
+      const boundValue = this.boundFormValue() as Record<string, unknown>;
       let newSaved = currentSaved;
 
       for (const [path, isHidden] of Object.entries(snapshot)) {
         if (isHidden && !this.prevVisibilitySnapshot[path]) {
           const segments = path.split('.');
-          const value = getValueAtPath(currentEntity, segments);
-          if (value !== undefined) {
-            newSaved = setValueAtPath(newSaved, segments, value);
+          const inEntity = getValueAtPath(currentEntity, segments);
+          const inBound = getValueAtPath(boundValue, segments);
+          if (inEntity !== undefined && inBound === undefined) {
+            newSaved = setValueAtPath(newSaved, segments, inEntity);
           }
         }
       }
@@ -908,8 +964,8 @@ export class FormStateManager<
       }
     });
 
-    // Schema change (config swap, teardown/restore) resets the saved store + transition tracker
-    // so values from a stale schema can't leak into the new one.
+    // Schema change resets the saved store + transition tracker so values from a stale schema
+    // can't leak into the new one.
     explicitEffect([this.formSetup], () => {
       this.prevVisibilitySnapshot = {};
       if (Object.keys(this.hiddenValueStore()).length > 0) {
@@ -917,11 +973,12 @@ export class FormStateManager<
       }
     });
 
-    // Outward sync uses filteredFormValue (not entity) so excluded fields don't leak their defaults.
-    explicitEffect([this.filteredFormValue], ([currentFiltered]) => {
+    // Outward sync uses boundFormValue (honors only explicit excludeValueIf* opt-ins) so
+    // global defaults that target submission output don't reshape the host's bound model.
+    explicitEffect([this.boundFormValue], ([currentBound]) => {
       const currentValue = this.deps.value();
-      if (!isEqual(currentFiltered, currentValue)) {
-        this.deps.value.set(currentFiltered as TModel);
+      if (!isEqual(currentBound, currentValue)) {
+        this.deps.value.set(currentBound as TModel);
       }
     });
 

--- a/packages/dynamic-forms/src/lib/utils/value-filter/value-filter.ts
+++ b/packages/dynamic-forms/src/lib/utils/value-filter/value-filter.ts
@@ -27,21 +27,25 @@ export function resolveExclusionConfig(
 }
 
 /**
- * Determines whether a field's value should be excluded based on its reactive state
+ * Determines whether a field's value should be excluded based on its reactive state,
+ * the field def's static state (for fields whose `state.hidden()` isn't wired — e.g. groups),
  * and the resolved exclusion config.
  */
-function shouldExcludeField(fieldState: FieldTree<unknown>, config: ResolvedValueExclusionConfig): boolean {
+function shouldExcludeField(field: FieldDef<unknown>, fieldState: FieldTree<unknown>, config: ResolvedValueExclusionConfig): boolean {
   const state = fieldState();
 
-  if (config.excludeValueIfHidden && state.hidden()) {
+  const isHidden = state.hidden() || field.hidden === true;
+  if (config.excludeValueIfHidden && isHidden) {
     return true;
   }
 
-  if (config.excludeValueIfDisabled && state.disabled()) {
+  const isDisabled = state.disabled() || field.disabled === true;
+  if (config.excludeValueIfDisabled && isDisabled) {
     return true;
   }
 
-  if (config.excludeValueIfReadonly && state.readonly()) {
+  const isReadonly = state.readonly() || field.readonly === true;
+  if (config.excludeValueIfReadonly && isReadonly) {
     return true;
   }
 
@@ -102,7 +106,7 @@ export function filterFormValue<T extends Record<string, unknown>>(
     const resolvedConfig = resolveExclusionConfig(globalDefaults, formOptions, fieldExclusion);
 
     // Check if this field should be excluded based on its state
-    if (shouldExcludeField(fieldState, resolvedConfig)) {
+    if (shouldExcludeField(field, fieldState, resolvedConfig)) {
       continue;
     }
 

--- a/packages/dynamic-forms/src/lib/utils/value-filter/value-filter.ts
+++ b/packages/dynamic-forms/src/lib/utils/value-filter/value-filter.ts
@@ -87,16 +87,6 @@ export function filterFormValue<T extends Record<string, unknown>>(
     // If the key doesn't exist in the raw value, skip
     if (!(key in rawValue)) continue;
 
-    // Try to access the field state from the form tree
-    const fieldState = formTree[key] as FieldTree<unknown> | undefined;
-
-    // If no field state is available (e.g., componentless hidden fields),
-    // include the value as-is since we can't determine reactive state
-    if (!fieldState || typeof fieldState !== 'function') {
-      result[key] = rawValue[key];
-      continue;
-    }
-
     // Resolve per-field exclusion config
     const fieldExclusion: ValueExclusionConfig = {
       excludeValueIfHidden: field.excludeValueIfHidden,
@@ -104,6 +94,19 @@ export function filterFormValue<T extends Record<string, unknown>>(
       excludeValueIfReadonly: field.excludeValueIfReadonly,
     };
     const resolvedConfig = resolveExclusionConfig(globalDefaults, formOptions, fieldExclusion);
+
+    // Componentless field (no FieldTree) — decide from the static field def alone, then include if not excluded.
+    const fieldState = formTree[key] as FieldTree<unknown> | undefined;
+    if (!fieldState || typeof fieldState !== 'function') {
+      const staticallyExcluded =
+        (resolvedConfig.excludeValueIfHidden && field.hidden === true) ||
+        (resolvedConfig.excludeValueIfDisabled && field.disabled === true) ||
+        (resolvedConfig.excludeValueIfReadonly && field.readonly === true);
+      if (!staticallyExcluded) {
+        result[key] = rawValue[key];
+      }
+      continue;
+    }
 
     // Check if this field should be excluded based on its state
     if (shouldExcludeField(field, fieldState, resolvedConfig)) {


### PR DESCRIPTION
## Summary

Closes #394.

The outward sync from `entity` → `deps.value` previously bypassed value-exclusion entirely, so a number field with `excludeValueIfHidden: true` would emit `NaN` into the host's two-way bound model when hidden. This PR makes the outward sync honor **explicit** field- and form-level `excludeValueIf*` opt-ins (across all three axes — hidden, disabled, readonly), captures values into a saved store when they're filtered, and restores them when the field becomes re-included.

### Design constraint: bound-sync respects explicit opt-in only

Global `withValueExclusionDefaults()` continues to apply only to submission output (`(submitted)` / `filteredFormValue`). The two-way bound model is reshaped **only when the field or form explicitly sets** `excludeValueIf*: true`. This preserves the V1 "the bound model carries all values" contract for code that hasn't opted in, while fixing the bug for code that has.

### Changes

- **`state/form-state-manager.ts`**
  - New `boundFormValue` computed: runs `filterFormValue` with an all-false baseline (`BOUND_VALUE_EXCLUSION_BASELINE`) so global defaults are intentionally ignored for the outward sync.
  - New `fieldStateSnapshot` computed: walks the schema (recursing into groups) and records `dottedPath → { hidden, disabled, readonly }` for every leaf/group. Drives the save-on-exclude effect.
  - New `excludedValueStore` + `prevFieldStateSnapshot` signals. The save effect fires once per "no axis asserted → any axis asserted" transition and only captures when the path is missing from `boundFormValue`. `NaN` is skipped via `isRestoreRelevant` to avoid re-leaking the number-input default.
  - `entity` linkedSignal merges saved values back in: `defaults < saved < input`. Re-shown/re-enabled/re-editable fields restore from the store; explicit external input always wins.
  - Outward sync writes `boundFormValue` (not raw `entity`); `reset()` / `clear()` flush the store; schema-change effect resets store + prev snapshot so stale values can't leak across config swaps.

- **`utils/value-filter/value-filter.ts`** — `shouldExcludeField` now also reads the static `field.hidden` / `field.disabled` / `field.readonly` flags, so groups (whose state isn't wired through Angular Signal Forms' propagation) get filtered consistently with leaf fields. Componentless fields (no `FieldTree`) honor the static exclusion check too.

- **`apps/docs/public/content/recipes/value-exclusion.md`** + regenerated `llms-full.txt` — documents the bound-model vs submission asymmetry: explicit field/form-level opt-in reshapes `[(value)]`; global defaults do not.

### TDD coverage

16 scenarios under `excludeValueIfHidden + outward value sync`:

- **Static hidden:** number NaN omission, string field omission with default, form-level option, sibling isolation, regression check for explicit `excludeValueIfHidden: false`, componentless field (`type: 'hidden'`)
- **Dynamic hidden:** visible→hidden removal, restoration on re-show, multi-cycle preservation, independent per-field hiding
- **Other exclusion axes:** restore-on-re-enable for `excludeValueIfDisabled`, restore-on-becoming-editable for `excludeValueIfReadonly`, overlapping hide→disable→drop-hide→re-enable cycle
- **Form reset:** store cleared so reset always falls back to field default (`Number.isNaN` assertion)
- **Groups:** static hidden + excluded group is omitted; per-child explicit-excluded leaf inside a visible group is preserved across hide/show cycles

## Test plan

- [x] `nx test dynamic-forms` — 2642 passed, 0 failed
- [x] `nx build dynamic-forms` — clean
- [x] `nx lint dynamic-forms` — no new lint issues introduced
- [x] `nx run core-examples:e2e` — full suite green (validates the V1 contract was preserved for non-opt-in fields and the saved-store doesn't interfere with rendering)
- [ ] Manual verification in a docs sandbox that a number field with `excludeValueIfHidden: true` no longer emits `NaN` to the bound model