### PR TITLE
fix(dynamic-forms): support nullable on checkbox/toggle fields

### DIFF
--- a/internal/examples-material/src/examples/scenarios/toggle.scenario.ts
+++ b/internal/examples-material/src/examples/scenarios/toggle.scenario.ts
@@ -4,7 +4,7 @@ import { ExampleScenario } from '../shared/types';
 export const toggleScenario: ExampleScenario = {
   id: 'toggle',
   title: 'Toggle Demo',
-  description: 'Demonstrates toggle switch fields.',
+  description: 'Demonstrates toggle switch fields, including a nullable checkbox variant (issue #415).',
   config: {
     fields: [
       {
@@ -21,6 +21,13 @@ export const toggleScenario: ExampleScenario = {
         key: 'autoSave',
         type: 'toggle',
         label: 'Auto-save Changes',
+      },
+      {
+        key: 'newsletterOptIn',
+        type: 'checkbox',
+        label: 'Newsletter (undecided — model permits null)',
+        value: null,
+        nullable: true,
       },
     ],
   } as const satisfies FormConfig,

--- a/packages/dynamic-form-mcp/src/registry/instructions.ts
+++ b/packages/dynamic-form-mcp/src/registry/instructions.ts
@@ -197,12 +197,13 @@ Available shorthands: \`required\`, \`email\`, \`min\`, \`max\`, \`minLength\`, 
 
 ### Nullable Values
 
-Value fields accept a \`nullable?: boolean\` flag. When \`true\`:
+Value fields and checked fields (\`checkbox\`, \`toggle\`) accept a \`nullable?: boolean\` flag. When \`true\`:
 
 - \`value\` accepts \`null\` in addition to the field's normal value type.
-- An omitted \`value\` resolves to \`null\` (instead of the type-specific empty default like \`''\`, \`NaN\`, or \`[]\`).
+- An omitted \`value\` resolves to \`null\` (instead of the type-specific empty default like \`''\`, \`NaN\`, \`false\`, or \`[]\`).
 - Orthogonal to \`required\`. \`nullable\` declares that the **model** accepts \`null\`; \`required\` is a **validation** constraint. Angular's \`Validators.required\` treats \`null\` as invalid, so a field that is both \`nullable\` and \`required\` will fail required-validation when the value is \`null\` — the two flags describe different layers (data shape vs. validation), not conflicting semantics.
 - Map OpenAPI \`nullable: true\` (3.0) or \`type: [T, null]\` (3.1) to this flag.
+- Container fields (\`group\`, \`array\`, \`row\`, \`page\`) do NOT support \`nullable\` — their null semantics are ambiguous.
 
 \`\`\`typescript
 {
@@ -211,6 +212,14 @@ Value fields accept a \`nullable?: boolean\` flag. When \`true\`:
   label: 'Middle Name',
   nullable: true,
   value: null,  // valid; default-resolves to null
+}
+
+{
+  key: 'active',
+  type: 'checkbox',
+  label: 'Active',
+  nullable: true,
+  value: null,  // undecided checkbox state — model permits null, UI renders unchecked
 }
 \`\`\`
 

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/checkbox/bs-checkbox.type-test.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/checkbox/bs-checkbox.type-test.ts
@@ -88,7 +88,8 @@ describe('BsCheckboxField - Exhaustive Whitelist', () => {
     | 'schemas'
     // From BaseCheckedField
     | 'value'
-    | 'placeholder';
+    | 'placeholder'
+    | 'nullable';
 
   type ActualKeys = keyof BsCheckboxField;
 
@@ -164,13 +165,48 @@ describe('BsCheckboxField - Exhaustive Whitelist', () => {
   });
 
   describe('value field keys', () => {
-    it('value is boolean', () => {
-      expectTypeOf<BsCheckboxField['value']>().toEqualTypeOf<boolean | undefined>();
+    it('value is boolean | null when nullable defaults to boolean', () => {
+      // TNullable defaults to `boolean` (= true | false), distributing the conditional
+      // value type to `boolean | null`. See base-checked-field.ts.
+      expectTypeOf<BsCheckboxField['value']>().toEqualTypeOf<boolean | null | undefined>();
+    });
+
+    it('nullable accepts boolean', () => {
+      expectTypeOf<BsCheckboxField['nullable']>().toEqualTypeOf<boolean | undefined>();
     });
 
     it('placeholder', () => {
       expectTypeOf<BsCheckboxField['placeholder']>().toEqualTypeOf<DynamicText | undefined>();
     });
+  });
+});
+
+// ============================================================================
+// Nullable - Issue #415
+// ============================================================================
+
+describe('BsCheckboxField - Nullable (issue #415)', () => {
+  it('should accept null value when nullable: true', () => {
+    const field = {
+      type: 'checkbox',
+      key: 'active',
+      label: 'Active',
+      value: null,
+      nullable: true,
+    } as const satisfies BsCheckboxField;
+
+    expectTypeOf(field.value).toEqualTypeOf<null>();
+    expectTypeOf(field.nullable).toEqualTypeOf<true>();
+  });
+
+  it('should accept null value without explicit nullable flag', () => {
+    const field: BsCheckboxField = {
+      type: 'checkbox',
+      key: 'active',
+      value: null,
+    };
+
+    expectTypeOf(field.value).toEqualTypeOf<boolean | null | undefined>();
   });
 });
 

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/toggle/bs-toggle.type-test.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/toggle/bs-toggle.type-test.ts
@@ -84,7 +84,8 @@ describe('BsToggleField - Exhaustive Whitelist', () => {
     | 'schemas'
     // From BaseCheckedField
     | 'value'
-    | 'placeholder';
+    | 'placeholder'
+    | 'nullable';
 
   type ActualKeys = keyof BsToggleField;
 
@@ -160,13 +161,48 @@ describe('BsToggleField - Exhaustive Whitelist', () => {
   });
 
   describe('value field keys', () => {
-    it('value is boolean', () => {
-      expectTypeOf<BsToggleField['value']>().toEqualTypeOf<boolean | undefined>();
+    it('value is boolean | null when nullable defaults to boolean', () => {
+      // TNullable defaults to `boolean` (= true | false), distributing the conditional
+      // value type to `boolean | null`. See base-checked-field.ts.
+      expectTypeOf<BsToggleField['value']>().toEqualTypeOf<boolean | null | undefined>();
+    });
+
+    it('nullable accepts boolean', () => {
+      expectTypeOf<BsToggleField['nullable']>().toEqualTypeOf<boolean | undefined>();
     });
 
     it('placeholder', () => {
       expectTypeOf<BsToggleField['placeholder']>().toEqualTypeOf<DynamicText | undefined>();
     });
+  });
+});
+
+// ============================================================================
+// Nullable - Issue #415
+// ============================================================================
+
+describe('BsToggleField - Nullable (issue #415)', () => {
+  it('should accept null value when nullable: true', () => {
+    const field = {
+      type: 'toggle',
+      key: 'notifications',
+      label: 'Notifications',
+      value: null,
+      nullable: true,
+    } as const satisfies BsToggleField;
+
+    expectTypeOf(field.value).toEqualTypeOf<null>();
+    expectTypeOf(field.nullable).toEqualTypeOf<true>();
+  });
+
+  it('should accept null value without explicit nullable flag', () => {
+    const field: BsToggleField = {
+      type: 'toggle',
+      key: 'notifications',
+      value: null,
+    };
+
+    expectTypeOf(field.value).toEqualTypeOf<boolean | null | undefined>();
   });
 });
 

--- a/packages/dynamic-forms-ionic/src/lib/fields/checkbox/ionic-checkbox.type-test.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/checkbox/ionic-checkbox.type-test.ts
@@ -86,7 +86,8 @@ describe('IonicCheckboxField - Exhaustive Whitelist', () => {
     | 'schemas'
     // From BaseCheckedField
     | 'value'
-    | 'placeholder';
+    | 'placeholder'
+    | 'nullable';
 
   type ActualKeys = keyof IonicCheckboxField;
 
@@ -186,13 +187,48 @@ describe('IonicCheckboxField - Exhaustive Whitelist', () => {
   });
 
   describe('checked field keys from BaseCheckedField', () => {
-    it('value is boolean', () => {
-      expectTypeOf<IonicCheckboxField['value']>().toEqualTypeOf<boolean | undefined>();
+    it('value is boolean | null when nullable defaults to boolean', () => {
+      // TNullable defaults to `boolean` (= true | false), distributing the conditional
+      // value type to `boolean | null`. See base-checked-field.ts.
+      expectTypeOf<IonicCheckboxField['value']>().toEqualTypeOf<boolean | null | undefined>();
+    });
+
+    it('nullable accepts boolean', () => {
+      expectTypeOf<IonicCheckboxField['nullable']>().toEqualTypeOf<boolean | undefined>();
     });
 
     it('placeholder', () => {
       expectTypeOf<IonicCheckboxField['placeholder']>().toEqualTypeOf<DynamicText | undefined>();
     });
+  });
+});
+
+// ============================================================================
+// Nullable - Issue #415
+// ============================================================================
+
+describe('IonicCheckboxField - Nullable (issue #415)', () => {
+  it('should accept null value when nullable: true', () => {
+    const field = {
+      type: 'checkbox',
+      key: 'active',
+      label: 'Active',
+      value: null,
+      nullable: true,
+    } as const satisfies IonicCheckboxField;
+
+    expectTypeOf(field.value).toEqualTypeOf<null>();
+    expectTypeOf(field.nullable).toEqualTypeOf<true>();
+  });
+
+  it('should accept null value without explicit nullable flag', () => {
+    const field: IonicCheckboxField = {
+      type: 'checkbox',
+      key: 'active',
+      value: null,
+    };
+
+    expectTypeOf(field.value).toEqualTypeOf<boolean | null | undefined>();
   });
 });
 

--- a/packages/dynamic-forms-ionic/src/lib/fields/toggle/ionic-toggle.type-test.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/toggle/ionic-toggle.type-test.ts
@@ -86,7 +86,8 @@ describe('IonicToggleField - Exhaustive Whitelist', () => {
     | 'schemas'
     // From BaseCheckedField
     | 'value'
-    | 'placeholder';
+    | 'placeholder'
+    | 'nullable';
 
   type ActualKeys = keyof IonicToggleField;
 
@@ -186,13 +187,48 @@ describe('IonicToggleField - Exhaustive Whitelist', () => {
   });
 
   describe('checked field keys from BaseCheckedField', () => {
-    it('value is boolean', () => {
-      expectTypeOf<IonicToggleField['value']>().toEqualTypeOf<boolean | undefined>();
+    it('value is boolean | null when nullable defaults to boolean', () => {
+      // TNullable defaults to `boolean` (= true | false), distributing the conditional
+      // value type to `boolean | null`. See base-checked-field.ts.
+      expectTypeOf<IonicToggleField['value']>().toEqualTypeOf<boolean | null | undefined>();
+    });
+
+    it('nullable accepts boolean', () => {
+      expectTypeOf<IonicToggleField['nullable']>().toEqualTypeOf<boolean | undefined>();
     });
 
     it('placeholder', () => {
       expectTypeOf<IonicToggleField['placeholder']>().toEqualTypeOf<DynamicText | undefined>();
     });
+  });
+});
+
+// ============================================================================
+// Nullable - Issue #415
+// ============================================================================
+
+describe('IonicToggleField - Nullable (issue #415)', () => {
+  it('should accept null value when nullable: true', () => {
+    const field = {
+      type: 'toggle',
+      key: 'notifications',
+      label: 'Notifications',
+      value: null,
+      nullable: true,
+    } as const satisfies IonicToggleField;
+
+    expectTypeOf(field.value).toEqualTypeOf<null>();
+    expectTypeOf(field.nullable).toEqualTypeOf<true>();
+  });
+
+  it('should accept null value without explicit nullable flag', () => {
+    const field: IonicToggleField = {
+      type: 'toggle',
+      key: 'notifications',
+      value: null,
+    };
+
+    expectTypeOf(field.value).toEqualTypeOf<boolean | null | undefined>();
   });
 });
 

--- a/packages/dynamic-forms-material/src/lib/fields/checkbox/mat-checkbox.type-test.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/checkbox/mat-checkbox.type-test.ts
@@ -89,7 +89,8 @@ describe('MatCheckboxField - Exhaustive Whitelist', () => {
     | 'schemas'
     // From BaseCheckedField
     | 'value'
-    | 'placeholder';
+    | 'placeholder'
+    | 'nullable';
 
   type ActualKeys = keyof MatCheckboxField;
 
@@ -165,13 +166,49 @@ describe('MatCheckboxField - Exhaustive Whitelist', () => {
   });
 
   describe('value field keys', () => {
-    it('value is boolean', () => {
-      expectTypeOf<MatCheckboxField['value']>().toEqualTypeOf<boolean | undefined>();
+    it('value is boolean | null when nullable defaults to boolean', () => {
+      // TNullable defaults to `boolean` (= true | false), distributing the conditional
+      // value type to `boolean | null`. See base-checked-field.ts.
+      expectTypeOf<MatCheckboxField['value']>().toEqualTypeOf<boolean | null | undefined>();
+    });
+
+    it('nullable accepts boolean', () => {
+      expectTypeOf<MatCheckboxField['nullable']>().toEqualTypeOf<boolean | undefined>();
     });
 
     it('placeholder', () => {
       expectTypeOf<MatCheckboxField['placeholder']>().toEqualTypeOf<DynamicText | undefined>();
     });
+  });
+});
+
+// ============================================================================
+// Nullable - Issue #415
+// ============================================================================
+
+describe('MatCheckboxField - Nullable (issue #415)', () => {
+  it('should accept null value when nullable: true', () => {
+    const field = {
+      type: 'checkbox',
+      key: 'active',
+      label: 'Active',
+      value: null,
+      nullable: true,
+    } as const satisfies MatCheckboxField;
+
+    expectTypeOf(field.value).toEqualTypeOf<null>();
+    expectTypeOf(field.nullable).toEqualTypeOf<true>();
+  });
+
+  it('should accept null value without explicit nullable flag', () => {
+    // Default TNullable resolves to `boolean`, so the value type accepts `null`.
+    const field: MatCheckboxField = {
+      type: 'checkbox',
+      key: 'active',
+      value: null,
+    };
+
+    expectTypeOf(field.value).toEqualTypeOf<boolean | null | undefined>();
   });
 });
 

--- a/packages/dynamic-forms-material/src/lib/fields/toggle/mat-toggle.type-test.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/toggle/mat-toggle.type-test.ts
@@ -94,7 +94,8 @@ describe('MatToggleField - Exhaustive Whitelist', () => {
     | 'schemas'
     // From BaseCheckedField
     | 'value'
-    | 'placeholder';
+    | 'placeholder'
+    | 'nullable';
 
   type ActualKeys = keyof MatToggleField;
 
@@ -170,13 +171,48 @@ describe('MatToggleField - Exhaustive Whitelist', () => {
   });
 
   describe('value field keys', () => {
-    it('value is boolean', () => {
-      expectTypeOf<MatToggleField['value']>().toEqualTypeOf<boolean | undefined>();
+    it('value is boolean | null when nullable defaults to boolean', () => {
+      // TNullable defaults to `boolean` (= true | false), distributing the conditional
+      // value type to `boolean | null`. See base-checked-field.ts.
+      expectTypeOf<MatToggleField['value']>().toEqualTypeOf<boolean | null | undefined>();
+    });
+
+    it('nullable accepts boolean', () => {
+      expectTypeOf<MatToggleField['nullable']>().toEqualTypeOf<boolean | undefined>();
     });
 
     it('placeholder', () => {
       expectTypeOf<MatToggleField['placeholder']>().toEqualTypeOf<DynamicText | undefined>();
     });
+  });
+});
+
+// ============================================================================
+// Nullable - Issue #415
+// ============================================================================
+
+describe('MatToggleField - Nullable (issue #415)', () => {
+  it('should accept null value when nullable: true', () => {
+    const field = {
+      type: 'toggle',
+      key: 'notifications',
+      label: 'Notifications',
+      value: null,
+      nullable: true,
+    } as const satisfies MatToggleField;
+
+    expectTypeOf(field.value).toEqualTypeOf<null>();
+    expectTypeOf(field.nullable).toEqualTypeOf<true>();
+  });
+
+  it('should accept null value without explicit nullable flag', () => {
+    const field: MatToggleField = {
+      type: 'toggle',
+      key: 'notifications',
+      value: null,
+    };
+
+    expectTypeOf(field.value).toEqualTypeOf<boolean | null | undefined>();
   });
 });
 

--- a/packages/dynamic-forms-primeng/src/lib/fields/checkbox/prime-checkbox.type-test.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/checkbox/prime-checkbox.type-test.ts
@@ -88,7 +88,8 @@ describe('PrimeCheckboxField - Exhaustive Whitelist', () => {
     | 'schemas'
     // From BaseCheckedField
     | 'value'
-    | 'placeholder';
+    | 'placeholder'
+    | 'nullable';
 
   type ActualKeys = keyof PrimeCheckboxField;
 
@@ -164,13 +165,48 @@ describe('PrimeCheckboxField - Exhaustive Whitelist', () => {
   });
 
   describe('value field keys', () => {
-    it('value is boolean', () => {
-      expectTypeOf<PrimeCheckboxField['value']>().toEqualTypeOf<boolean | undefined>();
+    it('value is boolean | null when nullable defaults to boolean', () => {
+      // TNullable defaults to `boolean` (= true | false), distributing the conditional
+      // value type to `boolean | null`. See base-checked-field.ts.
+      expectTypeOf<PrimeCheckboxField['value']>().toEqualTypeOf<boolean | null | undefined>();
+    });
+
+    it('nullable accepts boolean', () => {
+      expectTypeOf<PrimeCheckboxField['nullable']>().toEqualTypeOf<boolean | undefined>();
     });
 
     it('placeholder', () => {
       expectTypeOf<PrimeCheckboxField['placeholder']>().toEqualTypeOf<DynamicText | undefined>();
     });
+  });
+});
+
+// ============================================================================
+// Nullable - Issue #415
+// ============================================================================
+
+describe('PrimeCheckboxField - Nullable (issue #415)', () => {
+  it('should accept null value when nullable: true', () => {
+    const field = {
+      type: 'checkbox',
+      key: 'active',
+      label: 'Active',
+      value: null,
+      nullable: true,
+    } as const satisfies PrimeCheckboxField;
+
+    expectTypeOf(field.value).toEqualTypeOf<null>();
+    expectTypeOf(field.nullable).toEqualTypeOf<true>();
+  });
+
+  it('should accept null value without explicit nullable flag', () => {
+    const field: PrimeCheckboxField = {
+      type: 'checkbox',
+      key: 'active',
+      value: null,
+    };
+
+    expectTypeOf(field.value).toEqualTypeOf<boolean | null | undefined>();
   });
 });
 

--- a/packages/dynamic-forms-primeng/src/lib/fields/toggle/prime-toggle.type-test.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/toggle/prime-toggle.type-test.ts
@@ -76,7 +76,8 @@ describe('PrimeToggleField - Exhaustive Whitelist', () => {
     | 'schemas'
     // From BaseCheckedField
     | 'value'
-    | 'placeholder';
+    | 'placeholder'
+    | 'nullable';
 
   type ActualKeys = keyof PrimeToggleField;
 
@@ -152,13 +153,48 @@ describe('PrimeToggleField - Exhaustive Whitelist', () => {
   });
 
   describe('value field keys', () => {
-    it('value is boolean', () => {
-      expectTypeOf<PrimeToggleField['value']>().toEqualTypeOf<boolean | undefined>();
+    it('value is boolean | null when nullable defaults to boolean', () => {
+      // TNullable defaults to `boolean` (= true | false), distributing the conditional
+      // value type to `boolean | null`. See base-checked-field.ts.
+      expectTypeOf<PrimeToggleField['value']>().toEqualTypeOf<boolean | null | undefined>();
+    });
+
+    it('nullable accepts boolean', () => {
+      expectTypeOf<PrimeToggleField['nullable']>().toEqualTypeOf<boolean | undefined>();
     });
 
     it('placeholder', () => {
       expectTypeOf<PrimeToggleField['placeholder']>().toEqualTypeOf<DynamicText | undefined>();
     });
+  });
+});
+
+// ============================================================================
+// Nullable - Issue #415
+// ============================================================================
+
+describe('PrimeToggleField - Nullable (issue #415)', () => {
+  it('should accept null value when nullable: true', () => {
+    const field = {
+      type: 'toggle',
+      key: 'notifications',
+      label: 'Notifications',
+      value: null,
+      nullable: true,
+    } as const satisfies PrimeToggleField;
+
+    expectTypeOf(field.value).toEqualTypeOf<null>();
+    expectTypeOf(field.nullable).toEqualTypeOf<true>();
+  });
+
+  it('should accept null value without explicit nullable flag', () => {
+    const field: PrimeToggleField = {
+      type: 'toggle',
+      key: 'notifications',
+      value: null,
+    };
+
+    expectTypeOf(field.value).toEqualTypeOf<boolean | null | undefined>();
   });
 });
 

--- a/packages/dynamic-forms/integration/src/definitions/checkbox-field.ts
+++ b/packages/dynamic-forms/integration/src/definitions/checkbox-field.ts
@@ -1,5 +1,5 @@
-import { BaseCheckedField } from '@ng-forge/dynamic-forms';
+import { BaseCheckedField, FieldMeta } from '@ng-forge/dynamic-forms';
 
-export interface CheckboxField<TProps> extends BaseCheckedField<TProps> {
+export interface CheckboxField<TProps, TNullable extends boolean = boolean> extends BaseCheckedField<TProps, FieldMeta, TNullable> {
   type: 'checkbox';
 }

--- a/packages/dynamic-forms/integration/src/definitions/toggle-field.ts
+++ b/packages/dynamic-forms/integration/src/definitions/toggle-field.ts
@@ -1,5 +1,5 @@
-import { BaseCheckedField } from '@ng-forge/dynamic-forms';
+import { BaseCheckedField, FieldMeta } from '@ng-forge/dynamic-forms';
 
-export interface ToggleField<TProps> extends BaseCheckedField<TProps> {
+export interface ToggleField<TProps, TNullable extends boolean = boolean> extends BaseCheckedField<TProps, FieldMeta, TNullable> {
   type: 'toggle';
 }

--- a/packages/dynamic-forms/integration/src/mappers/checkbox/checkbox-field-mapper.ts
+++ b/packages/dynamic-forms/integration/src/mappers/checkbox/checkbox-field-mapper.ts
@@ -1,4 +1,4 @@
-import { BaseCheckedField } from '@ng-forge/dynamic-forms';
+import { BaseCheckedField, FieldMeta } from '@ng-forge/dynamic-forms';
 import { FieldDef } from '@ng-forge/dynamic-forms';
 import { computed, inject, Signal } from '@angular/core';
 import { FieldTree } from '@angular/forms/signals';
@@ -15,7 +15,7 @@ import { omit } from '@ng-forge/dynamic-forms';
  * @param fieldDef The checkbox field definition
  * @returns Signal containing Record of input names to values for ngComponentOutlet
  */
-export function checkboxFieldMapper(fieldDef: BaseCheckedField<unknown>): Signal<Record<string, unknown>> {
+export function checkboxFieldMapper(fieldDef: BaseCheckedField<unknown, FieldMeta, boolean>): Signal<Record<string, unknown>> {
   const context = injectFieldSignalContext();
   const defaultProps = inject(DEFAULT_PROPS);
 

--- a/packages/dynamic-forms/src/lib/definitions/base/base-checked-field.ts
+++ b/packages/dynamic-forms/src/lib/definitions/base/base-checked-field.ts
@@ -35,8 +35,8 @@ export interface BaseCheckedField<TProps, TMeta extends FieldMeta = FieldMeta, T
 
 export function isCheckedField<TProps, TMeta extends FieldMeta = FieldMeta>(
   field: FieldDef<TProps, TMeta>,
-): field is BaseCheckedField<TProps, TMeta> {
-  return field.type === 'checkbox';
+): field is BaseCheckedField<TProps, TMeta, boolean> {
+  return field.type === 'checkbox' || field.type === 'toggle';
 }
 
 // Note: 'meta' is NOT excluded - components must handle meta attributes

--- a/packages/dynamic-forms/src/lib/definitions/base/base-checked-field.ts
+++ b/packages/dynamic-forms/src/lib/definitions/base/base-checked-field.ts
@@ -5,8 +5,9 @@ import { WithInputSignals } from '../../models/component-type';
 import { Prettify } from '../../models/prettify';
 import { DynamicText } from '../../models/types/dynamic-text';
 
-export interface BaseCheckedField<TProps, TMeta extends FieldMeta = FieldMeta> extends FieldDef<TProps, TMeta>, FieldWithValidation {
-  value?: boolean;
+export interface BaseCheckedField<TProps, TMeta extends FieldMeta = FieldMeta, TNullable extends boolean = false>
+  extends FieldDef<TProps, TMeta>, FieldWithValidation {
+  value?: TNullable extends true ? boolean | null : boolean;
 
   /**
    * Placeholder text displayed when the field is empty.
@@ -15,6 +16,21 @@ export interface BaseCheckedField<TProps, TMeta extends FieldMeta = FieldMeta> e
   placeholder?: DynamicText;
 
   required?: boolean;
+
+  /**
+   * Whether the field accepts `null` as a valid value.
+   *
+   * When `true`, `value` may be `null` and an omitted `value` resolves to `null`
+   * (rather than the type-specific empty default of `false`). Orthogonal to `required`.
+   *
+   * The data model is decoupled from the UI: a null value is a legitimate
+   * "undecided" state at the storage / OpenAPI layer. Whether the rendered
+   * checkbox shows an indeterminate visual is controlled separately via
+   * `props.indeterminate` and is not driven by this flag.
+   *
+   * @default false
+   */
+  nullable?: TNullable;
 }
 
 export function isCheckedField<TProps, TMeta extends FieldMeta = FieldMeta>(
@@ -28,6 +44,7 @@ type ExcludedKeys =
   | 'type'
   | 'conditionals'
   | 'value'
+  | 'nullable'
   | 'disabled'
   | 'readonly'
   | 'hidden'
@@ -46,6 +63,6 @@ type ExcludedKeys =
   // Addons are an opt-in input — checkbox/toggle-style fields are Tier 3 and don't render them
   | 'addons';
 
-export type CheckedFieldComponent<T extends BaseCheckedField<Record<string, unknown> | unknown>> = Prettify<
+export type CheckedFieldComponent<T extends BaseCheckedField<Record<string, unknown> | unknown, FieldMeta, boolean>> = Prettify<
   WithInputSignals<Omit<T, ExcludedKeys>>
 >;

--- a/packages/dynamic-forms/src/lib/definitions/nullable-container-restriction.type-test.ts
+++ b/packages/dynamic-forms/src/lib/definitions/nullable-container-restriction.type-test.ts
@@ -1,12 +1,13 @@
 /**
- * Pins the nullable-restriction contract at the type level: container and checked
- * fields must NOT accept `nullable`. If a future refactor moves `nullable` into
+ * Pins the nullable-restriction contract at the type level: container fields
+ * must NOT accept `nullable`. If a future refactor moves `nullable` into
  * `FieldDef` (or a shared base), these `@ts-expect-error` assertions will stop
  * failing and break CI — drawing attention to the semantic expansion.
  *
  * Containers defer nullable because their "null" semantics are ambiguous
- * (see rationale in the PR for #341).
- * Checked fields defer because tri-state boolean requires UX design.
+ * (see rationale in the PR for #341). Checked fields (checkbox / toggle) now
+ * accept `nullable` via `BaseCheckedField<TProps, TMeta, TNullable>` — see
+ * `base-checked-field.ts` and issue #415.
  */
 import { expectTypeOf } from 'vitest';
 import type { GroupField } from './default/group-field';

--- a/packages/dynamic-forms/src/lib/models/types/form-value-inference.ts
+++ b/packages/dynamic-forms/src/lib/models/types/form-value-inference.ts
@@ -152,7 +152,11 @@ type ProcessField<T, D extends number = 5> = [D] extends [never]
               ? K extends string
                 ? { [P in K]: MaybeOptional<T, InferValueType<T, V>> }
                 : never
-              : // Value fields without explicit value: include as string (default input type)
+              : // Value fields without explicit value: include as string (default input type).
+                // The naive `string` fallback is intentional — switching to a type-discriminated
+                // helper (e.g. boolean for checkbox/toggle) widens `InferFormValue<RegisteredFieldTypes[]>`,
+                // which cascades through `FormConfig`'s default `TValue` and breaks consumers that
+                // inject an abstract `FormConfig` (see demo-scenario.component.ts in adapter sandboxes).
                 T extends { key: infer K }
                 ? K extends string
                   ? { [P in K]: MaybeOptional<T, T extends { nullable: true } ? string | null : string> }

--- a/packages/dynamic-forms/src/lib/models/types/form-value-inference.ts
+++ b/packages/dynamic-forms/src/lib/models/types/form-value-inference.ts
@@ -46,16 +46,30 @@ type Widen<T, D extends number = 5> = [D] extends [never]
             : T;
 
 /**
- * Infer value type based on field type and props.
- * - Slider fields: always number
- * - Input fields with props.type: 'number': number
- * - Other fields: widen the literal value type
+ * Resolves the "underlying" non-null value type for a field, based on its `type`
+ * discriminator and (where it matters) its `value` literal. Used when we need a
+ * base type independent of whether the literal happens to be `null` — i.e., when
+ * computing the nullable widening for `value: null, nullable: true`.
  */
-type InferValueType<T, V> = T extends { type: 'slider' }
+type ResolveBaseValueType<T, V> = T extends { type: 'slider' }
   ? number
   : T extends { type: 'input'; props: { type: 'number' } }
     ? number
-    : Widen<V>;
+    : T extends { type: 'checkbox' | 'toggle' }
+      ? boolean
+      : [V] extends [null]
+        ? string
+        : Widen<V>;
+
+/**
+ * Infer value type based on field type, value literal, and the `nullable` flag.
+ * - Slider fields: always number
+ * - Input fields with props.type: 'number': number
+ * - Checkbox / toggle fields: always boolean
+ * - Other fields: widen the literal value type (default to string when value is null)
+ * - When `nullable: true` is declared, widens the result to `T | null`.
+ */
+type InferValueType<T, V> = T extends { nullable: true } ? ResolveBaseValueType<T, V> | null : ResolveBaseValueType<T, V>;
 
 /**
  * Make type optional if field is not required.
@@ -65,17 +79,25 @@ type MaybeOptional<T, V> = T extends { type: 'hidden' } ? V : T extends { requir
 
 /**
  * Infers the value type from a single template field (for primitive arrays).
- * Mirrors InferValueType logic: slider → number, input[number] → number, else string.
+ * Mirrors InferValueType logic: slider → number, input[number] → number,
+ * checkbox/toggle → boolean, else widen `value` (string fallback). Widens to
+ * `T | null` when `nullable: true` is declared on the template field.
  */
-type InferSingleTemplateValue<T, D extends number> = T extends { type: 'slider' }
+type InferSingleTemplateValueBase<T, D extends number> = T extends { type: 'slider' }
   ? number
   : T extends { type: 'input'; props: { type: 'number' } }
     ? number
     : T extends { type: 'checkbox' | 'toggle' }
       ? boolean
       : T extends { value: infer V }
-        ? Widen<V, Depth[D]>
+        ? [V] extends [null]
+          ? string
+          : Widen<V, Depth[D]>
         : string;
+
+type InferSingleTemplateValue<T, D extends number> = T extends { nullable: true }
+  ? InferSingleTemplateValueBase<T, D> | null
+  : InferSingleTemplateValueBase<T, D>;
 
 /**
  * Infers the value type for an array field.
@@ -133,7 +155,7 @@ type ProcessField<T, D extends number = 5> = [D] extends [never]
               : // Value fields without explicit value: include as string (default input type)
                 T extends { key: infer K }
                 ? K extends string
-                  ? { [P in K]: MaybeOptional<T, string> }
+                  ? { [P in K]: MaybeOptional<T, T extends { nullable: true } ? string | null : string> }
                   : never
                 : never;
 

--- a/packages/dynamic-forms/src/lib/utils/default-value/default-value.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/default-value/default-value.spec.ts
@@ -11,6 +11,7 @@ describe('getFieldDefaultValue', () => {
     registry = new Map<string, FieldTypeDefinition>([
       ['input', { component: {} as any, valueHandling: 'include' }],
       ['checkbox', { component: {} as any, valueHandling: 'include' }],
+      ['toggle', { component: {} as any, valueHandling: 'include' }],
       ['select', { component: {} as any, valueHandling: 'include' }],
       ['array', { component: {} as any, valueHandling: 'include' }],
       ['group', { component: {} as any, valueHandling: 'include' }],

--- a/packages/dynamic-forms/src/lib/utils/default-value/default-value.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/default-value/default-value.spec.ts
@@ -739,13 +739,15 @@ describe('getFieldDefaultValue', () => {
 
   describe('nullable across field types', () => {
     // Single parametrized smoke test — if nullable resolution ever gets special-cased
-    // per field type, this catches it. Only includes value-bearing types (BaseValueField);
-    // checkbox/toggle (BaseCheckedField) do not support nullable in this pass.
+    // per field type, this catches it. Covers value-bearing types (BaseValueField)
+    // and checked types (BaseCheckedField — checkbox/toggle, see issue #415).
     const FIELD_TYPES = [
       { type: 'input' },
       { type: 'input', props: { type: 'number' } }, // numeric input
       { type: 'select' },
       { type: 'array' },
+      { type: 'checkbox' },
+      { type: 'toggle' },
     ] as const;
 
     for (const config of FIELD_TYPES) {

--- a/packages/openapi-generator/src/__tests__/integration/generate-pipeline.integration.spec.ts
+++ b/packages/openapi-generator/src/__tests__/integration/generate-pipeline.integration.spec.ts
@@ -509,17 +509,17 @@ describe('Nullable values', () => {
     expect(diagnostics, `Generated form should type-check cleanly. Errors:\n${diagnostics.join('\n')}`).toEqual([]);
   }, 30_000); // tsc program creation + type-check is slow in CI
 
-  it('should silently drop nullable:true for field types that do not support it', async () => {
+  it('should silently drop nullable:true for container field types that do not support it', async () => {
     await generate('nullable-edge-cases.yaml');
 
     const form = await readGenerated(outputDir, 'forms', 'create-entity.form.ts');
     // Nullable on value fields (select, datepicker, input) — emitted
     expect(form).toMatch(/key: 'status',[\s\S]+?type: 'select',[\s\S]+?nullable: true/);
     expect(form).toMatch(/key: 'startDate',[\s\S]+?type: 'datepicker',[\s\S]+?nullable: true/);
-    // Nullable on container/checked — NOT emitted
-    // (find the 'subscribed' block: checkbox field; it should NOT have `nullable: true` on that block)
+    // Nullable on checked fields (checkbox) — emitted since issue #415
     const subscribedBlock = form.substring(form.indexOf("key: 'subscribed'"));
-    expect(subscribedBlock.split('},')[0]).not.toContain('nullable: true');
+    expect(subscribedBlock.split('},')[0]).toContain('nullable: true');
+    // Nullable on container (group) — still NOT emitted
     const addressBlock = form.substring(form.indexOf("key: 'address'"), form.indexOf("key: 'tags'"));
     expect(addressBlock).not.toContain('nullable: true');
   });

--- a/packages/openapi-generator/src/__tests__/integration/generate-pipeline.integration.spec.ts
+++ b/packages/openapi-generator/src/__tests__/integration/generate-pipeline.integration.spec.ts
@@ -517,10 +517,13 @@ describe('Nullable values', () => {
     expect(form).toMatch(/key: 'status',[\s\S]+?type: 'select',[\s\S]+?nullable: true/);
     expect(form).toMatch(/key: 'startDate',[\s\S]+?type: 'datepicker',[\s\S]+?nullable: true/);
     // Nullable on checked fields (checkbox) — emitted since issue #415
-    const subscribedBlock = form.substring(form.indexOf("key: 'subscribed'"));
-    expect(subscribedBlock.split('},')[0]).toContain('nullable: true');
+    expect(form).toMatch(/key: 'subscribed',[\s\S]+?nullable:\s*true/);
     // Nullable on container (group) — still NOT emitted
-    const addressBlock = form.substring(form.indexOf("key: 'address'"), form.indexOf("key: 'tags'"));
+    const addressStart = form.indexOf("key: 'address'");
+    const tagsStart = form.indexOf("key: 'tags'");
+    expect(addressStart).toBeGreaterThanOrEqual(0);
+    expect(tagsStart).toBeGreaterThan(addressStart);
+    const addressBlock = form.slice(addressStart, tagsStart);
     expect(addressBlock).not.toContain('nullable: true');
   });
 

--- a/packages/openapi-generator/src/mapper/schema-to-fields.spec.ts
+++ b/packages/openapi-generator/src/mapper/schema-to-fields.spec.ts
@@ -340,7 +340,7 @@ describe('mapSchemaToFields', () => {
     expect(result.fields[0].nullable).toBeUndefined();
   });
 
-  it('should NOT emit nullable on checkbox (boolean) fields — tri-state deferred', () => {
+  it('should emit nullable on checkbox (boolean) fields (issue #415)', () => {
     const schema: SchemaObject = {
       type: 'object',
       properties: {
@@ -350,7 +350,7 @@ describe('mapSchemaToFields', () => {
 
     const result = mapSchemaToFields(schema, []);
     expect(result.fields[0].type).toBe('checkbox');
-    expect(result.fields[0].nullable).toBeUndefined();
+    expect(result.fields[0].nullable).toBe(true);
   });
 
   it('should NOT emit nullable on container (group) fields', () => {
@@ -406,7 +406,7 @@ describe('mapSchemaToFields', () => {
     expect(template.nullable).toBe(true);
   });
 
-  it('should NOT propagate nullable onto array template when item type does not support it (boolean items)', () => {
+  it('should propagate nullable onto array template for boolean items (checkbox supports nullable since #415)', () => {
     const schema: SchemaObject = {
       type: 'object',
       properties: {
@@ -419,7 +419,7 @@ describe('mapSchemaToFields', () => {
 
     const result = mapSchemaToFields(schema, []);
     const template = result.fields[0].template as { type: string; nullable?: boolean };
-    expect(template.nullable).toBeUndefined();
+    expect(template.nullable).toBe(true);
   });
 
   it('should filter null out of select options when enum includes null (OpenAPI 3.1 nullable enum)', () => {

--- a/packages/openapi-generator/src/mapper/schema-to-fields.ts
+++ b/packages/openapi-generator/src/mapper/schema-to-fields.ts
@@ -8,12 +8,23 @@ import { toLabel, toEnumLabel } from '../utils/naming.js';
 import { logger } from '../utils/logger.js';
 
 /**
- * Field types whose runtime `BaseValueField` accepts the `nullable` flag.
- * Container types (group, array, row, page), checked fields (checkbox, toggle)
- * and control/display fields do not support nullable in this release — the generator
- * silently drops nullable:true for those with a verbose log.
+ * Field types whose runtime `BaseValueField` / `BaseCheckedField` accepts the
+ * `nullable` flag. Container types (group, array, row, page) and control/display
+ * fields do not support nullable in this release — the generator silently drops
+ * `nullable: true` for those with a verbose log. Checkbox / toggle support
+ * nullable since issue #415.
  */
-const NULLABLE_SUPPORTED_FIELD_TYPES = new Set(['input', 'textarea', 'select', 'radio', 'multi-checkbox', 'slider', 'datepicker']);
+const NULLABLE_SUPPORTED_FIELD_TYPES = new Set([
+  'input',
+  'textarea',
+  'select',
+  'radio',
+  'multi-checkbox',
+  'slider',
+  'datepicker',
+  'checkbox',
+  'toggle',
+]);
 
 /**
  * Field types whose runtime definition declares `label?: never` and therefore


### PR DESCRIPTION
## Summary

Closes #415.

`BaseCheckedField` previously hard-coded `value?: boolean`, so passing `value: null` (with or without `nullable: true`) on a checkbox / toggle failed with `TS2322: Type null is not assignable to type boolean | undefined`. The runtime in `getFieldDefaultValue` already preserved `null` for any field declaring `nullable: true` — only the type layer was blocking it.

Mirrors the `BaseValueField<TProps, TValue, TMeta, TNullable>` shape on `BaseCheckedField`:

```ts
interface BaseCheckedField<TProps, TMeta = FieldMeta, TNullable extends boolean = false> {
  value?: TNullable extends true ? boolean | null : boolean;
  nullable?: TNullable;
  // …
}
```

The integration `CheckboxField` / `ToggleField` thread `TNullable` through (defaulting to `boolean`, matching the existing `InputField` pattern), so per-adapter aliases like `MatCheckboxField = CheckboxField<MatCheckboxProps>` stay permissive for both `nullable: true` and the non-nullable default.

## Why the previous restriction is gone

PR #344 (the original nullable PR) deferred checked fields with the comment *"tri-state boolean requires UX design"*. That conflated two concerns:

- **UI tri-state rendering** (indeterminate checkmark) — already exists per-adapter via `props.indeterminate`.
- **Data-level nullability** — `boolean | null` is a normal storage model (`NULLABLE BOOLEAN`, OpenAPI `nullable: true`) that does not require the UI to render a third state.

This PR only addresses the second. Container fields (`group`, `array`, `row`, `page`) remain non-nullable — that restriction is preserved (the `nullable-container-restriction.type-test.ts` assertions still pass).

## Changes

**Core**
- `base-checked-field.ts` — add `TNullable` generic + `nullable?: TNullable`; widen `CheckedFieldComponent`'s constraint to accept any `TNullable`.
- `form-value-inference.ts` — `InferValueType` and `InferSingleTemplateValue` now derive the base type from the field's `type` discriminator (so `value: null` on checkbox/toggle widens to `boolean`, on input to `string`, etc.) and wrap with `| null` when `nullable: true` is declared. Side-effect: fixes a latent bug where `InferFormValue` over `{ value: null, nullable: true }` was previously returning `null | undefined` instead of `T | null | undefined`.

**Integration**
- `checkbox-field.ts` / `toggle-field.ts` — propagate `TNullable`.

**OpenAPI generator**
- `NULLABLE_SUPPORTED_FIELD_TYPES` now includes `checkbox` and `toggle`. Schemas like `{ type: 'boolean', nullable: true }` now generate `nullable: true` instead of silently dropping it.

**Tests**
- `default-value.spec.ts` parametric nullable smoke test now also covers `checkbox` and `toggle`.
- Per-adapter type tests (Material, Bootstrap, PrimeNG, Ionic × checkbox + toggle = 8 files) add `'nullable'` to `ExpectedKeys`, update the `value` assertion to `boolean | null | undefined`, and add a "Nullable - Issue #415" describe block that compiles the exact failing config from the issue.
- Two openapi-generator specs flipped from "should NOT emit nullable" to "should emit nullable" for checkbox / boolean-array-item cases.

**MCP**
- `instructions.ts` — Nullable Values section now mentions checked fields and includes a checkbox example.

## Behavior change

The default `MatCheckboxField['value']` type widens from `boolean | undefined` to `boolean | null | undefined`, mirroring the existing `MatInputField['value']: string | null | undefined` behavior introduced in PR #344. Existing configs that pass `value: true` / `value: false` continue to typecheck — only the upper bound widens.

## Test plan

- [x] `nx run-many -t test -p dynamic-forms,dynamic-forms-{material,bootstrap,primeng,ionic},openapi-generator,dynamic-form-mcp` — all suites pass
- [x] `nx run-many -t type-test -p dynamic-forms,dynamic-forms-{material,bootstrap,primeng,ionic}` — 0 type errors
- [x] `nx run-many -t lint -p ...` — 0 errors (warnings unchanged)
- [x] `pnpm build:libs` — 7 libraries build clean
- [ ] Manual verification of the exact `value: null, nullable: true` checkbox in a docs sandbox scenario (not added — covered by type tests + default-value spec; happy to add an examples scenario if reviewers want one)