### PR TITLE
feat(dynamic-forms): inline function alternatives for conditions, derivations, validators

### DIFF
--- a/apps/docs/public/content/dynamic-behavior/conditional-logic.md
+++ b/apps/docs/public/content/dynamic-behavior/conditional-logic.md
@@ -603,12 +603,30 @@ const formConfig = {
 
 **Async condition properties:**
 
-| Property            | Type      | Required | Default | Description                                         |
-| ------------------- | --------- | -------- | ------- | --------------------------------------------------- |
-| `type`              | `'async'` | Yes      | —       | Identifies this as an async condition               |
-| `asyncFunctionName` | `string`  | Yes      | —       | Name registered in `customFnConfig.asyncConditions` |
-| `pendingValue`      | `boolean` | No       | `false` | Value returned while the function is resolving      |
-| `debounceMs`        | `number`  | No       | `300`   | Debounce delay before re-evaluating (ms)            |
+| Property            | Type                     | Required | Default | Description                                               |
+| ------------------- | ------------------------ | -------- | ------- | --------------------------------------------------------- |
+| `type`              | `'async'`                | Yes      | —       | Identifies this as an async condition                     |
+| `asyncFunctionName` | `string`                 | XOR\*    | —       | Name registered in `customFnConfig.asyncConditions`       |
+| `asyncFn`           | `AsyncConditionFunction` | XOR\*    | —       | Inline async function (code-only — not JSON-serializable) |
+| `pendingValue`      | `boolean`                | No       | `false` | Value returned while the function is resolving            |
+| `debounceMs`        | `number`                 | No       | `300`   | Debounce delay before re-evaluating (ms)                  |
+
+\* Exactly one of `asyncFunctionName` or `asyncFn` must be set. The two are mutually exclusive at the type level; if both keys appear at runtime (e.g. a JSON config that hand-edited both in), the library logs a warning and the inline `asyncFn` wins.
+
+**Inline `asyncFn` example (code-only):**
+
+```typescript
+import { inject } from '@angular/core';
+
+{
+  type: 'async',
+  asyncFn: async (context) => {
+    // Same Angular DI context as registered functions — `inject()` works here.
+    return inject(PermissionsService).canEdit(context.formValue.resourceId as string);
+  },
+  pendingValue: false,
+}
+```
 
 **Choosing `pendingValue`:**
 

--- a/apps/docs/public/content/dynamic-behavior/conditional-logic.md
+++ b/apps/docs/public/content/dynamic-behavior/conditional-logic.md
@@ -1110,25 +1110,33 @@ interface HttpCondition {
   debounceMs?: number; // Default: 300
 }
 
-interface AsyncCondition {
-  type: 'async';
-  asyncFunctionName: string;
-  pendingValue?: boolean; // Default: false
-  debounceMs?: number; // Default: 300
-}
+// AsyncCondition is a discriminated XOR — exactly one of asyncFunctionName / asyncFn must be set.
+type AsyncCondition =
+  | {
+      type: 'async';
+      asyncFunctionName: string;
+      pendingValue?: boolean; // Default: false
+      debounceMs?: number; // Default: 300
+    }
+  | {
+      type: 'async';
+      asyncFn: AsyncConditionFunction; // Inline (code-only, not JSON-serializable)
+      pendingValue?: boolean;
+      debounceMs?: number;
+    };
 ```
 
 **Expression types summary:**
 
-| Type         | Sync/Async | Key properties                   | Purpose                                                               |
-| ------------ | ---------- | -------------------------------- | --------------------------------------------------------------------- |
-| `fieldValue` | Sync       | `fieldPath`, `operator`, `value` | Compare a specific field's value                                      |
-| `formValue`  | Sync       | `operator`, `value`              | Compare entire form object                                            |
-| `javascript` | Sync       | `expression`                     | Custom JS with `fieldValue`/`formValue`/`fieldState`/`formFieldState` |
-| `custom`     | Sync       | `expression`                     | Inline expression with `fieldValue`/`formValue` (safe member access)  |
-| `and`/`or`   | Sync       | `conditions`                     | Combine multiple conditions                                           |
-| `http`       | Async      | `http`, `responseExpression`     | Server-driven condition via HTTP request                              |
-| `async`      | Async      | `asyncFunctionName`              | Custom async function registered in config                            |
+| Type         | Sync/Async | Key properties                         | Purpose                                                               |
+| ------------ | ---------- | -------------------------------------- | --------------------------------------------------------------------- |
+| `fieldValue` | Sync       | `fieldPath`, `operator`, `value`       | Compare a specific field's value                                      |
+| `formValue`  | Sync       | `operator`, `value`                    | Compare entire form object                                            |
+| `javascript` | Sync       | `expression`                           | Custom JS with `fieldValue`/`formValue`/`fieldState`/`formFieldState` |
+| `custom`     | Sync       | `functionName` \| `fn` (XOR)           | Registered or inline custom function                                  |
+| `and`/`or`   | Sync       | `conditions`                           | Combine multiple conditions                                           |
+| `http`       | Async      | `http`, `responseExpression`           | Server-driven condition via HTTP request                              |
+| `async`      | Async      | `asyncFunctionName` \| `asyncFn` (XOR) | Registered or inline async function                                   |
 
 ## Common Patterns
 

--- a/apps/docs/public/content/dynamic-behavior/conditional-logic.md
+++ b/apps/docs/public/content/dynamic-behavior/conditional-logic.md
@@ -385,6 +385,29 @@ Advanced custom expressions with access to both field and form values.
 }
 ```
 
+#### Function-based forms (registered vs inline)
+
+For logic that doesn't fit cleanly into an expression — Angular service calls, complex predicates, closures over TS enums/constants — use the function form. Two mutually exclusive variants:
+
+- **Registered (`functionName`)** — JSON-serializable; references a function in `customFnConfig.customFunctions`. Use for configs loaded from APIs, OpenAPI, or databases.
+- **Inline (`fn`)** — code-only, type-safe; the function reference is captured directly with no registry indirection. NOT JSON-serializable.
+
+```typescript
+// Registered — config can travel over the wire
+{
+  type: 'custom',
+  functionName: 'isAdmin',
+}
+
+// Inline — code-only, no registration needed
+{
+  type: 'custom',
+  fn: (ctx) => ctx.formValue.role === 'admin',
+}
+```
+
+TypeScript rejects setting both `fn` and `functionName` at compile time (`?: never` XOR). If a JSON-loaded config sneaks both through at runtime, the library logs a warning once and the inline `fn` wins.
+
 ### Field State in Expressions
 
 `javascript` and `custom` expressions have access to two additional variables for querying field interaction state:
@@ -627,6 +650,8 @@ import { inject } from '@angular/core';
   pendingValue: false,
 }
 ```
+
+**See also:** the same XOR pattern applies to [sync](/dynamic-behavior/derivation/values#inline-alternative-fn) and [async derivations](/dynamic-behavior/derivation/async#inline-alternative-asyncfn), and to [validators](/validation/custom-validators#inline-functions-vs-registered-names). See [Configuration](/configuration) for `customFnConfig` setup.
 
 **Choosing `pendingValue`:**
 

--- a/apps/docs/public/content/dynamic-behavior/derivation/async.md
+++ b/apps/docs/public/content/dynamic-behavior/derivation/async.md
@@ -259,8 +259,45 @@ The async function is only called when `enableLookup === true`.
 
 `source: 'asyncFunction'` requires:
 
-- **`asyncFunctionName: string`** — Name of the function registered in `customFnConfig.asyncDerivations`.
+- **One of `asyncFunctionName: string` or `asyncFn: AsyncDerivationFunction`** — see [Inline alternative](#inline-alternative-asyncfn) below. The two are mutually exclusive.
 - **`dependsOn: string[]`** — Explicit field dependencies. Without this, the function would re-run on every form change.
+
+### Inline alternative (`asyncFn`)
+
+When you don't need JSON-serializability, set `asyncFn` directly instead of registering the function in `customFnConfig.asyncDerivations`:
+
+```typescript
+import type { AsyncDerivationFunction, FormConfig } from '@ng-forge/dynamic-forms';
+import { inject } from '@angular/core';
+import { map } from 'rxjs';
+
+const lookupCity: AsyncDerivationFunction = (context) =>
+  inject(AddressService)
+    .lookup(context.formValue.zipCode as string)
+    .pipe(map((r) => r.city));
+
+const formConfig = {
+  fields: [
+    {
+      key: 'city',
+      type: 'input',
+      readonly: true,
+      logic: [
+        {
+          type: 'derivation',
+          source: 'asyncFunction',
+          asyncFn: lookupCity,
+          dependsOn: ['zipCode'],
+        },
+      ],
+    },
+  ],
+} as const satisfies FormConfig;
+```
+
+Inject Angular services inside `asyncFn` the same way you would inside a registered function — both run in the form's injection context.
+
+Use `asyncFunctionName` for configs loaded over the wire (APIs, OpenAPI, MCP); use `asyncFn` for code-only configs. TypeScript rejects setting both keys, and the runtime warns + prefers `asyncFn` if a JSON config sneaks both through.
 
 ## Stop On User Override
 

--- a/apps/docs/public/content/dynamic-behavior/derivation/async.md
+++ b/apps/docs/public/content/dynamic-behavior/derivation/async.md
@@ -299,6 +299,8 @@ Inject Angular services inside `asyncFn` the same way you would inside a registe
 
 Use `asyncFunctionName` for configs loaded over the wire (APIs, OpenAPI, MCP); use `asyncFn` for code-only configs. TypeScript rejects setting both keys, and the runtime warns + prefers `asyncFn` if a JSON config sneaks both through.
 
+**See also:** the same XOR pattern applies to [sync derivations (`fn`)](/dynamic-behavior/derivation/values#inline-alternative-fn), [conditions (`fn` / `asyncFn`)](/dynamic-behavior/conditional-logic#function-based-forms-registered-vs-inline), and [validators](/validation/custom-validators#inline-functions-vs-registered-names).
+
 ## Stop On User Override
 
 `stopOnUserOverride` turns a derivation into a "smart default" — the field is auto-filled initially, but derivation stops once the user manually edits it.

--- a/apps/docs/public/content/dynamic-behavior/derivation/async.md
+++ b/apps/docs/public/content/dynamic-behavior/derivation/async.md
@@ -415,7 +415,13 @@ When the user changes the country, the phone prefix is auto-filled again — ove
   type: 'derivation';
   source: 'asyncFunction'; // Required — identifies async function mode
 
-  asyncFunctionName: string; // Required — name in customFnConfig.asyncDerivations
+  // Required — one of:
+  //   • asyncFunctionName: string — name in customFnConfig.asyncDerivations (JSON-safe)
+  //   • asyncFn: AsyncDerivationFunction — inline async function (code-only)
+  // The two are mutually exclusive (XOR) at the type level.
+  asyncFunctionName?: string;
+  asyncFn?: AsyncDerivationFunction;
+
   dependsOn: string[];       // Required — explicit field dependencies
 
   // Shared optional fields

--- a/apps/docs/public/content/dynamic-behavior/derivation/values.md
+++ b/apps/docs/public/content/dynamic-behavior/derivation/values.md
@@ -469,8 +469,11 @@ interface DerivationLogicConfig {
   /** JavaScript expression (has access to formValue) */
   expression?: string;
 
-  /** Name of registered custom function */
+  /** Name of registered custom function. Mutually exclusive with `fn`. */
   functionName?: string;
+
+  /** Inline custom function (code-only). Mutually exclusive with `functionName`. */
+  fn?: CustomFunction;
 
   /** Explicit field dependencies */
   dependsOn?: string[];

--- a/apps/docs/public/content/dynamic-behavior/derivation/values.md
+++ b/apps/docs/public/content/dynamic-behavior/derivation/values.md
@@ -107,6 +107,35 @@ fields: [
 ],
 ```
 
+#### Inline alternative (`fn`)
+
+For code-only configs you can attach the function directly via `fn` and skip the `customFnConfig.derivations` registration. `fn` is mutually exclusive with `functionName` — TypeScript rejects setting both, and the runtime logs a warning + prefers `fn` if a JSON config sets both keys.
+
+```typescript
+import type { CustomFunction } from '@ng-forge/dynamic-forms';
+
+const calculateTax: CustomFunction = (ctx) => ctx.formValue.subtotal * getTaxRate(ctx.formValue.state);
+
+const config = {
+  fields: [
+    {
+      key: 'tax',
+      type: 'input',
+      readonly: true,
+      logic: [
+        {
+          type: 'derivation',
+          fn: calculateTax,
+          dependsOn: ['subtotal', 'state'],
+        },
+      ],
+    },
+  ],
+};
+```
+
+Use `functionName` when the config must survive JSON serialization (APIs, OpenAPI, databases, MCP). Use `fn` for code-only authoring where you'd rather not maintain a separate registry.
+
 ## Trigger Timing
 
 Control when derivations evaluate:

--- a/apps/docs/public/content/dynamic-behavior/derivation/values.md
+++ b/apps/docs/public/content/dynamic-behavior/derivation/values.md
@@ -114,6 +114,8 @@ For code-only configs you can attach the function directly via `fn` and skip the
 ```typescript
 import type { CustomFunction } from '@ng-forge/dynamic-forms';
 
+// getTaxRate is a TS helper from your codebase — the inline fn closes over
+// it directly, no need to register or serialize it.
 const calculateTax: CustomFunction = (ctx) => ctx.formValue.subtotal * getTaxRate(ctx.formValue.state);
 
 const config = {
@@ -126,7 +128,7 @@ const config = {
         {
           type: 'derivation',
           fn: calculateTax,
-          dependsOn: ['subtotal', 'state'],
+          dependsOn: ['subtotal', 'state'], // see "Default dependencies" below
         },
       ],
     },
@@ -134,7 +136,11 @@ const config = {
 };
 ```
 
-Use `functionName` when the config must survive JSON serialization (APIs, OpenAPI, databases, MCP). Use `fn` for code-only authoring where you'd rather not maintain a separate registry.
+**Default dependencies for function derivations:** if you omit `dependsOn`, both `functionName` and `fn` derivations default to a wildcard (`'*'`), meaning the derivation re-runs on every form change. In development, the library logs a one-time `Derivation: custom functions without explicit dependsOn detected` warning so you can narrow it down. Specify `dependsOn` whenever you know the exact inputs to avoid this.
+
+Use `functionName` when the config must survive JSON serialization (APIs, OpenAPI, databases, MCP). Use `fn` for code-only authoring where you'd rather not maintain a separate registry — especially when the function closes over TS enums, constants, or class-scoped helpers that don't round-trip through a string registry.
+
+**See also:** the same XOR pattern applies to [async derivations (`asyncFn`)](/dynamic-behavior/derivation/async#inline-alternative-asyncfn), [conditions (`fn` / `asyncFn`)](/dynamic-behavior/conditional-logic#function-based-forms-registered-vs-inline), and [validators](/validation/custom-validators#inline-functions-vs-registered-names). See [Configuration](/configuration) for setting up `customFnConfig`.
 
 ## Trigger Timing
 

--- a/apps/docs/public/content/validation/custom-validators.md
+++ b/apps/docs/public/content/validation/custom-validators.md
@@ -52,6 +52,13 @@ ng-forge supports two patterns for custom validators:
 1. **Function-based** - Register reusable validator functions (best for complex logic, reusability)
 2. **Expression-based** - Inline JavaScript expressions (best for simple, one-off validations)
 
+Function-based validators have two interchangeable authoring forms:
+
+- **Registered (`functionName`)** — JSON-serializable; safe to ship in configs loaded from APIs, OpenAPI, or databases.
+- **Inline (`fn`)** — code-only, type-safe; skips the registry round-trip but cannot survive JSON serialization. `fn` and `functionName` are mutually exclusive — TypeScript rejects setting both, and at runtime an explicit warning is logged before the inline form wins.
+
+The same `fn` / `asyncFn` alternative is available on conditions and derivations — see [Inline functions vs registered names](#inline-functions-vs-registered-names) below.
+
 ## Expression-Based Validators
 
 For simple validation logic, use inline JavaScript expressions without registering functions.
@@ -205,6 +212,33 @@ const config = {
   },
 };
 ```
+
+### Inline Alternative (`fn`)
+
+For code-only projects, you can skip the registry round-trip and pass the validator directly:
+
+```typescript
+import { CustomValidator } from '@ng-forge/dynamic-forms';
+
+const noSpaces: CustomValidator = (ctx) => {
+  const value = ctx.value();
+  return typeof value === 'string' && value.includes(' ') ? { kind: 'noSpaces' } : null;
+};
+
+const config = {
+  fields: [
+    {
+      key: 'username',
+      type: 'input',
+      // No customFnConfig.validators entry required — the function lives on the validator config.
+      validators: [{ type: 'custom', fn: noSpaces }],
+      validationMessages: { noSpaces: 'Spaces are not allowed' },
+    },
+  ],
+};
+```
+
+`fn` and `functionName` are mutually exclusive (XOR at the type level). The inline form is **not** JSON-serializable — for configs loaded from APIs, OpenAPI, or databases, stick to `functionName`.
 
 ### FieldContext API
 
@@ -838,6 +872,26 @@ const checkDomain: HttpCustomValidator<string, { valid: boolean }> = {
 6. **Message Priority**: Use field-level messages for customization, form-level for common errors
 7. **Conditional Validation**: Use `when` property with `ConditionalExpression` for dynamic validators
 8. **Inverted Logic**: HTTP validators check validity, not data fetching success
+
+## Inline functions vs registered names
+
+Every validator/condition/derivation surface that accepts a `functionName` (or `asyncFunctionName`) also accepts an inline `fn` (or `asyncFn`):
+
+| Surface                       | Registered (JSON-safe)                                               | Inline (code-only)                                         |
+| ----------------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Sync custom validator         | `{ type: 'custom', functionName }`                                   | `{ type: 'custom', fn }`                                   |
+| Async validator               | `{ type: 'async', functionName }`                                    | `{ type: 'async', fn }`                                    |
+| Function-based HTTP validator | `{ type: 'http', functionName }`                                     | `{ type: 'http', fn }`                                     |
+| Custom condition              | `{ type: 'custom', functionName }`                                   | `{ type: 'custom', fn }`                                   |
+| Async condition               | `{ type: 'async', asyncFunctionName }`                               | `{ type: 'async', asyncFn }`                               |
+| Function derivation           | `{ type: 'derivation', functionName }`                               | `{ type: 'derivation', fn }`                               |
+| Async function derivation     | `{ type: 'derivation', source: 'asyncFunction', asyncFunctionName }` | `{ type: 'derivation', source: 'asyncFunction', asyncFn }` |
+
+Rules of thumb:
+
+- Use **`functionName` / `asyncFunctionName`** for configs that travel over the wire — API responses, OpenAPI schemas, JSON files, database rows. The MCP server only emits the registered form.
+- Use **`fn` / `asyncFn`** for code-only configs in TypeScript when you don't need JSON serializability. The function reference is captured directly, with no registry indirection.
+- The two are **mutually exclusive**. TypeScript rejects setting both at compile time; if a JSON-loaded config sneaks both keys through at runtime, a warning is logged and the inline form wins.
 
 ## Related Documentation
 

--- a/apps/docs/public/content/validation/custom-validators.md
+++ b/apps/docs/public/content/validation/custom-validators.md
@@ -182,7 +182,7 @@ Best for validation that needs field value and access to other fields via FieldC
 ### Basic Example
 
 ```typescript
-import { CustomValidator } from '@ng-forge/dynamic-forms';
+import type { CustomValidator } from '@ng-forge/dynamic-forms';
 
 // ✅ RECOMMENDED: Return only kind
 const noSpaces: CustomValidator = (ctx) => {
@@ -239,6 +239,8 @@ const config = {
 ```
 
 `fn` and `functionName` are mutually exclusive (XOR at the type level). The inline form is **not** JSON-serializable — for configs loaded from APIs, OpenAPI, or databases, stick to `functionName`.
+
+**See also:** the same XOR pattern applies to [conditions](/dynamic-behavior/conditional-logic#function-based-forms-registered-vs-inline) and [derivations](/dynamic-behavior/derivation/values#inline-alternative-fn). See [Configuration](/configuration) for `customFnConfig` setup and [AI Integration (MCP)](/ai-integration) for the MCP server, which emits configs using `functionName` exclusively.
 
 ### FieldContext API
 
@@ -586,6 +588,37 @@ const config = {
 - Optimized for HTTP-specific validation
 
 **Important:** HTTP validators use "inverted logic" - `onSuccess` should return an error if validation fails, not if the HTTP request succeeds. You're checking validation status, not fetching data.
+
+### Inline Alternative (`fn`)
+
+For code-only projects, skip the `customFnConfig.httpValidators` registration and attach the validator inline. `FunctionHttpValidatorConfig.fn` is XOR with `functionName` — TypeScript rejects both keys at compile time, and the runtime warns + prefers inline if a JSON-loaded config sets them both.
+
+```typescript
+import type { HttpCustomValidator } from '@ng-forge/dynamic-forms';
+
+const checkEmailDomain: HttpCustomValidator = {
+  request: (ctx) => {
+    const email = ctx.value();
+    if (!email?.includes('@')) return undefined;
+    return { url: `/api/validate-domain`, method: 'POST', body: { domain: email.split('@')[1] } };
+  },
+  onSuccess: (response) => (response.valid ? null : { kind: 'invalidDomain' }),
+};
+
+const config = {
+  fields: [
+    {
+      key: 'email',
+      type: 'input',
+      // No customFnConfig.httpValidators entry required — the validator lives on the validator config.
+      validators: [{ type: 'http', fn: checkEmailDomain }],
+      validationMessages: { invalidDomain: 'This email domain is not allowed' },
+    },
+  ],
+};
+```
+
+Use `functionName` for configs loaded from JSON/APIs/OpenAPI; use `fn` for TS-authored configs where you'd rather not maintain a separate registry.
 
 ### Structure
 

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -1629,12 +1629,30 @@ const formConfig = {
 
 **Async condition properties:**
 
-| Property            | Type      | Required | Default | Description                                         |
-| ------------------- | --------- | -------- | ------- | --------------------------------------------------- |
-| `type`              | `'async'` | Yes      | —       | Identifies this as an async condition               |
-| `asyncFunctionName` | `string`  | Yes      | —       | Name registered in `customFnConfig.asyncConditions` |
-| `pendingValue`      | `boolean` | No       | `false` | Value returned while the function is resolving      |
-| `debounceMs`        | `number`  | No       | `300`   | Debounce delay before re-evaluating (ms)            |
+| Property            | Type                     | Required | Default | Description                                               |
+| ------------------- | ------------------------ | -------- | ------- | --------------------------------------------------------- |
+| `type`              | `'async'`                | Yes      | —       | Identifies this as an async condition                     |
+| `asyncFunctionName` | `string`                 | XOR\*    | —       | Name registered in `customFnConfig.asyncConditions`       |
+| `asyncFn`           | `AsyncConditionFunction` | XOR\*    | —       | Inline async function (code-only — not JSON-serializable) |
+| `pendingValue`      | `boolean`                | No       | `false` | Value returned while the function is resolving            |
+| `debounceMs`        | `number`                 | No       | `300`   | Debounce delay before re-evaluating (ms)                  |
+
+\* Exactly one of `asyncFunctionName` or `asyncFn` must be set. The two are mutually exclusive at the type level; if both keys appear at runtime (e.g. a JSON config that hand-edited both in), the library logs a warning and the inline `asyncFn` wins.
+
+**Inline `asyncFn` example (code-only):**
+
+```typescript
+import { inject } from '@angular/core';
+
+{
+  type: 'async',
+  asyncFn: async (context) => {
+    // Same Angular DI context as registered functions — `inject()` works here.
+    return inject(PermissionsService).canEdit(context.formValue.resourceId as string);
+  },
+  pendingValue: false,
+}
+```
 
 **Choosing `pendingValue`:**
 
@@ -2118,25 +2136,33 @@ interface HttpCondition {
   debounceMs?: number; // Default: 300
 }
 
-interface AsyncCondition {
-  type: 'async';
-  asyncFunctionName: string;
-  pendingValue?: boolean; // Default: false
-  debounceMs?: number; // Default: 300
-}
+// AsyncCondition is a discriminated XOR — exactly one of asyncFunctionName / asyncFn must be set.
+type AsyncCondition =
+  | {
+      type: 'async';
+      asyncFunctionName: string;
+      pendingValue?: boolean; // Default: false
+      debounceMs?: number; // Default: 300
+    }
+  | {
+      type: 'async';
+      asyncFn: AsyncConditionFunction; // Inline (code-only, not JSON-serializable)
+      pendingValue?: boolean;
+      debounceMs?: number;
+    };
 ```
 
 **Expression types summary:**
 
-| Type         | Sync/Async | Key properties                   | Purpose                                                               |
-| ------------ | ---------- | -------------------------------- | --------------------------------------------------------------------- |
-| `fieldValue` | Sync       | `fieldPath`, `operator`, `value` | Compare a specific field's value                                      |
-| `formValue`  | Sync       | `operator`, `value`              | Compare entire form object                                            |
-| `javascript` | Sync       | `expression`                     | Custom JS with `fieldValue`/`formValue`/`fieldState`/`formFieldState` |
-| `custom`     | Sync       | `expression`                     | Inline expression with `fieldValue`/`formValue` (safe member access)  |
-| `and`/`or`   | Sync       | `conditions`                     | Combine multiple conditions                                           |
-| `http`       | Async      | `http`, `responseExpression`     | Server-driven condition via HTTP request                              |
-| `async`      | Async      | `asyncFunctionName`              | Custom async function registered in config                            |
+| Type         | Sync/Async | Key properties                         | Purpose                                                               |
+| ------------ | ---------- | -------------------------------------- | --------------------------------------------------------------------- |
+| `fieldValue` | Sync       | `fieldPath`, `operator`, `value`       | Compare a specific field's value                                      |
+| `formValue`  | Sync       | `operator`, `value`                    | Compare entire form object                                            |
+| `javascript` | Sync       | `expression`                           | Custom JS with `fieldValue`/`formValue`/`fieldState`/`formFieldState` |
+| `custom`     | Sync       | `functionName` \| `fn` (XOR)           | Registered or inline custom function                                  |
+| `and`/`or`   | Sync       | `conditions`                           | Combine multiple conditions                                           |
+| `http`       | Async      | `http`, `responseExpression`           | Server-driven condition via HTTP request                              |
+| `async`      | Async      | `asyncFunctionName` \| `asyncFn` (XOR) | Registered or inline async function                                   |
 
 ## Common Patterns
 
@@ -2510,8 +2536,45 @@ The async function is only called when `enableLookup === true`.
 
 `source: 'asyncFunction'` requires:
 
-- **`asyncFunctionName: string`** — Name of the function registered in `customFnConfig.asyncDerivations`.
+- **One of `asyncFunctionName: string` or `asyncFn: AsyncDerivationFunction`** — see [Inline alternative](#inline-alternative-asyncfn) below. The two are mutually exclusive.
 - **`dependsOn: string[]`** — Explicit field dependencies. Without this, the function would re-run on every form change.
+
+### Inline alternative (`asyncFn`)
+
+When you don't need JSON-serializability, set `asyncFn` directly instead of registering the function in `customFnConfig.asyncDerivations`:
+
+```typescript
+import type { AsyncDerivationFunction, FormConfig } from '@ng-forge/dynamic-forms';
+import { inject } from '@angular/core';
+import { map } from 'rxjs';
+
+const lookupCity: AsyncDerivationFunction = (context) =>
+  inject(AddressService)
+    .lookup(context.formValue.zipCode as string)
+    .pipe(map((r) => r.city));
+
+const formConfig = {
+  fields: [
+    {
+      key: 'city',
+      type: 'input',
+      readonly: true,
+      logic: [
+        {
+          type: 'derivation',
+          source: 'asyncFunction',
+          asyncFn: lookupCity,
+          dependsOn: ['zipCode'],
+        },
+      ],
+    },
+  ],
+} as const satisfies FormConfig;
+```
+
+Inject Angular services inside `asyncFn` the same way you would inside a registered function — both run in the form's injection context.
+
+Use `asyncFunctionName` for configs loaded over the wire (APIs, OpenAPI, MCP); use `asyncFn` for code-only configs. TypeScript rejects setting both keys, and the runtime warns + prefers `asyncFn` if a JSON config sneaks both through.
 
 ## Stop On User Override
 
@@ -2629,7 +2692,13 @@ When the user changes the country, the phone prefix is auto-filled again — ove
   type: 'derivation';
   source: 'asyncFunction'; // Required — identifies async function mode
 
-  asyncFunctionName: string; // Required — name in customFnConfig.asyncDerivations
+  // Required — one of:
+  //   • asyncFunctionName: string — name in customFnConfig.asyncDerivations (JSON-safe)
+  //   • asyncFn: AsyncDerivationFunction — inline async function (code-only)
+  // The two are mutually exclusive (XOR) at the type level.
+  asyncFunctionName?: string;
+  asyncFn?: AsyncDerivationFunction;
+
   dependsOn: string[];       // Required — explicit field dependencies
 
   // Shared optional fields
@@ -3241,6 +3310,35 @@ fields: [
 ],
 ```
 
+#### Inline alternative (`fn`)
+
+For code-only configs you can attach the function directly via `fn` and skip the `customFnConfig.derivations` registration. `fn` is mutually exclusive with `functionName` — TypeScript rejects setting both, and the runtime logs a warning + prefers `fn` if a JSON config sets both keys.
+
+```typescript
+import type { CustomFunction } from '@ng-forge/dynamic-forms';
+
+const calculateTax: CustomFunction = (ctx) => ctx.formValue.subtotal * getTaxRate(ctx.formValue.state);
+
+const config = {
+  fields: [
+    {
+      key: 'tax',
+      type: 'input',
+      readonly: true,
+      logic: [
+        {
+          type: 'derivation',
+          fn: calculateTax,
+          dependsOn: ['subtotal', 'state'],
+        },
+      ],
+    },
+  ],
+};
+```
+
+Use `functionName` when the config must survive JSON serialization (APIs, OpenAPI, databases, MCP). Use `fn` for code-only authoring where you'd rather not maintain a separate registry.
+
 ## Trigger Timing
 
 Control when derivations evaluate:
@@ -3574,8 +3672,11 @@ interface DerivationLogicConfig {
   /** JavaScript expression (has access to formValue) */
   expression?: string;
 
-  /** Name of registered custom function */
+  /** Name of registered custom function. Mutually exclusive with `fn`. */
   functionName?: string;
+
+  /** Inline custom function (code-only). Mutually exclusive with `functionName`. */
+  fn?: CustomFunction;
 
   /** Explicit field dependencies */
   dependsOn?: string[];
@@ -14229,6 +14330,13 @@ ng-forge supports two patterns for custom validators:
 1. **Function-based** - Register reusable validator functions (best for complex logic, reusability)
 2. **Expression-based** - Inline JavaScript expressions (best for simple, one-off validations)
 
+Function-based validators have two interchangeable authoring forms:
+
+- **Registered (`functionName`)** — JSON-serializable; safe to ship in configs loaded from APIs, OpenAPI, or databases.
+- **Inline (`fn`)** — code-only, type-safe; skips the registry round-trip but cannot survive JSON serialization. `fn` and `functionName` are mutually exclusive — TypeScript rejects setting both, and at runtime an explicit warning is logged before the inline form wins.
+
+The same `fn` / `asyncFn` alternative is available on conditions and derivations — see [Inline functions vs registered names](#inline-functions-vs-registered-names) below.
+
 ## Expression-Based Validators
 
 For simple validation logic, use inline JavaScript expressions without registering functions.
@@ -14382,6 +14490,33 @@ const config = {
   },
 };
 ```
+
+### Inline Alternative (`fn`)
+
+For code-only projects, you can skip the registry round-trip and pass the validator directly:
+
+```typescript
+import { CustomValidator } from '@ng-forge/dynamic-forms';
+
+const noSpaces: CustomValidator = (ctx) => {
+  const value = ctx.value();
+  return typeof value === 'string' && value.includes(' ') ? { kind: 'noSpaces' } : null;
+};
+
+const config = {
+  fields: [
+    {
+      key: 'username',
+      type: 'input',
+      // No customFnConfig.validators entry required — the function lives on the validator config.
+      validators: [{ type: 'custom', fn: noSpaces }],
+      validationMessages: { noSpaces: 'Spaces are not allowed' },
+    },
+  ],
+};
+```
+
+`fn` and `functionName` are mutually exclusive (XOR at the type level). The inline form is **not** JSON-serializable — for configs loaded from APIs, OpenAPI, or databases, stick to `functionName`.
 
 ### FieldContext API
 
@@ -15015,6 +15150,26 @@ const checkDomain: HttpCustomValidator<string, { valid: boolean }> = {
 6. **Message Priority**: Use field-level messages for customization, form-level for common errors
 7. **Conditional Validation**: Use `when` property with `ConditionalExpression` for dynamic validators
 8. **Inverted Logic**: HTTP validators check validity, not data fetching success
+
+## Inline functions vs registered names
+
+Every validator/condition/derivation surface that accepts a `functionName` (or `asyncFunctionName`) also accepts an inline `fn` (or `asyncFn`):
+
+| Surface                       | Registered (JSON-safe)                                               | Inline (code-only)                                         |
+| ----------------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Sync custom validator         | `{ type: 'custom', functionName }`                                   | `{ type: 'custom', fn }`                                   |
+| Async validator               | `{ type: 'async', functionName }`                                    | `{ type: 'async', fn }`                                    |
+| Function-based HTTP validator | `{ type: 'http', functionName }`                                     | `{ type: 'http', fn }`                                     |
+| Custom condition              | `{ type: 'custom', functionName }`                                   | `{ type: 'custom', fn }`                                   |
+| Async condition               | `{ type: 'async', asyncFunctionName }`                               | `{ type: 'async', asyncFn }`                               |
+| Function derivation           | `{ type: 'derivation', functionName }`                               | `{ type: 'derivation', fn }`                               |
+| Async function derivation     | `{ type: 'derivation', source: 'asyncFunction', asyncFunctionName }` | `{ type: 'derivation', source: 'asyncFunction', asyncFn }` |
+
+Rules of thumb:
+
+- Use **`functionName` / `asyncFunctionName`** for configs that travel over the wire — API responses, OpenAPI schemas, JSON files, database rows. The MCP server only emits the registered form.
+- Use **`fn` / `asyncFn`** for code-only configs in TypeScript when you don't need JSON serializability. The function reference is captured directly, with no registry indirection.
+- The two are **mutually exclusive**. TypeScript rejects setting both at compile time; if a JSON-loaded config sneaks both keys through at runtime, a warning is logged and the inline form wins.
 
 ## Related Documentation
 

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -1411,6 +1411,29 @@ Advanced custom expressions with access to both field and form values.
 }
 ```
 
+#### Function-based forms (registered vs inline)
+
+For logic that doesn't fit cleanly into an expression — Angular service calls, complex predicates, closures over TS enums/constants — use the function form. Two mutually exclusive variants:
+
+- **Registered (`functionName`)** — JSON-serializable; references a function in `customFnConfig.customFunctions`. Use for configs loaded from APIs, OpenAPI, or databases.
+- **Inline (`fn`)** — code-only, type-safe; the function reference is captured directly with no registry indirection. NOT JSON-serializable.
+
+```typescript
+// Registered — config can travel over the wire
+{
+  type: 'custom',
+  functionName: 'isAdmin',
+}
+
+// Inline — code-only, no registration needed
+{
+  type: 'custom',
+  fn: (ctx) => ctx.formValue.role === 'admin',
+}
+```
+
+TypeScript rejects setting both `fn` and `functionName` at compile time (`?: never` XOR). If a JSON-loaded config sneaks both through at runtime, the library logs a warning once and the inline `fn` wins.
+
 ### Field State in Expressions
 
 `javascript` and `custom` expressions have access to two additional variables for querying field interaction state:
@@ -1653,6 +1676,8 @@ import { inject } from '@angular/core';
   pendingValue: false,
 }
 ```
+
+**See also:** the same XOR pattern applies to [sync](/dynamic-behavior/derivation/values#inline-alternative-fn) and [async derivations](/dynamic-behavior/derivation/async#inline-alternative-asyncfn), and to [validators](/validation/custom-validators#inline-functions-vs-registered-names). See [Configuration](/configuration) for `customFnConfig` setup.
 
 **Choosing `pendingValue`:**
 
@@ -2576,6 +2601,8 @@ Inject Angular services inside `asyncFn` the same way you would inside a registe
 
 Use `asyncFunctionName` for configs loaded over the wire (APIs, OpenAPI, MCP); use `asyncFn` for code-only configs. TypeScript rejects setting both keys, and the runtime warns + prefers `asyncFn` if a JSON config sneaks both through.
 
+**See also:** the same XOR pattern applies to [sync derivations (`fn`)](/dynamic-behavior/derivation/values#inline-alternative-fn), [conditions (`fn` / `asyncFn`)](/dynamic-behavior/conditional-logic#function-based-forms-registered-vs-inline), and [validators](/validation/custom-validators#inline-functions-vs-registered-names).
+
 ## Stop On User Override
 
 `stopOnUserOverride` turns a derivation into a "smart default" — the field is auto-filled initially, but derivation stops once the user manually edits it.
@@ -3317,6 +3344,8 @@ For code-only configs you can attach the function directly via `fn` and skip the
 ```typescript
 import type { CustomFunction } from '@ng-forge/dynamic-forms';
 
+// getTaxRate is a TS helper from your codebase — the inline fn closes over
+// it directly, no need to register or serialize it.
 const calculateTax: CustomFunction = (ctx) => ctx.formValue.subtotal * getTaxRate(ctx.formValue.state);
 
 const config = {
@@ -3329,7 +3358,7 @@ const config = {
         {
           type: 'derivation',
           fn: calculateTax,
-          dependsOn: ['subtotal', 'state'],
+          dependsOn: ['subtotal', 'state'], // see "Default dependencies" below
         },
       ],
     },
@@ -3337,7 +3366,11 @@ const config = {
 };
 ```
 
-Use `functionName` when the config must survive JSON serialization (APIs, OpenAPI, databases, MCP). Use `fn` for code-only authoring where you'd rather not maintain a separate registry.
+**Default dependencies for function derivations:** if you omit `dependsOn`, both `functionName` and `fn` derivations default to a wildcard (`'*'`), meaning the derivation re-runs on every form change. In development, the library logs a one-time `Derivation: custom functions without explicit dependsOn detected` warning so you can narrow it down. Specify `dependsOn` whenever you know the exact inputs to avoid this.
+
+Use `functionName` when the config must survive JSON serialization (APIs, OpenAPI, databases, MCP). Use `fn` for code-only authoring where you'd rather not maintain a separate registry — especially when the function closes over TS enums, constants, or class-scoped helpers that don't round-trip through a string registry.
+
+**See also:** the same XOR pattern applies to [async derivations (`asyncFn`)](/dynamic-behavior/derivation/async#inline-alternative-asyncfn), [conditions (`fn` / `asyncFn`)](/dynamic-behavior/conditional-logic#function-based-forms-registered-vs-inline), and [validators](/validation/custom-validators#inline-functions-vs-registered-names). See [Configuration](/configuration) for setting up `customFnConfig`.
 
 ## Trigger Timing
 
@@ -14460,7 +14493,7 @@ Best for validation that needs field value and access to other fields via FieldC
 ### Basic Example
 
 ```typescript
-import { CustomValidator } from '@ng-forge/dynamic-forms';
+import type { CustomValidator } from '@ng-forge/dynamic-forms';
 
 // ✅ RECOMMENDED: Return only kind
 const noSpaces: CustomValidator = (ctx) => {
@@ -14517,6 +14550,8 @@ const config = {
 ```
 
 `fn` and `functionName` are mutually exclusive (XOR at the type level). The inline form is **not** JSON-serializable — for configs loaded from APIs, OpenAPI, or databases, stick to `functionName`.
+
+**See also:** the same XOR pattern applies to [conditions](/dynamic-behavior/conditional-logic#function-based-forms-registered-vs-inline) and [derivations](/dynamic-behavior/derivation/values#inline-alternative-fn). See [Configuration](/configuration) for `customFnConfig` setup and [AI Integration (MCP)](/ai-integration) for the MCP server, which emits configs using `functionName` exclusively.
 
 ### FieldContext API
 
@@ -14864,6 +14899,37 @@ const config = {
 - Optimized for HTTP-specific validation
 
 **Important:** HTTP validators use "inverted logic" - `onSuccess` should return an error if validation fails, not if the HTTP request succeeds. You're checking validation status, not fetching data.
+
+### Inline Alternative (`fn`)
+
+For code-only projects, skip the `customFnConfig.httpValidators` registration and attach the validator inline. `FunctionHttpValidatorConfig.fn` is XOR with `functionName` — TypeScript rejects both keys at compile time, and the runtime warns + prefers inline if a JSON-loaded config sets them both.
+
+```typescript
+import type { HttpCustomValidator } from '@ng-forge/dynamic-forms';
+
+const checkEmailDomain: HttpCustomValidator = {
+  request: (ctx) => {
+    const email = ctx.value();
+    if (!email?.includes('@')) return undefined;
+    return { url: `/api/validate-domain`, method: 'POST', body: { domain: email.split('@')[1] } };
+  },
+  onSuccess: (response) => (response.valid ? null : { kind: 'invalidDomain' }),
+};
+
+const config = {
+  fields: [
+    {
+      key: 'email',
+      type: 'input',
+      // No customFnConfig.httpValidators entry required — the validator lives on the validator config.
+      validators: [{ type: 'http', fn: checkEmailDomain }],
+      validationMessages: { invalidDomain: 'This email domain is not allowed' },
+    },
+  ],
+};
+```
+
+Use `functionName` for configs loaded from JSON/APIs/OpenAPI; use `fn` for TS-authored configs where you'd rather not maintain a separate registry.
 
 ### Structure
 

--- a/packages/dynamic-form-mcp/src/registry/instructions.ts
+++ b/packages/dynamic-form-mcp/src/registry/instructions.ts
@@ -305,6 +305,8 @@ Invokes a registered custom function by name:
 
 Register functions via \`customFnConfig.customFunctions\`.
 
+> **TypeScript-authored configs:** the same surface also accepts an inline \`fn: CustomFunction\` instead of \`functionName\` (XOR with \`functionName\`, code-only — not JSON-serializable). The MCP server emits \`functionName\` exclusively; consumers writing configs in TS may prefer \`fn\` when they don't need JSON round-tripping. Same caveat applies to async conditions (\`asyncFn\`), function derivations (\`fn\`), async function derivations (\`asyncFn\`), and validators (\`fn\`).
+
 #### Async Custom Condition
 
 Invokes a registered async function that returns \`Promise<boolean>\` or \`Observable<boolean>\`:

--- a/packages/dynamic-form-mcp/src/registry/validators.ts
+++ b/packages/dynamic-form-mcp/src/registry/validators.ts
@@ -103,7 +103,7 @@ export const VALIDATORS: ValidatorInfo[] = [
     type: 'custom',
     category: 'custom',
     description:
-      "Custom synchronous validator using registered function or expression. IMPORTANT: The validator returns { kind: 'errorKind' } on failure. The actual error MESSAGE is defined in 'validationMessages' at the FIELD level, NOT in the validator config.",
+      "Custom synchronous validator using registered function or expression. IMPORTANT: The validator returns { kind: 'errorKind' } on failure. The actual error MESSAGE is defined in 'validationMessages' at the FIELD level, NOT in the validator config. NOTE: TypeScript-authored configs may also use an inline `fn: CustomValidator` instead of `functionName` (XOR with `functionName`, code-only — not JSON-serializable); MCP-generated configs should use `functionName`.",
     parameters: {
       functionName: {
         name: 'functionName',
@@ -156,7 +156,7 @@ export const VALIDATORS: ValidatorInfo[] = [
     type: 'async',
     category: 'async',
     description:
-      'Async validator using registered async function (resource-based). Register the function via customFnConfig.asyncValidators.',
+      'Async validator using registered async function (resource-based). Register the function via customFnConfig.asyncValidators. NOTE: TypeScript-authored configs may also use an inline `fn: AsyncCustomValidator` instead of `functionName` (XOR with `functionName`, code-only — not JSON-serializable); MCP-generated configs should use `functionName`.',
     parameters: {
       functionName: {
         name: 'functionName',
@@ -180,7 +180,7 @@ export const VALIDATORS: ValidatorInfo[] = [
     type: 'http',
     category: 'http',
     description:
-      'HTTP validator — supports two modes: (1) Declarative (fully JSON-serializable, no function registration) using http + responseMapping properties, or (2) Function-based using functionName to reference a registered HTTP validator function. Query param values and (optionally) body values are expressions evaluated against the form context. Response mapping uses validWhen (truthy = valid) and errorKind (maps to field-level validationMessages).',
+      'HTTP validator — supports two modes: (1) Declarative (fully JSON-serializable, no function registration) using http + responseMapping properties, or (2) Function-based using functionName to reference a registered HTTP validator function. Query param values and (optionally) body values are expressions evaluated against the form context. Response mapping uses validWhen (truthy = valid) and errorKind (maps to field-level validationMessages). NOTE: TypeScript-authored configs may also use an inline `fn: HttpCustomValidator` instead of `functionName` (XOR with `functionName`, code-only — not JSON-serializable); MCP-generated configs should use `functionName` or declarative mode.',
     parameters: {
       functionName: {
         name: 'functionName',

--- a/packages/dynamic-forms/src/lib/core/derivation/async-derivation-stream.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/async-derivation-stream.spec.ts
@@ -65,11 +65,13 @@ describe('createAsyncDerivationStream', () => {
   }
 
   function createAsyncEntry(fieldKey: string, options: Partial<DerivationEntry> = {}): DerivationEntry {
+    const useInline = options.asyncFn !== undefined;
     return {
       fieldKey,
       dependsOn: options.dependsOn ?? ['productId'],
       condition: options.condition ?? true,
-      asyncFunctionName: options.asyncFunctionName ?? 'fetchValue',
+      asyncFunctionName: options.asyncFunctionName ?? (useInline ? undefined : 'fetchValue'),
+      asyncFn: options.asyncFn,
       trigger: options.trigger ?? 'onChange',
       isShorthand: options.isShorthand ?? false,
       stopOnUserOverride: options.stopOnUserOverride,
@@ -465,6 +467,92 @@ describe('createAsyncDerivationStream', () => {
 
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('array field'));
       expect(emissions).toHaveLength(0);
+    });
+  });
+
+  describe('inline asyncFn alternative', () => {
+    it('calls and applies an inline asyncFn returning Observable', () => {
+      const { form, values } = createMockForm({ productId: 'abc', price: 0 });
+      const formValueSignal = signal<Record<string, unknown>>({ productId: 'abc', price: 0 });
+
+      const inlineFn = vi.fn().mockReturnValue(of(123));
+
+      const entry = createAsyncEntry('price', {
+        dependsOn: ['productId'],
+        asyncFn: inlineFn,
+      });
+
+      // No registration on context — relies solely on inline fn.
+      const context = createContext(form, formValueSignal, {
+        asyncDerivationFunctions: () => ({}),
+      });
+      const stream$ = createAsyncDerivationStream(entry, formValue$, context);
+      stream$.subscribe();
+
+      formValue$.next({ productId: 'abc', price: 0 });
+      formValue$.next({ productId: 'xyz', price: 0 });
+      vi.advanceTimersByTime(300);
+
+      expect(inlineFn).toHaveBeenCalledTimes(1);
+      expect(values.price).toBe(123);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('calls and applies an inline asyncFn returning a Promise', async () => {
+      const { form, values } = createMockForm({ productId: 'abc', price: 0 });
+      const formValueSignal = signal<Record<string, unknown>>({ productId: 'abc', price: 0 });
+
+      const inlineFn = vi.fn(async () => 77);
+
+      const entry = createAsyncEntry('price', {
+        dependsOn: ['productId'],
+        asyncFn: inlineFn,
+      });
+
+      const context = createContext(form, formValueSignal, {
+        asyncDerivationFunctions: () => ({}),
+      });
+      const stream$ = createAsyncDerivationStream(entry, formValue$, context);
+      stream$.subscribe();
+
+      formValue$.next({ productId: 'abc', price: 0 });
+      formValue$.next({ productId: 'xyz', price: 0 });
+      vi.advanceTimersByTime(300);
+
+      // Let the microtask flush the Promise resolution
+      await vi.runAllTimersAsync();
+
+      expect(inlineFn).toHaveBeenCalledTimes(1);
+      expect(values.price).toBe(77);
+    });
+
+    it('inline asyncFn wins and warns when both forms are set', () => {
+      const { form, values } = createMockForm({ productId: 'abc', price: 0 });
+      const formValueSignal = signal<Record<string, unknown>>({ productId: 'abc', price: 0 });
+
+      const inline = vi.fn().mockReturnValue(of(111));
+      const registered = vi.fn().mockReturnValue(of(222));
+
+      const entry = createAsyncEntry('price', {
+        dependsOn: ['productId'],
+        asyncFunctionName: 'registered',
+        asyncFn: inline,
+      });
+
+      const context = createContext(form, formValueSignal, {
+        asyncDerivationFunctions: () => ({ registered }),
+      });
+      const stream$ = createAsyncDerivationStream(entry, formValue$, context);
+      stream$.subscribe();
+
+      formValue$.next({ productId: 'abc', price: 0 });
+      formValue$.next({ productId: 'xyz', price: 0 });
+      vi.advanceTimersByTime(300);
+
+      expect(values.price).toBe(111);
+      expect(inline).toHaveBeenCalled();
+      expect(registered).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Both "asyncFn" and "asyncFunctionName" are set'));
     });
   });
 });

--- a/packages/dynamic-forms/src/lib/core/derivation/async-derivation-stream.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/async-derivation-stream.ts
@@ -80,10 +80,18 @@ export function createAsyncDerivationStream(
     return EMPTY;
   }
 
-  if (!entry.asyncFunctionName) {
+  if (!entry.asyncFunctionName && !entry.asyncFn) {
     return EMPTY;
   }
 
+  if (entry.asyncFn && entry.asyncFunctionName) {
+    context.logger.warn(
+      `${LOG_PREFIX} Both "asyncFn" and "asyncFunctionName" are set on derivation for '${entry.fieldKey}'. ` +
+        `Inline "asyncFn" takes precedence; "asyncFunctionName" is ignored.`,
+    );
+  }
+
+  const inlineAsyncFn = entry.asyncFn;
   const asyncFunctionName = entry.asyncFunctionName;
   const debounceMs = entry.debounceMs ?? DEFAULT_ASYNC_DEBOUNCE_MS;
 
@@ -136,8 +144,8 @@ export function createAsyncDerivationStream(
         const asyncDerivationFunctions = context.asyncDerivationFunctions?.();
         const externalData = context.externalData?.();
 
-        // Look up the async function
-        const asyncFn = asyncDerivationFunctions?.[asyncFunctionName];
+        // Inline `asyncFn` wins; otherwise look up the registered function.
+        const asyncFn = inlineAsyncFn ?? (asyncFunctionName ? asyncDerivationFunctions?.[asyncFunctionName] : undefined);
         if (!asyncFn) {
           context.logger.warn(
             `${LOG_PREFIX} Async derivation function '${asyncFunctionName}' not found for field '${entry.fieldKey}'. ` +

--- a/packages/dynamic-forms/src/lib/core/derivation/async-derivation-stream.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/async-derivation-stream.ts
@@ -81,6 +81,10 @@ export function createAsyncDerivationStream(
   }
 
   if (!entry.asyncFunctionName && !entry.asyncFn) {
+    context.logger.warn(
+      `${LOG_PREFIX} Derivation for '${entry.fieldKey}' has neither "asyncFunctionName" nor "asyncFn". ` +
+        `One of the two is required for source: 'asyncFunction'.`,
+    );
     return EMPTY;
   }
 

--- a/packages/dynamic-forms/src/lib/core/derivation/compute-derived-value.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/compute-derived-value.ts
@@ -39,7 +39,7 @@ export interface ComputeValueOptions {
  * @internal
  */
 export function computeValueFromEntry(
-  entry: Pick<BaseDerivationEntry, 'value' | 'expression' | 'functionName'>,
+  entry: Pick<BaseDerivationEntry, 'value' | 'expression' | 'functionName' | 'fn'>,
   evalContext: EvaluationContext,
   options: ComputeValueOptions,
 ): unknown {
@@ -51,8 +51,13 @@ export function computeValueFromEntry(
     return ExpressionParser.evaluate(entry.expression, evalContext);
   }
 
-  if (entry.functionName) {
-    const fn = options.derivationFunctions?.[entry.functionName];
+  if (entry.fn || entry.functionName) {
+    if (entry.fn && entry.functionName) {
+      evalContext.logger.warn(
+        `Both "fn" and "functionName" are set on derivation for '${options.subject}'. Inline "fn" takes precedence; "functionName" is ignored.`,
+      );
+    }
+    const fn = entry.fn ?? (entry.functionName ? options.derivationFunctions?.[entry.functionName] : undefined);
     if (!fn) {
       const kind = options.functionKind ?? 'Derivation function';
       throw new DynamicFormError(`${kind} '${entry.functionName}' not found in customFnConfig.derivations`);
@@ -60,5 +65,7 @@ export function computeValueFromEntry(
     return fn(evalContext);
   }
 
-  throw new DynamicFormError(`Derivation for ${options.subject} has no value source. Specify 'value', 'expression', or 'functionName'.`);
+  throw new DynamicFormError(
+    `Derivation for ${options.subject} has no value source. Specify 'value', 'expression', 'functionName', or 'fn'.`,
+  );
 }

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-applicator.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-applicator.spec.ts
@@ -94,6 +94,9 @@ describe('derivation-applicator', () => {
       value: options.value,
       expression: options.expression,
       functionName: options.functionName,
+      fn: options.fn,
+      asyncFunctionName: options.asyncFunctionName,
+      asyncFn: options.asyncFn,
       trigger: options.trigger ?? 'onChange',
       isShorthand: options.isShorthand ?? false,
       stopOnUserOverride: options.stopOnUserOverride,
@@ -255,6 +258,76 @@ describe('derivation-applicator', () => {
 
         expect(result.errorCount).toBeGreaterThanOrEqual(1);
         expect(logger.error).toHaveBeenCalled();
+      });
+
+      describe('inline fn alternative', () => {
+        it('calls and applies inline fn result', () => {
+          const { form, values } = createMockForm({ country: 'Germany', currency: '' });
+          formValueSignal.set({ country: 'Germany', currency: '' });
+
+          const inlineFn = vi.fn().mockReturnValue('EUR');
+
+          const collection = createCollection([createEntry('currency', { fn: inlineFn })]);
+
+          const context: DerivationApplicatorContext = {
+            formValue: formValueSignal,
+            rootForm: form as unknown as import('@angular/forms/signals').FieldTree<unknown>,
+            logger,
+            derivationLogger: createMockDerivationLogger(),
+          };
+
+          const result = applyDerivations(collection, context);
+
+          expect(inlineFn).toHaveBeenCalled();
+          expect(result.appliedCount).toBeGreaterThanOrEqual(1);
+          expect(values.currency).toBe('EUR');
+        });
+
+        it('inline fn does not require derivationFunctions registration', () => {
+          const { form, values } = createMockForm({ country: 'Germany', currency: '' });
+          formValueSignal.set({ country: 'Germany', currency: '' });
+
+          const collection = createCollection([createEntry('currency', { fn: () => 'EUR' })]);
+
+          // No derivationFunctions on context — should still work.
+          const context: DerivationApplicatorContext = {
+            formValue: formValueSignal,
+            rootForm: form as unknown as import('@angular/forms/signals').FieldTree<unknown>,
+            logger,
+            derivationLogger: createMockDerivationLogger(),
+          };
+
+          const result = applyDerivations(collection, context);
+
+          expect(result.appliedCount).toBeGreaterThanOrEqual(1);
+          expect(values.currency).toBe('EUR');
+          expect(logger.error).not.toHaveBeenCalled();
+        });
+
+        it('inline fn wins and warns when both fn and functionName are set', () => {
+          const { form, values } = createMockForm({ country: 'Germany', currency: '' });
+          formValueSignal.set({ country: 'Germany', currency: '' });
+
+          const registered = vi.fn().mockReturnValue('USD');
+          const inline = vi.fn().mockReturnValue('EUR');
+
+          const collection = createCollection([createEntry('currency', { fn: inline, functionName: 'registered' })]);
+
+          const context: DerivationApplicatorContext = {
+            formValue: formValueSignal,
+            rootForm: form as unknown as import('@angular/forms/signals').FieldTree<unknown>,
+            derivationFunctions: { registered },
+            logger,
+            derivationLogger: createMockDerivationLogger(),
+          };
+
+          applyDerivations(collection, context);
+
+          expect(values.currency).toBe('EUR');
+          expect(inline).toHaveBeenCalled();
+          expect(registered).not.toHaveBeenCalled();
+          expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Both "fn" and "functionName" are set'));
+        });
       });
     });
 

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-applicator.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-applicator.ts
@@ -267,7 +267,7 @@ function tryApplyDerivation(
   const { derivationLogger } = context;
 
   // HTTP and async entries are processed asynchronously in their own streams — skip in sync loop
-  if (entry.http || entry.asyncFunctionName) {
+  if (entry.http || entry.asyncFunctionName || entry.asyncFn) {
     return { applied: false, fieldKey: entry.fieldKey };
   }
 
@@ -628,9 +628,11 @@ function formatDerivationError(entry: DerivationEntry, phase: 'compute' | 'apply
     ? `expression: "${entry.expression.substring(0, 50)}${entry.expression.length > 50 ? '...' : ''}"`
     : entry.functionName
       ? `function: "${entry.functionName}"`
-      : entry.value !== undefined
-        ? 'static value'
-        : 'unknown source';
+      : entry.fn
+        ? 'inline fn'
+        : entry.value !== undefined
+          ? 'static value'
+          : 'unknown source';
 
   return `${ERROR_PREFIX} Failed to ${phase} derivation (field: ${entry.fieldKey}, ${source}): ${message}`;
 }
@@ -715,7 +717,7 @@ export function applyDerivationsForTrigger(
 ): DerivationProcessingResult {
   // Filter entries by trigger type, excluding HTTP and async entries (processed in async streams)
   const filteredEntries = collection.entries.filter((entry) => {
-    if (entry.http || entry.asyncFunctionName) return false;
+    if (entry.http || entry.asyncFunctionName || entry.asyncFn) return false;
     if (trigger === 'onChange') {
       return !entry.trigger || entry.trigger === 'onChange';
     }

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.ts
@@ -4,9 +4,9 @@ import { DynamicFormError } from '../../errors/dynamic-form-error';
 import { DerivationLogicConfig, hasTargetProperty, isDerivationLogicConfig } from '../../models/logic/logic-config';
 import { extractStringDependencies } from '../cross-field/cross-field-detector';
 import { topologicalSort } from './derivation-sorter';
-import type { BaseDerivationEntry } from './derivation-entry-base';
 import { DerivationCollection, DerivationEntry } from './derivation-types';
 import { extractDependenciesFromConfig } from './extract-dependencies';
+import { extractInlineAsyncFn, extractInlineFn } from './extract-inline-fn';
 import { traverseFieldsWithContext } from './field-traversal';
 
 /**
@@ -325,9 +325,6 @@ function createLogicEntry(fieldKey: string, config: DerivationLogicConfig, conte
   // The type system ensures debounceMs is only present when trigger is 'debounced'
   const debounceMs = trigger === 'debounced' ? (config as { debounceMs?: number }).debounceMs : undefined;
 
-  // `fn` / `asyncFn` only appear on the function-mode variants of the discriminated union, but
-  // we copy them through unconditionally — they'll just be `undefined` for other modes.
-  // Read-only access, no widening.
   return {
     fieldKey: effectiveFieldKey,
     dependsOn,
@@ -335,11 +332,11 @@ function createLogicEntry(fieldKey: string, config: DerivationLogicConfig, conte
     value: config.value,
     expression: config.expression,
     functionName: config.functionName,
-    fn: (config as { fn?: BaseDerivationEntry['fn'] }).fn,
+    fn: extractInlineFn(config),
     http: config.http,
     responseExpression: config.responseExpression,
     asyncFunctionName: config.asyncFunctionName,
-    asyncFn: (config as { asyncFn?: DerivationEntry['asyncFn'] }).asyncFn,
+    asyncFn: extractInlineAsyncFn(config),
     trigger,
     debounceMs,
     isShorthand: false,

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.ts
@@ -4,6 +4,7 @@ import { DynamicFormError } from '../../errors/dynamic-form-error';
 import { DerivationLogicConfig, hasTargetProperty, isDerivationLogicConfig } from '../../models/logic/logic-config';
 import { extractStringDependencies } from '../cross-field/cross-field-detector';
 import { topologicalSort } from './derivation-sorter';
+import type { BaseDerivationEntry } from './derivation-entry-base';
 import { DerivationCollection, DerivationEntry } from './derivation-types';
 import { extractDependenciesFromConfig } from './extract-dependencies';
 import { traverseFieldsWithContext } from './field-traversal';
@@ -331,9 +332,11 @@ function createLogicEntry(fieldKey: string, config: DerivationLogicConfig, conte
     value: config.value,
     expression: config.expression,
     functionName: config.functionName,
+    fn: (config as { fn?: BaseDerivationEntry['fn'] }).fn,
     http: config.http,
     responseExpression: config.responseExpression,
     asyncFunctionName: config.asyncFunctionName,
+    asyncFn: (config as { asyncFn?: DerivationEntry['asyncFn'] }).asyncFn,
     trigger,
     debounceMs,
     isShorthand: false,

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.ts
@@ -325,6 +325,9 @@ function createLogicEntry(fieldKey: string, config: DerivationLogicConfig, conte
   // The type system ensures debounceMs is only present when trigger is 'debounced'
   const debounceMs = trigger === 'debounced' ? (config as { debounceMs?: number }).debounceMs : undefined;
 
+  // `fn` / `asyncFn` only appear on the function-mode variants of the discriminated union, but
+  // we copy them through unconditionally — they'll just be `undefined` for other modes.
+  // Read-only access, no widening.
   return {
     fieldKey: effectiveFieldKey,
     dependsOn,

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-entry-base.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-entry-base.ts
@@ -1,5 +1,6 @@
 import { ConditionalExpression } from '../../models/expressions/conditional-expression';
 import { DerivationLogicConfig, LogicTrigger } from '../../models/logic/logic-config';
+import type { CustomFunction } from '../expressions/custom-function-types';
 
 /**
  * Common shape shared by `DerivationEntry` and `PropertyDerivationEntry`.
@@ -48,9 +49,15 @@ export interface BaseDerivationEntry {
 
   /**
    * Name of a registered custom derivation function.
-   * Mutually exclusive with `value` and `expression`.
+   * Mutually exclusive with `value`, `expression`, and `fn`.
    */
   functionName?: string;
+
+  /**
+   * Inline custom derivation function (code-only authoring).
+   * Mutually exclusive with `functionName`. NOT JSON-serializable.
+   */
+  fn?: CustomFunction;
 
   /**
    * When to evaluate the derivation.

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-orchestrator.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-orchestrator.ts
@@ -486,15 +486,15 @@ export class DerivationOrchestrator {
    * Used for smart teardown comparison.
    */
   private computeAsyncEntryKeys(entries: DerivationEntry[]): Set<string> {
-    // For inline `asyncFn` entries, we generate a per-entry unique token so
-    // smart-teardown treats them as distinct identities — JSON.stringify on
-    // a function would otherwise produce `undefined`, collapsing distinct
-    // inline functions into a single key.
+    // For inline `asyncFn` entries we tag the key with the field path (the real
+    // identity, since derivations are self-targeting) rather than the array
+    // index. Index-based tagging churned identities whenever topologicalSort
+    // reordered entries, causing unnecessary teardown + re-subscribe.
     return new Set(
-      entries.map((entry, index) => {
+      entries.map((entry) => {
         const config = {
           asyncFunctionName: entry.asyncFunctionName,
-          asyncFnId: entry.asyncFn ? `inline:${index}` : undefined,
+          asyncFnId: entry.asyncFn ? `inline:${entry.fieldKey}` : undefined,
           dependsOn: entry.dependsOn,
           debounceMs: entry.debounceMs,
           stopOnUserOverride: entry.stopOnUserOverride,

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-orchestrator.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-orchestrator.ts
@@ -428,7 +428,7 @@ export class DerivationOrchestrator {
     toObservable(this.derivationCollection, { injector: this.injector })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((collection) => {
-        const asyncEntries = collection?.entries.filter((entry) => entry.asyncFunctionName) ?? [];
+        const asyncEntries = collection?.entries.filter((entry) => entry.asyncFunctionName || entry.asyncFn) ?? [];
 
         if (asyncEntries.length === 0) {
           this.teardownAsyncFunctionStreams();
@@ -486,10 +486,15 @@ export class DerivationOrchestrator {
    * Used for smart teardown comparison.
    */
   private computeAsyncEntryKeys(entries: DerivationEntry[]): Set<string> {
+    // For inline `asyncFn` entries, we generate a per-entry unique token so
+    // smart-teardown treats them as distinct identities — JSON.stringify on
+    // a function would otherwise produce `undefined`, collapsing distinct
+    // inline functions into a single key.
     return new Set(
-      entries.map((entry) => {
+      entries.map((entry, index) => {
         const config = {
           asyncFunctionName: entry.asyncFunctionName,
+          asyncFnId: entry.asyncFn ? `inline:${index}` : undefined,
           dependsOn: entry.dependsOn,
           debounceMs: entry.debounceMs,
           stopOnUserOverride: entry.stopOnUserOverride,
@@ -546,12 +551,13 @@ function warnAboutWildcardDependencies(logger: Logger, entries: DerivationEntry[
     (entry) =>
       !entry.http &&
       !entry.asyncFunctionName &&
-      entry.functionName &&
+      !entry.asyncFn &&
+      (entry.functionName || entry.fn) &&
       (!entry.originalConfig?.dependsOn || entry.originalConfig.dependsOn.length === 0),
   );
 
   if (implicitWildcards.length > 0) {
-    const derivationDescs = implicitWildcards.map((e) => `${e.fieldKey} (${e.functionName})`);
+    const derivationDescs = implicitWildcards.map((e) => `${e.fieldKey} (${e.functionName ?? '<inline fn>'})`);
     logger.warn(
       'Derivation: custom functions without explicit dependsOn detected. ' +
         `These run on EVERY form change, which may impact performance (form has ${fieldCount} fields). ` +

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-types.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-types.ts
@@ -1,5 +1,6 @@
 import type { FormFieldStateMap } from '../../models/expressions/field-state-context';
 import { HttpRequestConfig } from '../../models/http/http-request-config';
+import type { AsyncDerivationFunction } from '../expressions/async-custom-function-types';
 import { BaseDerivationEntry } from './derivation-entry-base';
 
 /**
@@ -28,10 +29,17 @@ export interface DerivationEntry extends BaseDerivationEntry {
   /**
    * Name of a registered async derivation function.
    *
-   * Mutually exclusive with `value`, `expression`, `functionName`, and `http`.
+   * Mutually exclusive with `value`, `expression`, `functionName`, `asyncFn`, and `http`.
    * Processed asynchronously in a dedicated RxJS stream, not in the sync loop.
    */
   asyncFunctionName?: string;
+
+  /**
+   * Inline async derivation function (code-only authoring).
+   * Mutually exclusive with `asyncFunctionName`. NOT JSON-serializable.
+   * Processed asynchronously in a dedicated RxJS stream, not in the sync loop.
+   */
+  asyncFn?: AsyncDerivationFunction;
 
   /**
    * Expression to extract the derived value from an HTTP response.

--- a/packages/dynamic-forms/src/lib/core/derivation/extract-dependencies.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/extract-dependencies.ts
@@ -7,7 +7,7 @@ import { extractExpressionDependencies, extractStringDependencies } from '../cro
  * Combines:
  * - Explicit `dependsOn` (when provided, it takes precedence over auto-detection)
  * - Expression-detected dependencies (only used when `dependsOn` is empty)
- * - `'*'` wildcard for `functionName` (only when `dependsOn` is empty)
+ * - `'*'` wildcard for `functionName` / inline `fn` (only when `dependsOn` is empty)
  * - Condition expression dependencies (always included)
  *
  * @internal
@@ -21,7 +21,9 @@ export function extractDependenciesFromConfig(config: DerivationLogicConfig): st
     if (config.expression) {
       extractStringDependencies(config.expression).forEach((dep) => deps.add(dep));
     }
-    if (config.functionName) {
+    // Inline `fn` mirrors `functionName` semantics: without explicit dependsOn,
+    // assume the function may depend on anything in the form.
+    if (config.functionName || (config as { fn?: unknown }).fn) {
       deps.add('*');
     }
   }

--- a/packages/dynamic-forms/src/lib/core/derivation/extract-inline-fn.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/extract-inline-fn.ts
@@ -1,0 +1,29 @@
+import type { AsyncDerivationFunction } from '../expressions/async-custom-function-types';
+import type { CustomFunction } from '../expressions/custom-function-types';
+
+/**
+ * Reads the optional inline `fn` property off a derivation config.
+ *
+ * `fn` only appears on the function-mode branch of the discriminated union, so
+ * call sites that need to copy it through unconditionally must widen via cast.
+ * This helper centralises the cast and keeps it read-only — no widening, no
+ * mutation. Returns `undefined` for any non-function-mode variant.
+ *
+ * @internal
+ */
+export function extractInlineFn(config: object): CustomFunction | undefined {
+  return (config as { fn?: CustomFunction }).fn;
+}
+
+/**
+ * Reads the optional inline `asyncFn` property off a derivation config.
+ *
+ * Same rationale as {@link extractInlineFn}: `asyncFn` only appears on the
+ * `source: 'asyncFunction'` branch, so collectors that copy it through need a
+ * cast. Read-only access, no widening.
+ *
+ * @internal
+ */
+export function extractInlineAsyncFn(config: object): AsyncDerivationFunction | undefined {
+  return (config as { asyncFn?: AsyncDerivationFunction }).asyncFn;
+}

--- a/packages/dynamic-forms/src/lib/core/expressions/async-condition-logic-function.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/async-condition-logic-function.spec.ts
@@ -209,4 +209,103 @@ describe('createAsyncConditionLogicFunction', () => {
 
     expect(result).toBe(false);
   });
+
+  describe('inline asyncFn alternative', () => {
+    it('accepts an inline asyncFn returning a Promise', () => {
+      const inlineFn = vi.fn(async () => true);
+
+      const condition: AsyncCondition = {
+        type: 'async',
+        asyncFn: inlineFn,
+        pendingValue: false,
+      };
+
+      const result = runInInjectionContext(injector, () => {
+        const fn = createAsyncConditionLogicFunction(condition);
+        const ctx = createMockFieldContext('test');
+        return fn(ctx);
+      });
+
+      // Returns pendingValue synchronously — Promise not yet resolved
+      expect(result).toBe(false);
+    });
+
+    it('accepts an inline asyncFn returning an Observable', () => {
+      const inlineFn = vi.fn(() => of(true));
+
+      const condition: AsyncCondition = {
+        type: 'async',
+        asyncFn: inlineFn,
+        pendingValue: false,
+      };
+
+      const result = runInInjectionContext(injector, () => {
+        const fn = createAsyncConditionLogicFunction(condition);
+        const ctx = createMockFieldContext('test');
+        return fn(ctx);
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('does not require registration when asyncFn is set', () => {
+      // No registration call here — relies solely on inline asyncFn.
+      const inlineFn = vi.fn(async () => true);
+
+      const condition: AsyncCondition = {
+        type: 'async',
+        asyncFn: inlineFn,
+        pendingValue: true,
+      };
+
+      const result = runInInjectionContext(injector, () => {
+        const fn = createAsyncConditionLogicFunction(condition);
+        const ctx = createMockFieldContext('test');
+        return fn(ctx);
+      });
+
+      // Returns pendingValue; no "function not found" warning should be emitted.
+      expect(result).toBe(true);
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it('warns and prefers inline asyncFn when both forms are set', () => {
+      const registered = vi.fn(async () => false);
+      const inline = vi.fn(async () => true);
+      functionRegistry.registerAsyncConditionFunction('registered', registered);
+
+      // Cast — public XOR rejects this at compile time, but JSON-loaded configs
+      // can still produce both keys at runtime.
+      const condition = {
+        type: 'async',
+        asyncFunctionName: 'registered',
+        asyncFn: inline,
+        pendingValue: true,
+      } as unknown as AsyncCondition;
+
+      runInInjectionContext(injector, () => {
+        const fn = createAsyncConditionLogicFunction(condition);
+        const ctx = createMockFieldContext('test');
+        fn(ctx);
+      });
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Both "asyncFn" and "asyncFunctionName" are set'));
+    });
+
+    it('does not return a cached LogicFn from a string-keyed sibling for inline asyncFn configs', () => {
+      // Two distinct inline functions in two distinct condition objects
+      // produce two distinct LogicFn instances — they must not collide in the cache.
+      const a = vi.fn(async () => true);
+      const b = vi.fn(async () => false);
+
+      const condA: AsyncCondition = { type: 'async', asyncFn: a, pendingValue: false };
+      const condB: AsyncCondition = { type: 'async', asyncFn: b, pendingValue: false };
+
+      const [fn1, fn2] = runInInjectionContext(injector, () => {
+        return [createAsyncConditionLogicFunction(condA), createAsyncConditionLogicFunction(condB)];
+      });
+
+      expect(fn1).not.toBe(fn2);
+    });
+  });
 });

--- a/packages/dynamic-forms/src/lib/core/expressions/async-condition-logic-function.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/async-condition-logic-function.ts
@@ -34,12 +34,22 @@ export function createAsyncConditionLogicFunction<TValue>(condition: AsyncCondit
   const pendingValue = condition.pendingValue ?? false;
   const debounceMs = condition.debounceMs ?? 300;
 
-  // Check function cache
-  const cacheKey = stableStringify(condition);
+  if (condition.asyncFn && condition.asyncFunctionName) {
+    logger.warn(
+      'Both "asyncFn" and "asyncFunctionName" are set on async condition. Inline "asyncFn" takes precedence; "asyncFunctionName" is ignored.',
+    );
+  }
 
-  const cached = cacheService.asyncConditionFunctionCache.get(cacheKey);
-  if (cached) {
-    return cached as LogicFn<TValue, boolean>;
+  // Skip cross-condition caching when an inline function is used: stableStringify
+  // cannot distinguish two different inline functions, which would cause cache hits
+  // to wrongly reuse a LogicFn closing over a different function reference.
+  const cacheKey = condition.asyncFn ? undefined : stableStringify(condition);
+
+  if (cacheKey !== undefined) {
+    const cached = cacheService.asyncConditionFunctionCache.get(cacheKey);
+    if (cached) {
+      return cached as LogicFn<TValue, boolean>;
+    }
   }
 
   // Each condition needs its own per-field signal store.
@@ -80,8 +90,11 @@ export function createAsyncConditionLogicFunction<TValue>(condition: AsyncCondit
         const asyncResource = rxResource({
           params: () => debouncedTrigger() ?? undefined,
           stream: ({ params: triggerKey }) => {
-            // Look up the async function at call time (fresh reference)
-            const asyncFn = functionRegistry.getAsyncConditionFunction(condition.asyncFunctionName);
+            // Inline `asyncFn` wins; otherwise look up the registered function at call time
+            // (fresh reference, in case the registry was updated after LogicFn creation).
+            const asyncFn =
+              condition.asyncFn ??
+              (condition.asyncFunctionName ? functionRegistry.getAsyncConditionFunction(condition.asyncFunctionName) : undefined);
             if (!asyncFn) {
               logger.warn(
                 `Async Condition - function '${condition.asyncFunctionName}' not found. ` +
@@ -150,6 +163,8 @@ export function createAsyncConditionLogicFunction<TValue>(condition: AsyncCondit
     return resultResource.value();
   };
 
-  cacheService.asyncConditionFunctionCache.set(cacheKey, fn as LogicFn<unknown, boolean>);
+  if (cacheKey !== undefined) {
+    cacheService.asyncConditionFunctionCache.set(cacheKey, fn as LogicFn<unknown, boolean>);
+  }
   return fn;
 }

--- a/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.spec.ts
@@ -373,6 +373,81 @@ describe('condition-evaluator', () => {
         expect(result).toBe(true);
         expect(contextChecker).toHaveBeenCalledWith(contextWithChecker);
       });
+
+      describe('inline fn alternative', () => {
+        it('evaluates inline fn correctly', () => {
+          const inlineFn = vi.fn().mockReturnValue(true);
+          const expression: ConditionalExpression = {
+            type: 'custom',
+            fn: inlineFn,
+          };
+
+          const result = evaluateCondition(expression, mockContext);
+
+          expect(result).toBe(true);
+          expect(inlineFn).toHaveBeenCalledWith(mockContext);
+        });
+
+        it('coerces inline fn return value to boolean', () => {
+          const cases: Array<{ value: unknown; expected: boolean }> = [
+            { value: 1, expected: true },
+            { value: 0, expected: false },
+            { value: 'x', expected: true },
+            { value: '', expected: false },
+            { value: null, expected: false },
+            { value: undefined, expected: false },
+          ];
+
+          for (const { value, expected } of cases) {
+            const expression: ConditionalExpression = {
+              type: 'custom',
+              fn: () => value,
+            };
+            expect(evaluateCondition(expression, mockContext)).toBe(expected);
+          }
+        });
+
+        it('handles inline fn execution errors gracefully', () => {
+          const throwing = vi.fn(() => {
+            throw new Error('boom');
+          });
+
+          const expression: ConditionalExpression = {
+            type: 'custom',
+            fn: throwing,
+          };
+
+          const result = evaluateCondition(expression, mockContext);
+
+          expect(result).toBe(false);
+          expect(mockLogger.error).toHaveBeenCalledWith('Error executing custom function:', '<inline>', expect.any(Error));
+        });
+
+        it('inline fn wins and warns when both fn and functionName are set', () => {
+          const registered = vi.fn().mockReturnValue(false);
+          const inline = vi.fn().mockReturnValue(true);
+
+          // Use a type cast — the public XOR type rejects this at compile time,
+          // but the runtime guard must still cope with JSON-loaded configs.
+          const expression = {
+            type: 'custom',
+            functionName: 'registered',
+            fn: inline,
+          } as unknown as ConditionalExpression;
+
+          const context: EvaluationContext = {
+            ...mockContext,
+            customFunctions: { registered },
+          };
+
+          const result = evaluateCondition(expression, context);
+
+          expect(result).toBe(true);
+          expect(inline).toHaveBeenCalledTimes(1);
+          expect(registered).not.toHaveBeenCalled();
+          expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Both "fn" and "functionName" are set'));
+        });
+      });
     });
 
     describe('fieldValue with array-scoped context', () => {

--- a/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.ts
@@ -24,30 +24,15 @@ export function evaluateCondition(expression: ConditionalExpression, context: Ev
     case 'custom': {
       // Read both keys via cast — the XOR type narrows to `never` when both
       // would be truthy, but JSON-loaded configs can produce that state at
-      // runtime. We accept it here, warn once, and let inline win.
+      // runtime. We accept it here, warn, and let inline win.
       const bothSet = expression as { fn?: unknown; functionName?: string };
       const inlineFn = bothSet.fn as ((ctx: EvaluationContext) => unknown) | undefined;
       const registeredName = bothSet.functionName;
 
       if (inlineFn && registeredName) {
-        // Dedupe via the DI-scoped deprecation tracker so authoring mistakes
-        // log once per form instance — not on every reactive re-evaluation.
-        // Falls back to a marker on the expression object if no tracker is
-        // wired (unit-test contexts that don't construct one).
-        const key = `custom-condition:${registeredName}:both-set`;
-        const tracker = context.deprecationTracker;
-        const marker = expression as { __warnedBothSet?: boolean };
-        const shouldWarn = tracker ? !tracker.warnedKeys.has(key) : !marker.__warnedBothSet;
-        if (shouldWarn) {
-          context.logger.warn(
-            'Both "fn" and "functionName" are set on custom condition. Inline "fn" takes precedence; "functionName" is ignored.',
-          );
-          if (tracker) {
-            tracker.warnedKeys.add(key);
-          } else {
-            marker.__warnedBothSet = true;
-          }
-        }
+        context.logger.warn(
+          'Both "fn" and "functionName" are set on custom condition. Inline "fn" takes precedence; "functionName" is ignored.',
+        );
       }
 
       const customFn = inlineFn ?? (registeredName ? context.customFunctions?.[registeredName] : undefined);
@@ -72,7 +57,7 @@ export function evaluateCondition(expression: ConditionalExpression, context: Ev
 
     case 'http':
       context.logger.warn(
-        '[Dynamic Forms] HTTP conditions are resolved asynchronously via createHttpConditionLogicFunction(). ' +
+        'HTTP conditions are resolved asynchronously via createHttpConditionLogicFunction(). ' +
           'When used inside and/or composites, the HTTP result is not available synchronously. Returning false.',
       );
       return false;

--- a/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.ts
@@ -22,22 +22,44 @@ export function evaluateCondition(expression: ConditionalExpression, context: Ev
       return evaluateJavaScriptExpression(expression, context);
 
     case 'custom': {
-      if (expression.fn && expression.functionName) {
-        context.logger.warn(
-          'Both "fn" and "functionName" are set on custom condition. Inline "fn" takes precedence; "functionName" is ignored.',
-        );
+      // Read both keys via cast — the XOR type narrows to `never` when both
+      // would be truthy, but JSON-loaded configs can produce that state at
+      // runtime. We accept it here, warn once, and let inline win.
+      const bothSet = expression as { fn?: unknown; functionName?: string };
+      const inlineFn = bothSet.fn as ((ctx: EvaluationContext) => unknown) | undefined;
+      const registeredName = bothSet.functionName;
+
+      if (inlineFn && registeredName) {
+        // Dedupe via the DI-scoped deprecation tracker so authoring mistakes
+        // log once per form instance — not on every reactive re-evaluation.
+        // Falls back to a marker on the expression object if no tracker is
+        // wired (unit-test contexts that don't construct one).
+        const key = `custom-condition:${registeredName}:both-set`;
+        const tracker = context.deprecationTracker;
+        const marker = expression as { __warnedBothSet?: boolean };
+        const shouldWarn = tracker ? !tracker.warnedKeys.has(key) : !marker.__warnedBothSet;
+        if (shouldWarn) {
+          context.logger.warn(
+            'Both "fn" and "functionName" are set on custom condition. Inline "fn" takes precedence; "functionName" is ignored.',
+          );
+          if (tracker) {
+            tracker.warnedKeys.add(key);
+          } else {
+            marker.__warnedBothSet = true;
+          }
+        }
       }
 
-      const customFn = expression.fn ?? (expression.functionName ? context.customFunctions?.[expression.functionName] : undefined);
+      const customFn = inlineFn ?? (registeredName ? context.customFunctions?.[registeredName] : undefined);
       if (!customFn) {
-        context.logger.error('Custom function not found:', expression.functionName);
+        context.logger.error('Custom function not found:', registeredName);
         return false;
       }
 
       try {
         return !!customFn(context);
       } catch (error) {
-        context.logger.error('Error executing custom function:', expression.functionName ?? '<inline>', error);
+        context.logger.error('Error executing custom function:', registeredName ?? '<inline>', error);
         return false;
       }
     }

--- a/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.ts
@@ -22,7 +22,13 @@ export function evaluateCondition(expression: ConditionalExpression, context: Ev
       return evaluateJavaScriptExpression(expression, context);
 
     case 'custom': {
-      const customFn = context.customFunctions?.[expression.functionName];
+      if (expression.fn && expression.functionName) {
+        context.logger.warn(
+          'Both "fn" and "functionName" are set on custom condition. Inline "fn" takes precedence; "functionName" is ignored.',
+        );
+      }
+
+      const customFn = expression.fn ?? (expression.functionName ? context.customFunctions?.[expression.functionName] : undefined);
       if (!customFn) {
         context.logger.error('Custom function not found:', expression.functionName);
         return false;
@@ -31,7 +37,7 @@ export function evaluateCondition(expression: ConditionalExpression, context: Ev
       try {
         return !!customFn(context);
       } catch (error) {
-        context.logger.error('Error executing custom function:', expression.functionName, error);
+        context.logger.error('Error executing custom function:', expression.functionName ?? '<inline>', error);
         return false;
       }
     }

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-collector.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-collector.ts
@@ -4,6 +4,7 @@ import { DerivationLogicConfig, isDerivationLogicConfig, hasTargetProperty } fro
 import { Logger } from '../../providers/features/logger/logger.interface';
 import type { WarningTracker } from '../../utils/warning-tracker';
 import { extractDependenciesFromConfig } from '../derivation/extract-dependencies';
+import { extractInlineFn } from '../derivation/extract-inline-fn';
 import { traverseFieldsWithContext } from '../derivation/field-traversal';
 import { buildPropertyOverrideKey, PLACEHOLDER_INDEX } from './property-override-key';
 import { PropertyDerivationCollection, PropertyDerivationEntry } from './property-derivation-types';
@@ -98,10 +99,7 @@ function createPropertyDerivationEntryFromDerivation(
     value: config.value,
     expression: config.expression,
     functionName: config.functionName,
-    // `fn` lives on the function-derivation variant of DerivationLogicConfig but isn't surfaced
-    // on the discriminated union after narrowing to `targetProperty`-bearing entries — cast to
-    // read it through. Read-only access, no widening.
-    fn: (config as { fn?: PropertyDerivationEntry['fn'] }).fn,
+    fn: extractInlineFn(config),
     trigger,
     debounceMs,
     debugName: config.debugName,

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-collector.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-collector.ts
@@ -98,6 +98,9 @@ function createPropertyDerivationEntryFromDerivation(
     value: config.value,
     expression: config.expression,
     functionName: config.functionName,
+    // `fn` lives on the function-derivation variant of DerivationLogicConfig but isn't surfaced
+    // on the discriminated union after narrowing to `targetProperty`-bearing entries — cast to
+    // read it through. Read-only access, no widening.
     fn: (config as { fn?: PropertyDerivationEntry['fn'] }).fn,
     trigger,
     debounceMs,

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-collector.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-collector.ts
@@ -98,6 +98,7 @@ function createPropertyDerivationEntryFromDerivation(
     value: config.value,
     expression: config.expression,
     functionName: config.functionName,
+    fn: (config as { fn?: PropertyDerivationEntry['fn'] }).fn,
     trigger,
     debounceMs,
     debugName: config.debugName,

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-orchestrator.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-orchestrator.ts
@@ -248,12 +248,12 @@ function warnAboutWildcardDependencies(logger: Logger, entries: PropertyDerivati
   const implicitWildcards = entries.filter(
     (entry) =>
       entry.dependsOn.includes('*') &&
-      entry.functionName &&
+      (entry.functionName || entry.fn) &&
       (!entry.originalConfig?.dependsOn || entry.originalConfig.dependsOn.length === 0),
   );
 
   if (implicitWildcards.length > 0) {
-    const derivationDescs = implicitWildcards.map((e) => `${e.fieldKey}.${e.targetProperty} (${e.functionName})`);
+    const derivationDescs = implicitWildcards.map((e) => `${e.fieldKey}.${e.targetProperty} (${e.functionName ?? '<inline fn>'})`);
     logger.warn(
       'PropertyDerivation: custom functions without explicit dependsOn detected. ' +
         `These run on EVERY form change, which may impact performance (form has ${fieldCount} fields). ` +

--- a/packages/dynamic-forms/src/lib/core/validation/validator-factory.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/validation/validator-factory.spec.ts
@@ -495,6 +495,75 @@ describe('validator-factory', () => {
           expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Both "fn" and "functionName" are set'));
         });
       });
+
+      it('warns when both fn and functionName are set on HTTP validator', () => {
+        runInInjectionContext(injector, () => {
+          const registry = TestBed.inject(FunctionRegistryService);
+          registry.registerHttpValidator('registered', {
+            request: () => '/api/check',
+            onSuccess: () => null,
+          });
+
+          const formValue = signal({ username: 'test' });
+          const inline = { request: () => '/api/check', onSuccess: () => null };
+          // Cast — the public XOR rejects this at compile time, but JSON-loaded
+          // configs can still produce both keys at runtime.
+          const config = { type: 'http', functionName: 'registered', fn: inline } as unknown as ValidatorConfig;
+
+          const formInstance = form(
+            formValue,
+            schema<typeof formValue>((path) => {
+              applyValidator(config, path.username);
+            }),
+          );
+          mockFormSignal.set(formInstance);
+
+          expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Both "fn" and "functionName" are set'));
+        });
+      });
+
+      it('throws when neither fn nor functionName is set on async validator', () => {
+        runInInjectionContext(injector, () => {
+          const formValue = signal({ username: 'test' });
+          // Cast — XOR rejects neither-set at compile time; JSON-loaded configs can produce it.
+          const config = { type: 'async' } as unknown as ValidatorConfig;
+
+          let caught: unknown;
+          form(
+            formValue,
+            schema<typeof formValue>((path) => {
+              try {
+                applyValidator(config, path.username);
+              } catch (err) {
+                caught = err;
+              }
+            }),
+          );
+          expect(caught).toBeInstanceOf(Error);
+          expect(String(caught)).toMatch(/Async validator requires/);
+        });
+      });
+
+      it('throws when neither fn nor functionName is set on HTTP validator', () => {
+        runInInjectionContext(injector, () => {
+          const formValue = signal({ username: 'test' });
+          const config = { type: 'http' } as unknown as ValidatorConfig;
+
+          let caught: unknown;
+          form(
+            formValue,
+            schema<typeof formValue>((path) => {
+              try {
+                applyValidator(config, path.username);
+              } catch (err) {
+                caught = err;
+              }
+            }),
+          );
+          expect(caught).toBeInstanceOf(Error);
+          expect(String(caught)).toMatch(/HTTP validator requires/);
+        });
+      });
     });
 
     describe('custom validator inline fn alternative', () => {

--- a/packages/dynamic-forms/src/lib/core/validation/validator-factory.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/validation/validator-factory.spec.ts
@@ -426,6 +426,116 @@ describe('validator-factory', () => {
           mockFormSignal.set(formInstance);
         });
       });
+
+      it('accepts inline async validator via fn (no registration required)', () => {
+        runInInjectionContext(injector, () => {
+          const formValue = signal({ username: 'test' });
+          const inline = {
+            params: () => ({}),
+            factory: () => ({ value: signal(null) }) as never,
+            onSuccess: () => null,
+          };
+          const config: ValidatorConfig = { type: 'async', fn: inline };
+
+          const formInstance = form(
+            formValue,
+            schema<typeof formValue>((path) => {
+              expect(() => {
+                applyValidator(config, path.username);
+              }).not.toThrow();
+            }),
+          );
+          mockFormSignal.set(formInstance);
+        });
+      });
+
+      it('accepts inline HTTP validator via fn (no registration required)', () => {
+        runInInjectionContext(injector, () => {
+          const formValue = signal({ username: 'test' });
+          const inline = { request: () => '/api/check', onSuccess: () => null };
+          const config: ValidatorConfig = { type: 'http', fn: inline };
+
+          const formInstance = form(
+            formValue,
+            schema<typeof formValue>((path) => {
+              expect(() => {
+                applyValidator(config, path.username);
+              }).not.toThrow();
+            }),
+          );
+          mockFormSignal.set(formInstance);
+        });
+      });
+
+      it('warns when both fn and functionName are set on async validator', () => {
+        runInInjectionContext(injector, () => {
+          const registry = TestBed.inject(FunctionRegistryService);
+          registry.registerAsyncValidator('registered', {
+            params: () => ({}),
+            factory: () => ({ value: signal(null) }) as never,
+          });
+
+          const formValue = signal({ username: 'test' });
+          const inline = {
+            params: () => ({}),
+            factory: () => ({ value: signal(null) }) as never,
+          };
+          // Cast — the public XOR rejects this at compile time, but JSON-loaded
+          // configs can still produce both keys at runtime.
+          const config = { type: 'async', functionName: 'registered', fn: inline } as unknown as ValidatorConfig;
+
+          const formInstance = form(
+            formValue,
+            schema<typeof formValue>((path) => {
+              applyValidator(config, path.username);
+            }),
+          );
+          mockFormSignal.set(formInstance);
+
+          expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Both "fn" and "functionName" are set'));
+        });
+      });
+    });
+
+    describe('custom validator inline fn alternative', () => {
+      it('accepts inline fn validator without registration', () => {
+        runInInjectionContext(injector, () => {
+          const formValue = signal({ username: 'test' });
+          const inline = vi.fn().mockReturnValue(null);
+          const config: ValidatorConfig = { type: 'custom', fn: inline };
+
+          const formInstance = form(
+            formValue,
+            schema<typeof formValue>((path) => {
+              expect(() => {
+                applyValidator(config, path.username);
+              }).not.toThrow();
+            }),
+          );
+          mockFormSignal.set(formInstance);
+        });
+      });
+
+      it('warns when both fn and functionName are set on custom validator', () => {
+        runInInjectionContext(injector, () => {
+          const registry = TestBed.inject(FunctionRegistryService);
+          registry.registerValidator('registered', () => null);
+
+          const formValue = signal({ username: 'test' });
+          const inline = vi.fn().mockReturnValue(null);
+          const config = { type: 'custom', functionName: 'registered', fn: inline } as unknown as ValidatorConfig;
+
+          const formInstance = form(
+            formValue,
+            schema<typeof formValue>((path) => {
+              applyValidator(config, path.username);
+            }),
+          );
+          mockFormSignal.set(formInstance);
+
+          expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Both "fn" and "functionName" are set'));
+        });
+      });
     });
 
     describe('declarative HTTP validator (type: http)', () => {

--- a/packages/dynamic-forms/src/lib/core/validation/validator-factory.ts
+++ b/packages/dynamic-forms/src/lib/core/validation/validator-factory.ts
@@ -276,12 +276,15 @@ function applyAsyncValidator(config: AsyncValidatorConfig, fieldPath: SchemaPath
   let validatorConfig: ReturnType<FunctionRegistryService['getAsyncValidator']>;
   if (config.fn) {
     validatorConfig = config.fn;
-  } else {
+  } else if (config.functionName) {
     const registry = inject(FunctionRegistryService);
     validatorConfig = registry.getAsyncValidator(config.functionName);
     if (!validatorConfig) {
       throw new DynamicFormError(`Async validator "${config.functionName}" not found. Register it with customFnConfig.asyncValidators.`);
     }
+  } else {
+    // XOR type rejects this at compile time; JSON-loaded configs can still reach here at runtime.
+    throw new DynamicFormError('Async validator requires one of "functionName" or "fn".');
   }
 
   const whenLogic = createConditionalLogic(config.when);
@@ -308,9 +311,18 @@ function applyUnifiedHttpValidator(
 ): void {
   if (isFunctionHttpValidator(config)) {
     applyFunctionHttpValidator(config, fieldPath);
-  } else {
-    applyDeclarativeHttpValidator(config, fieldPath);
+    return;
   }
+  // Declarative path requires both `http` and `responseMapping` — reject early
+  // for JSON-loaded configs that have neither side fully populated. The
+  // discriminated union forbids this at compile time.
+  const declarative = config as DeclarativeHttpValidatorConfig;
+  if (!declarative.http || !declarative.responseMapping) {
+    throw new DynamicFormError(
+      'HTTP validator requires one of "functionName" / "fn" (function-based) or "http" + "responseMapping" (declarative).',
+    );
+  }
+  applyDeclarativeHttpValidator(config, fieldPath);
 }
 
 /**
@@ -330,12 +342,15 @@ function applyFunctionHttpValidator(config: FunctionHttpValidatorConfig, fieldPa
   let httpValidatorConfig: ReturnType<FunctionRegistryService['getHttpValidator']>;
   if (config.fn) {
     httpValidatorConfig = config.fn;
-  } else {
+  } else if (config.functionName) {
     const registry = inject(FunctionRegistryService);
     httpValidatorConfig = registry.getHttpValidator(config.functionName);
     if (!httpValidatorConfig) {
       throw new DynamicFormError(`HTTP validator "${config.functionName}" not found. Register it with customFnConfig.httpValidators.`);
     }
+  } else {
+    // XOR type rejects this at compile time; JSON-loaded configs can still reach here at runtime.
+    throw new DynamicFormError('HTTP validator requires one of "functionName" or "fn".');
   }
 
   const whenLogic = createConditionalLogic(config.when);

--- a/packages/dynamic-forms/src/lib/core/validation/validator-factory.ts
+++ b/packages/dynamic-forms/src/lib/core/validation/validator-factory.ts
@@ -168,11 +168,11 @@ function applyCustomValidator(config: CustomValidatorConfig, fieldPath: SchemaPa
 
   if (config.expression) {
     validatorFn = createExpressionValidator(config);
-  } else if (config.functionName) {
+  } else if (config.fn || config.functionName) {
     validatorFn = createFunctionValidator(config);
   } else {
     const logger = inject(DynamicFormLogger);
-    logger.warn('Custom validator must have either "expression" or "functionName"');
+    logger.warn('Custom validator must have one of "expression", "functionName", or "fn"');
     return;
   }
 
@@ -187,6 +187,16 @@ function createFunctionValidator(
   config: CustomValidatorConfig,
 ): (ctx: FieldContext<unknown>) => ValidationError | ValidationError[] | null {
   const logger = inject(DynamicFormLogger);
+
+  if (config.fn && config.functionName) {
+    logger.warn('Both "fn" and "functionName" are set on custom validator. Inline "fn" takes precedence; "functionName" is ignored.');
+  }
+
+  if (config.fn) {
+    const inlineFn = config.fn;
+    return (ctx: FieldContext<unknown>) => inlineFn(ctx, config.params);
+  }
+
   const functionName = config.functionName;
   if (!functionName) {
     logger.warn('Custom validator missing functionName');
@@ -258,11 +268,20 @@ function createExpressionValidator(
  * - onError: Optional handler for resource errors
  */
 function applyAsyncValidator(config: AsyncValidatorConfig, fieldPath: SchemaPath<unknown>): void {
-  const registry = inject(FunctionRegistryService);
-  const validatorConfig = registry.getAsyncValidator(config.functionName);
+  if (config.fn && config.functionName) {
+    const logger = inject(DynamicFormLogger);
+    logger.warn('Both "fn" and "functionName" are set on async validator. Inline "fn" takes precedence; "functionName" is ignored.');
+  }
 
-  if (!validatorConfig) {
-    throw new DynamicFormError(`Async validator "${config.functionName}" not found. Register it with customFnConfig.asyncValidators.`);
+  let validatorConfig: ReturnType<FunctionRegistryService['getAsyncValidator']>;
+  if (config.fn) {
+    validatorConfig = config.fn;
+  } else {
+    const registry = inject(FunctionRegistryService);
+    validatorConfig = registry.getAsyncValidator(config.functionName);
+    if (!validatorConfig) {
+      throw new DynamicFormError(`Async validator "${config.functionName}" not found. Register it with customFnConfig.asyncValidators.`);
+    }
   }
 
   const whenLogic = createConditionalLogic(config.when);
@@ -303,11 +322,20 @@ function applyUnifiedHttpValidator(
  * - onError: Optional handler for HTTP errors
  */
 function applyFunctionHttpValidator(config: FunctionHttpValidatorConfig, fieldPath: SchemaPath<unknown>): void {
-  const registry = inject(FunctionRegistryService);
-  const httpValidatorConfig = registry.getHttpValidator(config.functionName);
+  if (config.fn && config.functionName) {
+    const logger = inject(DynamicFormLogger);
+    logger.warn('Both "fn" and "functionName" are set on HTTP validator. Inline "fn" takes precedence; "functionName" is ignored.');
+  }
 
-  if (!httpValidatorConfig) {
-    throw new DynamicFormError(`HTTP validator "${config.functionName}" not found. Register it with customFnConfig.httpValidators.`);
+  let httpValidatorConfig: ReturnType<FunctionRegistryService['getHttpValidator']>;
+  if (config.fn) {
+    httpValidatorConfig = config.fn;
+  } else {
+    const registry = inject(FunctionRegistryService);
+    httpValidatorConfig = registry.getHttpValidator(config.functionName);
+    if (!httpValidatorConfig) {
+      throw new DynamicFormError(`HTTP validator "${config.functionName}" not found. Register it with customFnConfig.httpValidators.`);
+    }
   }
 
   const whenLogic = createConditionalLogic(config.when);

--- a/packages/dynamic-forms/src/lib/index.ts
+++ b/packages/dynamic-forms/src/lib/index.ts
@@ -133,6 +133,9 @@ export type { AsyncCustomValidator, CustomValidator, HttpCustomValidator } from 
 // Logic & Expression Types
 export type { ConditionalExpression, HttpCondition, AsyncCondition, EvaluationContext, LogicConfig, StateLogicConfig } from './models';
 
+// Custom Function Types (sync — for inline fn alternatives + customFnConfig)
+export type { CustomFunction } from './core/expressions/custom-function-types';
+
 // Async Custom Function Types
 export type { AsyncDerivationFunction, AsyncConditionFunction } from './core/expressions/async-custom-function-types';
 

--- a/packages/dynamic-forms/src/lib/models/expressions/conditional-expression.ts
+++ b/packages/dynamic-forms/src/lib/models/expressions/conditional-expression.ts
@@ -44,6 +44,11 @@ export interface FieldValueCondition {
  *
  * Exactly one of `functionName` or `fn` must be set.
  *
+ * Encoded as a strict discriminated union (XOR via `?: never`). `CustomValidatorConfig`
+ * intentionally uses a permissive interface for the same `fn`/`functionName` split
+ * because validators have a third source (`expression`) and the historical interface
+ * was already runtime-checked — the asymmetry is by design, not an oversight.
+ *
  * @public
  */
 export type CustomCondition =

--- a/packages/dynamic-forms/src/lib/models/expressions/conditional-expression.ts
+++ b/packages/dynamic-forms/src/lib/models/expressions/conditional-expression.ts
@@ -1,3 +1,5 @@
+import type { CustomFunction } from '../../core/expressions/custom-function-types';
+import type { AsyncConditionFunction } from '../../core/expressions/async-custom-function-types';
 import type { HttpRequestConfig } from '../http/http-request-config';
 
 /**
@@ -33,17 +35,38 @@ export interface FieldValueCondition {
 }
 
 /**
- * Condition that invokes a registered custom function by name.
+ * Condition that invokes a custom function.
  *
- * Register functions via `customFnConfig.customFunctions`.
+ * Two mutually exclusive forms:
+ * - `functionName`: name of a function registered in `customFnConfig.customFunctions`.
+ *   JSON-serializable; suitable for configs loaded from APIs, databases, or OpenAPI.
+ * - `fn`: inline function. NOT JSON-serializable; for code-only configs.
+ *
+ * Exactly one of `functionName` or `fn` must be set.
  *
  * @public
  */
-export interface CustomCondition {
-  type: 'custom';
-  /** Name of the registered custom function to invoke */
-  functionName: string;
-}
+export type CustomCondition =
+  | {
+      type: 'custom';
+      /** Name of the registered custom function to invoke */
+      functionName: string;
+      /** Inline form is forbidden when `functionName` is set */
+      fn?: never;
+    }
+  | {
+      type: 'custom';
+      /**
+       * Inline custom function. Mutually exclusive with `functionName`.
+       *
+       * NOT JSON-serializable — for code-only configs. For configs loaded
+       * from JSON / OpenAPI / databases, use `functionName` to reference
+       * a function registered in `customFnConfig.customFunctions`.
+       */
+      fn: CustomFunction;
+      /** Registered form is forbidden when `fn` is set */
+      functionName?: never;
+    };
 
 /**
  * Condition that evaluates a JavaScript expression using the secure AST-based parser.
@@ -101,21 +124,12 @@ export interface HttpCondition {
 }
 
 /**
- * Condition that evaluates based on a registered async function.
+ * Shared fields for both branches of {@link AsyncCondition}.
  *
- * The function is resolved reactively — when dependent form values change,
- * the function is re-evaluated (with debouncing). The result is cached per
- * evaluation to avoid redundant calls.
- *
- * Since `LogicFn` must return `boolean` synchronously, this condition uses
- * a signal-based async resolution pattern internally.
- *
- * @public
+ * @internal
  */
-export interface AsyncCondition {
+interface AsyncConditionBase {
   type: 'async';
-  /** Name of the registered async condition function */
-  asyncFunctionName: string;
   /**
    * Value to return while async resolution is pending.
    *
@@ -133,6 +147,45 @@ export interface AsyncCondition {
    */
   debounceMs?: number;
 }
+
+/**
+ * Condition that resolves asynchronously via a custom function.
+ *
+ * Two mutually exclusive forms:
+ * - `asyncFunctionName`: name of a function registered in `customFnConfig.asyncConditions`.
+ *   JSON-serializable; suitable for configs loaded from APIs, databases, or OpenAPI.
+ * - `asyncFn`: inline async function. NOT JSON-serializable; for code-only configs.
+ *
+ * Exactly one of `asyncFunctionName` or `asyncFn` must be set.
+ *
+ * The function is resolved reactively — when dependent form values change,
+ * the function is re-evaluated (with debouncing). The result is cached per
+ * evaluation to avoid redundant calls.
+ *
+ * Since `LogicFn` must return `boolean` synchronously, this condition uses
+ * a signal-based async resolution pattern internally.
+ *
+ * @public
+ */
+export type AsyncCondition =
+  | (AsyncConditionBase & {
+      /** Name of the registered async condition function */
+      asyncFunctionName: string;
+      /** Inline form is forbidden when `asyncFunctionName` is set */
+      asyncFn?: never;
+    })
+  | (AsyncConditionBase & {
+      /**
+       * Inline async condition function. Mutually exclusive with `asyncFunctionName`.
+       *
+       * NOT JSON-serializable — for code-only configs. For configs loaded
+       * from JSON / OpenAPI / databases, use `asyncFunctionName` to reference
+       * a function registered in `customFnConfig.asyncConditions`.
+       */
+      asyncFn: AsyncConditionFunction;
+      /** Registered form is forbidden when `asyncFn` is set */
+      asyncFunctionName?: never;
+    });
 
 /**
  * Logical AND — all sub-conditions must be true.

--- a/packages/dynamic-forms/src/lib/models/expressions/conditional-expression.type-test.ts
+++ b/packages/dynamic-forms/src/lib/models/expressions/conditional-expression.type-test.ts
@@ -73,21 +73,22 @@ const _asyncAsConditional: ConditionalExpression = asyncCondition;
 // ConditionalExpression discriminates type: 'async' correctly
 function handleAsyncCondition(expr: ConditionalExpression): void {
   if (expr.type === 'async') {
-    // Inside this block, expr is narrowed to AsyncCondition
-    const _fnName: string = expr.asyncFunctionName;
+    // Inside this block, expr is narrowed to AsyncCondition (a union of XOR branches),
+    // so name and inline-fn are each `T | undefined` until the branch is narrowed further.
+    const _fnName: string | undefined = expr.asyncFunctionName;
     const _pending: boolean | undefined = expr.pendingValue;
     const _debounce: number | undefined = expr.debounceMs;
     void [_fnName, _pending, _debounce];
   }
 }
 
-// Required properties only
+// Required properties only — registered-name branch
 const _asyncRequiredOnly: AsyncCondition = {
   type: 'async',
   asyncFunctionName: 'checkPermission',
 };
 
-// All optional properties
+// All optional properties — registered-name branch
 const _asyncAllProps: AsyncCondition = {
   type: 'async',
   asyncFunctionName: 'checkPermission',
@@ -95,31 +96,62 @@ const _asyncAllProps: AsyncCondition = {
   debounceMs: 500,
 };
 
+// Inline `asyncFn` branch
+const _asyncInline: AsyncCondition = {
+  type: 'async',
+  asyncFn: async () => true,
+  pendingValue: false,
+};
+
 // @ts-expect-error — type is required
 const _asyncMissingType: AsyncCondition = { asyncFunctionName: 'fn' };
 
-// @ts-expect-error — asyncFunctionName is required
+// @ts-expect-error — must supply one of asyncFunctionName or asyncFn
 const _asyncMissingFn: AsyncCondition = { type: 'async' };
+
+// @ts-expect-error — cannot set both asyncFunctionName and asyncFn
+const _asyncBothSet: AsyncCondition = {
+  type: 'async',
+  asyncFunctionName: 'check',
+  asyncFn: async () => true,
+};
 
 // ============================================================================
 // CustomCondition tests
 // ============================================================================
 
-// functionName field (required)
+// Registered-name branch
 const _customNew: CustomCondition = {
   type: 'custom',
   functionName: 'myValidator',
 };
 const _customNewAsConditional: ConditionalExpression = _customNew;
 
+// Inline `fn` branch
+const _customInline: CustomCondition = {
+  type: 'custom',
+  fn: (ctx) => !!ctx.fieldValue,
+};
+
 // ConditionalExpression discriminates type: 'custom' correctly
 function handleCustomCondition(expr: ConditionalExpression): void {
   if (expr.type === 'custom') {
-    // Inside this block, expr is narrowed to CustomCondition
-    const _fnName: string = expr.functionName;
+    // Narrowed to CustomCondition (a union of XOR branches) — name/fn are each
+    // `T | undefined` until the specific branch is narrowed further.
+    const _fnName: string | undefined = expr.functionName;
     void _fnName;
   }
 }
+
+// @ts-expect-error — must supply one of functionName or fn
+const _customNeither: CustomCondition = { type: 'custom' };
+
+// @ts-expect-error — cannot set both functionName and fn
+const _customBothSet: CustomCondition = {
+  type: 'custom',
+  functionName: 'myValidator',
+  fn: () => true,
+};
 
 void [
   _asConditional,
@@ -132,9 +164,14 @@ void [
   handleAsyncCondition,
   _asyncRequiredOnly,
   _asyncAllProps,
+  _asyncInline,
   _asyncMissingType,
   _asyncMissingFn,
+  _asyncBothSet,
   _customNew,
   _customNewAsConditional,
+  _customInline,
   handleCustomCondition,
+  _customNeither,
+  _customBothSet,
 ];

--- a/packages/dynamic-forms/src/lib/models/logic/logic-config.ts
+++ b/packages/dynamic-forms/src/lib/models/logic/logic-config.ts
@@ -1,3 +1,5 @@
+import type { AsyncDerivationFunction } from '../../core/expressions/async-custom-function-types';
+import type { CustomFunction } from '../../core/expressions/custom-function-types';
 import { ConditionalExpression } from '../expressions/conditional-expression';
 import { HttpRequestConfig } from '../http/http-request-config';
 
@@ -350,6 +352,10 @@ type DebouncedDerivationTrigger = { trigger: 'debounced'; debounceMs?: number };
 interface HttpDerivationBase extends SharedDerivationFields {
   /** Identifies this derivation as HTTP-driven. */
   source: 'http';
+  /** Forbidden on HTTP source */
+  fn?: never;
+  /** Forbidden on HTTP source */
+  asyncFn?: never;
   /**
    * HTTP request configuration for server-driven derivations.
    *
@@ -414,34 +420,15 @@ interface HttpDerivationBase extends SharedDerivationFields {
 // ============================================================================
 
 /**
- * Base for async function derivations. `source: 'asyncFunction'` is required.
- * TypeScript enforces `dependsOn` at the type level.
+ * Shared fields for both branches of {@link AsyncFunctionDerivationBase}.
  *
  * @internal
  */
-interface AsyncFunctionDerivationBase extends SharedDerivationFields {
+interface AsyncFunctionDerivationShared extends SharedDerivationFields {
   /** Identifies this derivation as async-function-driven. */
   source: 'asyncFunction';
-  /**
-   * Name of a registered async derivation function.
-   *
-   * The function receives the evaluation context and returns a Promise or Observable
-   * of the derived value. Register functions in `customFnConfig.asyncDerivations`.
-   *
-   * @example
-   * ```typescript
-   * {
-   *   key: 'suggestedPrice',
-   *   logic: [{
-   *     type: 'derivation',
-   *     source: 'asyncFunction',
-   *     asyncFunctionName: 'fetchSuggestedPrice',
-   *     dependsOn: ['productId', 'quantity'],
-   *   }]
-   * }
-   * ```
-   */
-  asyncFunctionName: string;
+  /** Forbidden on asyncFunction source */
+  fn?: never;
   /**
    * Explicit field dependencies. Required for async derivations to prevent
    * wildcard triggering on every form change.
@@ -461,6 +448,51 @@ interface AsyncFunctionDerivationBase extends SharedDerivationFields {
   responseExpression?: never;
 }
 
+/**
+ * Base for async function derivations. `source: 'asyncFunction'` is required.
+ * TypeScript enforces `dependsOn` at the type level, and `asyncFunctionName` /
+ * `asyncFn` are mutually exclusive (XOR).
+ *
+ * @internal
+ */
+type AsyncFunctionDerivationBase =
+  | (AsyncFunctionDerivationShared & {
+      /**
+       * Name of a registered async derivation function.
+       *
+       * The function receives the evaluation context and returns a Promise or Observable
+       * of the derived value. Register functions in `customFnConfig.asyncDerivations`.
+       *
+       * @example
+       * ```typescript
+       * {
+       *   key: 'suggestedPrice',
+       *   logic: [{
+       *     type: 'derivation',
+       *     source: 'asyncFunction',
+       *     asyncFunctionName: 'fetchSuggestedPrice',
+       *     dependsOn: ['productId', 'quantity'],
+       *   }]
+       * }
+       * ```
+       */
+      asyncFunctionName: string;
+      /** Inline form is forbidden when `asyncFunctionName` is set */
+      asyncFn?: never;
+    })
+  | (AsyncFunctionDerivationShared & {
+      /**
+       * Inline async derivation function. Mutually exclusive with `asyncFunctionName`.
+       *
+       * NOT JSON-serializable — for code-only configs. For configs loaded
+       * from JSON / OpenAPI / databases, use `asyncFunctionName` to reference
+       * a function registered in `customFnConfig.asyncDerivations`.
+       */
+      asyncFn: AsyncDerivationFunction;
+      /** Registered form is forbidden when `asyncFn` is set */
+      asyncFunctionName?: never;
+    });
+
 // ============================================================================
 // Sync derivation modes
 // ============================================================================
@@ -472,6 +504,10 @@ interface AsyncFunctionDerivationBase extends SharedDerivationFields {
  */
 interface ExpressionDerivationBase extends SharedDerivationFields {
   source?: never;
+  /** Forbidden on expression mode */
+  fn?: never;
+  /** Forbidden on expression mode */
+  asyncFn?: never;
   /**
    * JavaScript expression to evaluate for the derived value.
    *
@@ -522,6 +558,10 @@ interface ExpressionDerivationBase extends SharedDerivationFields {
  */
 interface ValueDerivationBase extends SharedDerivationFields {
   source?: never;
+  /** Forbidden on value mode */
+  fn?: never;
+  /** Forbidden on value mode */
+  asyncFn?: never;
   /**
    * Static value to set on this field.
    *
@@ -552,26 +592,14 @@ interface ValueDerivationBase extends SharedDerivationFields {
 }
 
 /**
- * Base for custom sync function derivations.
+ * Shared fields for both branches of {@link FunctionDerivationBase}.
  *
  * @internal
  */
-interface FunctionDerivationBase extends SharedDerivationFields {
+interface FunctionDerivationShared extends SharedDerivationFields {
   source?: never;
-  /**
-   * Name of a registered custom derivation function.
-   *
-   * The function receives the evaluation context and returns the derived value.
-   * Register functions in `customFnConfig.derivations`.
-   *
-   * @example
-   * ```typescript
-   * functionName: 'getCurrencyForCountry'
-   * functionName: 'calculateTax'
-   * functionName: 'formatPhoneNumber'
-   * ```
-   */
-  functionName: string;
+  /** Forbidden on function-derivation mode */
+  asyncFn?: never;
   /**
    * Explicit field dependencies for function derivations.
    *
@@ -600,6 +628,44 @@ interface FunctionDerivationBase extends SharedDerivationFields {
   asyncFunctionName?: never;
   responseExpression?: never;
 }
+
+/**
+ * Base for custom sync function derivations. `functionName` and `fn` are
+ * mutually exclusive (XOR).
+ *
+ * @internal
+ */
+type FunctionDerivationBase =
+  | (FunctionDerivationShared & {
+      /**
+       * Name of a registered custom derivation function.
+       *
+       * The function receives the evaluation context and returns the derived value.
+       * Register functions in `customFnConfig.derivations`.
+       *
+       * @example
+       * ```typescript
+       * functionName: 'getCurrencyForCountry'
+       * functionName: 'calculateTax'
+       * functionName: 'formatPhoneNumber'
+       * ```
+       */
+      functionName: string;
+      /** Inline form is forbidden when `functionName` is set */
+      fn?: never;
+    })
+  | (FunctionDerivationShared & {
+      /**
+       * Inline custom derivation function. Mutually exclusive with `functionName`.
+       *
+       * NOT JSON-serializable — for code-only configs. For configs loaded
+       * from JSON / OpenAPI / databases, use `functionName` to reference
+       * a function registered in `customFnConfig.derivations`.
+       */
+      fn: CustomFunction;
+      /** Registered form is forbidden when `fn` is set */
+      functionName?: never;
+    });
 
 /**
  * HTTP derivation that evaluates immediately on change (default).

--- a/packages/dynamic-forms/src/lib/models/logic/logic-config.type-test.ts
+++ b/packages/dynamic-forms/src/lib/models/logic/logic-config.type-test.ts
@@ -310,6 +310,15 @@ describe('DerivationLogicConfig - inline fn (sync) — XOR with functionName', (
     };
     void _both;
   });
+
+  it('should reject function-mode derivation with neither fn nor functionName', () => {
+    // @ts-expect-error — one of value / expression / functionName / fn is required
+    const _neither: DerivationLogicConfig = {
+      type: 'derivation',
+      dependsOn: ['country'],
+    };
+    void _neither;
+  });
 });
 
 describe('DerivationLogicConfig - sync sources (backwards compatible)', () => {

--- a/packages/dynamic-forms/src/lib/models/logic/logic-config.type-test.ts
+++ b/packages/dynamic-forms/src/lib/models/logic/logic-config.type-test.ts
@@ -91,6 +91,7 @@ describe('DerivationLogicConfig - Exhaustive Whitelist', () => {
     | 'value'
     | 'expression'
     | 'functionName'
+    | 'fn'
     | 'trigger'
     | 'debounceMs'
     | 'debugName'
@@ -100,7 +101,8 @@ describe('DerivationLogicConfig - Exhaustive Whitelist', () => {
     | 'targetProperty'
     | 'http'
     | 'responseExpression'
-    | 'asyncFunctionName';
+    | 'asyncFunctionName'
+    | 'asyncFn';
   type ActualKeys = keyof DerivationLogicConfig;
 
   it('should have exactly the expected keys', () => {
@@ -109,15 +111,15 @@ describe('DerivationLogicConfig - Exhaustive Whitelist', () => {
 
   describe('required keys', () => {
     // RequiredKeys<T> for a union = keys required in at least one member.
-    // With 10 mode × trigger variants, the required keys include:
+    // Mode/trigger × XOR (fn / functionName, asyncFn / asyncFunctionName) variants:
     // - type: required in all (SharedDerivationFields)
-    // - trigger: required in all 5 debounced variants
+    // - trigger: required in all debounced variants
     // - source: required in HTTP and asyncFunction variants
     // - http, dependsOn, responseExpression: required in HTTP variants
-    // - asyncFunctionName, dependsOn: required in asyncFunction variants
+    // - asyncFunctionName | asyncFn, dependsOn: required in asyncFunction variants
     // - expression: required in expression variants
     // - value: required in value variants
-    // - functionName: required in function variants
+    // - functionName | fn: required in function variants
     it('should have type, trigger, source, and all mode-specific required fields', () => {
       expectTypeOf<RequiredKeys<DerivationLogicConfig>>().toEqualTypeOf<
         | 'type'
@@ -127,9 +129,11 @@ describe('DerivationLogicConfig - Exhaustive Whitelist', () => {
         | 'dependsOn'
         | 'responseExpression'
         | 'asyncFunctionName'
+        | 'asyncFn'
         | 'expression'
         | 'value'
         | 'functionName'
+        | 'fn'
       >();
     });
   });
@@ -254,13 +258,57 @@ describe('DerivationLogicConfig - source: asyncFunction required fields', () => 
   });
 
   it('should reject async derivation missing asyncFunctionName', () => {
-    // @ts-expect-error — asyncFunctionName is required for source: 'asyncFunction'
+    // @ts-expect-error — one of asyncFunctionName or asyncFn is required for source: 'asyncFunction'
     const _missing: DerivationLogicConfig = {
       type: 'derivation',
       source: 'asyncFunction',
       dependsOn: ['field1'],
     };
     void _missing;
+  });
+
+  it('should accept inline asyncFn instead of asyncFunctionName', () => {
+    const logic = {
+      type: 'derivation',
+      source: 'asyncFunction',
+      asyncFn: async () => 42,
+      dependsOn: ['productId'],
+    } as const satisfies DerivationLogicConfig;
+
+    expectTypeOf(logic.source).toEqualTypeOf<'asyncFunction'>();
+  });
+
+  it('should reject async derivation with both asyncFn and asyncFunctionName', () => {
+    // @ts-expect-error — asyncFn and asyncFunctionName are mutually exclusive
+    const _both: DerivationLogicConfig = {
+      type: 'derivation',
+      source: 'asyncFunction',
+      asyncFunctionName: 'fetchData',
+      asyncFn: async () => 1,
+      dependsOn: ['field1'],
+    };
+    void _both;
+  });
+});
+
+describe('DerivationLogicConfig - inline fn (sync) — XOR with functionName', () => {
+  it('should accept inline fn derivation', () => {
+    const logic = {
+      type: 'derivation',
+      fn: (ctx) => (ctx.formValue.country === 'USA' ? 'USD' : 'EUR'),
+    } as const satisfies DerivationLogicConfig;
+
+    expectTypeOf(logic.type).toEqualTypeOf<'derivation'>();
+  });
+
+  it('should reject derivation with both fn and functionName', () => {
+    // @ts-expect-error — fn and functionName are mutually exclusive
+    const _both: DerivationLogicConfig = {
+      type: 'derivation',
+      functionName: 'getCurrency',
+      fn: () => 'USD',
+    };
+    void _both;
   });
 });
 

--- a/packages/dynamic-forms/src/lib/models/validation/validator-config.ts
+++ b/packages/dynamic-forms/src/lib/models/validation/validator-config.ts
@@ -213,5 +213,6 @@ export type ValidatorConfig =
 export function isFunctionHttpValidator(
   config: FunctionHttpValidatorConfig | DeclarativeHttpValidatorConfig,
 ): config is FunctionHttpValidatorConfig {
-  return ('functionName' in config && !!config.functionName) || ('fn' in config && typeof (config as { fn?: unknown }).fn === 'function');
+  const c = config as { functionName?: unknown; fn?: unknown };
+  return typeof c.functionName === 'string' || (c.fn !== null && typeof c.fn === 'object');
 }

--- a/packages/dynamic-forms/src/lib/models/validation/validator-config.ts
+++ b/packages/dynamic-forms/src/lib/models/validation/validator-config.ts
@@ -1,3 +1,4 @@
+import type { AsyncCustomValidator, CustomValidator, HttpCustomValidator } from '../../core/validation/validator-types';
 import { ConditionalExpression } from '../expressions/conditional-expression';
 import { HttpRequestConfig } from '../http/http-request-config';
 import { HttpValidationResponseMapping } from '../http/http-response-mapping';
@@ -25,12 +26,17 @@ export interface BuiltInValidatorConfig extends BaseValidatorConfig {
 }
 
 /**
- * Custom validator configuration using Angular's public FieldContext API
- * Returns ValidationError | ValidationError[] | null synchronously
+ * Custom validator configuration using Angular's public FieldContext API.
+ * Returns ValidationError | ValidationError[] | null synchronously.
  *
- * Supports two patterns:
- * 1. Function-based: { type: 'custom', functionName: 'myValidator' }
- * 2. Expression-based: { type: 'custom', expression: 'fieldValue === formValue.password', kind: 'passwordMismatch' }
+ * Three mutually exclusive authoring forms:
+ * 1. Registered function: `{ type: 'custom', functionName: 'myValidator' }`
+ * 2. Inline function (code-only): `{ type: 'custom', fn: (ctx) => ... }`
+ * 3. Expression-based: `{ type: 'custom', expression: 'fieldValue === formValue.password', kind: 'passwordMismatch' }`
+ *
+ * `fn` is NOT JSON-serializable — for code-only configs. For configs loaded from
+ * JSON / OpenAPI / databases, prefer `functionName` to reference a function
+ * registered in `customFnConfig.validators`.
  */
 export interface CustomValidatorConfig extends BaseValidatorConfig {
   /** Validator type identifier */
@@ -38,6 +44,12 @@ export interface CustomValidatorConfig extends BaseValidatorConfig {
 
   /** Name of registered validator function (function-based pattern) */
   functionName?: string;
+
+  /**
+   * Inline custom validator (code-only authoring).
+   * Mutually exclusive with `functionName`. NOT JSON-serializable.
+   */
+  fn?: CustomValidator;
 
   /** Optional parameters to pass to validator function */
   params?: Record<string, unknown>;
@@ -63,40 +75,92 @@ export interface CustomValidatorConfig extends BaseValidatorConfig {
 }
 
 /**
- * Async custom validator configuration using Angular's validateAsync API.
- * Returns Observable<ValidationError | ValidationError[] | null>.
+ * Shared fields for both branches of {@link AsyncValidatorConfig}.
  *
+ * @internal
  */
-export interface AsyncValidatorConfig extends BaseValidatorConfig {
+interface AsyncValidatorConfigShared extends BaseValidatorConfig {
   /** Validator type identifier. */
   type: 'async';
-
-  /** Name of registered async validator function */
-  functionName: string;
-
   /** Optional parameters to pass to validator function */
   params?: Record<string, unknown>;
 }
 
 /**
- * Function-based HTTP validator configuration — requires a registered function.
+ * Async custom validator configuration using Angular's `validateAsync` API.
+ * Returns Observable<ValidationError | ValidationError[] | null>.
  *
- * Uses Angular's `validateHttp` API. The function is registered via
- * `customFnConfig.httpValidators`.
+ * Two mutually exclusive authoring forms:
+ * - `functionName`: name of a function registered in `customFnConfig.asyncValidators`.
+ *   JSON-serializable; suitable for configs loaded from APIs, databases, or OpenAPI.
+ * - `fn`: inline async validator. NOT JSON-serializable; for code-only configs.
  *
- * Discriminated from `DeclarativeHttpValidatorConfig` by the presence of `functionName`.
- *
+ * Exactly one of `functionName` or `fn` must be set.
  */
-export interface FunctionHttpValidatorConfig extends BaseValidatorConfig {
+export type AsyncValidatorConfig =
+  | (AsyncValidatorConfigShared & {
+      /** Name of registered async validator function */
+      functionName: string;
+      /** Inline form is forbidden when `functionName` is set */
+      fn?: never;
+    })
+  | (AsyncValidatorConfigShared & {
+      /**
+       * Inline async validator. Mutually exclusive with `functionName`.
+       *
+       * NOT JSON-serializable — for code-only configs. For configs loaded
+       * from JSON / OpenAPI / databases, use `functionName` to reference
+       * a validator registered in `customFnConfig.asyncValidators`.
+       */
+      fn: AsyncCustomValidator;
+      /** Registered form is forbidden when `fn` is set */
+      functionName?: never;
+    });
+
+/**
+ * Shared fields for both branches of {@link FunctionHttpValidatorConfig}.
+ *
+ * @internal
+ */
+interface FunctionHttpValidatorConfigShared extends BaseValidatorConfig {
   /** Validator type identifier. */
   type: 'http';
-
-  /** Name of registered HTTP validator configuration */
-  functionName: string;
-
   /** Optional parameters to pass to HTTP validator */
   params?: Record<string, unknown>;
 }
+
+/**
+ * Function-based HTTP validator configuration. Uses Angular's `validateHttp` API.
+ *
+ * Two mutually exclusive authoring forms:
+ * - `functionName`: name of an HTTP validator registered in `customFnConfig.httpValidators`.
+ *   JSON-serializable.
+ * - `fn`: inline HTTP validator. NOT JSON-serializable; for code-only configs.
+ *
+ * Exactly one of `functionName` or `fn` must be set.
+ *
+ * Discriminated from `DeclarativeHttpValidatorConfig` by the presence of `functionName`
+ * or `fn` (and absence of `http` + `responseMapping`).
+ */
+export type FunctionHttpValidatorConfig =
+  | (FunctionHttpValidatorConfigShared & {
+      /** Name of registered HTTP validator configuration */
+      functionName: string;
+      /** Inline form is forbidden when `functionName` is set */
+      fn?: never;
+    })
+  | (FunctionHttpValidatorConfigShared & {
+      /**
+       * Inline HTTP validator. Mutually exclusive with `functionName`.
+       *
+       * NOT JSON-serializable — for code-only configs. For configs loaded
+       * from JSON / OpenAPI / databases, use `functionName` to reference
+       * an HTTP validator registered in `customFnConfig.httpValidators`.
+       */
+      fn: HttpCustomValidator;
+      /** Registered form is forbidden when `fn` is set */
+      functionName?: never;
+    });
 
 /**
  * Declarative HTTP validator configuration — fully JSON-serializable, no function registration required.
@@ -142,5 +206,5 @@ export type ValidatorConfig =
 export function isFunctionHttpValidator(
   config: FunctionHttpValidatorConfig | DeclarativeHttpValidatorConfig,
 ): config is FunctionHttpValidatorConfig {
-  return 'functionName' in config && !!config.functionName;
+  return ('functionName' in config && !!config.functionName) || ('fn' in config && typeof (config as { fn?: unknown }).fn === 'function');
 }

--- a/packages/dynamic-forms/src/lib/models/validation/validator-config.ts
+++ b/packages/dynamic-forms/src/lib/models/validation/validator-config.ts
@@ -29,10 +29,17 @@ export interface BuiltInValidatorConfig extends BaseValidatorConfig {
  * Custom validator configuration using Angular's public FieldContext API.
  * Returns ValidationError | ValidationError[] | null synchronously.
  *
- * Three mutually exclusive authoring forms:
+ * Three authoring forms (mutually exclusive at runtime, not enforced by TypeScript):
  * 1. Registered function: `{ type: 'custom', functionName: 'myValidator' }`
  * 2. Inline function (code-only): `{ type: 'custom', fn: (ctx) => ... }`
  * 3. Expression-based: `{ type: 'custom', expression: 'fieldValue === formValue.password', kind: 'passwordMismatch' }`
+ *
+ * Unlike `AsyncValidatorConfig` and `FunctionHttpValidatorConfig` (strict `fn` ↔
+ * `functionName` XOR via discriminated unions), this surface keeps a permissive
+ * interface — the historical expression-vs-functionName split was already
+ * runtime-checked, so adding `fn` follows the same precedent. The runtime
+ * resolver picks one source and warns if `fn` and `functionName` are both set;
+ * inline `fn` wins.
  *
  * `fn` is NOT JSON-serializable — for code-only configs. For configs loaded from
  * JSON / OpenAPI / databases, prefer `functionName` to reference a function

--- a/packages/dynamic-forms/src/lib/models/validation/validator-config.type-test.ts
+++ b/packages/dynamic-forms/src/lib/models/validation/validator-config.type-test.ts
@@ -139,6 +139,21 @@ describe('CustomValidatorConfig - Exhaustive Whitelist', () => {
       } as const satisfies CustomValidatorConfig;
       expectTypeOf(config.fn).not.toBeUndefined();
     });
+
+    it('intentionally accepts BOTH fn and functionName at compile time (runtime-enforced XOR)', () => {
+      // CustomValidatorConfig is a permissive interface, not a discriminated union.
+      // The historical functionName-vs-expression split was already runtime-checked,
+      // so the inline `fn` follows the same precedent — mutual exclusivity is enforced
+      // at runtime (logger.warn + inline-wins resolution), not by TypeScript.
+      // AsyncValidatorConfig and FunctionHttpValidatorConfig encode strict XOR via
+      // discriminated unions; this surface intentionally does not.
+      const both = {
+        type: 'custom',
+        functionName: 'registered',
+        fn: () => null,
+      } as const satisfies CustomValidatorConfig;
+      expectTypeOf(both).toMatchTypeOf<CustomValidatorConfig>();
+    });
   });
 });
 

--- a/packages/dynamic-forms/src/lib/models/validation/validator-config.type-test.ts
+++ b/packages/dynamic-forms/src/lib/models/validation/validator-config.type-test.ts
@@ -88,7 +88,7 @@ describe('BuiltInValidatorConfig - Exhaustive Whitelist', () => {
 // ============================================================================
 
 describe('CustomValidatorConfig - Exhaustive Whitelist', () => {
-  type ExpectedKeys = 'type' | 'functionName' | 'params' | 'expression' | 'kind' | 'errorParams' | 'when';
+  type ExpectedKeys = 'type' | 'functionName' | 'fn' | 'params' | 'expression' | 'kind' | 'errorParams' | 'when';
   type ActualKeys = keyof CustomValidatorConfig;
 
   it('should have exactly the expected keys', () => {
@@ -130,6 +130,16 @@ describe('CustomValidatorConfig - Exhaustive Whitelist', () => {
       expectTypeOf<CustomValidatorConfig['when']>().toEqualTypeOf<ConditionalExpression | undefined>();
     });
   });
+
+  describe('inline fn alternative', () => {
+    it('accepts inline fn', () => {
+      const config = {
+        type: 'custom',
+        fn: () => null,
+      } as const satisfies CustomValidatorConfig;
+      expectTypeOf(config.fn).not.toBeUndefined();
+    });
+  });
 });
 
 // ============================================================================
@@ -137,7 +147,7 @@ describe('CustomValidatorConfig - Exhaustive Whitelist', () => {
 // ============================================================================
 
 describe('AsyncValidatorConfig - Exhaustive Whitelist', () => {
-  type ExpectedKeys = 'type' | 'functionName' | 'params' | 'when';
+  type ExpectedKeys = 'type' | 'functionName' | 'fn' | 'params' | 'when';
   type ActualKeys = keyof AsyncValidatorConfig;
 
   it('should have exactly the expected keys', () => {
@@ -145,8 +155,10 @@ describe('AsyncValidatorConfig - Exhaustive Whitelist', () => {
   });
 
   describe('required keys', () => {
-    it('should have type and functionName as required', () => {
-      expectTypeOf<RequiredKeys<AsyncValidatorConfig>>().toEqualTypeOf<'type' | 'functionName'>();
+    // With XOR (functionName vs fn), neither alone is universally required —
+    // RequiredKeys for a union returns keys required in at least one member.
+    it('should have type, functionName, and fn as required-in-at-least-one-branch', () => {
+      expectTypeOf<RequiredKeys<AsyncValidatorConfig>>().toEqualTypeOf<'type' | 'functionName' | 'fn'>();
     });
   });
 
@@ -155,8 +167,8 @@ describe('AsyncValidatorConfig - Exhaustive Whitelist', () => {
       expectTypeOf<AsyncValidatorConfig['type']>().toEqualTypeOf<'async'>();
     });
 
-    it('functionName should be string', () => {
-      expectTypeOf<AsyncValidatorConfig['functionName']>().toEqualTypeOf<string>();
+    it('functionName should be string or undefined (XOR with fn)', () => {
+      expectTypeOf<AsyncValidatorConfig['functionName']>().toEqualTypeOf<string | undefined>();
     });
 
     it('params should be Record<string, unknown>', () => {
@@ -167,6 +179,37 @@ describe('AsyncValidatorConfig - Exhaustive Whitelist', () => {
       expectTypeOf<AsyncValidatorConfig['when']>().toEqualTypeOf<ConditionalExpression | undefined>();
     });
   });
+
+  describe('XOR shape', () => {
+    it('accepts the registered-name branch', () => {
+      const c: AsyncValidatorConfig = { type: 'async', functionName: 'check' };
+      expectTypeOf(c).toMatchTypeOf<AsyncValidatorConfig>();
+    });
+
+    it('accepts the inline-fn branch', () => {
+      const c: AsyncValidatorConfig = {
+        type: 'async',
+        fn: { params: () => ({}), factory: () => ({}) as never },
+      };
+      expectTypeOf(c).toMatchTypeOf<AsyncValidatorConfig>();
+    });
+
+    it('rejects both branches set simultaneously', () => {
+      // @ts-expect-error - cannot set both functionName and fn
+      const _bad: AsyncValidatorConfig = {
+        type: 'async',
+        functionName: 'check',
+        fn: { params: () => ({}), factory: () => ({}) as never },
+      };
+      void _bad;
+    });
+
+    it('rejects neither branch set', () => {
+      // @ts-expect-error - must set one of functionName or fn
+      const _bad: AsyncValidatorConfig = { type: 'async' };
+      void _bad;
+    });
+  });
 });
 
 // ============================================================================
@@ -174,7 +217,7 @@ describe('AsyncValidatorConfig - Exhaustive Whitelist', () => {
 // ============================================================================
 
 describe('FunctionHttpValidatorConfig - Exhaustive Whitelist', () => {
-  type ExpectedKeys = 'type' | 'functionName' | 'params' | 'when';
+  type ExpectedKeys = 'type' | 'functionName' | 'fn' | 'params' | 'when';
   type ActualKeys = keyof FunctionHttpValidatorConfig;
 
   it('should have exactly the expected keys', () => {
@@ -182,8 +225,8 @@ describe('FunctionHttpValidatorConfig - Exhaustive Whitelist', () => {
   });
 
   describe('required keys', () => {
-    it('should have type and functionName as required', () => {
-      expectTypeOf<RequiredKeys<FunctionHttpValidatorConfig>>().toEqualTypeOf<'type' | 'functionName'>();
+    it('should have type, functionName, and fn as required-in-at-least-one-branch', () => {
+      expectTypeOf<RequiredKeys<FunctionHttpValidatorConfig>>().toEqualTypeOf<'type' | 'functionName' | 'fn'>();
     });
   });
 
@@ -192,8 +235,8 @@ describe('FunctionHttpValidatorConfig - Exhaustive Whitelist', () => {
       expectTypeOf<FunctionHttpValidatorConfig['type']>().toEqualTypeOf<'http'>();
     });
 
-    it('functionName should be string', () => {
-      expectTypeOf<FunctionHttpValidatorConfig['functionName']>().toEqualTypeOf<string>();
+    it('functionName should be string or undefined (XOR with fn)', () => {
+      expectTypeOf<FunctionHttpValidatorConfig['functionName']>().toEqualTypeOf<string | undefined>();
     });
 
     it('params should be Record<string, unknown>', () => {
@@ -202,6 +245,37 @@ describe('FunctionHttpValidatorConfig - Exhaustive Whitelist', () => {
 
     it('when should be ConditionalExpression', () => {
       expectTypeOf<FunctionHttpValidatorConfig['when']>().toEqualTypeOf<ConditionalExpression | undefined>();
+    });
+  });
+
+  describe('XOR shape', () => {
+    it('accepts the registered-name branch', () => {
+      const c: FunctionHttpValidatorConfig = { type: 'http', functionName: 'check' };
+      expectTypeOf(c).toMatchTypeOf<FunctionHttpValidatorConfig>();
+    });
+
+    it('accepts the inline-fn branch', () => {
+      const c: FunctionHttpValidatorConfig = {
+        type: 'http',
+        fn: { request: () => undefined, onSuccess: () => null },
+      };
+      expectTypeOf(c).toMatchTypeOf<FunctionHttpValidatorConfig>();
+    });
+
+    it('rejects both branches set simultaneously', () => {
+      // @ts-expect-error - cannot set both functionName and fn
+      const _bad: FunctionHttpValidatorConfig = {
+        type: 'http',
+        functionName: 'check',
+        fn: { request: () => undefined, onSuccess: () => null },
+      };
+      void _bad;
+    });
+
+    it('rejects neither branch set', () => {
+      // @ts-expect-error - must set one of functionName or fn
+      const _bad: FunctionHttpValidatorConfig = { type: 'http' };
+      void _bad;
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds inline-function alternatives (`fn` / `asyncFn`) to seven string-keyed authoring surfaces. Mirrors the addon pattern from #377 — exactly one of the registered name or the inline function must be set, with type-level XOR + runtime warning enforcement.

## Surfaces

**Conditions** (`packages/dynamic-forms/src/lib/models/expressions/conditional-expression.ts`)
- `CustomCondition.functionName` ↔ new `fn` (sync)
- `AsyncCondition.asyncFunctionName` ↔ new `asyncFn` (async)

**Derivations** (`packages/dynamic-forms/src/lib/models/logic/logic-config.ts`)
- `FunctionDerivation.functionName` ↔ new `fn` (sync)
- `AsyncFunctionDerivation.asyncFunctionName` ↔ new `asyncFn` (async)

**Validators** (`packages/dynamic-forms/src/lib/models/validation/validator-config.ts`)
- `CustomValidatorConfig.functionName` ↔ new `fn` (sync)
- `AsyncValidatorConfig.functionName` ↔ new `fn` (async)
- `FunctionHttpValidatorConfig.functionName` ↔ new `fn` (HTTP)

Uniform naming: `fn` for sync, `asyncFn` for async, applied identically across all 7 surfaces.

## Behaviour

- **Type-level XOR**: `?: never` on each side enforces "exactly one" at compile time. `@ts-expect-error` type tests cover both-set and neither-set rejection per surface.
- **Inline wins**: resolver short-circuits on `fn`/`asyncFn` before the registry lookup. If a JSON-loaded config sets both keys at runtime, a lenient warning is logged through `DynamicFormLogger` and the inline form wins.
- **Purely additive**: every existing config keeps working — `functionName`/`asyncFunctionName` paths are unchanged.
- **JSON-safety preserved**: the MCP registry continues to document only the registered form, since `fn` is by definition not JSON-serializable.

## Notes

- `CustomFunction` is now exported from the main entry for inline-fn ergonomics.
- Inline `fn` derivations without explicit `dependsOn` default to wildcard (`'*'`) — same semantics as registered `functionName` derivations. The dev-mode warning surfaces both via the same path.
- Async-condition cache key skips caching for inline configs to avoid conflating distinct inline functions under the same `stableStringify` key.

## Test plan

- [x] `pnpm build:libs` — all 7 packages clean
- [x] `pnpm nx test dynamic-forms` — green (2813 tests passing, +13 new for inline-fn surfaces)
- [x] `pnpm nx run-many -t type-test` — green (5 projects, XOR types behave as expected)
- [x] `pnpm nx run-many -t lint` on library packages — green
- [x] `pnpm nx test dynamic-form-mcp` — green

Pattern source: #377.