### PR TITLE
feat(dynamic-forms)!: allow overlapping leaf keys in different groups (#401)

### DIFF
--- a/apps/e2e/bootstrap/src/app/testing/submission-behavior/submission-behavior.spec.ts
+++ b/apps/e2e/bootstrap/src/app/testing/submission-behavior/submission-behavior.spec.ts
@@ -395,7 +395,8 @@ test.describe('Submission Behavior Tests', () => {
       await expect(scenario).toBeVisible();
 
       // Submit button inside group should be disabled initially (form is empty/invalid)
-      const submitButton = scenario.locator('#submitInGroup button');
+      // Submit button inside `actionsGroup` — DOM ID is scoped through the parent group.
+      const submitButton = scenario.locator('#actionsGroup_submitInGroup button');
       await expect(submitButton).toBeDisabled();
 
       // Fill one field (still invalid)
@@ -426,9 +427,9 @@ test.describe('Submission Behavior Tests', () => {
       const scenario = helpers.getScenario('hidden-field');
       await expect(scenario).toBeVisible();
 
-      // Fill the visible input fields
+      // Fill the visible input fields (description lives inside `metadata` group)
       await helpers.fillInput(helpers.getInput(scenario, 'name'), 'John Doe');
-      await helpers.fillInput(helpers.getInput(scenario, 'description'), 'Test description');
+      await helpers.fillInput(helpers.getInput(scenario, 'metadata_description'), 'Test description');
 
       // Hidden fields should not have any visible elements
       await expect(scenario.locator('[id="id"]')).not.toBeVisible();
@@ -436,9 +437,9 @@ test.describe('Submission Behavior Tests', () => {
       await expect(scenario.locator('[id="isActive"]')).not.toBeVisible();
       await expect(scenario.locator('[id="tagIds"]')).not.toBeVisible();
       await expect(scenario.locator('[id="labels"]')).not.toBeVisible();
-      // Hidden fields inside groups should also not be visible
-      await expect(scenario.locator('[id="createdBy"]')).not.toBeVisible();
-      await expect(scenario.locator('[id="source"]')).not.toBeVisible();
+      // Hidden fields inside `metadata` group also get scoped DOM IDs.
+      await expect(scenario.locator('[id="metadata_createdBy"]')).not.toBeVisible();
+      await expect(scenario.locator('[id="metadata_source"]')).not.toBeVisible();
 
       // Submit the form
       const submitButton = scenario.locator('#submitHidden button');
@@ -473,7 +474,8 @@ test.describe('Submission Behavior Tests', () => {
       // Count visible input fields
       // We expect to see: name input + description input (in group)
       const nameInput = scenario.locator('#name input');
-      const descriptionInput = scenario.locator('#description input');
+      // description lives inside `metadata` group → scoped ID.
+      const descriptionInput = scenario.locator('#metadata_description input');
       const visibleButtons = scenario.locator('#submitHidden button');
 
       await expect(nameInput).toHaveCount(1);

--- a/apps/e2e/core/src/app/testing/cascading-validation/cascading-validation.spec.ts
+++ b/apps/e2e/core/src/app/testing/cascading-validation/cascading-validation.spec.ts
@@ -112,8 +112,9 @@ test.describe('Cascading Validation Tests', () => {
 
       const submitButton = helpers.getSubmitButton(scenario);
       const showAddressCheckbox = helpers.getCheckbox(scenario, 'showAddress');
-      const streetInput = scenario.locator('#street input');
-      const cityInput = scenario.locator('#city input');
+      // street/city are inside the `address` group — DOM IDs are scoped.
+      const streetInput = scenario.locator('#address_street input');
+      const cityInput = scenario.locator('#address_city input');
 
       // Initially showAddress=false → group hidden → required leaves skip → submit enabled.
       await expect(streetInput).not.toBeVisible({ timeout: 5000 });

--- a/apps/e2e/core/src/app/testing/container-conditional-visibility/container-conditional-visibility.spec.ts
+++ b/apps/e2e/core/src/app/testing/container-conditional-visibility/container-conditional-visibility.spec.ts
@@ -23,10 +23,10 @@ test.describe('Container Conditional Visibility Tests', () => {
       const personalRadio = scenario.locator('#accountType mat-radio-button:has-text("Personal")');
       const businessRadio = scenario.locator('#accountType mat-radio-button:has-text("Business")');
 
-      // Get business group fields
-      const companyNameInput = scenario.locator('#companyName input');
-      const taxIdInput = scenario.locator('#taxId input');
-      const employeeCountSelect = helpers.getSelect(scenario, 'employeeCount');
+      // Get business group fields (DOM IDs scoped through `businessDetails` group)
+      const companyNameInput = scenario.locator('#businessDetails_companyName input');
+      const taxIdInput = scenario.locator('#businessDetails_taxId input');
+      const employeeCountSelect = helpers.getSelect(scenario, 'businessDetails_employeeCount');
 
       // Common field should always be visible
       const emailInput = scenario.locator('#commonField input');
@@ -69,15 +69,17 @@ test.describe('Container Conditional Visibility Tests', () => {
 
       // Get controls
       const showPersonalCheckbox = helpers.getCheckbox(scenario, 'showPersonal');
-      const hasMiddleNameCheckbox = helpers.getCheckbox(scenario, 'hasMiddleName');
+      // hasMiddleName lives inside the `personal` group — DOM IDs are scoped.
+      const hasMiddleNameCheckbox = helpers.getCheckbox(scenario, 'personal_hasMiddleName');
       const emailRadio = scenario.locator('#personal mat-radio-button:has-text("Email")');
       const phoneRadio = scenario.locator('#personal mat-radio-button:has-text("Phone")');
 
       // Get fields
-      const firstNameInput = scenario.locator('#personal #firstName input');
-      const middleNameInput = scenario.locator('#personal #middleName input');
-      const emailInput = scenario.locator('#personal #email input');
-      const phoneInput = scenario.locator('#personal #phone input');
+      // Group children get DOM IDs scoped through the parent group key.
+      const firstNameInput = scenario.locator('#personal_firstName input');
+      const middleNameInput = scenario.locator('#personal_middleName input');
+      const emailInput = scenario.locator('#personal_email input');
+      const phoneInput = scenario.locator('#personal_phone input');
 
       // Initially group is visible (checkbox is checked by default)
       await expect(firstNameInput).toBeVisible({ timeout: 5000 });
@@ -131,13 +133,13 @@ test.describe('Container Conditional Visibility Tests', () => {
       const includeAddressCheckbox = helpers.getCheckbox(scenario, 'includeAddress');
       const includeBillingCheckbox = helpers.getCheckbox(scenario, 'includeBilling');
 
-      // Get address group fields
-      const streetInput = scenario.locator('#street input');
-      const cityInput = scenario.locator('#city input');
-      const stateSelect = helpers.getSelect(scenario, 'state');
+      // Get address group fields (DOM IDs scoped through parent group key)
+      const streetInput = scenario.locator('#address_street input');
+      const cityInput = scenario.locator('#address_city input');
+      const stateSelect = helpers.getSelect(scenario, 'address_state');
 
       // Get billing group fields
-      const billingStreetInput = scenario.locator('#billingStreet input');
+      const billingStreetInput = scenario.locator('#billing_billingStreet input');
 
       // Initially both groups should be hidden
       await expect(streetInput).not.toBeVisible({ timeout: 5000 });
@@ -627,8 +629,8 @@ test.describe('Container Conditional Visibility Tests', () => {
       const checkbox = helpers.getCheckbox(scenario, 'includeAddress');
       await checkbox.click();
 
-      // Wait for fields to hide
-      const streetInput = scenario.locator('#addressGroup #street input');
+      // Wait for fields to hide (group children get scoped DOM IDs)
+      const streetInput = scenario.locator('#addressGroup_street input');
       await expect(streetInput).not.toBeVisible({ timeout: 5000 });
 
       // Submit and check data
@@ -653,10 +655,10 @@ test.describe('Container Conditional Visibility Tests', () => {
       // Get controls
       const showAddressCheckbox = helpers.getCheckbox(scenario, 'showAddress');
 
-      // Get group child fields
-      const streetInput = scenario.locator('#street input');
-      const cityInput = scenario.locator('#city input');
-      const zipInput = scenario.locator('#zip input');
+      // Get group child fields (DOM IDs scoped through parent group key)
+      const streetInput = scenario.locator('#addressGroup_street input');
+      const cityInput = scenario.locator('#addressGroup_city input');
+      const zipInput = scenario.locator('#addressGroup_zip input');
 
       // Notes field should always be visible
       const notesInput = scenario.locator('#notes input');
@@ -820,9 +822,9 @@ test.describe('Container Conditional Visibility Tests', () => {
       const scenario = helpers.getScenario('container-level-submission');
       await expect(scenario).toBeVisible({ timeout: 10000 });
 
-      // Verify initial state - group is visible
-      const streetInput = scenario.locator('#street input');
-      const cityInput = scenario.locator('#city input');
+      // Verify initial state - group is visible (children scoped under addressGroup)
+      const streetInput = scenario.locator('#addressGroup_street input');
+      const cityInput = scenario.locator('#addressGroup_city input');
       await expect(streetInput).toBeVisible({ timeout: 5000 });
       await expect(streetInput).toHaveValue('123 Main St', { timeout: 5000 });
       await expect(cityInput).toHaveValue('Springfield', { timeout: 5000 });
@@ -846,8 +848,8 @@ test.describe('Container Conditional Visibility Tests', () => {
       const showAddressCheckbox = helpers.getCheckbox(scenario, 'showAddress');
       await showAddressCheckbox.click();
 
-      // Verify group is hidden
-      const streetInput = scenario.locator('#street input');
+      // Verify group is hidden (children scoped under addressGroup)
+      const streetInput = scenario.locator('#addressGroup_street input');
       await expect(streetInput).not.toBeVisible({ timeout: 5000 });
 
       // Submit and check data - child values should still be in submission (V1 behavior: CSS-only hiding)

--- a/apps/e2e/core/src/app/testing/container-nesting/container-nesting.spec.ts
+++ b/apps/e2e/core/src/app/testing/container-nesting/container-nesting.spec.ts
@@ -53,9 +53,10 @@ test.describe('Container Nesting E2E Tests', () => {
       await expect(empNameInput).toBeVisible({ timeout: 5000 });
       await empNameInput.fill('Charlie');
 
-      // Fill address group inside array item (field IDs: street_0, city_0)
-      const streetInput = scenario.locator('#street_0 input');
-      const cityInput = scenario.locator('#city_0 input');
+      // Fill address group inside array item — group prefix + array index
+      // produce IDs like `address_street_0`.
+      const streetInput = scenario.locator('#address_street_0 input');
+      const cityInput = scenario.locator('#address_city_0 input');
       await expect(streetInput).toBeVisible({ timeout: 5000 });
       await streetInput.fill('123 Main St');
       await cityInput.fill('Springfield');
@@ -160,7 +161,8 @@ test.describe('Container Nesting E2E Tests', () => {
       const scenario = helpers.getScenario('container-inside-group');
       await expect(scenario).toBeVisible({ timeout: 10000 });
 
-      const stateInput = scenario.locator('#state input');
+      // DOM IDs of fields inside a group are scoped: `state` becomes `address_state`.
+      const stateInput = scenario.locator('#address_state input');
       await expect(stateInput).toBeVisible({ timeout: 5000 });
       await fillInput(stateInput, 'tx');
 
@@ -179,7 +181,7 @@ test.describe('Container Nesting E2E Tests', () => {
       const scenario = helpers.getScenario('container-inside-group-self');
       await expect(scenario).toBeVisible({ timeout: 10000 });
 
-      const stateInput = scenario.locator('#state input');
+      const stateInput = scenario.locator('#address_state input');
       await expect(stateInput).toBeVisible({ timeout: 5000 });
       await fillInput(stateInput, 'tx');
 
@@ -197,8 +199,8 @@ test.describe('Container Nesting E2E Tests', () => {
       const scenario = helpers.getScenario('container-inside-group-parent');
       await expect(scenario).toBeVisible({ timeout: 10000 });
 
-      const countryInput = scenario.locator('#country input');
-      const stateInput = scenario.locator('#state input');
+      const countryInput = scenario.locator('#address_country input');
+      const stateInput = scenario.locator('#address_state input');
       await expect(countryInput).toBeVisible({ timeout: 5000 });
 
       // $group resolves to 'address' — fires the derivation on any sibling change.

--- a/apps/e2e/core/src/app/testing/form-reset-clear/form-reset-clear.spec.ts
+++ b/apps/e2e/core/src/app/testing/form-reset-clear/form-reset-clear.spec.ts
@@ -290,8 +290,9 @@ test.describe('Form Reset and Clear Events Tests', () => {
       const scenario = helpers.getScenario('reset-nested');
       await expect(scenario).toBeVisible();
 
-      const firstNameInput = scenario.locator('#firstName input');
-      const lastNameInput = scenario.locator('#lastName input');
+      // firstName/lastName live inside the `userInfo` group — DOM IDs are scoped.
+      const firstNameInput = scenario.locator('#userInfo_firstName input');
+      const lastNameInput = scenario.locator('#userInfo_lastName input');
 
       // Verify defaults
       expect(await firstNameInput.inputValue()).toBe('John');
@@ -363,8 +364,9 @@ test.describe('Form Reset and Clear Events Tests', () => {
       await expect(scenario).toBeVisible();
 
       const nameInput = scenario.locator('#name input');
-      const streetInput = scenario.locator('#address #street input');
-      const cityInput = scenario.locator('#address #city input');
+      // street/city are inside the `address` group — DOM IDs are scoped.
+      const streetInput = scenario.locator('#address_street input');
+      const cityInput = scenario.locator('#address_city input');
 
       // Verify default values
       expect(await nameInput.inputValue()).toBe('Default Name');

--- a/apps/e2e/core/src/app/testing/multi-page-navigation/multi-page-navigation.routes.ts
+++ b/apps/e2e/core/src/app/testing/multi-page-navigation/multi-page-navigation.routes.ts
@@ -43,6 +43,11 @@ const routes: Routes = [
     loadComponent: () => import('../shared/test-scenario.component').then((m) => m.TestScenarioComponent),
     data: { scenario: getMultiPageNavigationScenario('page-dynamic-navigation') },
   },
+  {
+    path: 'overlapping-group-keys',
+    loadComponent: () => import('../shared/test-scenario.component').then((m) => m.TestScenarioComponent),
+    data: { scenario: getMultiPageNavigationScenario('overlapping-group-keys') },
+  },
 ];
 
 export default routes;

--- a/apps/e2e/core/src/app/testing/multi-page-navigation/multi-page-navigation.spec.ts
+++ b/apps/e2e/core/src/app/testing/multi-page-navigation/multi-page-navigation.spec.ts
@@ -586,4 +586,46 @@ test.describe('Multi-Page Navigation Tests', () => {
       });
     });
   });
+
+  test.describe('Overlapping Group Keys (issue #401)', () => {
+    test('should accept the same leaf key inside different groups and preserve scoped values', async ({ page, helpers }) => {
+      await page.goto('/#/test/multi-page-navigation/overlapping-group-keys');
+      await page.waitForLoadState('networkidle');
+
+      const scenario = helpers.getScenario('overlapping-group-keys');
+      await expect(scenario).toBeVisible();
+
+      // Page 1: fill `createADto.name` and advance. With group-scoped DOM IDs,
+      // each `name` field gets a distinct `#{group}_name` selector.
+      const aName = scenario.locator('#createADto_name input');
+      await expect(aName).toBeVisible();
+      await aName.fill('Alpha');
+
+      // Page 1's `next` button shares the `submit` key with page 2's submit
+      // (rows don't add scope). The inner <button> data-testid is
+      // `${buttonType}-${key}` — disambiguate via the next type.
+      await scenario.locator('[data-testid="button-submit"]').click();
+
+      const bName = scenario.locator('#createBDto_name input');
+      await expect(bName).toBeVisible();
+      await bName.fill('Bravo');
+
+      // The shared `submitFormAndCapture` helper targets `#submit button`, which
+      // matches BOTH page 1's next-button and page 2's submit-button (same key).
+      // Disambiguate via data-testid (`{type}-{key}`) and inline the capture.
+      const submittedDataPromise = page.evaluate(
+        () =>
+          new Promise((resolve) => {
+            window.addEventListener('formSubmitted', (event: Event) => resolve((event as CustomEvent).detail.data), { once: true });
+          }),
+      );
+      await scenario.locator('[data-testid="submit-submit"]').click();
+      const submittedData = (await submittedDataPromise) as Record<string, unknown>;
+
+      expect(submittedData).toMatchObject({
+        createADto: { name: 'Alpha' },
+        createBDto: { name: 'Bravo' },
+      });
+    });
+  });
 });

--- a/apps/e2e/core/src/app/testing/multi-page-navigation/multi-page-navigation.suite.ts
+++ b/apps/e2e/core/src/app/testing/multi-page-navigation/multi-page-navigation.suite.ts
@@ -6,6 +6,7 @@ import { pageTransitionsScenario } from './scenarios/page-transitions.scenario';
 import { validationNavigationScenario } from './scenarios/validation-navigation.scenario';
 import { pageConditionalVisibilityScenario } from './scenarios/page-conditional-visibility.scenario';
 import { pageDynamicNavigationScenario } from './scenarios/page-dynamic-navigation.scenario';
+import { overlappingGroupKeysScenario } from './scenarios/overlapping-group-keys.scenario';
 
 export const multiPageNavigationSuite: TestSuite = {
   id: 'multi-page-navigation',
@@ -23,6 +24,9 @@ export const multiPageNavigationSuite: TestSuite = {
     // Conditional Visibility
     pageConditionalVisibilityScenario,
     pageDynamicNavigationScenario,
+
+    // Regression: issue #401
+    overlappingGroupKeysScenario,
   ],
 };
 

--- a/apps/e2e/core/src/app/testing/multi-page-navigation/scenarios/overlapping-group-keys.scenario.ts
+++ b/apps/e2e/core/src/app/testing/multi-page-navigation/scenarios/overlapping-group-keys.scenario.ts
@@ -1,0 +1,79 @@
+import { FormConfig } from '@ng-forge/dynamic-forms';
+import { TestScenario } from '../../shared/types';
+
+/**
+ * Issue #401: same leaf key (`name`) inside two different group containers,
+ * plus identical button keys (`previous`, `submit`) repeated on each page.
+ *
+ * Two independent things must hold for this scenario to render at all:
+ *   - The validator scopes keys by group ancestor — `createADto.name` and
+ *     `createBDto.name` are distinct paths, so no duplicate-key error.
+ *   - Buttons (`valueHandling: 'exclude'`) are skipped from the duplicate
+ *     check, so the same `previous`/`submit` keys can appear on every page.
+ *
+ * The submitted value should keep the two `name`s in their respective groups.
+ */
+const config = {
+  fields: [
+    {
+      key: 'aPage',
+      type: 'page',
+      fields: [
+        {
+          key: 'createADto',
+          type: 'group',
+          fields: [
+            {
+              key: 'name',
+              type: 'input',
+              label: 'Name',
+              props: { hint: 'The name of a.', type: 'text' },
+              required: true,
+              col: 12,
+            },
+          ],
+        },
+        {
+          key: 'aButtons',
+          type: 'row',
+          fields: [{ key: 'submit', type: 'next', label: 'Next', col: 12 }],
+        },
+      ],
+    },
+    {
+      key: 'bPage',
+      type: 'page',
+      fields: [
+        {
+          key: 'createBDto',
+          type: 'group',
+          fields: [
+            {
+              key: 'name',
+              type: 'input',
+              label: 'Name',
+              props: { hint: 'The name of b.', type: 'text' },
+              required: true,
+              col: 12,
+            },
+          ],
+        },
+        {
+          key: 'bButtons',
+          type: 'row',
+          fields: [
+            { key: 'previous', type: 'previous', label: 'Back', col: 6 },
+            { key: 'submit', type: 'submit', label: 'Submit', col: 6 },
+          ],
+        },
+      ],
+    },
+  ],
+} as const satisfies FormConfig;
+
+export const overlappingGroupKeysScenario: TestScenario = {
+  testId: 'overlapping-group-keys',
+  title: 'Overlapping Group Keys (issue #401)',
+  description: 'Same leaf key inside different groups + repeated button keys across pages',
+  config,
+};

--- a/apps/e2e/core/src/app/testing/zod-schema-validation/zod-schema-validation.spec.ts
+++ b/apps/e2e/core/src/app/testing/zod-schema-validation/zod-schema-validation.spec.ts
@@ -194,12 +194,12 @@ test.describe('Zod Schema Validation E2E Tests', () => {
       const scenario = helpers.getScenario('comprehensive-validation-test');
 
       // Get nested email input (inside user group)
-      const emailInput = scenario.locator('#user #email input');
+      const emailInput = scenario.locator('#user_email input');
       await helpers.fillInput(emailInput, 'invalid-email');
       await helpers.blurInput(emailInput);
 
       // Verify error is displayed on email field
-      const errorElement = scenario.locator('#user #email mat-error').first();
+      const errorElement = scenario.locator('#user_email mat-error').first();
       await expect(errorElement).toContainText('Invalid email');
     });
 
@@ -210,12 +210,12 @@ test.describe('Zod Schema Validation E2E Tests', () => {
       const scenario = helpers.getScenario('comprehensive-validation-test');
 
       // Get firstName input inside user group
-      const firstNameInput = scenario.locator('#user #firstName input');
+      const firstNameInput = scenario.locator('#user_firstName input');
       await helpers.fillInput(firstNameInput, 'A');
       await helpers.blurInput(firstNameInput);
 
       // Verify error is displayed
-      const errorElement = scenario.locator('#user #firstName mat-error').first();
+      const errorElement = scenario.locator('#user_firstName mat-error').first();
       await expect(errorElement).toContainText('at least 2 characters');
     });
 
@@ -244,13 +244,13 @@ test.describe('Zod Schema Validation E2E Tests', () => {
       const submitButton = helpers.getSubmitButton(scenario);
 
       // Fill user info
-      const emailInput = scenario.locator('#user #email input');
+      const emailInput = scenario.locator('#user_email input');
       await helpers.fillInput(emailInput, 'test@example.com');
 
-      const firstNameInput = scenario.locator('#user #firstName input');
+      const firstNameInput = scenario.locator('#user_firstName input');
       await helpers.fillInput(firstNameInput, 'John');
 
-      const lastNameInput = scenario.locator('#user #lastName input');
+      const lastNameInput = scenario.locator('#user_lastName input');
       await helpers.fillInput(lastNameInput, 'Springfield');
 
       // Fill address with city matching last name (for cross-field validation)

--- a/apps/e2e/ionic/src/app/testing/submission-behavior/submission-behavior.spec.ts
+++ b/apps/e2e/ionic/src/app/testing/submission-behavior/submission-behavior.spec.ts
@@ -549,8 +549,9 @@ test.describe('Submission Behavior Tests', () => {
       await page.waitForSelector('[data-testid="submit-inside-group"] #email input', { state: 'visible', timeout: 10000 });
       await page.waitForSelector('[data-testid="submit-inside-group"] #name input', { state: 'visible', timeout: 10000 });
 
-      // Submit button inside group should be disabled initially (form is empty/invalid)
-      const submitButton = scenario.locator('#submitInGroup ion-button');
+      // Submit button inside group should be disabled initially (form is empty/invalid).
+      // The button lives inside `actionsGroup` — DOM ID is scoped.
+      const submitButton = scenario.locator('#actionsGroup_submitInGroup ion-button');
       await expect(submitButton).toHaveAttribute('aria-disabled', 'true', { timeout: 10000 });
 
       // Fill one field (still invalid)
@@ -569,7 +570,7 @@ test.describe('Submission Behavior Tests', () => {
       await ionBlur(nameInput);
 
       // Wait for submit button to be enabled
-      await page.waitForSelector('[data-testid="submit-inside-group"] #submitInGroup ion-button:not([aria-disabled="true"])', {
+      await page.waitForSelector('[data-testid="submit-inside-group"] #actionsGroup_submitInGroup ion-button:not([aria-disabled="true"])', {
         state: 'visible',
         timeout: 10000,
       });
@@ -605,7 +606,7 @@ test.describe('Submission Behavior Tests', () => {
       await expect(nameInput).toHaveValue('John Doe', { timeout: 5000 });
       await ionBlur(nameInput);
 
-      const descriptionInput = helpers.getInput(scenario, 'description');
+      const descriptionInput = helpers.getInput(scenario, 'metadata_description');
       await descriptionInput.fill('Test description');
       await expect(descriptionInput).toHaveValue('Test description', { timeout: 5000 });
       await ionBlur(descriptionInput);
@@ -616,9 +617,9 @@ test.describe('Submission Behavior Tests', () => {
       await expect(scenario.locator('[id="isActive"]')).not.toBeVisible();
       await expect(scenario.locator('[id="tagIds"]')).not.toBeVisible();
       await expect(scenario.locator('[id="labels"]')).not.toBeVisible();
-      // Hidden fields inside groups should also not be visible
-      await expect(scenario.locator('[id="createdBy"]')).not.toBeVisible();
-      await expect(scenario.locator('[id="source"]')).not.toBeVisible();
+      // Hidden fields inside `metadata` group also scope DOM IDs.
+      await expect(scenario.locator('[id="metadata_createdBy"]')).not.toBeVisible();
+      await expect(scenario.locator('[id="metadata_source"]')).not.toBeVisible();
 
       // Wait for submit button to be enabled
       await page.waitForSelector('[data-testid="hidden-field"] #submitHidden ion-button:not([aria-disabled="true"])', {
@@ -660,8 +661,9 @@ test.describe('Submission Behavior Tests', () => {
 
       // Count visible field containers - should only have visible inputs and submit button
       // Ionic uses ion-input and ion-button
+      // description lives inside `metadata` group — DOM ID is scoped.
       const nameInput = scenario.locator('#name input');
-      const descriptionInput = scenario.locator('#description input');
+      const descriptionInput = scenario.locator('#metadata_description input');
       const visibleButtons = scenario.locator('#submitHidden ion-button');
 
       // We expect to see: 2 input fields (name + description) + 1 submit button

--- a/apps/e2e/material/src/app/testing/array-fields/array-fields.spec.ts
+++ b/apps/e2e/material/src/app/testing/array-fields/array-fields.spec.ts
@@ -307,9 +307,10 @@ test.describe('Array Fields E2E Tests', () => {
       await emailInput.focus();
       await emailInput.blur();
 
-      // Error messages should be visible for empty required fields
-      const nameErrors = scenario.locator('#name_0 mat-error');
-      const emailErrors = scenario.locator('#email_0 mat-error');
+      // Error messages should be visible for empty required fields.
+      // Items have group `member` inside each array entry → IDs scope as `member_{key}_{index}`.
+      const nameErrors = scenario.locator('#member_name_0 mat-error');
+      const emailErrors = scenario.locator('#member_email_0 mat-error');
       await expect(nameErrors).toBeVisible({ timeout: 5000 });
       await expect(emailErrors).toBeVisible({ timeout: 5000 });
 

--- a/apps/e2e/material/src/app/testing/group-fields/group-fields.spec.ts
+++ b/apps/e2e/material/src/app/testing/group-fields/group-fields.spec.ts
@@ -15,8 +15,8 @@ test.describe('Group Fields E2E Tests', () => {
       await page.waitForLoadState('networkidle');
       await expect(scenario).toBeVisible({ timeout: 10000 });
 
-      const passwordInput = scenario.locator('#password input');
-      const confirmInput = scenario.locator('#confirmPassword input');
+      const passwordInput = scenario.locator('#credentials_password input');
+      const confirmInput = scenario.locator('#credentials_confirmPassword input');
 
       await expect(passwordInput).toBeVisible({ timeout: 5000 });
 
@@ -26,7 +26,7 @@ test.describe('Group Fields E2E Tests', () => {
       await confirmInput.blur();
 
       // The cross-field error must appear on confirmPassword
-      const errorEl = scenario.locator('#confirmPassword mat-error');
+      const errorEl = scenario.locator('#credentials_confirmPassword mat-error');
       await expect(errorEl).toBeVisible({ timeout: 5000 });
       await expect(errorEl).toContainText('Passwords must match');
     });
@@ -37,8 +37,8 @@ test.describe('Group Fields E2E Tests', () => {
       await page.waitForLoadState('networkidle');
       await expect(scenario).toBeVisible({ timeout: 10000 });
 
-      const passwordInput = scenario.locator('#password input');
-      const confirmInput = scenario.locator('#confirmPassword input');
+      const passwordInput = scenario.locator('#credentials_password input');
+      const confirmInput = scenario.locator('#credentials_confirmPassword input');
 
       await expect(passwordInput).toBeVisible({ timeout: 5000 });
 
@@ -46,13 +46,13 @@ test.describe('Group Fields E2E Tests', () => {
       await passwordInput.fill('secret123');
       await confirmInput.fill('different');
       await confirmInput.blur();
-      await expect(scenario.locator('#confirmPassword mat-error')).toBeVisible({ timeout: 5000 });
+      await expect(scenario.locator('#credentials_confirmPassword mat-error')).toBeVisible({ timeout: 5000 });
 
       // Now fix by matching the password
       await confirmInput.fill('secret123');
       await confirmInput.blur();
 
-      await expect(scenario.locator('#confirmPassword mat-error')).not.toBeVisible({ timeout: 5000 });
+      await expect(scenario.locator('#credentials_confirmPassword mat-error')).not.toBeVisible({ timeout: 5000 });
     });
   });
 
@@ -72,9 +72,9 @@ test.describe('Group Fields E2E Tests', () => {
       await nameInput.fill('Test User');
 
       // Fill nested group fields
-      const streetInput = scenario.locator('#street input');
-      const cityInput = scenario.locator('#city input');
-      const zipInput = scenario.locator('#zip input');
+      const streetInput = scenario.locator('#address_street input');
+      const cityInput = scenario.locator('#address_city input');
+      const zipInput = scenario.locator('#address_zip input');
 
       await expect(streetInput).toBeVisible({ timeout: 5000 });
       await streetInput.fill('123 Main St');
@@ -102,7 +102,7 @@ test.describe('Group Fields E2E Tests', () => {
       await expect(scenario).toBeVisible({ timeout: 10000 });
 
       // Fill a nested field
-      const streetInput = scenario.locator('#street input');
+      const streetInput = scenario.locator('#address_street input');
       await expect(streetInput).toBeVisible({ timeout: 5000 });
       await streetInput.fill('456 Oak Ave');
 
@@ -122,9 +122,10 @@ test.describe('Group Fields E2E Tests', () => {
       await expect(scenario).toBeVisible({ timeout: 10000 });
 
       // Verify initial values are displayed
-      await expect(scenario.locator('#firstName input')).toHaveValue('John', { timeout: 5000 });
-      await expect(scenario.locator('#lastName input')).toHaveValue('Doe', { timeout: 5000 });
-      await expect(scenario.locator('#email input')).toHaveValue('john.doe@example.com', { timeout: 5000 });
+      // Fields live inside `profile` group — DOM IDs are scoped.
+      await expect(scenario.locator('#profile_firstName input')).toHaveValue('John', { timeout: 5000 });
+      await expect(scenario.locator('#profile_lastName input')).toHaveValue('Doe', { timeout: 5000 });
+      await expect(scenario.locator('#profile_email input')).toHaveValue('john.doe@example.com', { timeout: 5000 });
     });
 
     test('should allow editing initial values in group fields', async ({ page, helpers }) => {
@@ -134,7 +135,8 @@ test.describe('Group Fields E2E Tests', () => {
       await expect(scenario).toBeVisible({ timeout: 10000 });
 
       // Edit the first name
-      const firstNameInput = scenario.locator('#firstName input');
+      // Field lives inside `profile` group — DOM ID is scoped.
+      const firstNameInput = scenario.locator('#profile_firstName input');
       await expect(firstNameInput).toHaveValue('John', { timeout: 5000 });
 
       await firstNameInput.clear();
@@ -143,7 +145,7 @@ test.describe('Group Fields E2E Tests', () => {
       await expect(firstNameInput).toHaveValue('Jane', { timeout: 5000 });
 
       // Other fields should remain unchanged
-      await expect(scenario.locator('#lastName input')).toHaveValue('Doe', { timeout: 5000 });
+      await expect(scenario.locator('#profile_lastName input')).toHaveValue('Doe', { timeout: 5000 });
     });
   });
 
@@ -155,16 +157,17 @@ test.describe('Group Fields E2E Tests', () => {
       await expect(scenario).toBeVisible({ timeout: 10000 });
 
       // Fill personal group fields
-      const firstNameInput = scenario.locator('#firstName input');
-      const lastNameInput = scenario.locator('#lastName input');
+      // Fields live inside `personal` group — DOM IDs are scoped.
+      const firstNameInput = scenario.locator('#personal_firstName input');
+      const lastNameInput = scenario.locator('#personal_lastName input');
       await expect(firstNameInput).toBeVisible({ timeout: 5000 });
 
       await firstNameInput.fill('John');
       await lastNameInput.fill('Doe');
 
       // Fill work group fields
-      const companyInput = scenario.locator('#company input');
-      const positionInput = scenario.locator('#position input');
+      const companyInput = scenario.locator('#work_company input');
+      const positionInput = scenario.locator('#work_position input');
       await expect(companyInput).toBeVisible({ timeout: 5000 });
 
       await companyInput.fill('Acme Corp');
@@ -187,12 +190,12 @@ test.describe('Group Fields E2E Tests', () => {
       await expect(scenario).toBeVisible({ timeout: 10000 });
 
       // Fill work group first
-      const companyInput = scenario.locator('#company input');
+      const companyInput = scenario.locator('#work_company input');
       await expect(companyInput).toBeVisible({ timeout: 5000 });
       await companyInput.fill('TechCorp');
 
       // Then fill personal group
-      const firstNameInput = scenario.locator('#firstName input');
+      const firstNameInput = scenario.locator('#personal_firstName input');
       await firstNameInput.fill('Jane');
 
       // Verify work group value is maintained

--- a/apps/e2e/material/src/app/testing/submission-behavior/submission-behavior.spec.ts
+++ b/apps/e2e/material/src/app/testing/submission-behavior/submission-behavior.spec.ts
@@ -395,8 +395,9 @@ test.describe('Submission Behavior Tests', () => {
       const scenario = helpers.getScenario('submit-inside-group');
       await expect(scenario).toBeVisible();
 
-      // Submit button inside group should be disabled initially (form is empty/invalid)
-      const submitButton = scenario.locator('#submitInGroup button');
+      // Submit button inside group should be disabled initially (form is empty/invalid).
+      // The button lives inside `actionsGroup` — DOM ID is scoped through the parent group.
+      const submitButton = scenario.locator('#actionsGroup_submitInGroup button');
       await expect(submitButton).toBeDisabled();
 
       // Fill one field (still invalid)
@@ -427,9 +428,9 @@ test.describe('Submission Behavior Tests', () => {
       const scenario = helpers.getScenario('hidden-field');
       await expect(scenario).toBeVisible();
 
-      // Fill the visible input fields
+      // Fill the visible input fields (description lives inside `metadata` group → scoped ID)
       await helpers.fillInput(helpers.getInput(scenario, 'name'), 'John Doe');
-      await helpers.fillInput(helpers.getInput(scenario, 'description'), 'Test description');
+      await helpers.fillInput(helpers.getInput(scenario, 'metadata_description'), 'Test description');
 
       // Hidden fields should not have any visible elements
       await expect(scenario.locator('[id="id"]')).not.toBeVisible();
@@ -437,9 +438,9 @@ test.describe('Submission Behavior Tests', () => {
       await expect(scenario.locator('[id="isActive"]')).not.toBeVisible();
       await expect(scenario.locator('[id="tagIds"]')).not.toBeVisible();
       await expect(scenario.locator('[id="labels"]')).not.toBeVisible();
-      // Hidden fields inside groups should also not be visible
-      await expect(scenario.locator('[id="createdBy"]')).not.toBeVisible();
-      await expect(scenario.locator('[id="source"]')).not.toBeVisible();
+      // Hidden fields inside groups should also not be visible (DOM IDs scoped through `metadata`)
+      await expect(scenario.locator('[id="metadata_createdBy"]')).not.toBeVisible();
+      await expect(scenario.locator('[id="metadata_source"]')).not.toBeVisible();
 
       // Submit the form
       const submitButton = scenario.locator('#submitHidden button');

--- a/apps/e2e/primeng/src/app/testing/submission-behavior/submission-behavior.spec.ts
+++ b/apps/e2e/primeng/src/app/testing/submission-behavior/submission-behavior.spec.ts
@@ -546,7 +546,7 @@ test.describe('Submission Behavior Tests', () => {
       await page.waitForSelector('[data-testid="submit-inside-group"] #name input', { state: 'visible', timeout: 10000 });
 
       // Submit button inside group should be disabled initially (form is empty/invalid)
-      const submitButton = scenario.locator('#submitInGroup button');
+      const submitButton = scenario.locator('#actionsGroup_submitInGroup button');
       await expect(submitButton).toBeDisabled({ timeout: 10000 });
 
       // Fill one field (still invalid)
@@ -565,7 +565,7 @@ test.describe('Submission Behavior Tests', () => {
       await nameInput.blur();
 
       // Wait for submit button to be enabled
-      await page.waitForSelector('[data-testid="submit-inside-group"] #submitInGroup button:not([disabled])', {
+      await page.waitForSelector('[data-testid="submit-inside-group"] #actionsGroup_submitInGroup button:not([disabled])', {
         state: 'visible',
         timeout: 10000,
       });
@@ -601,7 +601,7 @@ test.describe('Submission Behavior Tests', () => {
       await expect(nameInput).toHaveValue('John Doe', { timeout: 5000 });
       await nameInput.blur();
 
-      const descriptionInput = helpers.getInput(scenario, 'description');
+      const descriptionInput = helpers.getInput(scenario, 'metadata_description');
       await descriptionInput.fill('Test description');
       await expect(descriptionInput).toHaveValue('Test description', { timeout: 5000 });
       await descriptionInput.blur();
@@ -612,9 +612,9 @@ test.describe('Submission Behavior Tests', () => {
       await expect(scenario.locator('[id="isActive"]')).not.toBeVisible();
       await expect(scenario.locator('[id="tagIds"]')).not.toBeVisible();
       await expect(scenario.locator('[id="labels"]')).not.toBeVisible();
-      // Hidden fields inside groups should also not be visible
-      await expect(scenario.locator('[id="createdBy"]')).not.toBeVisible();
-      await expect(scenario.locator('[id="source"]')).not.toBeVisible();
+      // Hidden fields inside `metadata` group also scope DOM IDs.
+      await expect(scenario.locator('[id="metadata_createdBy"]')).not.toBeVisible();
+      await expect(scenario.locator('[id="metadata_source"]')).not.toBeVisible();
 
       // Wait for submit button to be enabled
       await page.waitForSelector('[data-testid="hidden-field"] #submitHidden button:not([disabled])', {
@@ -657,7 +657,8 @@ test.describe('Submission Behavior Tests', () => {
       // Count visible field containers - should only have visible inputs and submit button
       // PrimeNG uses p-floatlabel for inputs and p-button for buttons
       const nameInput = scenario.locator('#name input');
-      const descriptionInput = scenario.locator('#description input');
+      // description lives inside `metadata` group → scoped ID.
+      const descriptionInput = scenario.locator('#metadata_description input');
       const visibleButtons = scenario.locator('#submitHidden button');
 
       // We expect to see: 2 input fields (name + description) + 1 submit button

--- a/packages/dynamic-form-mcp/src/registry/instructions.ts
+++ b/packages/dynamic-form-mcp/src/registry/instructions.ts
@@ -38,7 +38,7 @@ const config: FormConfig = {
 
 Every field MUST have:
 
-- \`key\`: Unique identifier (except for \`row\` type which is layout-only)
+- \`key\`: Identifier, unique within its group scope (the same leaf key may repeat inside different groups, e.g. \`createA.name\` and \`createB.name\`). Page/row/array containers do not introduce a scope. Buttons (which don't bind to form values) don't need unique keys.
 - \`type\`: One of the registered field types
 - \`label\`: Human-readable label (for accessibility)
 
@@ -412,7 +412,7 @@ Available adapters:
 
 1. **Missing labels** - Always include labels for accessibility
 2. **Missing validation messages** - Users need clear feedback
-3. **Duplicate keys** - Each key must be unique within its scope
+3. **Duplicate keys within a group scope** - Keys must be unique within the same group. Same key in different groups is fine (different scoped paths). Buttons are exempt.
 4. **Select without options** - Select/radio fields must have options
 5. **Array without fields** - Array fields need a fields template
 6. **Group without fields** - Group fields need child fields

--- a/packages/dynamic-form-mcp/src/registry/instructions.ts
+++ b/packages/dynamic-form-mcp/src/registry/instructions.ts
@@ -39,6 +39,8 @@ const config: FormConfig = {
 Every field MUST have:
 
 - \`key\`: Identifier, unique within its group scope (the same leaf key may repeat inside different groups, e.g. \`createA.name\` and \`createB.name\`). Page/row/array containers do not introduce a scope. Buttons (which don't bind to form values) don't need unique keys.
+  - **DOM id / data-testid composition:** keys are joined with \`_\` through group ancestors to form the rendered DOM id. A leaf \`street\` inside group \`address\` renders as \`id="address_street"\`. Inside an array item, the item index is appended after: \`id="address_street_0"\`. Use this exact form for \`for=\`, \`aria-describedby\`, \`aria-labelledby\`, or CSS selectors that target group-nested fields.
+  - **Avoid \`_\` in keys when they could collide with a group-prefixed id.** A top-level key \`foo_bar\` and a leaf \`bar\` inside group \`foo\` would both render as \`id="foo_bar"\`. The validator catches this collision at boot, but it's easier to just not put \`_\` in keys that share a name with an existing group + leaf pair.
 - \`type\`: One of the registered field types
 - \`label\`: Human-readable label (for accessibility)
 

--- a/packages/dynamic-forms/src/lib/core/page-orchestrator/page-orchestrator.component.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/page-orchestrator/page-orchestrator.component.spec.ts
@@ -224,7 +224,8 @@ describe('PageOrchestratorComponent', () => {
       await waitForFormInit(fixture, 1500);
 
       const section = fixture.nativeElement.querySelector('[data-testid="section"]');
-      const renderedRows = fixture.nativeElement.querySelectorAll('[data-testid^="row"]');
+      // Rows inside the `section` group are scoped — DOM IDs become `section_row_*`.
+      const renderedRows = fixture.nativeElement.querySelectorAll('[data-testid^="section_row"]');
 
       expect(section).toBeTruthy();
       expect(renderedRows).toHaveLength(rowCount);

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-collector.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-collector.spec.ts
@@ -200,10 +200,74 @@ describe('property-derivation-collector', () => {
       const collection = collectPropertyDerivations(fields, logger, tracker);
 
       expect(collection.entries).toHaveLength(2);
-      expect(collection.entries[0].fieldKey).toBe('zipField');
+      // Group ancestors are folded into the store key so overlapping leaf keys
+      // in different groups stay distinct (issue #401). Layout containers
+      // (page, row) do not contribute.
+      expect(collection.entries[0].fieldKey).toBe('addressGroup.zipField');
       expect(collection.entries[0].targetProperty).toBe('placeholder');
       expect(collection.entries[1].fieldKey).toBe('citySelect');
       expect(collection.entries[1].targetProperty).toBe('options');
+    });
+
+    it('should distinguish overlapping leaf keys in different groups (issue #401)', () => {
+      const fields: FieldDef<unknown>[] = [
+        {
+          key: 'createADto',
+          type: 'group',
+          fields: [
+            {
+              key: 'name',
+              type: 'input',
+              logic: [{ type: 'derivation', targetProperty: 'label', value: 'A Name' }],
+            } as unknown as FieldDef<unknown>,
+          ],
+        } as unknown as FieldDef<unknown>,
+        {
+          key: 'createBDto',
+          type: 'group',
+          fields: [
+            {
+              key: 'name',
+              type: 'input',
+              logic: [{ type: 'derivation', targetProperty: 'label', value: 'B Name' }],
+            } as unknown as FieldDef<unknown>,
+          ],
+        } as unknown as FieldDef<unknown>,
+      ];
+
+      const collection = collectPropertyDerivations(fields, logger, tracker);
+
+      expect(collection.entries).toHaveLength(2);
+      expect(collection.entries[0].fieldKey).toBe('createADto.name');
+      expect(collection.entries[1].fieldKey).toBe('createBDto.name');
+    });
+
+    it('should combine arrayPath with inner groupPath (array > group > input)', () => {
+      const fields: FieldDef<unknown>[] = [
+        {
+          key: 'contacts',
+          type: 'array',
+          fields: [
+            {
+              key: 'profile',
+              type: 'group',
+              fields: [
+                {
+                  key: 'email',
+                  type: 'input',
+                  logic: [{ type: 'derivation', targetProperty: 'placeholder', expression: 'formValue.x' }],
+                } as unknown as FieldDef<unknown>,
+              ],
+            } as unknown as FieldDef<unknown>,
+          ],
+        } as unknown as FieldDef<unknown>,
+      ];
+
+      const collection = collectPropertyDerivations(fields, logger, tracker);
+
+      expect(collection.entries).toHaveLength(1);
+      // Array resets ancestor groupPath; the inner group contributes to the per-item key.
+      expect(collection.entries[0].fieldKey).toBe('contacts.$.profile.email');
     });
 
     it('should handle array field context by creating placeholder paths with $', () => {

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-collector.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-collector.ts
@@ -9,13 +9,21 @@ import { buildPropertyOverrideKey, PLACEHOLDER_INDEX } from './property-override
 import { PropertyDerivationCollection, PropertyDerivationEntry } from './property-derivation-types';
 
 /**
- * Context for collecting property derivations, tracking array path for relative references.
+ * Context for collecting property derivations, tracking array and group ancestry.
  *
  * @internal
  */
 interface CollectionContext {
   /** Current array path for resolving relative field references. */
   arrayPath?: string;
+  /**
+   * Dot-joined ancestor group keys scoped to the current array item
+   * (or top-level when not inside an array). Reset at array boundaries —
+   * group ancestors OUTSIDE an array don't contribute to descendants'
+   * store keys because the array placeholder `{arrayKey}.$.` already
+   * encodes the field's location relative to each array item.
+   */
+  groupPath?: string;
   logger: Logger;
   tracker: WarningTracker;
 }
@@ -43,8 +51,15 @@ export function collectPropertyDerivations(
   const context: CollectionContext = { logger, tracker };
 
   traverseFieldsWithContext<CollectionContext>(fields, context, (field, ctx) => collectFromField(field, entries, ctx), {
-    onArrayChild: (_, field) => ({ arrayPath: field.key }),
-    // Group and layout containers do not affect property-derivation paths.
+    // Array boundary: each item is its own model root. Reset groupPath so
+    // ancestor groups OUTSIDE the array don't bleed into per-item keys.
+    onArrayChild: (_, field) => ({ arrayPath: field.key, groupPath: undefined }),
+    onGroupChild: (parent, field) => {
+      // Keyless groups (rare) act like layout containers — pass through.
+      if (!field.key) return {};
+      return { groupPath: parent.groupPath ? `${parent.groupPath}.${field.key}` : field.key };
+    },
+    // Layout containers (page, row, container) leave context unchanged.
   });
 
   return { entries };
@@ -84,7 +99,12 @@ function createPropertyDerivationEntryFromDerivation(
   config: DerivationLogicConfig & { targetProperty: string },
   context: CollectionContext,
 ): PropertyDerivationEntry {
-  const effectiveFieldKey = buildPropertyOverrideKey(context.arrayPath, context.arrayPath ? PLACEHOLDER_INDEX : undefined, fieldKey);
+  const effectiveFieldKey = buildPropertyOverrideKey(
+    context.arrayPath,
+    context.arrayPath ? PLACEHOLDER_INDEX : undefined,
+    fieldKey,
+    context.groupPath,
+  );
   const dependsOn = extractDependenciesFromConfig(config);
   const condition = config.condition ?? true;
   const trigger = config.trigger ?? 'onChange';

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-override-key.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-override-key.spec.ts
@@ -33,4 +33,26 @@ describe('buildPropertyOverrideKey', () => {
   it('should return just fieldKey when using PLACEHOLDER_INDEX without arrayKey', () => {
     expect(buildPropertyOverrideKey(undefined, PLACEHOLDER_INDEX, 'name')).toBe('name');
   });
+
+  it('should prefix the groupPath for top-level group fields', () => {
+    expect(buildPropertyOverrideKey(undefined, undefined, 'name', 'createADto')).toBe('createADto.name');
+  });
+
+  it('should distinguish overlapping leaf keys via groupPath (issue #401)', () => {
+    expect(buildPropertyOverrideKey(undefined, undefined, 'name', 'createADto')).not.toBe(
+      buildPropertyOverrideKey(undefined, undefined, 'name', 'createBDto'),
+    );
+  });
+
+  it('should join nested groupPath segments with dots', () => {
+    expect(buildPropertyOverrideKey(undefined, undefined, 'street', 'user.address')).toBe('user.address.street');
+  });
+
+  it('should place groupPath inside the array placeholder (group nested under array item)', () => {
+    expect(buildPropertyOverrideKey('contacts', PLACEHOLDER_INDEX, 'email', 'profile')).toBe('contacts.$.profile.email');
+  });
+
+  it('should ignore empty groupPath', () => {
+    expect(buildPropertyOverrideKey(undefined, undefined, 'name', '')).toBe('name');
+  });
 });

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-override-key.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-override-key.ts
@@ -17,14 +17,22 @@ export const PLACEHOLDER_INDEX = '$' as const;
 /**
  * Builds a property override store key for a field.
  *
- * For non-array fields, the key is just the field's key.
- * For array item fields, the key includes the array path and either a concrete
- * index (e.g., `contacts.0.email`) or the `$` placeholder (e.g., `contacts.$.email`).
+ * For non-array fields, the key is the dot-joined group ancestors plus the
+ * field's leaf key (e.g., `address.street` for `street` inside `address`).
+ * For array item fields, the key includes the array path, either a concrete
+ * index or the `$` placeholder, and any group ancestors INSIDE the array
+ * item (e.g., `contacts.0.email`, `contacts.$.email`, or
+ * `contacts.0.profile.email` for a group nested under each contact).
+ *
+ * `groupPath` matches the form-value path of nested groups (collector resets
+ * it at array boundaries — see `property-derivation-collector.ts`), so the
+ * resulting key always mirrors the field's location in `formValue`.
  *
  * @param arrayKey - The array field key (e.g., 'contacts'), or undefined for non-array fields
  * @param index - The array item index, `PLACEHOLDER_INDEX` for the wildcard format, or undefined for non-array fields
  * @param fieldKey - The leaf field key (e.g., 'email')
- * @returns The store key (e.g., 'email', 'contacts.0.email', or 'contacts.$.email')
+ * @param groupPath - Dot-joined group ancestors scoped to the current array item (or top-level), or undefined when not inside any group
+ * @returns The store key (e.g., 'email', 'address.street', 'contacts.0.email', 'contacts.$.profile.email')
  *
  * @public
  */
@@ -32,9 +40,11 @@ export function buildPropertyOverrideKey(
   arrayKey: string | undefined,
   index: number | typeof PLACEHOLDER_INDEX | undefined,
   fieldKey: string,
+  groupPath?: string,
 ): string {
+  const leafScope = groupPath ? `${groupPath}.${fieldKey}` : fieldKey;
   if (arrayKey != null && index != null) {
-    return `${arrayKey}.${index}.${fieldKey}`;
+    return `${arrayKey}.${index}.${leafScope}`;
   }
-  return fieldKey;
+  return leafScope;
 }

--- a/packages/dynamic-forms/src/lib/dynamic-form.component.spec.ts
+++ b/packages/dynamic-forms/src/lib/dynamic-form.component.spec.ts
@@ -2285,7 +2285,8 @@ describe('DynamicFormComponent', () => {
       await waitForDynamicComponents(fixture);
 
       const groupElement = fixture.nativeElement.querySelector('[data-testid="contact"]');
-      const rowContainer = fixture.nativeElement.querySelector('[data-testid="name"]');
+      // Children of `contact` get DOM IDs scoped through the parent group key.
+      const rowContainer = fixture.nativeElement.querySelector('[data-testid="contact_name"]');
       const rowElement = rowContainer?.querySelector('df-row-wrapper');
 
       // Should create nested structure with group containing row-flattened fields
@@ -2408,7 +2409,8 @@ describe('DynamicFormComponent', () => {
       await waitForDynamicComponents(fixture);
 
       const groupElement = fixture.nativeElement.querySelector('[data-testid="contact"]');
-      const rowContainer = fixture.nativeElement.querySelector('[data-testid="nameRow"]');
+      // Row's DOM ID is scoped through the parent group key.
+      const rowContainer = fixture.nativeElement.querySelector('[data-testid="contact_nameRow"]');
       const rowElement = rowContainer?.querySelector('df-row-wrapper');
 
       expect(component.formValue()).toEqual({

--- a/packages/dynamic-forms/src/lib/fields/group/group-field.component.ts
+++ b/packages/dynamic-forms/src/lib/fields/group/group-field.component.ts
@@ -189,23 +189,16 @@ export default class GroupFieldComponent<TModel extends Record<string, unknown> 
   /**
    * Group context propagated to descendants — carries the dot-separated path of
    * group ancestors so child fields can scope their DOM IDs (issue #401).
-   * `groupPath` is computed lazily via a getter because it reads the required
-   * `field` input, which isn't bound at class-init time.
+   * Reactive via `computed()`: a nested group composes its path from the parent
+   * context signal + its own key, so the chain stays consistent if either changes.
    */
-  private readonly groupContext: GroupContext = (() => {
-    const fieldSignal = this.field;
-    const parent = this.parentGroupContext;
-    let cached: string | undefined;
-    return {
-      get groupPath(): string {
-        if (cached === undefined) {
-          const ownKey = untracked(() => fieldSignal().key);
-          cached = parent?.groupPath ? `${parent.groupPath}.${ownKey}` : ownKey;
-        }
-        return cached;
-      },
-    };
-  })();
+  private readonly groupContext: GroupContext = {
+    groupPath: computed(() => {
+      const ownKey = this.field().key;
+      const parentPath = this.parentGroupContext?.groupPath();
+      return parentPath ? `${parentPath}.${ownKey}` : ownKey;
+    }),
+  };
 
   private readonly groupInjector = Injector.create({
     parent: this.injector,

--- a/packages/dynamic-forms/src/lib/fields/group/group-field.component.ts
+++ b/packages/dynamic-forms/src/lib/fields/group/group-field.component.ts
@@ -24,8 +24,8 @@ import { GroupField } from '../../definitions/default/group-field';
 import { injectFieldRegistry } from '../../utils/inject-field-registry/inject-field-registry';
 import { FieldTree, form } from '@angular/forms/signals';
 import { FieldDef } from '../../definitions/base/field-def';
-import { FieldSignalContext } from '../../mappers/types';
-import { FIELD_SIGNAL_CONTEXT } from '../../models/field-signal-context.token';
+import { FieldSignalContext, GroupContext } from '../../mappers/types';
+import { FIELD_SIGNAL_CONTEXT, GROUP_CONTEXT } from '../../models/field-signal-context.token';
 import { createSchemaFromFields } from '../../core/schema-builder';
 import { EventBus } from '../../events/event.bus';
 import { SubmitEvent } from '../../events/constants/submit.event';
@@ -65,6 +65,7 @@ export default class GroupFieldComponent<TModel extends Record<string, unknown> 
   private readonly destroyRef = inject(DestroyRef);
   private readonly fieldRegistry = injectFieldRegistry();
   private readonly parentFieldSignalContext = inject(FIELD_SIGNAL_CONTEXT) as FieldSignalContext<TModel>;
+  private readonly parentGroupContext = inject(GROUP_CONTEXT, { optional: true });
   private readonly injector = inject(Injector);
   protected readonly environmentInjector = inject(EnvironmentInjector);
   private readonly eventBus = inject(EventBus);
@@ -185,9 +186,33 @@ export default class GroupFieldComponent<TModel extends Record<string, unknown> 
     };
   })();
 
+  /**
+   * Group context propagated to descendants — carries the dot-separated path of
+   * group ancestors so child fields can scope their DOM IDs (issue #401).
+   * `groupPath` is computed lazily via a getter because it reads the required
+   * `field` input, which isn't bound at class-init time.
+   */
+  private readonly groupContext: GroupContext = (() => {
+    const fieldSignal = this.field;
+    const parent = this.parentGroupContext;
+    let cached: string | undefined;
+    return {
+      get groupPath(): string {
+        if (cached === undefined) {
+          const ownKey = untracked(() => fieldSignal().key);
+          cached = parent?.groupPath ? `${parent.groupPath}.${ownKey}` : ownKey;
+        }
+        return cached;
+      },
+    };
+  })();
+
   private readonly groupInjector = Injector.create({
     parent: this.injector,
-    providers: [{ provide: FIELD_SIGNAL_CONTEXT, useValue: this.groupFieldSignalContext }],
+    providers: [
+      { provide: FIELD_SIGNAL_CONTEXT, useValue: this.groupFieldSignalContext },
+      { provide: GROUP_CONTEXT, useValue: this.groupContext },
+    ],
   });
 
   // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/dynamic-forms/src/lib/fields/group/group-field.component.ts
+++ b/packages/dynamic-forms/src/lib/fields/group/group-field.component.ts
@@ -52,6 +52,9 @@ import { SubmitEvent } from '../../events/constants/submit.event';
     '[class.disabled]': 'disabled()',
     '[class.df-container-hidden]': 'hidden()',
     '[attr.aria-hidden]': 'hidden() || null',
+    // The group element's own id is the plain `key()` — only its DESCENDANTS
+    // compose scoped ids via GROUP_CONTEXT (e.g. children of an `address`
+    // group render as `address_street`). The group selector is `#address`.
     '[id]': '`${key()}`',
     '[attr.data-testid]': 'key()',
   },

--- a/packages/dynamic-forms/src/lib/index.ts
+++ b/packages/dynamic-forms/src/lib/index.ts
@@ -216,7 +216,15 @@ export type { FieldScope, FieldTypeDefinition, ValueHandlingMode } from './model
 export { FIELD_REGISTRY } from './models';
 
 // Signal Context - injection tokens for field components
-export { ARRAY_CONTEXT, DEFAULT_PROPS, DEFAULT_VALIDATION_MESSAGES, DEFAULT_WRAPPERS, FIELD_SIGNAL_CONTEXT, FORM_OPTIONS } from './models';
+export {
+  ARRAY_CONTEXT,
+  DEFAULT_PROPS,
+  DEFAULT_VALIDATION_MESSAGES,
+  DEFAULT_WRAPPERS,
+  FIELD_SIGNAL_CONTEXT,
+  FORM_OPTIONS,
+  GROUP_CONTEXT,
+} from './models';
 
 // Dynamic Text utilities
 export { dynamicTextToObservable } from './utils';

--- a/packages/dynamic-forms/src/lib/mappers/index.ts
+++ b/packages/dynamic-forms/src/lib/mappers/index.ts
@@ -1,4 +1,4 @@
-export type { ArrayContext, FieldSignalContext, MapperFn } from './types';
+export type { ArrayContext, FieldSignalContext, GroupContext, MapperFn } from './types';
 export { baseFieldMapper, buildBaseInputs } from './base/base-field-mapper';
 export { rowFieldMapper } from './row/row-field-mapper';
 export { groupFieldMapper } from './group/group-field-mapper';

--- a/packages/dynamic-forms/src/lib/mappers/types.ts
+++ b/packages/dynamic-forms/src/lib/mappers/types.ts
@@ -45,6 +45,22 @@ export interface ArrayContext {
 }
 
 /**
+ * Group context for fields rendered inside `group` containers.
+ *
+ * Carries the dot-separated chain of group ancestors (including the current
+ * group). Used by `mapFieldToInputs` to scope DOM IDs of group children, so
+ * the same leaf key can appear inside different groups without producing
+ * duplicate `id` attributes (issue #401).
+ *
+ * Re-provided by every group's child injector — a nested group reads its
+ * parent's context and appends its own key.
+ */
+export interface GroupContext {
+  /** Dot-separated path of group ancestors, including the current group's key (e.g. `'address'` or `'user.address'`). */
+  groupPath: string;
+}
+
+/**
  * Mapper function that converts a field definition to component inputs.
  *
  * Mappers run within an injection context and can inject FIELD_SIGNAL_CONTEXT.

--- a/packages/dynamic-forms/src/lib/mappers/types.ts
+++ b/packages/dynamic-forms/src/lib/mappers/types.ts
@@ -47,17 +47,17 @@ export interface ArrayContext {
 /**
  * Group context for fields rendered inside `group` containers.
  *
- * Carries the dot-separated chain of group ancestors (including the current
- * group). Used by `mapFieldToInputs` to scope DOM IDs of group children, so
- * the same leaf key can appear inside different groups without producing
- * duplicate `id` attributes (issue #401).
+ * Carries a reactive dot-separated chain of group ancestors (including the
+ * current group). Used by `mapFieldToInputs` to scope DOM IDs of group
+ * children, so the same leaf key can appear inside different groups without
+ * producing duplicate `id` attributes (issue #401).
  *
  * Re-provided by every group's child injector — a nested group reads its
- * parent's context and appends its own key.
+ * parent's context signal and composes its own path through `computed()`.
  */
 export interface GroupContext {
   /** Dot-separated path of group ancestors, including the current group's key (e.g. `'address'` or `'user.address'`). */
-  groupPath: string;
+  groupPath: Signal<string>;
 }
 
 /**

--- a/packages/dynamic-forms/src/lib/models/field-signal-context.token.ts
+++ b/packages/dynamic-forms/src/lib/models/field-signal-context.token.ts
@@ -92,15 +92,13 @@ export const ARRAY_CONTEXT = new InjectionToken<ArrayContext>('ARRAY_CONTEXT');
  * Inject with `{ optional: true }` because top-level fields (and fields inside
  * page/row/array containers — none of which scope keys) won't have it.
  */
-export const GROUP_CONTEXT = new InjectionToken<GroupContext>('GROUP_CONTEXT', {
-  providedIn: null,
-  factory: () => {
-    throw new DynamicFormError(
-      'GROUP_CONTEXT was not provided. ' +
-        'Inject with { optional: true } — this token is only provided when a field is nested inside a group container.',
-    );
-  },
-});
+// No factory: GROUP_CONTEXT is optional-by-design (only provided inside group
+// descendants). Mirrors the ARRAY_CONTEXT pattern — consumers must inject with
+// `{ optional: true }` and handle the `null` case. Adding a throwing factory
+// here fires even when injected optionally (Angular still evaluates the
+// tree-shakable factory before honoring `optional`), so non-group fields would
+// crash on every render.
+export const GROUP_CONTEXT = new InjectionToken<GroupContext>('GROUP_CONTEXT');
 
 /**
  * Injection token for form-level default props.

--- a/packages/dynamic-forms/src/lib/models/field-signal-context.token.ts
+++ b/packages/dynamic-forms/src/lib/models/field-signal-context.token.ts
@@ -1,5 +1,5 @@
 import { InjectionToken, Signal } from '@angular/core';
-import type { FieldSignalContext, ArrayContext } from '../mappers/types';
+import type { FieldSignalContext, ArrayContext, GroupContext } from '../mappers/types';
 import type { WrapperConfig } from './wrapper-type';
 import type { ValidationMessages } from './validation-types';
 import type { FormOptions } from './form-config';
@@ -79,6 +79,20 @@ export const FIELD_SIGNAL_CONTEXT = new InjectionToken<FieldSignalContext>('FIEL
  * ```
  */
 export const ARRAY_CONTEXT = new InjectionToken<ArrayContext>('ARRAY_CONTEXT');
+
+/**
+ * Injection token for providing group ancestry to mappers and components.
+ *
+ * Optionally provided by `GroupFieldComponent` in the child injector it builds
+ * for its descendants. Carries the dot-separated path of group ancestors
+ * (including the current group), used by `mapFieldToInputs` to scope DOM IDs
+ * so the same leaf key can appear inside different groups without producing
+ * duplicate `id` attributes.
+ *
+ * Inject with `{ optional: true }` because top-level fields (and fields inside
+ * page/row/array containers — none of which scope keys) won't have it.
+ */
+export const GROUP_CONTEXT = new InjectionToken<GroupContext>('GROUP_CONTEXT');
 
 /**
  * Injection token for form-level default props.

--- a/packages/dynamic-forms/src/lib/models/field-signal-context.token.ts
+++ b/packages/dynamic-forms/src/lib/models/field-signal-context.token.ts
@@ -92,7 +92,15 @@ export const ARRAY_CONTEXT = new InjectionToken<ArrayContext>('ARRAY_CONTEXT');
  * Inject with `{ optional: true }` because top-level fields (and fields inside
  * page/row/array containers — none of which scope keys) won't have it.
  */
-export const GROUP_CONTEXT = new InjectionToken<GroupContext>('GROUP_CONTEXT');
+export const GROUP_CONTEXT = new InjectionToken<GroupContext>('GROUP_CONTEXT', {
+  providedIn: null,
+  factory: () => {
+    throw new DynamicFormError(
+      'GROUP_CONTEXT was not provided. ' +
+        'Inject with { optional: true } — this token is only provided when a field is nested inside a group container.',
+    );
+  },
+});
 
 /**
  * Injection token for form-level default props.

--- a/packages/dynamic-forms/src/lib/models/field-signal-context.token.ts
+++ b/packages/dynamic-forms/src/lib/models/field-signal-context.token.ts
@@ -83,21 +83,28 @@ export const ARRAY_CONTEXT = new InjectionToken<ArrayContext>('ARRAY_CONTEXT');
 /**
  * Injection token for providing group ancestry to mappers and components.
  *
- * Optionally provided by `GroupFieldComponent` in the child injector it builds
- * for its descendants. Carries the dot-separated path of group ancestors
- * (including the current group), used by `mapFieldToInputs` to scope DOM IDs
- * so the same leaf key can appear inside different groups without producing
- * duplicate `id` attributes.
+ * Re-provided in two places:
+ * 1. `GroupFieldComponent` provides a context whose `groupPath()` is the
+ *    parent path extended by its own key (e.g. `'address'` or `'user.address'`).
+ * 2. `createArrayItemInjector` provides a sentinel with an empty `groupPath`,
+ *    resetting the chain at array boundaries — descendants of an array item
+ *    that re-enter a group compose paths INSIDE the array item, matching the
+ *    property-derivation collector's keying.
  *
- * Inject with `{ optional: true }` because top-level fields (and fields inside
- * page/row/array containers — none of which scope keys) won't have it.
+ * `mapFieldToInputs` reads this to scope DOM IDs and override-store keys so
+ * the same leaf key can appear in different groups without colliding (#401).
+ *
+ * Inject with `{ optional: true }` because top-level fields with no group
+ * ancestor (and no enclosing array) won't have the token provided. The token
+ * IS present for fields inside an array even when no inner group exists — the
+ * array-boundary sentinel makes injection succeed with an empty `groupPath`.
  */
-// No factory: GROUP_CONTEXT is optional-by-design (only provided inside group
-// descendants). Mirrors the ARRAY_CONTEXT pattern — consumers must inject with
-// `{ optional: true }` and handle the `null` case. Adding a throwing factory
-// here fires even when injected optionally (Angular still evaluates the
-// tree-shakable factory before honoring `optional`), so non-group fields would
-// crash on every render.
+// No factory: GROUP_CONTEXT is optional-by-design — `GroupFieldComponent` and
+// `createArrayItemInjector` re-provide it where it makes sense, and consumers
+// inject with `{ optional: true }` to handle the top-level case. Mirrors the
+// ARRAY_CONTEXT pattern. Adding a throwing factory here fires even when
+// injected optionally (Angular still evaluates the tree-shakable factory
+// before honoring `optional`), so non-group fields would crash on every render.
 export const GROUP_CONTEXT = new InjectionToken<GroupContext>('GROUP_CONTEXT');
 
 /**

--- a/packages/dynamic-forms/src/lib/models/index.ts
+++ b/packages/dynamic-forms/src/lib/models/index.ts
@@ -16,6 +16,7 @@ export {
   DEFAULT_WRAPPERS,
   FIELD_SIGNAL_CONTEXT,
   FORM_OPTIONS,
+  GROUP_CONTEXT,
 } from './field-signal-context.token';
 export type { ArrayTemplateRegistry } from './field-signal-context.token';
 export type { ValidationError, ValidationMessages } from './validation-types';

--- a/packages/dynamic-forms/src/lib/utils/array-field/create-array-item-injector.ts
+++ b/packages/dynamic-forms/src/lib/utils/array-field/create-array-item-injector.ts
@@ -1,9 +1,9 @@
-import { computed, Injector, runInInjectionContext, Signal } from '@angular/core';
+import { computed, Injector, runInInjectionContext, signal, Signal } from '@angular/core';
 import { FieldTree } from '@angular/forms/signals';
 import { ArrayField } from '../../definitions/default/array-field';
 import { FieldDef } from '../../definitions/base/field-def';
-import { ArrayContext, FieldSignalContext } from '../../mappers/types';
-import { ARRAY_CONTEXT, FIELD_SIGNAL_CONTEXT } from '../../models/field-signal-context.token';
+import { ArrayContext, FieldSignalContext, GroupContext } from '../../mappers/types';
+import { ARRAY_CONTEXT, FIELD_SIGNAL_CONTEXT, GROUP_CONTEXT } from '../../models/field-signal-context.token';
 import { FieldTypeDefinition } from '../../models/field-type';
 import { mapFieldToInputs } from '../field-mapper/field-mapper';
 import { RootFormRegistryService } from '../../core/registry/root-form-registry.service';
@@ -193,6 +193,20 @@ function createItemInjector<TModel extends Record<string, unknown>>(options: Cre
         deps: [Injector],
       },
       { provide: ARRAY_CONTEXT, useValue: arrayContext },
+      // Reset GROUP_CONTEXT at the array boundary: inner groups inside each
+      // item start their path fresh, matching how value-derivation and
+      // property-derivation collectors key entries
+      // (`{arrayKey}.$.{innerGroupPath}.{fieldKey}`). Without this, an outer
+      // group around the array would leak into descendants' DOM IDs and
+      // override-store keys, drifting from the collector.
+      { provide: GROUP_CONTEXT, useValue: EMPTY_GROUP_CONTEXT },
     ],
   });
 }
+
+/**
+ * Sentinel `GroupContext` provided at array item boundaries. Static `signal('')`
+ * means `applyGroupPrefix` no-ops (empty path) and any inner group composes its
+ * own path from this empty base.
+ */
+const EMPTY_GROUP_CONTEXT: GroupContext = { groupPath: signal('') };

--- a/packages/dynamic-forms/src/lib/utils/config-validation/config-validator.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/config-validation/config-validator.spec.ts
@@ -138,6 +138,45 @@ describe('validateFormConfig', () => {
       expect(() => validateFormConfig(fields, emptyRegistry(), mockLogger())).toThrow(DynamicFormError);
     });
 
+    it('should flag two sibling groups sharing the same key', () => {
+      // The groups themselves collide at the form-value root regardless of children.
+      const fields: FieldDef<unknown>[] = [
+        { key: 'address', type: 'group', fields: [{ key: 'street', type: 'input' }] },
+        { key: 'address', type: 'group', fields: [{ key: 'city', type: 'input' }] },
+      ];
+      expect(() => validateFormConfig(fields, emptyRegistry(), mockLogger())).toThrow(DynamicFormError);
+      expect(() => validateFormConfig(fields, emptyRegistry(), mockLogger())).toThrow("'address'");
+    });
+
+    it('should flag DOM id collision between top-level key and group/leaf pair', () => {
+      // DOM ids are underscore-projected: top-level `'foo_bar'` collides with leaf
+      // `'bar'` inside group `'foo'` — both render as id='foo_bar' even though their
+      // form-value paths ('foo_bar' vs 'foo.bar') are distinct.
+      const fields: FieldDef<unknown>[] = [
+        { key: 'foo_bar', type: 'input' },
+        { key: 'foo', type: 'group', fields: [{ key: 'bar', type: 'input' }] },
+      ];
+      expect(() => validateFormConfig(fields, emptyRegistry(), mockLogger())).toThrow(DynamicFormError);
+      expect(() => validateFormConfig(fields, emptyRegistry(), mockLogger())).toThrow(/DOM id collision/);
+      expect(() => validateFormConfig(fields, emptyRegistry(), mockLogger())).toThrow("'foo_bar'");
+    });
+
+    it('should validate deeply nested groups with non-colliding overlapping keys', () => {
+      // `user.address.name` and `user.contact.name` — same leaf 'name' under
+      // different grandchild scopes. Distinct form-value paths AND distinct DOM ids.
+      const fields: FieldDef<unknown>[] = [
+        {
+          key: 'user',
+          type: 'group',
+          fields: [
+            { key: 'address', type: 'group', fields: [{ key: 'name', type: 'input' }] },
+            { key: 'contact', type: 'group', fields: [{ key: 'name', type: 'input' }] },
+          ],
+        },
+      ];
+      expect(() => validateFormConfig(fields, emptyRegistry(), mockLogger())).not.toThrow();
+    });
+
     it('should not flag duplicate button keys across pages (excluded from value)', () => {
       // Buttons have valueHandling: 'exclude' — they don't bind to a form-value path,
       // so the same `previous`/`submit` keys can repeat on every page (issue #401).

--- a/packages/dynamic-forms/src/lib/utils/config-validation/config-validator.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/config-validation/config-validator.spec.ts
@@ -50,7 +50,41 @@ describe('validateFormConfig', () => {
       expect(() => validateFormConfig(fields, emptyRegistry(), mockLogger())).toThrow(/Duplicate field keys detected.*'a'.*'b'/s);
     });
 
-    it('should detect duplicates in nested containers', () => {
+    it('should not flag the same key in different group scopes', () => {
+      // Same leaf key inside two different groups produces distinct scoped paths
+      // (createADto.name vs createBDto.name) — no conflict at the form-value level.
+      const fields: FieldDef<unknown>[] = [
+        {
+          key: 'createADto',
+          type: 'group',
+          fields: [{ key: 'name', type: 'input' }],
+        },
+        {
+          key: 'createBDto',
+          type: 'group',
+          fields: [{ key: 'name', type: 'input' }],
+        },
+      ];
+      expect(() => validateFormConfig(fields, emptyRegistry(), mockLogger())).not.toThrow();
+    });
+
+    it('should still flag duplicates within the same group scope', () => {
+      const fields: FieldDef<unknown>[] = [
+        {
+          key: 'address',
+          type: 'group',
+          fields: [
+            { key: 'street', type: 'input' },
+            { key: 'street', type: 'input' },
+          ],
+        },
+      ];
+      expect(() => validateFormConfig(fields, emptyRegistry(), mockLogger())).toThrow(DynamicFormError);
+      expect(() => validateFormConfig(fields, emptyRegistry(), mockLogger())).toThrow("'address.street'");
+    });
+
+    it('should not flag a leaf key shadowed by a same-named group child', () => {
+      // Top-level 'name' (path: name) and 'address.name' (path: address.name) — distinct scopes.
       const fields: FieldDef<unknown>[] = [
         { key: 'name', type: 'input' },
         {
@@ -59,7 +93,7 @@ describe('validateFormConfig', () => {
           fields: [{ key: 'name', type: 'input' }],
         },
       ];
-      expect(() => validateFormConfig(fields, emptyRegistry(), mockLogger())).toThrow(DynamicFormError);
+      expect(() => validateFormConfig(fields, emptyRegistry(), mockLogger())).not.toThrow();
     });
 
     it('should not flag array item template keys as duplicates', () => {
@@ -102,6 +136,52 @@ describe('validateFormConfig', () => {
         { key: 'address', type: 'group', fields: [{ key: 'city', type: 'input' }] },
       ];
       expect(() => validateFormConfig(fields, emptyRegistry(), mockLogger())).toThrow(DynamicFormError);
+    });
+
+    it('should not flag duplicate button keys across pages (excluded from value)', () => {
+      // Buttons have valueHandling: 'exclude' — they don't bind to a form-value path,
+      // so the same `previous`/`submit` keys can repeat on every page (issue #401).
+      const registry = new Map<string, FieldTypeDefinition>([
+        ['page', { valueHandling: 'flatten' } as FieldTypeDefinition],
+        ['row', { valueHandling: 'flatten' } as FieldTypeDefinition],
+        ['group', { valueHandling: 'include' } as FieldTypeDefinition],
+        ['input', { valueHandling: 'include' } as FieldTypeDefinition],
+        ['previous', { valueHandling: 'exclude' } as FieldTypeDefinition],
+        ['submit', { valueHandling: 'exclude' } as FieldTypeDefinition],
+      ]);
+      const fields: FieldDef<unknown>[] = [
+        {
+          key: 'aPage',
+          type: 'page',
+          fields: [
+            { key: 'createADto', type: 'group', fields: [{ key: 'name', type: 'input' }] },
+            {
+              key: 'aButtons',
+              type: 'row',
+              fields: [
+                { key: 'previous', type: 'previous' },
+                { key: 'submit', type: 'submit' },
+              ],
+            },
+          ],
+        },
+        {
+          key: 'bPage',
+          type: 'page',
+          fields: [
+            { key: 'createBDto', type: 'group', fields: [{ key: 'name', type: 'input' }] },
+            {
+              key: 'bButtons',
+              type: 'row',
+              fields: [
+                { key: 'previous', type: 'previous' },
+                { key: 'submit', type: 'submit' },
+              ],
+            },
+          ],
+        },
+      ];
+      expect(() => validateFormConfig(fields, registry, mockLogger())).not.toThrow();
     });
   });
 

--- a/packages/dynamic-forms/src/lib/utils/config-validation/config-validator.ts
+++ b/packages/dynamic-forms/src/lib/utils/config-validation/config-validator.ts
@@ -1,7 +1,7 @@
 import { FieldDef } from '../../definitions/base/field-def';
 import { FieldWithValidation } from '../../definitions/base/field-with-validation';
-import { FieldTypeDefinition } from '../../models/field-type';
-import { hasChildFields } from '../../models/types/type-guards';
+import { FieldTypeDefinition, getFieldValueHandling } from '../../models/field-type';
+import { hasChildFields, isGroupField } from '../../models/types/type-guards';
 import { normalizeFieldsArray } from '../object-utils';
 import { DynamicFormError } from '../../errors/dynamic-form-error';
 import { Logger } from '../../providers/features/logger/logger.interface';
@@ -17,15 +17,31 @@ interface ConfigTraversalData {
  * Collects all field keys, types, and validates regex patterns from a field tree
  * by recursively traversing containers (page, row, group, array).
  *
- * @param collectKeys - Whether to add field keys to data.keys for duplicate detection.
- *   Set to false when inside an array container: array item fields share template keys
- *   across items by design (e.g. every item has 'name', 'email'), so they must not
- *   participate in global duplicate-key checking.
+ * Keys are scoped by their group ancestors (e.g. `address.city` instead of `city`),
+ * so the same leaf key can appear inside different groups without conflict. Page and
+ * row containers do not contribute to the path because they flatten their children
+ * into the parent scope. Array items are excluded entirely from key collection
+ * because they share template keys across items by design.
+ *
+ * Fields whose registered `valueHandling` is anything other than `include` (e.g.
+ * buttons with `exclude`, page/row with `flatten`) are not collected: they don't
+ * bind to a form-value path, so duplicate-key uniqueness isn't meaningful for them.
+ *
+ * @param collectKeys - When false, the entire subtree skips key collection (used
+ *   when descending into an array container).
  */
-function collectFieldData(fields: FieldDef<unknown>[], data: ConfigTraversalData, collectKeys = true): void {
+function collectFieldData(
+  fields: FieldDef<unknown>[],
+  data: ConfigTraversalData,
+  registry: Map<string, FieldTypeDefinition>,
+  pathPrefix: string,
+  collectKeys = true,
+): void {
   for (const field of fields) {
-    if (collectKeys && field.key) {
-      data.keys.push(field.key);
+    const valueHandling = field.type ? getFieldValueHandling(field.type, registry) : 'include';
+
+    if (collectKeys && field.key && valueHandling === 'include') {
+      data.keys.push(pathPrefix ? `${pathPrefix}.${field.key}` : field.key);
     }
     if (field.type) {
       data.types.add(field.type);
@@ -48,12 +64,15 @@ function collectFieldData(fields: FieldDef<unknown>[], data: ConfigTraversalData
       // Array item fields share template keys across items by design — stop collecting keys
       // once inside an array. Types and regex patterns are still validated.
       const childCollectKeys = collectKeys && field.type !== 'array';
+      // Only group containers extend the scoping path — page/row flatten into the parent
+      // scope, and array items use dynamic indices that aren't statically knowable.
+      const childPrefix = isGroupField(field) && field.key ? (pathPrefix ? `${pathPrefix}.${field.key}` : field.key) : pathPrefix;
       const children = normalizeFieldsArray(field.fields) as (FieldDef<unknown> | FieldDef<unknown>[])[];
       for (const child of children) {
         if (Array.isArray(child)) {
-          collectFieldData(child as FieldDef<unknown>[], data, childCollectKeys);
+          collectFieldData(child as FieldDef<unknown>[], data, registry, childPrefix, childCollectKeys);
         } else {
-          collectFieldData([child], data, childCollectKeys);
+          collectFieldData([child], data, registry, childPrefix, childCollectKeys);
         }
       }
     }
@@ -92,7 +111,9 @@ function validateNoDuplicateKeys(allKeys: string[]): void {
     const duplicateList = Array.from(duplicates)
       .map((k) => `'${k}'`)
       .join(', ');
-    throw new DynamicFormError(`Duplicate field keys detected: ${duplicateList}. Each field key must be unique within a form config.`);
+    throw new DynamicFormError(
+      `Duplicate field keys detected: ${duplicateList}. Field keys must be unique within their group scope (the same key may appear inside different groups).`,
+    );
   }
 }
 
@@ -140,7 +161,7 @@ export function validateFormConfig(fields: FieldDef<unknown>[], registry: Map<st
     regexErrors: [],
   };
 
-  collectFieldData(fields, data);
+  collectFieldData(fields, data, registry, '');
 
   validateNoDuplicateKeys(data.keys);
   validateFieldTypesRegistered(data.types, registry, logger);

--- a/packages/dynamic-forms/src/lib/utils/config-validation/config-validator.ts
+++ b/packages/dynamic-forms/src/lib/utils/config-validation/config-validator.ts
@@ -8,7 +8,18 @@ import { Logger } from '../../providers/features/logger/logger.interface';
 
 /** Data collected during a single config traversal. */
 interface ConfigTraversalData {
+  /**
+   * Dot-scoped paths (e.g. `'address.street'`) — checked for form-value uniqueness:
+   * two leaves landing at the same form-value path are a real conflict.
+   */
   keys: string[];
+  /**
+   * Underscore-projected DOM-ID paths (e.g. `'address_street'`) — checked for
+   * DOM `id` / `data-testid` uniqueness. Catches the otherwise-silent collision
+   * where a top-level key like `'foo_bar'` would render the same DOM id as a
+   * leaf `'bar'` inside group `'foo'`.
+   */
+  domIds: string[];
   types: Set<string>;
   regexErrors: string[];
 }
@@ -38,10 +49,18 @@ function collectFieldData(
   collectKeys = true,
 ): void {
   for (const field of fields) {
+    // Defensively skip only known non-include modes — unexpected/missing
+    // valueHandling defaults back to participating in duplicate detection so a
+    // mis-registered field type doesn't silently drop from collision checks.
     const valueHandling = field.type ? getFieldValueHandling(field.type, registry) : 'include';
+    const participatesInValue = valueHandling !== 'exclude' && valueHandling !== 'flatten';
 
-    if (collectKeys && field.key && valueHandling === 'include') {
-      data.keys.push(pathPrefix ? `${pathPrefix}.${field.key}` : field.key);
+    if (collectKeys && field.key && participatesInValue) {
+      const scopedKey = pathPrefix ? `${pathPrefix}.${field.key}` : field.key;
+      data.keys.push(scopedKey);
+      // Project to the DOM-ID format (dots → underscores) so we can detect
+      // collisions like top-level `'foo_bar'` vs group `'foo'` + leaf `'bar'`.
+      data.domIds.push(scopedKey.replace(/\./g, '_'));
     }
     if (field.type) {
       data.types.add(field.type);
@@ -118,6 +137,42 @@ function validateNoDuplicateKeys(allKeys: string[]): void {
 }
 
 /**
+ * Validates that the underscore-projected DOM-ID namespace has no collisions.
+ *
+ * DOM IDs are built by underscore-joining the group ancestor path with the
+ * leaf key (e.g. `address_street`). Two scoped paths can land on the same
+ * DOM ID even when their form-value paths differ — e.g. a top-level key
+ * `'foo_bar'` and a leaf `'bar'` inside group `'foo'` both render as
+ * `id="foo_bar"`. The form-value-path check accepts this (paths are
+ * `'foo_bar'` vs `'foo.bar'` — distinct) but the rendered DOM would have
+ * duplicate IDs, breaking aria associations and CSS selectors.
+ *
+ * @throws {DynamicFormError} When two scoped paths project to the same DOM ID
+ */
+function validateNoDomIdCollisions(domIds: string[]): void {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+
+  for (const id of domIds) {
+    if (seen.has(id)) {
+      duplicates.add(id);
+    }
+    seen.add(id);
+  }
+
+  if (duplicates.size > 0) {
+    const duplicateList = Array.from(duplicates)
+      .map((k) => `'${k}'`)
+      .join(', ');
+    throw new DynamicFormError(
+      `DOM id collision detected for: ${duplicateList}. Group-nested keys are joined with '_' to form DOM ids ` +
+        `(e.g. group 'foo' + leaf 'bar' renders as id='foo_bar'). A separate top-level key like 'foo_bar' or a different ` +
+        `group/leaf pair that underscores to the same string will produce duplicate ids. Rename one of the colliding keys.`,
+    );
+  }
+}
+
+/**
  * Validates that every field type referenced in the config exists in the registry.
  * Logs a warning for unregistered types — unknown fields are skipped during rendering
  * rather than blocking the whole form (graceful degradation).
@@ -157,6 +212,7 @@ function validateFieldTypesRegistered(allTypes: Set<string>, registry: Map<strin
 export function validateFormConfig(fields: FieldDef<unknown>[], registry: Map<string, FieldTypeDefinition>, logger: Logger): void {
   const data: ConfigTraversalData = {
     keys: [],
+    domIds: [],
     types: new Set<string>(),
     regexErrors: [],
   };
@@ -164,6 +220,7 @@ export function validateFormConfig(fields: FieldDef<unknown>[], registry: Map<st
   collectFieldData(fields, data, registry, '');
 
   validateNoDuplicateKeys(data.keys);
+  validateNoDomIdCollisions(data.domIds);
   validateFieldTypesRegistered(data.types, registry, logger);
 
   if (data.regexErrors.length > 0) {

--- a/packages/dynamic-forms/src/lib/utils/field-mapper/field-mapper.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/field-mapper/field-mapper.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { computed, signal, Signal } from '@angular/core';
+import { computed, Injector, Provider, runInInjectionContext, signal, Signal, Type } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { mapFieldToInputs } from './field-mapper';
 import { FieldDef } from '../../definitions/base';
@@ -331,7 +331,7 @@ describe('mapFieldToInputs', () => {
    *  - when both apply, group prefix runs BEFORE array suffix → `{group}_{key}_{index}`
    */
   describe('key rewriting (issue #401 group + array scoping)', () => {
-    function runWithProviders<T>(providers: any[], fn: () => T): T {
+    function runWithProviders<T>(providers: Provider[], fn: () => T): T {
       TestBed.resetTestingModule();
       TestBed.configureTestingModule({
         providers: [{ provide: PROPERTY_OVERRIDE_STORE, useFactory: createPropertyOverrideStore }, ...providers],
@@ -401,10 +401,60 @@ describe('mapFieldToInputs', () => {
     it('leaves non-string keys untouched', () => {
       // Custom mapper that returns a numeric `key` (escape hatch — must not be string-prefixed).
       const customMapper = () => computed(() => ({ key: 42 as unknown as string, other: true }));
-      registry.set('custom', { component: {} as any, mapper: customMapper });
+      registry.set('custom', { component: {} as Type<unknown>, mapper: customMapper });
       const field: FieldDef<unknown> = { type: 'custom', key: 'ignored' };
       const result = runWithProviders([{ provide: GROUP_CONTEXT, useValue: groupCtx('address') }], () => mapFieldToInputs(field, registry));
       expect(result!()['key']).toBe(42);
+    });
+  });
+
+  /**
+   * Regression test for issue #401: when two fields share the same leaf key
+   * inside different groups, their property-derivation override slots in the
+   * PropertyOverrideStore must remain distinct. Before this fix, both fields
+   * read/wrote the same `'name'` slot, so one derivation silently overwrote
+   * the other.
+   */
+  describe('property override store keys (issue #401 group scoping)', () => {
+    function makeGroupCtx(path: string): GroupContext {
+      return { groupPath: signal(path) };
+    }
+
+    it('uses distinct override-store slots for same leaf key in different groups', () => {
+      TestBed.resetTestingModule();
+      const store = createPropertyOverrideStore();
+      TestBed.configureTestingModule({
+        providers: [{ provide: PROPERTY_OVERRIDE_STORE, useValue: store }],
+      });
+
+      // Pre-populate per-group overrides for the SAME leaf key.
+      store.setOverride('createADto.name', 'label', 'A Label');
+      store.setOverride('createBDto.name', 'label', 'B Label');
+
+      const fieldDef: FieldDef<unknown> = {
+        type: 'input',
+        key: 'name',
+        logic: [{ type: 'derivation', targetProperty: 'label', value: 'static' }],
+      } as unknown as FieldDef<unknown>;
+
+      const rootInjector = TestBed.inject(Injector);
+
+      // Field rendered inside the `createADto` group.
+      const injA = Injector.create({
+        parent: rootInjector,
+        providers: [{ provide: GROUP_CONTEXT, useValue: makeGroupCtx('createADto') }],
+      });
+      const resultA = runInInjectionContext(injA, () => mapFieldToInputs(fieldDef, registry));
+
+      // Field rendered inside the `createBDto` group — same leaf key.
+      const injB = Injector.create({
+        parent: rootInjector,
+        providers: [{ provide: GROUP_CONTEXT, useValue: makeGroupCtx('createBDto') }],
+      });
+      const resultB = runInInjectionContext(injB, () => mapFieldToInputs(fieldDef, registry));
+
+      expect(resultA!()['label']).toBe('A Label');
+      expect(resultB!()['label']).toBe('B Label');
     });
   });
 });

--- a/packages/dynamic-forms/src/lib/utils/field-mapper/field-mapper.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/field-mapper/field-mapper.spec.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { computed, Signal } from '@angular/core';
+import { computed, signal, Signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { mapFieldToInputs } from './field-mapper';
 import { FieldDef } from '../../definitions/base';
 import { FieldTypeDefinition } from '../../models/field-type';
 import { createPropertyOverrideStore, PROPERTY_OVERRIDE_STORE } from '../../core/property-derivation/property-override-store';
+import { ARRAY_CONTEXT, GROUP_CONTEXT } from '../../models/field-signal-context.token';
+import type { ArrayContext, GroupContext } from '../../mappers/types';
 
 describe('mapFieldToInputs', () => {
   let registry: Map<string, FieldTypeDefinition>;
@@ -319,6 +321,90 @@ describe('mapFieldToInputs', () => {
       expect(typeof resultSignal).toBe('function'); // Signal is a function
       const result = resultSignal();
       expect(typeof result).toBe('object');
+    });
+  });
+
+  /**
+   * Tests for the DOM-ID rewriting contract added for issue #401:
+   *  - inside a GROUP_CONTEXT, the `key` input is prefixed with the underscored ancestor path
+   *  - inside an ARRAY_CONTEXT, the `key` input is suffixed with `_${index}`
+   *  - when both apply, group prefix runs BEFORE array suffix → `{group}_{key}_{index}`
+   */
+  describe('key rewriting (issue #401 group + array scoping)', () => {
+    function runWithProviders<T>(providers: any[], fn: () => T): T {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [{ provide: PROPERTY_OVERRIDE_STORE, useFactory: createPropertyOverrideStore }, ...providers],
+      });
+      return TestBed.runInInjectionContext(fn);
+    }
+
+    function groupCtx(path: string): GroupContext {
+      return { groupPath: signal(path) };
+    }
+
+    function arrayCtx(index: number, arrayKey = 'items'): ArrayContext {
+      return {
+        arrayKey,
+        index: signal(index),
+        formValue: null,
+        field: { type: 'array', key: arrayKey } as FieldDef<unknown>,
+      };
+    }
+
+    it('passes the key through unchanged when neither context is provided', () => {
+      const field: FieldDef<unknown> = { type: 'input', key: 'name' };
+      const result = run(() => mapFieldToInputs(field, registry));
+      expect(result!()['key']).toBe('name');
+    });
+
+    it('prefixes the key with the underscored group path when inside a group', () => {
+      const field: FieldDef<unknown> = { type: 'input', key: 'street' };
+      const result = runWithProviders([{ provide: GROUP_CONTEXT, useValue: groupCtx('address') }], () => mapFieldToInputs(field, registry));
+      expect(result!()['key']).toBe('address_street');
+    });
+
+    it('underscores nested group paths in the prefix', () => {
+      const field: FieldDef<unknown> = { type: 'input', key: 'street' };
+      const result = runWithProviders([{ provide: GROUP_CONTEXT, useValue: groupCtx('user.address') }], () =>
+        mapFieldToInputs(field, registry),
+      );
+      expect(result!()['key']).toBe('user_address_street');
+    });
+
+    it('appends the array index suffix when inside an array', () => {
+      const field: FieldDef<unknown> = { type: 'input', key: 'value' };
+      const result = runWithProviders([{ provide: ARRAY_CONTEXT, useValue: arrayCtx(2) }], () => mapFieldToInputs(field, registry));
+      expect(result!()['key']).toBe('value_2');
+    });
+
+    it('applies group prefix BEFORE array suffix (contract: {group}_{key}_{index})', () => {
+      // A group inside an array item — e.g. an `address` group inside each `users` item.
+      // Renders as `address_street_0` for the first item's street field.
+      const field: FieldDef<unknown> = { type: 'input', key: 'street' };
+      const result = runWithProviders(
+        [
+          { provide: GROUP_CONTEXT, useValue: groupCtx('address') },
+          { provide: ARRAY_CONTEXT, useValue: arrayCtx(0, 'users') },
+        ],
+        () => mapFieldToInputs(field, registry),
+      );
+      expect(result!()['key']).toBe('address_street_0');
+    });
+
+    it('skips the prefix when the group path is empty', () => {
+      const field: FieldDef<unknown> = { type: 'input', key: 'street' };
+      const result = runWithProviders([{ provide: GROUP_CONTEXT, useValue: groupCtx('') }], () => mapFieldToInputs(field, registry));
+      expect(result!()['key']).toBe('street');
+    });
+
+    it('leaves non-string keys untouched', () => {
+      // Custom mapper that returns a numeric `key` (escape hatch — must not be string-prefixed).
+      const customMapper = () => computed(() => ({ key: 42 as unknown as string, other: true }));
+      registry.set('custom', { component: {} as any, mapper: customMapper });
+      const field: FieldDef<unknown> = { type: 'custom', key: 'ignored' };
+      const result = runWithProviders([{ provide: GROUP_CONTEXT, useValue: groupCtx('address') }], () => mapFieldToInputs(field, registry));
+      expect(result!()['key']).toBe(42);
     });
   });
 });

--- a/packages/dynamic-forms/src/lib/utils/field-mapper/field-mapper.ts
+++ b/packages/dynamic-forms/src/lib/utils/field-mapper/field-mapper.ts
@@ -3,8 +3,8 @@ import { FieldDef } from '../../definitions/base/field-def';
 import { FieldWithValidation } from '../../definitions/base/field-with-validation';
 import { FieldMeta } from '../../definitions/base/field-meta';
 import { FieldTypeDefinition } from '../../models/field-type';
-import { ARRAY_CONTEXT } from '../../models/field-signal-context.token';
-import { ArrayContext } from '../../mappers/types';
+import { ARRAY_CONTEXT, GROUP_CONTEXT } from '../../models/field-signal-context.token';
+import { ArrayContext, GroupContext } from '../../mappers/types';
 import { baseFieldMapper } from '../../mappers/base/base-field-mapper';
 import { PROPERTY_OVERRIDE_STORE } from '../../core/property-derivation/property-override-store';
 import { applyPropertyOverrides } from '../../core/property-derivation/apply-property-overrides';
@@ -95,6 +95,25 @@ function applyIndexSuffix(inputs: Record<string, unknown>, index: number): Recor
 }
 
 /**
+ * Prefixes the key with the underscored group ancestor path so that the same
+ * leaf key inside different groups produces distinct DOM IDs (issue #401).
+ * Form-schema keys remain clean — only the rendered `key` input is rewritten.
+ *
+ * Dots in the path (group nesting) become underscores: `user.address` → `user_address_street`.
+ */
+function applyGroupPrefix(inputs: Record<string, unknown>, groupPath: string): Record<string, unknown> {
+  const key = inputs['key'];
+  if (typeof key !== 'string' || groupPath.length === 0) {
+    return inputs;
+  }
+
+  return {
+    ...inputs,
+    key: `${groupPath.replace(/\./g, '_')}_${key}`,
+  };
+}
+
+/**
  * Main field mapper function that uses the field registry to get the appropriate mapper
  * based on the field's type property.
  *
@@ -136,6 +155,11 @@ export function mapFieldToInputs(
   // Optional because ARRAY_CONTEXT is only provided inside array item injectors
   const arrayContext = inject(ARRAY_CONTEXT, { optional: true });
 
+  // Check if we're inside a group context - if so, prefix the key with the group path
+  // so overlapping leaf keys across groups produce distinct DOM IDs (issue #401).
+  // Optional because GROUP_CONTEXT is only provided by GroupFieldComponent.
+  const groupContext = inject(GROUP_CONTEXT, { optional: true });
+
   // Inject the property override store for property derivation overrides
   // Always available — provided at the DynamicForm component level via provideDynamicFormDI
   const store = inject(PROPERTY_OVERRIDE_STORE);
@@ -148,6 +172,7 @@ export function mapFieldToInputs(
   // Check that arrayContext exists and has a valid index signal (guards against mock injectors)
   const indexSignal = arrayContext?.index;
   const hasArrayContext = indexSignal !== undefined && isSignal(indexSignal);
+  const hasGroupContext = groupContext != null;
 
   // Fast-path check for property overrides: only fields whose definition declares
   // a property-derivation enter the computed() wrapper. We inspect the FieldDef
@@ -158,7 +183,7 @@ export function mapFieldToInputs(
   const hasOverrides = fieldHasPropertyDerivations(fieldDef);
 
   // Fast path: no transformations needed
-  if (!hasPropsForwarding && !hasArrayContext && !hasOverrides) {
+  if (!hasPropsForwarding && !hasArrayContext && !hasGroupContext && !hasOverrides) {
     return mapperResult;
   }
 
@@ -169,6 +194,13 @@ export function mapFieldToInputs(
     // Apply props forwarding if configured
     if (hasPropsForwarding) {
       inputs = mergeForwardedPropsToMeta(inputs, propsToMeta);
+    }
+
+    // Apply group prefix BEFORE array suffix so the resulting key reads as
+    // `{groupPath}_{key}_{index}` (e.g. `address_street_0`) — matching the
+    // form-value path order: group → leaf → array index.
+    if (hasGroupContext) {
+      inputs = applyGroupPrefix(inputs, (groupContext as GroupContext).groupPath);
     }
 
     // Apply index suffix for array items

--- a/packages/dynamic-forms/src/lib/utils/field-mapper/field-mapper.ts
+++ b/packages/dynamic-forms/src/lib/utils/field-mapper/field-mapper.ts
@@ -200,7 +200,7 @@ export function mapFieldToInputs(
     // `{groupPath}_{key}_{index}` (e.g. `address_street_0`) — matching the
     // form-value path order: group → leaf → array index.
     if (hasGroupContext) {
-      inputs = applyGroupPrefix(inputs, (groupContext as GroupContext).groupPath);
+      inputs = applyGroupPrefix(inputs, (groupContext as GroupContext).groupPath());
     }
 
     // Apply index suffix for array items

--- a/packages/dynamic-forms/src/lib/utils/field-mapper/field-mapper.ts
+++ b/packages/dynamic-forms/src/lib/utils/field-mapper/field-mapper.ts
@@ -4,7 +4,7 @@ import { FieldWithValidation } from '../../definitions/base/field-with-validatio
 import { FieldMeta } from '../../definitions/base/field-meta';
 import { FieldTypeDefinition } from '../../models/field-type';
 import { ARRAY_CONTEXT, GROUP_CONTEXT } from '../../models/field-signal-context.token';
-import { ArrayContext, GroupContext } from '../../mappers/types';
+import { ArrayContext } from '../../mappers/types';
 import { baseFieldMapper } from '../../mappers/base/base-field-mapper';
 import { PROPERTY_OVERRIDE_STORE } from '../../core/property-derivation/property-override-store';
 import { applyPropertyOverrides } from '../../core/property-derivation/apply-property-overrides';
@@ -200,7 +200,8 @@ export function mapFieldToInputs(
     // `{groupPath}_{key}_{index}` (e.g. `address_street_0`) — matching the
     // form-value path order: group → leaf → array index.
     if (hasGroupContext) {
-      inputs = applyGroupPrefix(inputs, (groupContext as GroupContext).groupPath());
+      // Non-null after the hasGroupContext guard.
+      inputs = applyGroupPrefix(inputs, groupContext!.groupPath());
     }
 
     // Apply index suffix for array items

--- a/packages/dynamic-forms/src/lib/utils/field-mapper/field-mapper.ts
+++ b/packages/dynamic-forms/src/lib/utils/field-mapper/field-mapper.ts
@@ -99,7 +99,9 @@ function applyIndexSuffix(inputs: Record<string, unknown>, index: number): Recor
  * leaf key inside different groups produces distinct DOM IDs (issue #401).
  * Form-schema keys remain clean — only the rendered `key` input is rewritten.
  *
- * Dots in the path (group nesting) become underscores: `user.address` → `user_address_street`.
+ * Dots in the group path become underscores, then the original leaf key is
+ * appended: `(groupPath='user.address', inputs.key='street')` →
+ * `inputs.key = 'user_address_street'`.
  */
 function applyGroupPrefix(inputs: Record<string, unknown>, groupPath: string): Record<string, unknown> {
   const key = inputs['key'];
@@ -210,13 +212,27 @@ export function mapFieldToInputs(
       inputs = applyIndexSuffix(inputs, index);
     }
 
-    // Apply property overrides from the store (AFTER all static transformations)
+    // Apply property overrides from the store (AFTER all static transformations).
+    //
+    // INVARIANT: the store key MUST be built from `fieldDef.key` + the group/array
+    // ancestry (via buildPropertyOverrideKey) — NEVER from the DOM-scoped
+    // `inputs['key']` produced by applyGroupPrefix/applyIndexSuffix above. The
+    // collector (property-derivation-collector.ts) registers using the same
+    // shape; if these drift, overrides silently miss their target.
     if (hasOverrides) {
-      // Build the store key inside computed() so index signal read establishes reactive dependency
-      // Safe to access arrayContext/indexSignal directly — hasArrayContext already confirmed they exist
+      // Build inside computed() so the index/group signals establish reactive deps.
+      // GROUP_CONTEXT resets at array boundaries (see create-array-item-injector.ts),
+      // so groupPath() represents ancestors inside the current array item (or
+      // top-level groups when not in an array) — matching the collector.
+      const groupPath = hasGroupContext ? groupContext!.groupPath() : undefined;
       const key = hasArrayContext
-        ? buildPropertyOverrideKey((arrayContext as ArrayContext).arrayKey, (indexSignal as Signal<number>)(), fieldDef.key)
-        : fieldDef.key;
+        ? buildPropertyOverrideKey(
+            (arrayContext as ArrayContext).arrayKey,
+            (indexSignal as Signal<number>)(),
+            fieldDef.key,
+            groupPath || undefined,
+          )
+        : buildPropertyOverrideKey(undefined, undefined, fieldDef.key, groupPath || undefined);
       const overrides = store.getOverrides(key)();
       inputs = applyPropertyOverrides(inputs, overrides);
     }


### PR DESCRIPTION
## Summary

Closes #401.

- Validator scopes duplicate-key checks through group ancestors and skips fields with `valueHandling !== 'include'` (buttons, page/row), so the same leaf key (e.g. `name`) can appear inside two different groups, and identical button keys can repeat across pages.
- New `GROUP_CONTEXT` injection token + `GroupContext` interface, provided by `GroupFieldComponent` in its child injector. `mapFieldToInputs` reads it and prefixes the rendered field key with the underscored group path (e.g. `address_street`), mirroring the existing `_{index}` array suffix. Nested groups extend the parent's path. Form-value paths and cross-field collector paths already handled scoping correctly; only the rendered `key` (DOM `id` / `data-testid`) needed wiring.
- Regression scenario `overlapping-group-keys` registered under `multi-page-navigation`, asserting the captured submission shape preserves group scoping (`{ createADto: { name }, createBDto: { name } }`).

## Breaking change

DOM IDs (and `data-testid` attributes) for fields rendered inside a `group` container are now scoped by the group's key — an input with `key: 'street'` inside `key: 'address'` group is emitted as `id="address_street"` (previously `id="street"`). Selectors or styles targeting raw field keys for group-nested fields must update. Top-level and array-item field IDs are unchanged.

## Test plan

- [x] `nx test dynamic-forms` — 2796 passed (validator spec rewritten with new cases: same key in different groups OK, same key in same group still rejected, button keys across pages OK, plus the exact issue #401 example end-to-end through the validator)
- [x] `nx build dynamic-forms` — success
- [x] `nx e2e core-examples` — 316 passed (includes the new `overlapping-group-keys` Playwright test)
- [x] `E2E_BROWSERS=chromium nx e2e material-examples` — 161 passed
- [x] `E2E_BROWSERS=chromium nx e2e bootstrap-examples` — 128 passed
- [x] `E2E_BROWSERS=chromium nx e2e ionic-examples` — 96 passed (1 pre-existing `Grid Layout` screenshot baseline drift, unrelated)
- [x] `E2E_BROWSERS=chromium nx e2e primeng-examples` — 117 passed (6 pre-existing screenshot baseline drifts, unrelated — these run cleanly in Docker on CI)
- [x] MCP server `instructions.ts` updated to document the new uniqueness rule + scoped IDs

## Files updated for the new scoped IDs

- 2 unit specs: `dynamic-form.component.spec.ts`, `page-orchestrator.component.spec.ts`
- 6 core E2E specs: cascading-validation, container-conditional-visibility, container-nesting, form-reset-clear, zod-schema-validation, multi-page-navigation
- Material: group-fields, submission-behavior, array-fields
- Ionic / PrimeNG / Bootstrap: submission-behavior (the `submit-inside-group` and `hidden-field` scenarios)