### PR TITLE
chore(dynamic-forms): 1.0 readiness cleanup pass

### DIFF
--- a/apps/docs/public/content/building-an-adapter.md
+++ b/apps/docs/public/content/building-an-adapter.md
@@ -404,22 +404,35 @@ Register with `valueHandling: 'exclude'` and `renderReadyWhen: []` since action 
 
 `NgForgeField` declares `field` and `key` as `input.required()`. The form engine guarantees both are bound before the component renders, but the contract is enforced via the `renderReadyWhen` mechanism on the `FieldTypeDefinition`.
 
-For value-bearing fields (`valueFieldMapper`, `checkboxFieldMapper`, etc.), `renderReadyWhen: ['field']` is the implicit default — no need to declare it. The renderer waits for the mapper to emit `field` before instantiating the component, so the required-input contract is satisfied on first CD.
+The renderer resolves the effective `renderReadyWhen` per registration in this order:
 
-For fields that don't bind to a form value (buttons, display-only text), declare `renderReadyWhen: []` to opt out of the default wait:
+1. `FieldTypeDefinition.renderReadyWhen` — explicit on the registration. Always wins (escape hatch).
+2. `valueHandling: 'exclude'` — short-circuits to `[]`. Display / action / layout fields don't bind to a form value, so they never wait.
+3. Default `['field']`. In dev mode the renderer also emits a one-time warning via `DynamicFormLogger` so adapter authors learn to declare the contract explicitly.
+
+Every registration in your adapter should declare `renderReadyWhen` (directly or via a shared base constant) so the contract is visible at the registration site. The convention the built-in adapters follow:
 
 ```typescript
+const VALUE_FIELD_TYPES_BASE = {
+  renderReadyWhen: ['field'],
+} as const;
+
 const BUTTON_FIELD_TYPES_BASE = {
-  renderReadyWhen: [] as string[],
-};
+  renderReadyWhen: [],
+  valueHandling: 'exclude',
+} as const;
 
 export const ADAPTER_FIELD_TYPES: FieldTypeDefinition[] = [
-  // ...
+  {
+    name: 'input',
+    loadComponent: () => import('./input/input.component'),
+    mapper: valueFieldMapper,
+    ...VALUE_FIELD_TYPES_BASE,
+  },
   {
     name: 'submit',
     loadComponent: () => import('./buttons/submit-button.component'),
     mapper: submitButtonFieldMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
 ];

--- a/apps/docs/public/llms-full.txt
+++ b/apps/docs/public/llms-full.txt
@@ -786,22 +786,35 @@ Register with `valueHandling: 'exclude'` and `renderReadyWhen: []` since action 
 
 `NgForgeField` declares `field` and `key` as `input.required()`. The form engine guarantees both are bound before the component renders, but the contract is enforced via the `renderReadyWhen` mechanism on the `FieldTypeDefinition`.
 
-For value-bearing fields (`valueFieldMapper`, `checkboxFieldMapper`, etc.), `renderReadyWhen: ['field']` is the implicit default — no need to declare it. The renderer waits for the mapper to emit `field` before instantiating the component, so the required-input contract is satisfied on first CD.
+The renderer resolves the effective `renderReadyWhen` per registration in this order:
 
-For fields that don't bind to a form value (buttons, display-only text), declare `renderReadyWhen: []` to opt out of the default wait:
+1. `FieldTypeDefinition.renderReadyWhen` — explicit on the registration. Always wins (escape hatch).
+2. `valueHandling: 'exclude'` — short-circuits to `[]`. Display / action / layout fields don't bind to a form value, so they never wait.
+3. Default `['field']`. In dev mode the renderer also emits a one-time warning via `DynamicFormLogger` so adapter authors learn to declare the contract explicitly.
+
+Every registration in your adapter should declare `renderReadyWhen` (directly or via a shared base constant) so the contract is visible at the registration site. The convention the built-in adapters follow:
 
 ```typescript
+const VALUE_FIELD_TYPES_BASE = {
+  renderReadyWhen: ['field'],
+} as const;
+
 const BUTTON_FIELD_TYPES_BASE = {
-  renderReadyWhen: [] as string[],
-};
+  renderReadyWhen: [],
+  valueHandling: 'exclude',
+} as const;
 
 export const ADAPTER_FIELD_TYPES: FieldTypeDefinition[] = [
-  // ...
+  {
+    name: 'input',
+    loadComponent: () => import('./input/input.component'),
+    mapper: valueFieldMapper,
+    ...VALUE_FIELD_TYPES_BASE,
+  },
   {
     name: 'submit',
     loadComponent: () => import('./buttons/submit-button.component'),
     mapper: submitButtonFieldMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
 ];

--- a/apps/e2e/bootstrap/src/app/testing/bootstrap-components/bootstrap-components.routes.ts
+++ b/apps/e2e/bootstrap/src/app/testing/bootstrap-components/bootstrap-components.routes.ts
@@ -107,6 +107,11 @@ const routes: Routes = [
     loadComponent: () => import('../shared/test-scenario.component').then((m) => m.TestScenarioComponent),
     data: { scenario: getBootstrapComponentsScenario('multi-checkbox-validation') },
   },
+  {
+    path: 'textarea-readonly-runtime',
+    loadComponent: () => import('../shared/test-scenario.component').then((m) => m.TestScenarioComponent),
+    data: { scenario: getBootstrapComponentsScenario('textarea-readonly-runtime') },
+  },
 ];
 
 export default routes;

--- a/apps/e2e/bootstrap/src/app/testing/bootstrap-components/bootstrap-components.spec.ts
+++ b/apps/e2e/bootstrap/src/app/testing/bootstrap-components/bootstrap-components.spec.ts
@@ -425,4 +425,31 @@ test.describe('Bootstrap Components Tests', () => {
       await expect(option1).toBeChecked();
     });
   });
+
+  test.describe('Textarea Readonly Sync', () => {
+    test('readonly() toggled at runtime syncs to the native textarea in both directions', async ({ page, helpers }) => {
+      await page.goto('/#/test/bootstrap-components/textarea-readonly-runtime');
+      await page.waitForLoadState('networkidle');
+
+      const scenario = helpers.getScenario('textarea-readonly-runtime');
+      await expect(scenario).toBeVisible();
+
+      const textarea = scenario.locator('#notes textarea');
+      const checkbox = scenario.locator('#lockEdit input[type="checkbox"]');
+
+      // Asserting on the DOM `readOnly` property — Angular's [formField] writes
+      // `readonly="true"` rather than the canonical `readonly=""`, both of which
+      // the browser treats as readonly=true. The property is unambiguous.
+      await expect(textarea).toBeVisible();
+      await expect(textarea).toHaveJSProperty('readOnly', false);
+
+      // Toggle ON: native readOnly must flip true.
+      await checkbox.click();
+      await expect(textarea).toHaveJSProperty('readOnly', true);
+
+      // Toggle OFF: native readOnly must flip back to false.
+      await checkbox.click();
+      await expect(textarea).toHaveJSProperty('readOnly', false);
+    });
+  });
 });

--- a/apps/e2e/bootstrap/src/app/testing/bootstrap-components/bootstrap-components.suite.ts
+++ b/apps/e2e/bootstrap/src/app/testing/bootstrap-components/bootstrap-components.suite.ts
@@ -15,6 +15,7 @@ import { sliderBoundsScenario } from './scenarios/slider-bounds.scenario';
 import { sliderDisabledScenario } from './scenarios/slider-disabled.scenario';
 import { sliderStepsScenario } from './scenarios/slider-steps.scenario';
 import { sliderValueDisplayScenario } from './scenarios/slider-value-display.scenario';
+import { textareaReadonlyRuntimeScenario } from './scenarios/textarea-readonly-runtime.scenario';
 import { toggleBasicScenario } from './scenarios/toggle-basic.scenario';
 import { toggleDisabledScenario } from './scenarios/toggle-disabled.scenario';
 import { toggleKeyboardScenario } from './scenarios/toggle-keyboard.scenario';
@@ -42,6 +43,7 @@ export const bootstrapComponentsSuite: TestSuite = {
     sliderDisabledScenario,
     sliderStepsScenario,
     sliderValueDisplayScenario,
+    textareaReadonlyRuntimeScenario,
     toggleBasicScenario,
     toggleDisabledScenario,
     toggleKeyboardScenario,

--- a/apps/e2e/bootstrap/src/app/testing/bootstrap-components/scenarios/textarea-readonly-runtime.scenario.ts
+++ b/apps/e2e/bootstrap/src/app/testing/bootstrap-components/scenarios/textarea-readonly-runtime.scenario.ts
@@ -1,0 +1,43 @@
+import { FormConfig } from '@ng-forge/dynamic-forms';
+import { TestScenario } from '../../shared/types';
+
+/**
+ * Bootstrap mirror of the Material textarea-readonly-runtime regression test.
+ * Verifies that toggling readonly() at runtime propagates to the native
+ * `<textarea>` readonly attribute after the afterRenderEffect workaround
+ * was removed from bs-textarea.component.ts.
+ */
+const config = {
+  fields: [
+    {
+      key: 'lockEdit',
+      type: 'checkbox',
+      label: 'Lock textarea',
+      value: false,
+    },
+    {
+      key: 'notes',
+      type: 'textarea',
+      label: 'Notes',
+      value: 'initial content',
+      logic: [
+        {
+          type: 'readonly',
+          condition: {
+            type: 'fieldValue',
+            fieldPath: 'lockEdit',
+            operator: 'equals',
+            value: true,
+          },
+        },
+      ],
+    },
+  ],
+} as const satisfies FormConfig;
+
+export const textareaReadonlyRuntimeScenario: TestScenario = {
+  testId: 'textarea-readonly-runtime',
+  title: 'Textarea - Runtime Readonly Toggle',
+  description: 'Toggles readonly() at runtime via a logic rule and asserts the native DOM attribute syncs in both directions',
+  config,
+};

--- a/apps/e2e/material/src/app/testing/material-components/material-components.routes.ts
+++ b/apps/e2e/material/src/app/testing/material-components/material-components.routes.ts
@@ -107,6 +107,11 @@ const routes: Routes = [
     loadComponent: () => import('../shared/test-scenario.component').then((m) => m.TestScenarioComponent),
     data: { scenario: getMaterialComponentsScenario('multi-checkbox-validation') },
   },
+  {
+    path: 'textarea-readonly-runtime',
+    loadComponent: () => import('../shared/test-scenario.component').then((m) => m.TestScenarioComponent),
+    data: { scenario: getMaterialComponentsScenario('textarea-readonly-runtime') },
+  },
 ];
 
 export default routes;

--- a/apps/e2e/material/src/app/testing/material-components/material-components.spec.ts
+++ b/apps/e2e/material/src/app/testing/material-components/material-components.spec.ts
@@ -400,4 +400,31 @@ test.describe('Material Components Tests', () => {
       await expect(option1).toHaveClass(/mat-mdc-checkbox-checked/);
     });
   });
+
+  test.describe('Textarea Readonly Sync', () => {
+    test('readonly() toggled at runtime syncs to the native textarea in both directions', async ({ page, helpers }) => {
+      await page.goto('/#/test/material-components/textarea-readonly-runtime');
+      await page.waitForLoadState('networkidle');
+
+      const scenario = helpers.getScenario('textarea-readonly-runtime');
+      await expect(scenario).toBeVisible();
+
+      const textarea = scenario.locator('#notes textarea');
+      const checkbox = scenario.locator('#lockEdit mat-checkbox');
+
+      // Asserting on the DOM `readOnly` property rather than the attribute string —
+      // Angular's [formField] writes `readonly="true"` rather than the canonical
+      // `readonly=""`, both of which the browser treats as readonly=true.
+      await expect(textarea).toBeVisible();
+      await expect(textarea).toHaveJSProperty('readOnly', false);
+
+      // Toggle ON: native readOnly must flip true.
+      await checkbox.click();
+      await expect(textarea).toHaveJSProperty('readOnly', true);
+
+      // Toggle OFF: native readOnly must flip back to false.
+      await checkbox.click();
+      await expect(textarea).toHaveJSProperty('readOnly', false);
+    });
+  });
 });

--- a/apps/e2e/material/src/app/testing/material-components/material-components.suite.ts
+++ b/apps/e2e/material/src/app/testing/material-components/material-components.suite.ts
@@ -15,6 +15,7 @@ import { sliderBoundsScenario } from './scenarios/slider-bounds.scenario';
 import { sliderDisabledScenario } from './scenarios/slider-disabled.scenario';
 import { sliderStepsScenario } from './scenarios/slider-steps.scenario';
 import { sliderValueDisplayScenario } from './scenarios/slider-value-display.scenario';
+import { textareaReadonlyRuntimeScenario } from './scenarios/textarea-readonly-runtime.scenario';
 import { toggleBasicScenario } from './scenarios/toggle-basic.scenario';
 import { toggleDisabledScenario } from './scenarios/toggle-disabled.scenario';
 import { toggleKeyboardScenario } from './scenarios/toggle-keyboard.scenario';
@@ -42,6 +43,7 @@ export const materialComponentsSuite: TestSuite = {
     sliderDisabledScenario,
     sliderStepsScenario,
     sliderValueDisplayScenario,
+    textareaReadonlyRuntimeScenario,
     toggleBasicScenario,
     toggleDisabledScenario,
     toggleKeyboardScenario,

--- a/apps/e2e/material/src/app/testing/material-components/scenarios/textarea-readonly-runtime.scenario.ts
+++ b/apps/e2e/material/src/app/testing/material-components/scenarios/textarea-readonly-runtime.scenario.ts
@@ -1,0 +1,45 @@
+import { FormConfig } from '@ng-forge/dynamic-forms';
+import { TestScenario } from '../../shared/types';
+
+/**
+ * Regression test for the readonly DOM-sync workaround removal — a runtime
+ * toggle of `readonly()` on the field state must propagate to the native
+ * `readonly` attribute on the underlying `<textarea>`. Previously a viewChild
+ * + afterRenderEffect was needed; Angular 21.0.7's `[formField]` now does
+ * this natively. If a regression in Angular re-breaks the sync, this test
+ * fails immediately instead of silently shipping a broken textarea.
+ */
+const config = {
+  fields: [
+    {
+      key: 'lockEdit',
+      type: 'checkbox',
+      label: 'Lock textarea',
+      value: false,
+    },
+    {
+      key: 'notes',
+      type: 'textarea',
+      label: 'Notes',
+      value: 'initial content',
+      logic: [
+        {
+          type: 'readonly',
+          condition: {
+            type: 'fieldValue',
+            fieldPath: 'lockEdit',
+            operator: 'equals',
+            value: true,
+          },
+        },
+      ],
+    },
+  ],
+} as const satisfies FormConfig;
+
+export const textareaReadonlyRuntimeScenario: TestScenario = {
+  testId: 'textarea-readonly-runtime',
+  title: 'Textarea - Runtime Readonly Toggle',
+  description: 'Toggles readonly() at runtime via a logic rule and asserts the native DOM attribute syncs in both directions',
+  config,
+};

--- a/packages/dynamic-forms-bootstrap/src/lib/config/bootstrap-field-config.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/config/bootstrap-field-config.ts
@@ -15,9 +15,14 @@ import { BsField } from '../types/types';
 import { buttonFieldMapper } from '../fields/button/bs-button.mapper';
 import { nextButtonFieldMapper, previousButtonFieldMapper, submitButtonFieldMapper } from '../fields/button/bs-specific-button.mapper';
 
+const VALUE_FIELD_TYPES_BASE = {
+  renderReadyWhen: ['field'],
+} as const;
+
 const BUTTON_FIELD_TYPES_BASE = {
-  renderReadyWhen: [] as string[],
-};
+  renderReadyWhen: [],
+  valueHandling: 'exclude',
+} as const;
 
 export const BOOTSTRAP_FIELD_TYPES: FieldTypeDefinition[] = [
   {
@@ -26,87 +31,80 @@ export const BOOTSTRAP_FIELD_TYPES: FieldTypeDefinition[] = [
     mapper: valueFieldMapper,
     propsToMeta: ['type'],
     scope: ['text-input', 'numeric'],
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: BsField.Select,
     loadComponent: () => import('../fields/select/bs-select.component'),
     mapper: optionsFieldMapper,
     scope: 'single-select',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: BsField.Checkbox,
     loadComponent: () => import('../fields/checkbox/bs-checkbox.component'),
     mapper: checkboxFieldMapper,
     scope: 'boolean',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: BsField.Button,
     loadComponent: () => import('../fields/button/bs-button.component'),
     mapper: buttonFieldMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: BsField.Submit,
     loadComponent: () => import('../fields/button/bs-button.component'),
     mapper: submitButtonFieldMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: BsField.Next,
     loadComponent: () => import('../fields/button/bs-button.component'),
     mapper: nextButtonFieldMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: BsField.Previous,
     loadComponent: () => import('../fields/button/bs-button.component'),
     mapper: previousButtonFieldMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: BsField.AddArrayItem,
     loadComponent: () => import('../fields/button/bs-button.component'),
     mapper: addArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: BsField.PrependArrayItem,
     loadComponent: () => import('../fields/button/bs-button.component'),
     mapper: prependArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: BsField.InsertArrayItem,
     loadComponent: () => import('../fields/button/bs-button.component'),
     mapper: insertArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: BsField.RemoveArrayItem,
     loadComponent: () => import('../fields/button/bs-button.component'),
     mapper: removeArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: BsField.PopArrayItem,
     loadComponent: () => import('../fields/button/bs-button.component'),
     mapper: popArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: BsField.ShiftArrayItem,
     loadComponent: () => import('../fields/button/bs-button.component'),
     mapper: shiftArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
@@ -115,35 +113,41 @@ export const BOOTSTRAP_FIELD_TYPES: FieldTypeDefinition[] = [
     mapper: valueFieldMapper,
     propsToMeta: ['rows'],
     scope: 'text-input',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: BsField.Radio,
     loadComponent: () => import('../fields/radio/bs-radio.component'),
     mapper: optionsFieldMapper,
     scope: 'single-select',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: BsField.MultiCheckbox,
     loadComponent: () => import('../fields/multi-checkbox/bs-multi-checkbox.component'),
     mapper: optionsFieldMapper,
     scope: 'multi-select',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: BsField.Datepicker,
     loadComponent: () => import('../fields/datepicker/bs-datepicker.component'),
     mapper: datepickerFieldMapper,
     scope: 'date',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: BsField.Slider,
     loadComponent: () => import('../fields/slider/bs-slider.component'),
     mapper: valueFieldMapper,
     scope: 'numeric',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: BsField.Toggle,
     loadComponent: () => import('../fields/toggle/bs-toggle.component'),
     mapper: checkboxFieldMapper,
     scope: 'boolean',
+    ...VALUE_FIELD_TYPES_BASE,
   },
 ];

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/textarea/bs-textarea.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/textarea/bs-textarea.component.ts
@@ -1,4 +1,4 @@
-import { afterRenderEffect, ChangeDetectionStrategy, Component, computed, ElementRef, input, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { FormField } from '@angular/forms/signals';
 import { DynamicTextPipe } from '@ng-forge/dynamic-forms';
 import { NgForgeControl, injectNgForgeField, NgForgeFieldHost } from '@ng-forge/dynamic-forms/integration';
@@ -17,7 +17,6 @@ import { AsyncPipe } from '@angular/common';
       <div class="form-floating mb-3">
         <textarea
           ngForgeControl
-          #textareaRef
           [formField]="f"
           [id]="textareaId"
           [placeholder]="(ngf.placeholder() | dynamicText | async) ?? ''"
@@ -52,7 +51,6 @@ import { AsyncPipe } from '@angular/common';
 
         <textarea
           ngForgeControl
-          #textareaRef
           [formField]="f"
           [id]="textareaId"
           [placeholder]="(ngf.placeholder() | dynamicText | async) ?? ''"
@@ -90,35 +88,4 @@ export default class BsTextareaFieldComponent {
   protected readonly ngf = injectNgForgeField<string>();
 
   readonly props = input<BsTextareaProps>();
-
-  /**
-   * Reference to the native textarea element.
-   * Used to imperatively sync the readonly attribute since Angular Signal Forms'
-   * [field] directive doesn't sync FieldState.readonly() to the DOM.
-   */
-  private readonly textareaRef = viewChild<ElementRef<HTMLTextAreaElement>>('textareaRef');
-
-  /**
-   * Computed signal that extracts the readonly state from the field.
-   */
-  private readonly isReadonly = computed(() => this.ngf.field()().readonly());
-
-  /**
-   * Workaround: Angular Signal Forms' [field] directive does NOT sync the readonly
-   * attribute to the DOM. This effect imperatively sets/removes the readonly attribute
-   * on the native textarea element whenever the readonly state changes.
-   */
-  private readonly syncReadonlyToDom = afterRenderEffect({
-    write: () => {
-      const textareaRef = this.textareaRef();
-      const isReadonly = this.isReadonly();
-      if (textareaRef?.nativeElement) {
-        if (isReadonly) {
-          textareaRef.nativeElement.setAttribute('readonly', '');
-        } else {
-          textareaRef.nativeElement.removeAttribute('readonly');
-        }
-      }
-    },
-  });
 }

--- a/packages/dynamic-forms-ionic/src/lib/config/ionic-field-config.ts
+++ b/packages/dynamic-forms-ionic/src/lib/config/ionic-field-config.ts
@@ -15,9 +15,14 @@ import { IonicField } from '../types/types';
 import { buttonFieldMapper } from '../fields/button/ionic-button.mapper';
 import { nextButtonFieldMapper, previousButtonFieldMapper, submitButtonFieldMapper } from '../fields/button/ionic-specific-button.mapper';
 
+const VALUE_FIELD_TYPES_BASE = {
+  renderReadyWhen: ['field'],
+} as const;
+
 const BUTTON_FIELD_TYPES_BASE = {
-  renderReadyWhen: [] as string[],
-};
+  renderReadyWhen: [],
+  valueHandling: 'exclude',
+} as const;
 
 /**
  * Ionic field type definitions
@@ -30,87 +35,80 @@ export const IONIC_FIELD_TYPES: FieldTypeDefinition[] = [
     mapper: valueFieldMapper,
     propsToMeta: ['type'],
     scope: ['text-input', 'numeric'],
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: IonicField.Select,
     loadComponent: () => import('../fields/select/ionic-select.component'),
     mapper: optionsFieldMapper,
     scope: 'single-select',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: IonicField.Checkbox,
     loadComponent: () => import('../fields/checkbox/ionic-checkbox.component'),
     mapper: checkboxFieldMapper,
     scope: 'boolean',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: IonicField.Button,
     loadComponent: () => import('../fields/button/ionic-button.component'),
     mapper: buttonFieldMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: IonicField.Submit,
     loadComponent: () => import('../fields/button/ionic-button.component'),
     mapper: submitButtonFieldMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: IonicField.Next,
     loadComponent: () => import('../fields/button/ionic-button.component'),
     mapper: nextButtonFieldMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: IonicField.Previous,
     loadComponent: () => import('../fields/button/ionic-button.component'),
     mapper: previousButtonFieldMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: IonicField.AddArrayItem,
     loadComponent: () => import('../fields/button/ionic-button.component'),
     mapper: addArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: IonicField.PrependArrayItem,
     loadComponent: () => import('../fields/button/ionic-button.component'),
     mapper: prependArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: IonicField.InsertArrayItem,
     loadComponent: () => import('../fields/button/ionic-button.component'),
     mapper: insertArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: IonicField.RemoveArrayItem,
     loadComponent: () => import('../fields/button/ionic-button.component'),
     mapper: removeArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: IonicField.PopArrayItem,
     loadComponent: () => import('../fields/button/ionic-button.component'),
     mapper: popArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: IonicField.ShiftArrayItem,
     loadComponent: () => import('../fields/button/ionic-button.component'),
     mapper: shiftArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
@@ -119,35 +117,41 @@ export const IONIC_FIELD_TYPES: FieldTypeDefinition[] = [
     mapper: valueFieldMapper,
     propsToMeta: ['rows'],
     scope: 'text-input',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: IonicField.Radio,
     loadComponent: () => import('../fields/radio/ionic-radio.component'),
     mapper: optionsFieldMapper,
     scope: 'single-select',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: IonicField.MultiCheckbox,
     loadComponent: () => import('../fields/multi-checkbox/ionic-multi-checkbox.component'),
     mapper: optionsFieldMapper,
     scope: 'multi-select',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: IonicField.Datepicker,
     loadComponent: () => import('../fields/datepicker/ionic-datepicker.component'),
     mapper: datepickerFieldMapper,
     scope: 'date',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: IonicField.Slider,
     loadComponent: () => import('../fields/slider/ionic-slider.component'),
     mapper: valueFieldMapper,
     scope: 'numeric',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: IonicField.Toggle,
     loadComponent: () => import('../fields/toggle/ionic-toggle.component'),
     mapper: checkboxFieldMapper,
     scope: 'boolean',
+    ...VALUE_FIELD_TYPES_BASE,
   },
 ];

--- a/packages/dynamic-forms-material/src/lib/config/material-field-config.ts
+++ b/packages/dynamic-forms-material/src/lib/config/material-field-config.ts
@@ -16,12 +16,22 @@ import { buttonFieldMapper } from '../fields/button/mat-button.mapper';
 import { nextButtonFieldMapper, previousButtonFieldMapper, submitButtonFieldMapper } from '../fields/button/mat-specific-button.mapper';
 
 /**
- * Base definition for button field types that don't use the `field` input.
- * Button fields render immediately without waiting for form value integration.
+ * Base for value-bearing field types — waits for the mapper to emit the `field`
+ * input before instantiating the component (matches NgForgeField's
+ * `input.required<FieldTree<T>>()` contract).
+ */
+const VALUE_FIELD_TYPES_BASE = {
+  renderReadyWhen: ['field'],
+} as const;
+
+/**
+ * Base for action/button field types that don't bind to a form value.
+ * Renders immediately, opted out of form-value collection.
  */
 const BUTTON_FIELD_TYPES_BASE = {
-  renderReadyWhen: [] as string[],
-};
+  renderReadyWhen: [],
+  valueHandling: 'exclude',
+} as const;
 
 /**
  * Material Design field type definitions
@@ -34,87 +44,80 @@ export const MATERIAL_FIELD_TYPES: FieldTypeDefinition[] = [
     mapper: valueFieldMapper,
     propsToMeta: ['type'],
     scope: ['text-input', 'numeric'],
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: MatField.Select,
     loadComponent: () => import('../fields/select/mat-select.component'),
     mapper: optionsFieldMapper,
     scope: 'single-select',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: MatField.Checkbox,
     loadComponent: () => import('../fields/checkbox/mat-checkbox.component'),
     mapper: checkboxFieldMapper,
     scope: 'boolean',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: MatField.Button,
     loadComponent: () => import('../fields/button/mat-button.component'),
     mapper: buttonFieldMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: MatField.Submit,
     loadComponent: () => import('../fields/button/mat-button.component'),
     mapper: submitButtonFieldMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: MatField.Next,
     loadComponent: () => import('../fields/button/mat-button.component'),
     mapper: nextButtonFieldMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: MatField.Previous,
     loadComponent: () => import('../fields/button/mat-button.component'),
     mapper: previousButtonFieldMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: MatField.AddArrayItem,
     loadComponent: () => import('../fields/button/mat-button.component'),
     mapper: addArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: MatField.PrependArrayItem,
     loadComponent: () => import('../fields/button/mat-button.component'),
     mapper: prependArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: MatField.InsertArrayItem,
     loadComponent: () => import('../fields/button/mat-button.component'),
     mapper: insertArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: MatField.RemoveArrayItem,
     loadComponent: () => import('../fields/button/mat-button.component'),
     mapper: removeArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: MatField.PopArrayItem,
     loadComponent: () => import('../fields/button/mat-button.component'),
     mapper: popArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: MatField.ShiftArrayItem,
     loadComponent: () => import('../fields/button/mat-button.component'),
     mapper: shiftArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
@@ -123,35 +126,41 @@ export const MATERIAL_FIELD_TYPES: FieldTypeDefinition[] = [
     mapper: valueFieldMapper,
     propsToMeta: ['rows', 'cols'],
     scope: 'text-input',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: MatField.Radio,
     loadComponent: () => import('../fields/radio/mat-radio.component'),
     mapper: optionsFieldMapper,
     scope: 'single-select',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: MatField.MultiCheckbox,
     loadComponent: () => import('../fields/multi-checkbox/mat-multi-checkbox.component'),
     mapper: optionsFieldMapper,
     scope: 'multi-select',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: MatField.Datepicker,
     loadComponent: () => import('../fields/datepicker/mat-datepicker.component'),
     mapper: datepickerFieldMapper,
     scope: 'date',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: MatField.Slider,
     loadComponent: () => import('../fields/slider/mat-slider.component'),
     mapper: valueFieldMapper,
     scope: 'numeric',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: MatField.Toggle,
     loadComponent: () => import('../fields/toggle/mat-toggle.component'),
     mapper: checkboxFieldMapper,
     scope: 'boolean',
+    ...VALUE_FIELD_TYPES_BASE,
   },
 ];

--- a/packages/dynamic-forms-material/src/lib/fields/textarea/mat-textarea.component.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/textarea/mat-textarea.component.ts
@@ -1,4 +1,4 @@
-import { afterRenderEffect, ChangeDetectionStrategy, Component, computed, ElementRef, inject, input, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { FormField } from '@angular/forms/signals';
 import { MatError, MatFormField, MatLabel } from '@angular/material/form-field';
 import { MatHint, MatInput } from '@angular/material/input';
@@ -27,7 +27,6 @@ import { MATERIAL_CONFIG } from '../../models/material-config.token';
 
       <textarea
         ngForgeControl
-        #textareaRef
         matInput
         [id]="textareaId"
         [formField]="ngf.field()"
@@ -59,46 +58,6 @@ export default class MatTextareaFieldComponent {
   protected readonly ngf = injectNgForgeField<string>();
 
   readonly props = input<MatTextareaProps>();
-
-  /**
-   * Reference to the native textarea element.
-   * Used to imperatively sync the readonly attribute since Angular Signal Forms'
-   * [field] directive doesn't sync FieldState.readonly() to the DOM.
-   */
-  private readonly textareaRef = viewChild<ElementRef<HTMLTextAreaElement>>('textareaRef');
-
-  /**
-   * Computed signal that extracts the readonly state from the field.
-   * Used by the effect to reactively sync the readonly attribute to the DOM.
-   */
-  private readonly isReadonly = computed(() => this.ngf.field()().readonly());
-
-  /**
-   * Workaround: Angular Signal Forms' [field] directive does NOT sync the readonly
-   * attribute to the DOM, even though FieldState.readonly() returns the correct value.
-   * This effect imperatively sets/removes the readonly attribute on the native textarea
-   * element whenever the readonly state changes.
-   *
-   * Note: We cannot use [readonly] or [attr.readonly] bindings because Angular throws
-   * NG8022: "Binding to '[readonly]' is not allowed on nodes using the '[field]' directive"
-   *
-   * Uses afterRenderEffect to ensure DOM is ready before manipulating attributes.
-   *
-   * @see https://github.com/angular/angular/issues/65897
-   */
-  private readonly syncReadonlyToDom = afterRenderEffect({
-    write: () => {
-      const textareaRef = this.textareaRef();
-      const isReadonly = this.isReadonly();
-      if (textareaRef?.nativeElement) {
-        if (isReadonly) {
-          textareaRef.nativeElement.setAttribute('readonly', '');
-        } else {
-          textareaRef.nativeElement.removeAttribute('readonly');
-        }
-      }
-    },
-  });
 
   readonly appearance = computed(() => this.props()?.appearance ?? this.materialConfig?.appearance ?? 'outline');
   readonly subscriptSizing = computed(() => this.props()?.subscriptSizing ?? this.materialConfig?.subscriptSizing ?? 'dynamic');

--- a/packages/dynamic-forms-primeng/src/lib/config/primeng-field-config.ts
+++ b/packages/dynamic-forms-primeng/src/lib/config/primeng-field-config.ts
@@ -15,9 +15,14 @@ import { PrimeField } from '../types/types';
 import { buttonFieldMapper } from '../fields/button/prime-button.mapper';
 import { nextButtonFieldMapper, previousButtonFieldMapper, submitButtonFieldMapper } from '../fields/button/prime-specific-button.mapper';
 
+const VALUE_FIELD_TYPES_BASE = {
+  renderReadyWhen: ['field'],
+} as const;
+
 const BUTTON_FIELD_TYPES_BASE = {
-  renderReadyWhen: [] as string[],
-};
+  renderReadyWhen: [],
+  valueHandling: 'exclude',
+} as const;
 
 /**
  * PrimeNG field type definitions
@@ -30,87 +35,80 @@ export const PRIMENG_FIELD_TYPES: FieldTypeDefinition[] = [
     mapper: valueFieldMapper,
     propsToMeta: ['type'],
     scope: ['text-input', 'numeric'],
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: PrimeField.Select,
     loadComponent: () => import('../fields/select/prime-select.component'),
     mapper: optionsFieldMapper,
     scope: 'single-select',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: PrimeField.Checkbox,
     loadComponent: () => import('../fields/checkbox/prime-checkbox.component'),
     mapper: checkboxFieldMapper,
     scope: 'boolean',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: PrimeField.Button,
     loadComponent: () => import('../fields/button/prime-button.component'),
     mapper: buttonFieldMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: PrimeField.Submit,
     loadComponent: () => import('../fields/button/prime-button.component'),
     mapper: submitButtonFieldMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: PrimeField.Next,
     loadComponent: () => import('../fields/button/prime-button.component'),
     mapper: nextButtonFieldMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: PrimeField.Previous,
     loadComponent: () => import('../fields/button/prime-button.component'),
     mapper: previousButtonFieldMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: PrimeField.AddArrayItem,
     loadComponent: () => import('../fields/button/prime-button.component'),
     mapper: addArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: PrimeField.PrependArrayItem,
     loadComponent: () => import('../fields/button/prime-button.component'),
     mapper: prependArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: PrimeField.InsertArrayItem,
     loadComponent: () => import('../fields/button/prime-button.component'),
     mapper: insertArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: PrimeField.RemoveArrayItem,
     loadComponent: () => import('../fields/button/prime-button.component'),
     mapper: removeArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: PrimeField.PopArrayItem,
     loadComponent: () => import('../fields/button/prime-button.component'),
     mapper: popArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
     name: PrimeField.ShiftArrayItem,
     loadComponent: () => import('../fields/button/prime-button.component'),
     mapper: shiftArrayItemButtonMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
   {
@@ -119,35 +117,41 @@ export const PRIMENG_FIELD_TYPES: FieldTypeDefinition[] = [
     mapper: valueFieldMapper,
     propsToMeta: ['rows', 'cols'],
     scope: 'text-input',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: PrimeField.Radio,
     loadComponent: () => import('../fields/radio/prime-radio.component'),
     mapper: optionsFieldMapper,
     scope: 'single-select',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: PrimeField.MultiCheckbox,
     loadComponent: () => import('../fields/multi-checkbox/prime-multi-checkbox.component'),
     mapper: optionsFieldMapper,
     scope: 'multi-select',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: PrimeField.Datepicker,
     loadComponent: () => import('../fields/datepicker/prime-datepicker.component'),
     mapper: datepickerFieldMapper,
     scope: 'date',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: PrimeField.Slider,
     loadComponent: () => import('../fields/slider/prime-slider.component'),
     mapper: valueFieldMapper,
     scope: 'numeric',
+    ...VALUE_FIELD_TYPES_BASE,
   },
   {
     name: PrimeField.Toggle,
     loadComponent: () => import('../fields/toggle/prime-toggle.component'),
     mapper: checkboxFieldMapper,
     scope: 'boolean',
+    ...VALUE_FIELD_TYPES_BASE,
   },
 ];

--- a/packages/dynamic-forms/CLAUDE.md
+++ b/packages/dynamic-forms/CLAUDE.md
@@ -80,56 +80,44 @@ Cannot call `mapFieldToInputs` inside a `computed` that IS `resolvedFields`. Map
 
 ### Required mapped inputs for adapter fields
 
-When a `FieldTypeDefinition` has a `mapper`, the renderer automatically waits for the `field` input before instantiating the component. This convention eliminates the need to explicitly declare `renderReadyWhen: ['field']` for standard value-bearing fields.
-
-```typescript
-// Automatic - no renderReadyWhen needed when mapper is present
-{
-  name: 'datepicker',
-  loadComponent: () => import('./my-datepicker.component'),
-  mapper: datepickerFieldMapper,
-}
-```
-
-**Fields that don't use `field` input need `renderReadyWhen: []`:**
-
-Button fields (button, submit, next, previous, addArrayItem, prependArrayItem, insertArrayItem, removeArrayItem, popArrayItem, shiftArrayItem) and display fields (text) don't use the `field` input. Their mappers provide other inputs directly (event, disabled, etc.). Use a shared base constant to apply `renderReadyWhen: []`:
+Every `FieldTypeDefinition` declares `renderReadyWhen` explicitly at the registration site (resolver cascade: explicit on the registration → `valueHandling: 'exclude'` short-circuit to `[]` → fallback `['field']` + one-shot dev warning via `DynamicFormLogger`). Both built-in and adapter registrations spread one of two shared base constants per file:
 
 ```typescript
 // In adapter config files (e.g., material-field-config.ts)
+const VALUE_FIELD_TYPES_BASE = {
+  renderReadyWhen: ['field'],
+} as const;
+
 const BUTTON_FIELD_TYPES_BASE = {
-  renderReadyWhen: [] as string[],
-};
+  renderReadyWhen: [],
+  valueHandling: 'exclude',
+} as const;
 
 export const MATERIAL_FIELD_TYPES: FieldTypeDefinition[] = [
+  {
+    name: MatField.Input,
+    loadComponent: () => import('../fields/input/mat-input.component'),
+    mapper: valueFieldMapper,
+    ...VALUE_FIELD_TYPES_BASE,
+  },
   {
     name: MatField.Button,
     loadComponent: () => import('../fields/button/mat-button.component'),
     mapper: buttonFieldMapper,
-    valueHandling: 'exclude',
     ...BUTTON_FIELD_TYPES_BASE,
   },
-  // ... all other button types
+  // ...
 ];
 ```
 
-Similarly for display-only fields:
+Custom mappers that emit other required inputs should list them explicitly on the registration:
 
 ```typescript
-const DISPLAY_FIELD_TYPES_BASE = {
-  renderReadyWhen: [] as string[],
-};
-```
-
-Custom mappers that provide other reactive inputs should use explicit `renderReadyWhen` to declare which inputs the renderer should wait for:
-
-```typescript
-// Wait for custom input from your mapper
 {
   name: 'my-field',
   loadComponent: () => import('./my-field.component'),
   mapper: myCustomMapper,
-  renderReadyWhen: ['title', 'items'],  // Wait for multiple custom inputs
+  renderReadyWhen: ['field', 'allowedTypes'],
 }
 ```
 

--- a/packages/dynamic-forms/src/lib/definitions/base/base-value-field.type-test.ts
+++ b/packages/dynamic-forms/src/lib/definitions/base/base-value-field.type-test.ts
@@ -2,6 +2,7 @@
  * Exhaustive type tests for BaseValueField interface.
  */
 import { expectTypeOf } from 'vitest';
+import type { RegisteredFieldTypes } from '../../models/registry/field-registry';
 import type { DynamicText } from '../../models/types/dynamic-text';
 import type { BaseValueField, ValueType, ValueFieldComponent } from './base-value-field';
 import type { FieldDef } from './field-def';
@@ -140,7 +141,7 @@ describe('BaseValueField - Property Types', () => {
 
   it('should inherit all FieldDef properties', () => {
     expectTypeOf<TestField['key']>().toEqualTypeOf<string>();
-    expectTypeOf<TestField['type']>().toEqualTypeOf<string>();
+    expectTypeOf<TestField['type']>().toEqualTypeOf<RegisteredFieldTypes['type'] | (string & {})>();
     expectTypeOf<TestField['label']>().toEqualTypeOf<DynamicText | undefined>();
   });
 

--- a/packages/dynamic-forms/src/lib/definitions/base/field-def.ts
+++ b/packages/dynamic-forms/src/lib/definitions/base/field-def.ts
@@ -1,5 +1,6 @@
 import { WithInputSignals } from '../../models/component-type';
 import { Prettify } from '../../models/prettify';
+import { RegisteredFieldTypes } from '../../models/registry/field-registry';
 import { DynamicText } from '../../models/types/dynamic-text';
 import { WrapperConfig } from '../../models/wrapper-type';
 import { FieldMeta } from './field-meta';
@@ -71,18 +72,23 @@ export interface FieldDef<TProps, TMeta extends FieldMeta = FieldMeta> {
   /**
    * Field type identifier for component selection.
    *
-   * Determines which component will be rendered for this field.
-   * Must match a registered field type name in the field registry.
+   * Determines which component will be rendered for this field. Names
+   * registered through module augmentation of `DynamicFormFieldRegistry`
+   * are surfaced as IDE autocomplete suggestions via `RegisteredFieldTypes`;
+   * the `(string & {})` branch keeps arbitrary custom identifiers accepted
+   * as an escape hatch for fields that haven't been augmented into the
+   * registry.
    *
    * @example
    * ```typescript
-   * type: 'input'     // Text input field
-   * type: 'select'    // Dropdown selection
-   * type: 'checkbox'  // Boolean checkbox
-   * type: 'group'     // Field group container
+   * type: 'input'     // Text input field (registered)
+   * type: 'select'    // Dropdown selection (registered)
+   * type: 'checkbox'  // Boolean checkbox  (registered)
+   * type: 'group'     // Field group container (registered)
+   * type: 'my-custom' // Unregistered — still accepted, no autocomplete
    * ```
    */
-  type: string;
+  type: RegisteredFieldTypes['type'] | (string & {});
 
   /**
    * Human-readable field label displayed to users.

--- a/packages/dynamic-forms/src/lib/definitions/base/field-def.ts
+++ b/packages/dynamic-forms/src/lib/definitions/base/field-def.ts
@@ -87,6 +87,9 @@ export interface FieldDef<TProps, TMeta extends FieldMeta = FieldMeta> {
    * type: 'group'     // Field group container (registered)
    * type: 'my-custom' // Unregistered — still accepted, no autocomplete
    * ```
+   *
+   * Wrapper types are intentionally excluded — wrappers are configured through
+   * `wrappers` / `withFormWrappers()` rather than via the field-type discriminant.
    */
   type: RegisteredFieldTypes['type'] | (string & {});
 

--- a/packages/dynamic-forms/src/lib/definitions/base/field-def.type-test.ts
+++ b/packages/dynamic-forms/src/lib/definitions/base/field-def.type-test.ts
@@ -2,6 +2,7 @@
  * Exhaustive type tests for FieldDef interface.
  */
 import { expectTypeOf } from 'vitest';
+import type { RegisteredFieldTypes } from '../../models/registry/field-registry';
 import type { DynamicText } from '../../models/types/dynamic-text';
 import type { WrapperConfig } from '../../models/wrapper-type';
 import type { FieldDef, FieldComponent } from './field-def';
@@ -47,8 +48,10 @@ describe('FieldDef - Exhaustive Whitelist', () => {
       expectTypeOf<FieldDef<TestProps>['key']>().toEqualTypeOf<string>();
     });
 
-    it('type is required', () => {
-      expectTypeOf<FieldDef<TestProps>['type']>().toEqualTypeOf<string>();
+    it('type accepts known field types and any string', () => {
+      // The string & {} branch preserves IDE suggestions for known types
+      // (RegisteredFieldTypes['type']) while still accepting arbitrary strings.
+      expectTypeOf<FieldDef<TestProps>['type']>().toEqualTypeOf<RegisteredFieldTypes['type'] | (string & {})>();
     });
   });
 

--- a/packages/dynamic-forms/src/lib/models/field-type.ts
+++ b/packages/dynamic-forms/src/lib/models/field-type.ts
@@ -99,7 +99,7 @@ export interface FieldTypeDefinition<T extends FieldDef<any> = any> {
   /** Semantic scope for tooling to discover interchangeable field alternatives */
   scope?: FieldScope | FieldScope[];
   /** Mapped component inputs that must exist before the renderer instantiates the component */
-  renderReadyWhen?: RenderReadyInput[];
+  renderReadyWhen?: readonly RenderReadyInput[];
 }
 
 /**

--- a/packages/dynamic-forms/src/lib/models/submission-config.ts
+++ b/packages/dynamic-forms/src/lib/models/submission-config.ts
@@ -71,7 +71,6 @@ export type SubmissionActionResult = Promise<TreeValidationResult> | Observable<
  * @typeParam TValue - The form value type
  *
  * @public
- * @experimental
  */
 export interface SubmissionConfig<TValue = unknown> {
   /**

--- a/packages/dynamic-forms/src/lib/providers/built-in-fields.ts
+++ b/packages/dynamic-forms/src/lib/providers/built-in-fields.ts
@@ -47,13 +47,20 @@ import { CssWrapper, RowWrapper } from '../definitions/default';
  * ```
  */
 /**
- * Base field type definitions for fields that don't use the `field` input.
- * Used by display-only fields like `text` that render immediately without
+ * Base for container field types that consume the mapper-emitted `field` input
+ * (row, group, array, page, container).
+ */
+const CONTAINER_FIELD_TYPES_BASE = {
+  renderReadyWhen: ['field'],
+} as const;
+
+/**
+ * Base for display-only fields (`text`) that render immediately without
  * waiting for form value integration.
  */
 const DISPLAY_FIELD_TYPES_BASE = {
-  renderReadyWhen: [] as string[],
-};
+  renderReadyWhen: [],
+} as const;
 
 /**
  * Built-in field types provided by the dynamic form library.
@@ -71,24 +78,28 @@ export const BUILT_IN_FIELDS: FieldTypeDefinition[] = [
     loadComponent: () => import('../fields/container/container-field.component'),
     mapper: rowFieldMapper,
     valueHandling: 'flatten',
+    ...CONTAINER_FIELD_TYPES_BASE,
   } satisfies FieldTypeDefinition<RowField>,
   {
     name: 'group',
     loadComponent: () => import('../fields/group/group-field.component'),
     mapper: groupFieldMapper,
     valueHandling: 'include',
+    ...CONTAINER_FIELD_TYPES_BASE,
   } satisfies FieldTypeDefinition<GroupField>,
   {
     name: 'array',
     loadComponent: () => import('../fields/array/array-field.component'),
     mapper: arrayFieldMapper,
     valueHandling: 'include',
+    ...CONTAINER_FIELD_TYPES_BASE,
   } satisfies FieldTypeDefinition<ArrayField>,
   {
     name: 'page',
     loadComponent: () => import('../fields/page/page-field.component'),
     mapper: pageFieldMapper,
     valueHandling: 'flatten',
+    ...CONTAINER_FIELD_TYPES_BASE,
   } satisfies FieldTypeDefinition<PageField>,
   {
     name: 'text',
@@ -107,6 +118,7 @@ export const BUILT_IN_FIELDS: FieldTypeDefinition[] = [
     loadComponent: () => import('../fields/container/container-field.component'),
     mapper: containerFieldMapper,
     valueHandling: 'flatten',
+    ...CONTAINER_FIELD_TYPES_BASE,
   } satisfies FieldTypeDefinition<ContainerField>,
 ];
 

--- a/packages/dynamic-forms/src/lib/utils/resource-composition/with-previous-value.ts
+++ b/packages/dynamic-forms/src/lib/utils/resource-composition/with-previous-value.ts
@@ -15,8 +15,6 @@ import { linkedSignal, Resource, ResourceSnapshot, resourceFromSnapshots } from 
  * );
  * // user.value() keeps the old user data during loading transitions
  * ```
- *
- * @experimental Uses Angular's experimental resource composition APIs.
  */
 export function withPreviousValue<T>(input: Resource<T>): Resource<T> {
   const derived = linkedSignal<ResourceSnapshot<T>, ResourceSnapshot<T>>({


### PR DESCRIPTION
## Summary

A bundled 1.0 readiness sweep. The 5 originally-planned tasks shipped as 4 commits — task 5 (`[data-*]` template-binding sweep) found zero hits, so no fix was needed. History was force-pushed once to collapse intermediate review iterations on the `renderReadyWhen` refactor.

### Commits

- **fix(dynamic-forms): drop stale readonly DOM sync workaround** — Angular 21.0.7 ships native `readonly` attribute sync through `[formField]`. Removed the `viewChild` + `afterRenderEffect` workaround from `mat-textarea` and `bs-textarea`. See angular/angular#65897.
- **chore(dynamic-forms): drop stale @experimental markers** — Signal Forms graduated to public API in Angular 22.0. Removed the misleading `@experimental` JSDoc tags from `SubmissionConfig` and `withPreviousValue`.
- **feat(dynamic-forms): narrow FieldDef.type against RegisteredFieldTypes** — `FieldDef.type` is now `RegisteredFieldTypes['type'] | (string & {})`. IDE autocomplete suggests every field-type name registered via module augmentation of `DynamicFormFieldRegistry` while still accepting arbitrary strings. Downstream consumers using a literal type that isn't augmented will see a type error — fix by augmenting `FieldRegistryLeaves` / `FieldRegistryContainers`. Wrappers are intentionally excluded from the discriminant (called out in the JSDoc).
- **feat(dynamic-forms): make renderReadyWhen explicit at registration sites** — Resolver cascade: explicit `FieldTypeDefinition.renderReadyWhen` → `valueHandling: 'exclude'` short-circuit to `[]` → fallback `['field']` + one-shot dev warning via `DynamicFormLogger`. Dedup `Set` is captured in `createFieldResolutionPipe`'s closure and threaded through `resolve-array-item.ts` (DI- / closure-scoped, SSR-safe). Each adapter's `FIELD_TYPES` config spreads one of two `as const` base constants — `VALUE_FIELD_TYPES_BASE = { renderReadyWhen: ['field'] }` for value fields, `BUTTON_FIELD_TYPES_BASE = { renderReadyWhen: [], valueHandling: 'exclude' }` for buttons / actions. `FieldTypeDefinition.renderReadyWhen` relaxed to `readonly RenderReadyInput[]` so readonly tuples flow through cleanly. Adds a Material textarea E2E that flips `readonly()` at runtime via a `logic` rule and asserts the native DOM `readOnly` property syncs both ways — covers the regression-by-omission risk from removing the `afterRenderEffect` workaround in the first commit.

### Docs

`apps/docs/public/content/building-an-adapter.md` updated to describe the cascade and the BASE-constant convention. `llms-full.txt` regenerated.

### `[data-*]` sweep (no-op)

Searched `packages/`, `apps/`, `internal/` for legacy `[data-foo]="…"` input bindings (not `[attr.data-foo]`). Zero hits across the repo.

### MCP server

`packages/dynamic-form-mcp/` is intentionally untouched. The MCP exposes the `FormConfig` shape that form *authors* generate; `renderReadyWhen` is an *adapter-authoring* concern that doesn't appear in the FormConfig schema. The MCP's `custom-integrations` documentation entry already routes adapter authors to the live docs page, which is where the cascade description was updated.

## Test plan

- [x] `pnpm build:libs` — all 7 packages clean
- [x] `pnpm nx run-many -t test` — green (2845 tests)
- [x] `pnpm nx run-many -t type-test` — green
- [x] `pnpm nx run material-examples:e2e --grep "Textarea Readonly Sync"` — 3/3 browsers green
- [x] Existing Firefox + webkit flakiness on array-fields / group-fields / row-fields / wrapper-fields is documented pre-existing per `packages/dynamic-forms/CLAUDE.md`; no new failures from this PR.