### PR TITLE
ci(release): gate notify on release-creation success

### DIFF
--- a/.github/workflows/discord-release-notify.yml
+++ b/.github/workflows/discord-release-notify.yml
@@ -1,8 +1,10 @@
 name: Discord Release Notification
 
 on:
-  release:
-    types: [published]
+  # release.yml dispatches this workflow at the end of a successful publish — see its
+  # "Notify Discord" step. We used to also listen for `release: published`, but App-
+  # token-created releases never propagated that event to this workflow, so the
+  # listener was dead weight and removed.
   workflow_run:
     # Fires whenever release.yml finishes; the notify-failure job below filters to failures.
     # Runs from main's copy of this file (workflow_run always uses the default branch),
@@ -12,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag to (re)post (e.g. v0.8.0 or next/0.8.1-next.5). Used for backfill when an auto-fire was missed.'
+        description: 'Release tag to post (e.g. v0.8.0 or next/0.8.1-next.5). Fired automatically by release.yml on successful publish; can also be invoked manually to re-post.'
         required: true
         type: string
 
@@ -22,21 +24,21 @@ permissions:
 jobs:
   notify:
     name: Post release to Discord
-    # workflow_run firings are handled by notify-failure below; this job only handles
-    # the "release published" embed path.
-    if: github.event_name != 'workflow_run'
+    # Only fires from workflow_dispatch — release.yml dispatches us here after a
+    # successful publish. workflow_run firings are handled by notify-failure below.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Build payload and post to Discord
-        # Both triggers route through `gh release view` so the embed-building logic stays
-        # identical regardless of how we were fired. For release: published events we could
-        # use github.event.release.* directly, but going through the API also dodges subtle
-        # interpolation issues with bodies containing backticks or YAML-significant chars.
+        # Goes through `gh release view` (not raw event fields) so the embed renders
+        # release notes consistently regardless of how the workflow was fired, and
+        # dodges interpolation issues with bodies containing backticks or YAML-
+        # significant chars.
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          TAG: ${{ inputs.tag || github.event.release.tag_name }}
+          TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -476,6 +476,8 @@ jobs:
         # AND publishes the release in one step. Runs AFTER npm publish so a failed publish
         # doesn't leave a stale tag/release behind. Idempotent on retry: if the release
         # already exists, the action updates it. Manual recovery: re-dispatch mode=publish.
+        # `id` is consumed by the Notify Discord step below to gate on actual success.
+        id: gh-release
         if: inputs.mode == 'publish'
         uses: softprops/action-gh-release@v3
         with:
@@ -518,7 +520,12 @@ jobs:
         # a phantom tag could permanently block future publishes.
         # continue-on-error: makes the job succeed even if release creation flakes — npm
         # is already published and rolling back that is worse than a missing GH release.
+        # The Notify Discord step below uses `steps.gh-prerelease.outcome` (not job
+        # conclusion) to detect the flake and skip Discord — `outcome` is the value
+        # BEFORE continue-on-error is applied, so a failed creation still reads as
+        # 'failure' here even though the job succeeds overall.
         # Idempotent on retry: if the release already exists, action-gh-release updates it.
+        id: gh-prerelease
         if: github.event_name == 'schedule' || inputs.mode == 'next'
         continue-on-error: true
         uses: softprops/action-gh-release@v3
@@ -538,11 +545,14 @@ jobs:
         # event propagation, which doesn't fire reliably for App-token releases here.
         # continue-on-error: notifications are best-effort — npm+GH release already
         # succeeded, so a Discord hiccup must not fail the run.
-        # Skipped on dry-run (no real release was created to post about).
+        # Gated on the matching gh-* step's outcome so a flaky release-creation
+        # doesn't ping Discord about a non-existent tag. The two creation steps are
+        # mutually exclusive (publish vs schedule|next), so exactly one outcome will
+        # be 'success' on a valid run; the other will be 'skipped'. Dry-run skips
+        # both, so neither outcome fires.
         if: |
-          inputs.mode == 'publish' ||
-          github.event_name == 'schedule' ||
-          inputs.mode == 'next'
+          steps.gh-release.outcome == 'success' ||
+          steps.gh-prerelease.outcome == 'success'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Follow-up to #405 with the three review fixes:

1. **Gate the Notify Discord step on actual release-creation success.** The @next prerelease step has `continue-on-error: true`, so a flaky GH release creation previously slipped through and pinged Discord about a tag that never got created. Added `id: gh-release` / `id: gh-prerelease` to the two `action-gh-release` steps and gated Notify Discord on `steps.gh-{release,prerelease}.outcome == 'success'`. Using `outcome` (not `conclusion`) because `outcome` reflects the actual step result *before* `continue-on-error` masks it.
2. **Removed the dormant `release: published` listener** in `discord-release-notify.yml`. Empirically that event has never fired for this repo's releases — no `event: release` rows have ever appeared in the workflow run history. Now that release.yml dispatches the notify workflow directly via `workflow_dispatch`, the listener was dead weight and a future "why two pings?" footgun.
3. **Cleaned up comments + input description** to match the new single-source-of-truth dispatch model.

## Test plan

- [ ] Trigger via Actions → Release → `mode=next` on `main`. Confirm: prerelease + npm publish + Discord post.
- [ ] Trigger again on a `mode=next` run where the prerelease creation fails (simulate by transiently breaking the App token). Confirm: workflow still succeeds, **no** Discord ping fires.
- [ ] Confirm `discord-release-notify.yml` no longer lists `release` under its trigger events in the Actions UI.