### PR TITLE
fix: emit array minLength/maxLength as direct properties in openapi-generator (#416)

### DIFF
--- a/packages/openapi-generator/src/__tests__/integration/__fixtures__/array-required.yaml
+++ b/packages/openapi-generator/src/__tests__/integration/__fixtures__/array-required.yaml
@@ -1,0 +1,36 @@
+openapi: '3.0.3'
+info:
+  title: Issue #416 regression
+  version: '1.0.0'
+paths:
+  /geolocation:
+    post:
+      operationId: createGeolocation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - phone
+                - currency
+                - languages
+              properties:
+                phone:
+                  type: array
+                  items:
+                    type: number
+                currency:
+                  type: array
+                  minItems: 1
+                  maxItems: 3
+                  items:
+                    type: string
+                languages:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '201':
+          description: Created

--- a/packages/openapi-generator/src/__tests__/integration/generate-pipeline.integration.spec.ts
+++ b/packages/openapi-generator/src/__tests__/integration/generate-pipeline.integration.spec.ts
@@ -243,14 +243,13 @@ describe('Arrays', () => {
     await generate('array-required.yaml');
 
     const form = await readGenerated(outputDir, 'forms', 'create-geolocation.form.ts');
-    // Anchored regexes: outer array fields (phone, currency, languages) must NOT
-    // emit a `validators:` line — ArrayField/SimplifiedArrayField don't declare one,
-    // and `required` from the parent schema cannot be transferred to a container.
-    expect(form).toMatch(/key: 'phone',\s*type: 'array',\s*(?!validators:)/);
-    expect(form).toMatch(/key: 'languages',\s*type: 'array',\s*(?!validators:)/);
+    // The fixture has only required primitive arrays with no item-level constraints,
+    // so the entire generated form must contain ZERO `validators: [` blocks. This is
+    // stronger than per-field regexes — even if the emitter ever reorders properties
+    // and pushes `validators:` further down a block, this assertion still fails.
+    expect(form).not.toContain('validators: [');
     // The `currency` array carries minItems/maxItems → these must surface as direct
     // minLength/maxLength properties on the field, not inside a `validators` array.
-    expect(form).toMatch(/key: 'currency',\s*type: 'array',\s*(?!validators:)/);
     expect(form).toContain('minLength: 1,');
     expect(form).toContain('maxLength: 3,');
   });

--- a/packages/openapi-generator/src/__tests__/integration/generate-pipeline.integration.spec.ts
+++ b/packages/openapi-generator/src/__tests__/integration/generate-pipeline.integration.spec.ts
@@ -238,6 +238,31 @@ describe('Arrays', () => {
 
     expect(diagnostics, `Generated form should type-check cleanly. Errors:\n${diagnostics.join('\n')}`).toEqual([]);
   }, 30_000); // tsc program creation + type-check is slow in CI
+
+  it('should not emit validators on required array fields (regression for #416)', async () => {
+    await generate('array-required.yaml');
+
+    const form = await readGenerated(outputDir, 'forms', 'create-geolocation.form.ts');
+    // Anchored regexes: outer array fields (phone, currency, languages) must NOT
+    // emit a `validators:` line — ArrayField/SimplifiedArrayField don't declare one,
+    // and `required` from the parent schema cannot be transferred to a container.
+    expect(form).toMatch(/key: 'phone',\s*type: 'array',\s*(?!validators:)/);
+    expect(form).toMatch(/key: 'languages',\s*type: 'array',\s*(?!validators:)/);
+    // The `currency` array carries minItems/maxItems → these must surface as direct
+    // minLength/maxLength properties on the field, not inside a `validators` array.
+    expect(form).toMatch(/key: 'currency',\s*type: 'array',\s*(?!validators:)/);
+    expect(form).toContain('minLength: 1,');
+    expect(form).toContain('maxLength: 3,');
+  });
+
+  it('should produce a form file that compiles against the published types (regression for #416)', async () => {
+    await generate('array-required.yaml');
+
+    const formPath = join(outputDir, 'forms', 'create-geolocation.form.ts');
+    const diagnostics = typecheckGeneratedForm(formPath);
+
+    expect(diagnostics, `Generated form should type-check cleanly. Errors:\n${diagnostics.join('\n')}`).toEqual([]);
+  }, 30_000); // tsc program creation + type-check is slow in CI
 });
 
 // ─── F. allOf ────────────────────────────────────────────────────────

--- a/packages/openapi-generator/src/generator/form-config-generator.spec.ts
+++ b/packages/openapi-generator/src/generator/form-config-generator.spec.ts
@@ -325,24 +325,25 @@ describe('array template rendering', () => {
     expect(result).toContain('removeButton: false,');
   });
 
-  it('should render array-level validators', () => {
+  it('should render array-level minLength/maxLength as direct properties', () => {
+    // ArrayField/SimplifiedArrayField don't accept a `validators` array — the
+    // emitter must render minLength/maxLength as direct field properties (issue #416).
     const fields: FieldConfig[] = [
       {
         key: 'tags',
         type: 'array',
         label: 'Tags',
         template: { key: 'value', type: 'input', label: 'Tag' },
-        validators: [
-          { type: 'minLength', value: 1 },
-          { type: 'maxLength', value: 10 },
-        ],
+        minLength: 1,
+        maxLength: 10,
         addButton: { label: 'Add Tag' },
       },
     ];
 
     const result = generateFormConfig(fields, defaultOptions);
-    expect(result).toContain("{ type: 'minLength', value: 1 }");
-    expect(result).toContain("{ type: 'maxLength', value: 10 }");
+    expect(result).toContain('minLength: 1,');
+    expect(result).toContain('maxLength: 10,');
+    expect(result).not.toContain('validators: [');
   });
 
   it('should render template with validators', () => {

--- a/packages/openapi-generator/src/generator/form-config-generator.ts
+++ b/packages/openapi-generator/src/generator/form-config-generator.ts
@@ -75,6 +75,14 @@ function generateFieldLines(field: FieldConfig, indent: string): string[] {
     lines.push(`${indent}  ],`);
   }
 
+  if (field.minLength !== undefined) {
+    lines.push(`${indent}  minLength: ${field.minLength},`);
+  }
+
+  if (field.maxLength !== undefined) {
+    lines.push(`${indent}  maxLength: ${field.maxLength},`);
+  }
+
   if (field.disabled) {
     lines.push(`${indent}  disabled: true,`);
   }

--- a/packages/openapi-generator/src/mapper/schema-to-fields.spec.ts
+++ b/packages/openapi-generator/src/mapper/schema-to-fields.spec.ts
@@ -724,7 +724,7 @@ describe('mapSchemaToFields', () => {
       expect(field.fields).toBeUndefined();
     });
 
-    it('should include minLength/maxLength validators from minItems/maxItems', () => {
+    it('should map minItems/maxItems to direct minLength/maxLength properties on array field', () => {
       const schema = {
         type: 'object',
         properties: {
@@ -739,8 +739,53 @@ describe('mapSchemaToFields', () => {
 
       const result = mapSchemaToFields(schema, []);
       const field = result.fields[0];
-      expect(field.validators).toContainEqual({ type: 'minLength', value: 1 });
-      expect(field.validators).toContainEqual({ type: 'maxLength', value: 5 });
+      // ArrayField/SimplifiedArrayField don't accept a `validators` property — array
+      // constraints live as direct properties (issue #416).
+      expect(field.minLength).toBe(1);
+      expect(field.maxLength).toBe(5);
+      expect(field.validators).toBeUndefined();
+    });
+
+    it('should not emit validators on required array fields (issue #416)', () => {
+      // Reproduces issue #416: array property listed in parent's `required` array
+      // previously emitted `validators: [{ type: 'required' }]`, which fails to
+      // type-check against ArrayField/SimplifiedArrayField (TS2353).
+      const schema = {
+        type: 'object',
+        required: ['phone'],
+        properties: {
+          phone: {
+            type: 'array',
+            items: { type: 'number' },
+          },
+        },
+      } as SchemaObject;
+
+      const result = mapSchemaToFields(schema, ['phone']);
+      const field = result.fields[0];
+      expect(field.type).toBe('array');
+      expect(field.validators).toBeUndefined();
+    });
+
+    it('should keep minItems/maxItems off validators even when array is required', () => {
+      const schema = {
+        type: 'object',
+        required: ['tags'],
+        properties: {
+          tags: {
+            type: 'array',
+            items: { type: 'string' },
+            minItems: 2,
+            maxItems: 8,
+          },
+        },
+      } as SchemaObject;
+
+      const result = mapSchemaToFields(schema, ['tags']);
+      const field = result.fields[0];
+      expect(field.minLength).toBe(2);
+      expect(field.maxLength).toBe(8);
+      expect(field.validators).toBeUndefined();
     });
 
     it('should apply item-level validators to primitive array template', () => {

--- a/packages/openapi-generator/src/mapper/schema-to-fields.ts
+++ b/packages/openapi-generator/src/mapper/schema-to-fields.ts
@@ -55,9 +55,10 @@ export interface FieldConfig {
   addButton?: { label: string; props?: Record<string, unknown> } | false;
   removeButton?: { label: string; props?: Record<string, unknown> } | false;
   logic?: LogicConfig[];
-  /** Direct property on array fields — translates OpenAPI `minItems`. Array fields do not accept `validators`. */
+  // Direct properties on array fields — translate OpenAPI `minItems`/`maxItems`. Array
+  // fields do NOT accept a `validators` array (issue #416). Keep these in sync with
+  // ArrayField / SimplifiedArrayField in `packages/dynamic-forms/src/lib/definitions/default/array-field.ts`.
   minLength?: number;
-  /** Direct property on array fields — translates OpenAPI `maxItems`. Array fields do not accept `validators`. */
   maxLength?: number;
 }
 
@@ -292,18 +293,18 @@ function mapPropertyToField(
 
   // Add validators. Container field types (group, array, row, page, container) declare
   // `validators?: never` in their library types — emitting validators on them produces
-  // TS2353 in consumer code (issue #416). Drop them with a verbose log so users see why
-  // a `required` from the parent schema didn't translate.
+  // TS2353 in consumer code (issue #416). Drop them with a verbose log so users see
+  // exactly what was dropped and how to recover the intent.
   if (validators.length > 0) {
     if (CONTAINER_FIELD_TYPES.has(finalType)) {
-      if (prop.required) {
-        logger.verbose(
-          `Field '${fieldPath}': '${finalType}' container fields do not accept field-level validators — 'required' from parent schema was dropped. ` +
-            (finalType === 'array'
-              ? `Use \`minLength: 1\` on the array or add a \`required\` validator to the template field.`
-              : `Add \`required\` validators to individual child fields instead.`),
-        );
-      }
+      const droppedTypes = validators.map((v) => v.type).join(', ');
+      const recovery =
+        finalType === 'array'
+          ? ` Use \`minLength: 1\` on the array or add validators to the template field.`
+          : ` Add validators to individual child fields instead.`;
+      logger.verbose(
+        `Field '${fieldPath}': '${finalType}' container fields do not accept field-level validators — dropped: ${droppedTypes}.${recovery}`,
+      );
     } else {
       field.validators = validators;
     }

--- a/packages/openapi-generator/src/mapper/schema-to-fields.ts
+++ b/packages/openapi-generator/src/mapper/schema-to-fields.ts
@@ -291,10 +291,11 @@ function mapPropertyToField(
     }
   }
 
-  // Add validators. Container field types (group, array, row, page, container) declare
-  // `validators?: never` in their library types — emitting validators on them produces
-  // TS2353 in consumer code (issue #416). Drop them with a verbose log so users see
-  // exactly what was dropped and how to recover the intent.
+  // Add validators. Container field types (group, array, row, page, container) do not
+  // declare a `validators` property in their library types — under `as const satisfies
+  // FormConfig`, TypeScript's excess-property check on the field union rejects it with
+  // TS2353 (issue #416). Drop with a verbose log so users see exactly what was dropped
+  // and how to recover the intent.
   if (validators.length > 0) {
     if (CONTAINER_FIELD_TYPES.has(finalType)) {
       const droppedTypes = validators.map((v) => v.type).join(', ');

--- a/packages/openapi-generator/src/mapper/schema-to-fields.ts
+++ b/packages/openapi-generator/src/mapper/schema-to-fields.ts
@@ -55,6 +55,10 @@ export interface FieldConfig {
   addButton?: { label: string; props?: Record<string, unknown> } | false;
   removeButton?: { label: string; props?: Record<string, unknown> } | false;
   logic?: LogicConfig[];
+  /** Direct property on array fields — translates OpenAPI `minItems`. Array fields do not accept `validators`. */
+  minLength?: number;
+  /** Direct property on array fields — translates OpenAPI `maxItems`. Array fields do not accept `validators`. */
+  maxLength?: number;
 }
 
 export interface MappingResult {
@@ -198,21 +202,23 @@ function mapPropertyToField(
 
   const validators = mapSchemaToValidators(prop.schema, prop.required);
 
-  // Array-level validators: minItems/maxItems → minLength/maxLength
-  const arraySchema = prop.schema as Record<string, unknown>;
-  if (typeResult.fieldType === 'array') {
-    if (arraySchema['minItems'] !== undefined) {
-      validators.push({ type: 'minLength', value: arraySchema['minItems'] as number });
-    }
-    if (arraySchema['maxItems'] !== undefined) {
-      validators.push({ type: 'maxLength', value: arraySchema['maxItems'] as number });
-    }
-  }
-
   const field: FieldConfig = {
     key: prop.name,
     type: finalType,
   };
+
+  // Array-level constraints: minItems/maxItems become direct minLength/maxLength
+  // properties on the array field. ArrayField/SimplifiedArrayField do NOT accept a
+  // `validators` array — the runtime reads these directly (see issue #416).
+  const arraySchema = prop.schema as Record<string, unknown>;
+  if (finalType === 'array') {
+    if (arraySchema['minItems'] !== undefined) {
+      field.minLength = arraySchema['minItems'] as number;
+    }
+    if (arraySchema['maxItems'] !== undefined) {
+      field.maxLength = arraySchema['maxItems'] as number;
+    }
+  }
 
   // Container types declare `label?: never` (issue #348) — only emit on value-bearing types.
   if (!CONTAINER_FIELD_TYPES.has(finalType)) {
@@ -284,9 +290,23 @@ function mapPropertyToField(
     }
   }
 
-  // Add validators
+  // Add validators. Container field types (group, array, row, page, container) declare
+  // `validators?: never` in their library types — emitting validators on them produces
+  // TS2353 in consumer code (issue #416). Drop them with a verbose log so users see why
+  // a `required` from the parent schema didn't translate.
   if (validators.length > 0) {
-    field.validators = validators;
+    if (CONTAINER_FIELD_TYPES.has(finalType)) {
+      if (prop.required) {
+        logger.verbose(
+          `Field '${fieldPath}': '${finalType}' container fields do not accept field-level validators — 'required' from parent schema was dropped. ` +
+            (finalType === 'array'
+              ? `Use \`minLength: 1\` on the array or add a \`required\` validator to the template field.`
+              : `Add \`required\` validators to individual child fields instead.`),
+        );
+      }
+    } else {
+      field.validators = validators;
+    }
   }
 
   // Disable for non-editable GET responses


### PR DESCRIPTION
## Summary

- Fixes #416 — the OpenAPI generator was emitting `validators: [...]` on `type: 'array'` fields, but `ArrayField` / `SimplifiedArrayField` declare `minLength` / `maxLength` as **direct properties** and don't accept a `validators` array. The output failed TS2353 against the published types.
- `minItems` / `maxItems` now map to direct `field.minLength` / `field.maxLength` (the runtime already reads these and translates them to validators internally — see `dynamic-forms/src/lib/core/form-mapping.ts:379-383`).
- The parent-schema `required: ['phone']` case (the exact reproducer in the issue) no longer leaks `{ type: 'required' }` onto array fields. Same fix incidentally covers the latent identical bug for required `group` / `row` / `page` properties. A verbose log explains the dropped flag and suggests the right path (`minLength: 1` for arrays, child-level `required` for groups).

### Behavior changes worth a second look

- `required` on a container property is now **dropped with a verbose log** instead of producing broken validators. Previously this didn't compile at all, so any consumer relying on it was already patching the output by hand.
- `x-ng-forge-type` overrides from `array` → non-array no longer transfer `minItems` / `maxItems` constraints. This matches how `field.props` from the auto-detected type is already dropped on override (`schema-to-fields.ts:254`). Narrow edge case, no existing test covered it, and the previous behavior was semantically dubious (array-length validator applied to a non-array field).

## Test plan

- [x] `nx test openapi-generator` — 353/353 (added +2 integration tests)
- [x] `nx lint openapi-generator` — no new warnings
- [x] `nx build openapi-generator` — clean
- [x] New unit test: exact issue reproducer (required array → no `validators`)
- [x] New unit test: required + `minItems`/`maxItems` combined → direct properties, no `validators`
- [x] New integration test: assert `validators:` line absent on each required array in the generated form file
- [x] New integration test: **TS-compile** the generated form file against the published `FormConfig` type (the strongest regression guard for this class of bug)