### PR TITLE
ci(release): fix spurious nightly failures and missing discord pings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,11 @@ on:
 permissions:
   contents: write
   id-token: write
-  actions: read
+  # `actions: write` needed so the post-publish step can dispatch
+  # discord-release-notify.yml via `gh workflow run` — the `release: published`
+  # event was supposed to fire it, but empirically doesn't (no `event: release`
+  # rows ever appear in the notify workflow history, even for App-token releases).
+  actions: write
 
 # Serialize @next runs against @next runs, stable against stable — but allow @next and
 # stable to run in parallel (they publish different versions and different tag names,
@@ -168,13 +172,15 @@ jobs:
           # npm. Only changes under `packages/**` (the seven workspaces in
           # LIBRARY_PACKAGES) qualify.
           #
-          # Disable pipefail for this pipeline so we can distinguish grep's "no matches"
-          # (exit 1, fine) from a real grep error (exit ≥2, fail loud).
-          set +o pipefail
+          # Disable errexit + pipefail for this pipeline so we can distinguish grep's
+          # "no matches" (exit 1, fine) from a real grep error (exit ≥2, fail loud).
+          # `set -e` alone would kill the script on grep's exit-1 BEFORE GREP_EXIT is
+          # captured, turning every "nothing to release" cron into a workflow failure.
+          set +e +o pipefail
           RELEVANT=$(git log "${BASE}..HEAD" --pretty=format:'%s' -- packages/ \
             | grep -cE '^(feat|fix|perf|revert)(\([^)]+\))?!?: ')
           GREP_EXIT=$?
-          set -o pipefail
+          set -e -o pipefail
           if [ "$GREP_EXIT" -gt 1 ]; then
             echo "::error::grep failed unexpectedly (exit $GREP_EXIT)"
             exit 1
@@ -525,6 +531,29 @@ jobs:
           draft: false
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Notify Discord
+        # Dispatches discord-release-notify.yml's workflow_dispatch trigger with
+        # the just-published tag. Decouples the notify path from `release: published`
+        # event propagation, which doesn't fire reliably for App-token releases here.
+        # continue-on-error: notifications are best-effort — npm+GH release already
+        # succeeded, so a Discord hiccup must not fail the run.
+        # Skipped on dry-run (no real release was created to post about).
+        if: |
+          inputs.mode == 'publish' ||
+          github.event_name == 'schedule' ||
+          inputs.mode == 'next'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "$DIST_TAG" = "next" ]; then
+            TAG="next/${VERSION}"
+          else
+            TAG="v${VERSION}"
+          fi
+          echo "Dispatching discord-release-notify.yml for tag: $TAG"
+          gh workflow run discord-release-notify.yml -f tag="$TAG"
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary

Two bugs in the nightly release workflow, both surfacing as Discord noise:

- **Spurious failure when nothing to publish.** The gate step uses `RELEVANT=$(git log ... | grep -c ...)` inside `set -euo pipefail`. `set +o pipefail` was set before the pipeline, but `set -e` was still active — so when grep returns exit 1 (no matches), the command substitution fails the script before `GREP_EXIT=$?` can capture it. Result: every cron with no bump-worthy commits failed instead of skipping. Reproduced locally; 8 of the last 10 scheduled runs concluded `failure` for this reason, all firing the `notify-failure` Discord embed.

- **No notification when a nightly actually publishes.** `discord-release-notify.yml` listens for `release: published`, but no `event: release` row has ever appeared in its run history — not for the recent nightly prereleases (v0.9.0-next.9, v0.9.0-next.10), not even for the App-token-created v0.8.0 stable. The App-token path was supposed to fix the GITHUB_TOKEN recursion limit but empirically doesn't propagate the event here.

## Changes

`.github/workflows/release.yml`:

1. **Gate fix:** `set +o pipefail` → `set +e +o pipefail`, restore both at the end. `GREP_EXIT` now actually gets captured and the "no bump-worthy commits — skip" branch is reachable.
2. **Notify dispatch:** new `Notify Discord` step at the end of the release job that runs `gh workflow run discord-release-notify.yml -f tag=$TAG` for stable publishes, scheduled nightlies, and `mode=next` dispatches. Reuses the existing notify workflow's `workflow_dispatch` path with full embed-building. `continue-on-error: true` so a Discord hiccup can't fail an already-published release. Skipped on dry-run.
3. **Permissions:** `actions: read` → `actions: write` to allow the dispatch.

The existing `release: published` handler in `discord-release-notify.yml` is left in place as a dormant backup (per request).

## Test plan

- [ ] Trigger via Actions → Release → `mode=next` on `main`. Confirm: workflow succeeds, prerelease + npm publish happen, **and** a `workflow_dispatch` run of `discord-release-notify.yml` fires with a Discord post.
- [ ] When the next cron fires on a day with no `feat|fix|perf|revert` commits under `packages/`, confirm: workflow concludes `success` (job output `should_publish=false`), no Discord failure ping.
- [ ] When the next cron fires on a day with bump-worthy commits, confirm: nightly publishes and Discord success post appears.