### PR TITLE
fix(dynamic-forms): hide wrapper chrome when field hides post-mount

### DIFF
--- a/packages/dynamic-forms/src/lib/directives/df-field-outlet/df-field-outlet.directive.spec.ts
+++ b/packages/dynamic-forms/src/lib/directives/df-field-outlet/df-field-outlet.directive.spec.ts
@@ -290,6 +290,62 @@ describe('DfFieldOutlet', () => {
     expect(leaf?.getAttribute('data-label')).toBe('A');
   });
 
+  it('hides wrapped chrome when hidden flips true post-mount WITHOUT unmounting the wrapper', async () => {
+    // Mirrors the HelloSubs reproduction: when a wrapped field flips from
+    // visible to hidden after the chain has mounted, the wrapper component
+    // instance survives (so focus/caret/scroll re-show is cheap) but its host
+    // is visually suppressed via the controller's hide effect. Without the
+    // split-signal fix, the inner field would `display: none` itself while the
+    // wrapper chrome (section header etc.) stayed on screen.
+    const sectionDef: WrapperTypeDefinition = {
+      wrapperName: 'section',
+      loadComponent: () => Promise.resolve({ default: TestSectionWrapper }),
+    };
+    TestBed.overrideProvider(WRAPPER_REGISTRY, { useValue: new Map([['section', sectionDef]]) });
+
+    const envInjector = TestBed.inject(EnvironmentInjector);
+    fixture = TestBed.createComponent(OutletHostComponent);
+    const hiddenSignal = signal(false);
+    fixture.componentRef.setInput(
+      'field',
+      buildResolvedField({
+        wrappers: [{ type: 'section', title: 'Primary' }] as readonly WrapperConfig[],
+        hidden: hiddenSignal,
+        injector: envInjector,
+      }),
+    );
+    fixture.detectChanges();
+    await flush();
+
+    const sectionInitial = fixture.nativeElement.querySelector('test-section');
+    expect(sectionInitial).toBeTruthy();
+    expect(sectionInitial.classList.contains('df-chain-hidden')).toBe(false);
+    expect(sectionInitial.style.display).toBe('');
+
+    hiddenSignal.set(true);
+    fixture.detectChanges();
+    await flush();
+
+    // Wrapper component instance is still in the DOM — same node, just hidden.
+    const sectionAfterHide = fixture.nativeElement.querySelector('test-section');
+    expect(sectionAfterHide).toBe(sectionInitial);
+    expect(sectionAfterHide.classList.contains('df-chain-hidden')).toBe(true);
+    expect(sectionAfterHide.style.display).toBe('none');
+
+    // The field component was likewise not torn down.
+    expect(TestLeafComponent.instances).toBe(1);
+
+    hiddenSignal.set(false);
+    fixture.detectChanges();
+    await flush();
+
+    const sectionAfterShow = fixture.nativeElement.querySelector('test-section');
+    expect(sectionAfterShow).toBe(sectionInitial); // never re-created
+    expect(sectionAfterShow.classList.contains('df-chain-hidden')).toBe(false);
+    expect(sectionAfterShow.style.display).toBe('');
+    expect(TestLeafComponent.instances).toBe(1);
+  });
+
   it('destroys the field + wrappers when the host is destroyed (vcr.clear cascade)', async () => {
     const sectionDef: WrapperTypeDefinition = {
       wrapperName: 'section',

--- a/packages/dynamic-forms/src/lib/directives/df-field-outlet/df-field-outlet.directive.ts
+++ b/packages/dynamic-forms/src/lib/directives/df-field-outlet/df-field-outlet.directive.ts
@@ -30,11 +30,15 @@ import { FieldComponentSlot } from './field-component-slot';
  * includes the field's mapper outputs and a `ReadonlyFieldTree` view of its
  * form state.
  *
- * Rendering is gated by `field.renderReady() && !field.hidden()` — the
- * directive waits until the mapper produces the required inputs AND the
- * field isn't hidden before instantiating the component. Once rendered, a
- * transient `renderReady → false` does *not* tear the chain down; the
- * controller keeps the mounted components alive and ignores the flicker.
+ * Initial rendering is gated by `field.renderReady() && !field.hidden()` —
+ * the directive waits until the mapper produces the required inputs AND the
+ * field isn't hidden before instantiating the component. Once rendered:
+ * - A transient `renderReady → false` does *not* tear the chain down; the
+ *   controller keeps the mounted components alive and ignores the flicker.
+ * - A `hidden → true` does *not* tear the chain down either; the controller
+ *   applies a hide-class + `display: none` to the outermost wrapper's host so
+ *   wrapper chrome (section headers, icons, hint copy) disappears alongside
+ *   the field. Focus/caret state survive a subsequent re-show.
  * Only a structural change (wrappers or component class) triggers a rebuild.
  *
  * Imperative `ComponentRef` / `ViewContainerRef` lifecycle is encapsulated
@@ -69,12 +73,16 @@ export class DfFieldOutlet {
 
   private readonly componentIdentity: Signal<Type<unknown>> = computed(() => this.dfFieldOutlet().component);
   /**
-   * Gate for the wrapper chain controller: true only when required inputs are populated AND the
-   * field isn't hidden. Combining the two prevents an initial-mount race where the chain mounts
-   * during the brief window between `renderReady` flipping true and `hidden()` settling — that
-   * window is exactly where Angular Signal Forms' `[formField]` directive emits NG01916.
+   * Forwarded straight to the controller. The controller combines `renderReady`
+   * (flicker tolerance — preserves chain on transient false) with `hidden`
+   * (post-mount hide via outermost-host class instead of unmount) — keeping
+   * them separate here lets the controller respond differently to each. The
+   * initial-mount gate behaves like `renderReady && !hidden` so we still don't
+   * mount during the window where Angular Signal Forms' `[formField]` directive
+   * would emit NG01916.
    */
-  private readonly renderReady: Signal<boolean> = computed(() => this.dfFieldOutlet().renderReady() && !this.dfFieldOutlet().hidden());
+  private readonly renderReady: Signal<boolean> = computed(() => this.dfFieldOutlet().renderReady());
+  private readonly hidden: Signal<boolean> = computed(() => this.dfFieldOutlet().hidden());
   private readonly rawInputs = computed(() => this.dfFieldOutlet().inputs());
 
   /**
@@ -108,7 +116,8 @@ export class DfFieldOutlet {
     createWrapperChainController({
       vcr: this.vcr,
       wrappers: this.wrappers,
-      gate: this.renderReady,
+      renderReady: this.renderReady,
+      hidden: this.hidden,
       rebuildKey: this.componentIdentity,
       fieldInputs: this.fieldInputs,
       fieldInjector: this.fieldInjector,

--- a/packages/dynamic-forms/src/lib/fields/container/container-field.component.spec.ts
+++ b/packages/dynamic-forms/src/lib/fields/container/container-field.component.spec.ts
@@ -12,16 +12,23 @@ import {
 } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { form, schema, type SchemaPath } from '@angular/forms/signals';
+import { delay } from '@ng-forge/utils';
 import { ContainerFieldComponent } from './container-field.component';
 import { ContainerField } from '../../definitions/default/container-field';
 import { FieldDef } from '../../definitions/base/field-def';
 import { createSimpleTestField, TestFieldComponent } from '../../../../testing/src/simple-test-utils';
-import { baseFieldMapper, FieldSignalContext } from '../../mappers';
+import { baseFieldMapper, containerFieldMapper, FieldSignalContext } from '../../mappers';
 import { provideDynamicForm } from '../../providers';
 import { FieldTypeDefinition } from '../../models/field-type';
 import { FIELD_SIGNAL_CONTEXT } from '../../models/field-signal-context.token';
 import { EventBus } from '../../events';
-import { FieldWrapper, WrapperTypeDefinition } from '../../models/wrapper-type';
+import {
+  FieldWrapper,
+  WRAPPER_AUTO_ASSOCIATIONS,
+  WRAPPER_COMPONENT_CACHE,
+  WRAPPER_REGISTRY,
+  WrapperTypeDefinition,
+} from '../../models/wrapper-type';
 import { applyValidator } from '../../core/validation/validator-factory';
 import { FunctionRegistryService } from '../../core/registry/function-registry.service';
 import { FieldContextRegistryService } from '../../core/registry/field-context-registry.service';
@@ -29,6 +36,9 @@ import { RootFormRegistryService } from '../../core/registry/root-form-registry.
 import { FormStateManager } from '../../state/form-state-manager';
 import { DynamicFormLogger } from '../../providers/features/logger/logger.token';
 import { ConsoleLogger } from '../../providers/features/logger/console-logger';
+import { NoopLogger } from '../../providers/features/logger/noop-logger';
+import { DfFieldOutlet } from '../../directives/df-field-outlet/df-field-outlet.directive';
+import { ResolvedField } from '../../utils/resolve-field/resolve-field';
 
 // ─── Mock Wrapper Components ──────────────────────────────────────────────────
 
@@ -418,6 +428,132 @@ describe('ContainerFieldComponent', () => {
 
       expect(wrapper.classList.contains('form-invalid')).toBe(true);
       expect(wrapper.classList.contains('form-valid')).toBe(false);
+    });
+  });
+
+  describe('empty fields + logic.hidden end-to-end (HelloSubs repro)', () => {
+    // Host that renders a ResolvedField through DfFieldOutlet — mirrors the
+    // production wiring (the parent form / row / array iterates and emits
+    // *dfFieldOutlet per child). Container fields with field-level `wrappers`
+    // route those wrappers through DfFieldOutlet (the mapper strips them off
+    // the inner ContainerFieldComponent input), so this is the surface area
+    // where the chrome-leak bug lives.
+    @Component({
+      imports: [DfFieldOutlet],
+      template: `<ng-container *dfFieldOutlet="field()" />`,
+      changeDetection: ChangeDetectionStrategy.OnPush,
+    })
+    class OutletHostComponent {
+      readonly field = input.required<ResolvedField>();
+    }
+
+    async function flush(fixture: { detectChanges: () => void; whenStable: () => Promise<void> }): Promise<void> {
+      await fixture.whenStable();
+      fixture.detectChanges();
+      await delay(0);
+      fixture.detectChanges();
+      await delay(0);
+      fixture.detectChanges();
+    }
+
+    function buildContainerResolvedField(opts: { injector: Injector }): ResolvedField {
+      // Reproduce the HelloSubs setup: empty `fields`, one wrapper (`section`),
+      // and a `hidden` logic condition keyed off `formValue.fillType`. When
+      // fillType !== 'KEEP_PRIVATE', the container hides.
+      const containerField = {
+        key: 'requiredDetails',
+        type: 'container',
+        fields: [],
+        wrappers: [{ type: 'section', header: 'Private Job' }],
+        logic: [
+          {
+            type: 'hidden',
+            condition: { type: 'fieldValue', fieldPath: 'fillType', operator: 'notEquals', value: 'KEEP_PRIVATE' },
+          },
+        ],
+      } as unknown as ContainerField;
+
+      // Drive the inputs signal through the real containerFieldMapper so
+      // applyHiddenLogic is exercised end-to-end. The mapper's `inject` calls
+      // resolve through the TestBed injector (which provides RootFormRegistryService).
+      const inputs = runInInjectionContext(opts.injector, () => containerFieldMapper(containerField));
+
+      // Use a no-op test leaf as the innermost component — the bug lives in
+      // wrapper chrome leakage, not the container's own rendering. This keeps
+      // the test focused on mapper → outlet → hide-effect integration without
+      // pulling in ContainerFieldComponent's full DI dependency set.
+      return {
+        key: containerField.key,
+        fieldDef: containerField,
+        component: TestFieldComponent,
+        injector: opts.injector,
+        inputs,
+        renderReady: computed(() => true),
+        hidden: computed(() => inputs()['hidden'] === true),
+      };
+    }
+
+    it('hides the wrapper chrome (section header) when logic.hidden flips true post-mount', async () => {
+      // Stub RootFormRegistryService: a writable formValue signal that we
+      // mutate to flip the hidden condition. The "rootForm" itself is a
+      // callable stub matching the FieldTree shape that evaluateNonFieldHidden
+      // probes (`form().value()` is the fallback path; we satisfy it for safety
+      // even though `ctx.formValue` is the primary signal-driven path).
+      const formValue = signal<Record<string, unknown>>({ fillType: 'KEEP_PRIVATE' });
+      const stubFieldTree = (() => ({ value: () => formValue() })) as never;
+      const stubRootForm = signal<never>(stubFieldTree);
+
+      const wrapperRegistry = new Map<string, WrapperTypeDefinition>([
+        ['section', { wrapperName: 'section', loadComponent: async () => TestSectionWrapperComponent }],
+      ]);
+      const wrapperCache = new Map<string, typeof TestSectionWrapperComponent>();
+
+      TestBed.configureTestingModule({
+        imports: [OutletHostComponent],
+        providers: [
+          { provide: WRAPPER_REGISTRY, useValue: wrapperRegistry },
+          { provide: WRAPPER_COMPONENT_CACHE, useValue: wrapperCache },
+          { provide: WRAPPER_AUTO_ASSOCIATIONS, useValue: new Map() },
+          { provide: RootFormRegistryService, useValue: new RootFormRegistryService(formValue, stubRootForm) },
+          { provide: DynamicFormLogger, useValue: new NoopLogger() },
+        ],
+      });
+
+      const fixture = TestBed.createComponent(OutletHostComponent);
+      const injector = TestBed.inject(Injector);
+
+      const resolved = buildContainerResolvedField({ injector });
+
+      fixture.componentRef.setInput('field', resolved);
+      fixture.detectChanges();
+      await flush(fixture);
+
+      // Initial state: fillType === 'KEEP_PRIVATE' → hidden=false → chrome visible.
+      const section = fixture.nativeElement.querySelector('test-section-wrapper') as HTMLElement | null;
+      expect(section).toBeTruthy();
+      expect(section!.classList.contains('df-chain-hidden')).toBe(false);
+      expect(section!.style.display).toBe('');
+
+      // Flip the form value so the `notEquals KEEP_PRIVATE` condition is true.
+      formValue.set({ fillType: 'ALLOW_ANYONE_TO_APPLY' });
+      fixture.detectChanges();
+      await flush(fixture);
+
+      // Wrapper component instance survives — same DOM node.
+      const sectionAfter = fixture.nativeElement.querySelector('test-section-wrapper') as HTMLElement | null;
+      expect(sectionAfter).toBe(section);
+      expect(sectionAfter!.classList.contains('df-chain-hidden')).toBe(true);
+      expect(sectionAfter!.style.display).toBe('none');
+
+      // Flip back — chrome re-appears without rebuilding.
+      formValue.set({ fillType: 'KEEP_PRIVATE' });
+      fixture.detectChanges();
+      await flush(fixture);
+
+      const sectionRestored = fixture.nativeElement.querySelector('test-section-wrapper') as HTMLElement | null;
+      expect(sectionRestored).toBe(section);
+      expect(sectionRestored!.classList.contains('df-chain-hidden')).toBe(false);
+      expect(sectionRestored!.style.display).toBe('');
     });
   });
 });

--- a/packages/dynamic-forms/src/lib/mappers/apply-hidden-logic.spec.ts
+++ b/packages/dynamic-forms/src/lib/mappers/apply-hidden-logic.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { signal } from '@angular/core';
+import { applyHiddenLogic } from './apply-hidden-logic';
+import { RootFormRegistryService } from '../core/registry/root-form-registry.service';
+import { LogicConfig } from '../models/logic';
+
+function makeRegistry(formValue: Record<string, unknown>, rootForm: unknown): RootFormRegistryService {
+  return new RootFormRegistryService(signal(formValue), signal(rootForm) as never);
+}
+
+describe('applyHiddenLogic', () => {
+  describe('when rootForm is null (initial-render race)', () => {
+    it('defaults hidden=true when the field has hidden logic but no form is registered yet', () => {
+      // The mapper's computed can fire before the form registers. Without this
+      // guard we'd briefly emit `inputs.hidden=undefined` (treated as false by
+      // consumers), letting wrapper chrome flash on screen for one tick before
+      // the form registers and the condition is evaluable.
+      const inputs: Record<string, unknown> = {};
+      const fieldDef = {
+        logic: [{ type: 'hidden', condition: { type: 'fieldValue', fieldPath: 'x', operator: 'equals', value: 1 } }] as LogicConfig[],
+      };
+      const registry = makeRegistry({}, null);
+
+      applyHiddenLogic(inputs, fieldDef, registry);
+
+      expect(inputs['hidden']).toBe(true);
+    });
+
+    it('defaults hidden=true for explicit hidden:true when no form is registered yet', () => {
+      const inputs: Record<string, unknown> = {};
+      const registry = makeRegistry({}, null);
+
+      applyHiddenLogic(inputs, { hidden: true }, registry);
+
+      expect(inputs['hidden']).toBe(true);
+    });
+
+    it('leaves hidden untouched when the field has NO hidden logic — bare fields stay visible', () => {
+      // Don't pessimize fields that never participate in hidden logic.
+      const inputs: Record<string, unknown> = {};
+      const registry = makeRegistry({}, null);
+
+      applyHiddenLogic(inputs, {}, registry);
+
+      expect('hidden' in inputs).toBe(false);
+    });
+  });
+
+  describe('when rootForm is registered', () => {
+    function fakeForm(value: Record<string, unknown>): unknown {
+      // Minimal FieldTree-shaped callable: invoking it returns the FieldState
+      // whose `value()` getter the logic resolver falls back to. The hidden
+      // resolver actually consumes `ctx.formValue` first (which we pass), so
+      // the callable is here for shape consistency with the production type.
+      return () => ({ value: () => value });
+    }
+
+    it('evaluates the condition and sets hidden=true when it matches', () => {
+      const inputs: Record<string, unknown> = {};
+      const fieldDef = {
+        logic: [
+          {
+            type: 'hidden',
+            condition: { type: 'fieldValue', fieldPath: 'fillType', operator: 'notEquals', value: 'KEEP_PRIVATE' },
+          },
+        ] as LogicConfig[],
+      };
+      const value = { fillType: 'ALLOW_ANYONE_TO_APPLY' };
+      const registry = makeRegistry(value, fakeForm(value));
+
+      applyHiddenLogic(inputs, fieldDef, registry);
+
+      expect(inputs['hidden']).toBe(true);
+    });
+
+    it('evaluates the condition and sets hidden=false when it does NOT match', () => {
+      const inputs: Record<string, unknown> = {};
+      const fieldDef = {
+        logic: [
+          {
+            type: 'hidden',
+            condition: { type: 'fieldValue', fieldPath: 'fillType', operator: 'notEquals', value: 'KEEP_PRIVATE' },
+          },
+        ] as LogicConfig[],
+      };
+      const value = { fillType: 'KEEP_PRIVATE' };
+      const registry = makeRegistry(value, fakeForm(value));
+
+      applyHiddenLogic(inputs, fieldDef, registry);
+
+      expect(inputs['hidden']).toBe(false);
+    });
+
+    it('honours explicit hidden=true regardless of logic', () => {
+      const inputs: Record<string, unknown> = {};
+      const value = { fillType: 'KEEP_PRIVATE' };
+      const registry = makeRegistry(value, fakeForm(value));
+
+      applyHiddenLogic(inputs, { hidden: true }, registry);
+
+      expect(inputs['hidden']).toBe(true);
+    });
+  });
+});

--- a/packages/dynamic-forms/src/lib/mappers/apply-hidden-logic.ts
+++ b/packages/dynamic-forms/src/lib/mappers/apply-hidden-logic.ts
@@ -8,12 +8,23 @@ interface FieldWithHiddenLogic {
   logic?: readonly (ContainerLogicConfig | LogicConfig)[];
 }
 
+function hasAnyHiddenSpec(fieldDef: FieldWithHiddenLogic): boolean {
+  return fieldDef.hidden === true || (fieldDef.logic?.some((l) => l.type === 'hidden') ?? false);
+}
+
 /**
  * Applies hidden logic to a mapper's input record.
  *
  * Evaluates the field's `hidden` property and `logic` array to determine
  * if the component should be hidden. Only runs evaluation when there's
  * actually something to evaluate (explicit `hidden: true` or logic with type 'hidden').
+ *
+ * Initial-render race: a mapper computed can fire before the root form has
+ * registered with `RootFormRegistryService` — `rootForm()` returns `null` for
+ * one emission while Angular runs the first CD pass. If the field declares
+ * any hidden logic, we DEFAULT to `hidden: true` for that single emission so
+ * wrapper chrome doesn't briefly leak before the condition is evaluable. As
+ * soon as the form registers, the computed re-fires with the real value.
  *
  * @param inputs The mutable input record to potentially add `hidden` to
  * @param fieldDef The field definition containing `hidden` and `logic`
@@ -24,8 +35,10 @@ export function applyHiddenLogic(
   fieldDef: FieldWithHiddenLogic,
   rootFormRegistry: RootFormRegistryService,
 ): void {
+  if (!hasAnyHiddenSpec(fieldDef)) return;
+
   const rootForm = rootFormRegistry.rootForm();
-  if (rootForm && (fieldDef.hidden === true || fieldDef.logic?.some((l) => l.type === 'hidden'))) {
+  if (rootForm) {
     // Cast is safe: evaluateNonFieldHidden only reads the array, never mutates it.
     // The readonly + union type from container/leaf field definitions is compatible at runtime.
     inputs['hidden'] = evaluateNonFieldHidden({
@@ -34,5 +47,11 @@ export function applyHiddenLogic(
       explicitValue: fieldDef.hidden,
       formValue: rootFormRegistry.formValue(),
     });
+    return;
   }
+
+  // No root form yet — assume hidden until the form registers and the
+  // condition can be evaluated. Prevents wrapper chrome flashing during the
+  // single mapper emission that fires before form registration.
+  inputs['hidden'] = true;
 }

--- a/packages/dynamic-forms/src/lib/utils/wrapper-chain/wrapper-chain-controller.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/wrapper-chain/wrapper-chain-controller.spec.ts
@@ -19,7 +19,7 @@ import { FieldWrapper, WRAPPER_COMPONENT_CACHE, WRAPPER_REGISTRY, WrapperConfig,
 import { DynamicFormLogger } from '../../providers/features/logger/logger.token';
 import { NoopLogger } from '../../providers/features/logger/noop-logger';
 import { WrapperFieldInputs } from '../../wrappers/wrapper-field-inputs';
-import { createWrapperChainController } from './wrapper-chain-controller';
+import { CHAIN_HIDDEN_CLASS, createWrapperChainController } from './wrapper-chain-controller';
 
 @Component({
   selector: 'test-leaf-a',
@@ -100,7 +100,8 @@ interface ControllerFixture {
   slot: ViewContainerRef;
   wrappers: WritableSignal<readonly WrapperConfig[]>;
   rebuildKey: WritableSignal<unknown>;
-  gate: WritableSignal<boolean>;
+  renderReady: WritableSignal<boolean>;
+  hidden: WritableSignal<boolean>;
   fieldInputs: WritableSignal<WrapperFieldInputs | undefined>;
   innermostCalls: number;
   lastInnermostSlot: ViewContainerRef | undefined;
@@ -129,7 +130,8 @@ function setupController(
 
   const wrappers = signal<readonly WrapperConfig[]>([]);
   const rebuildKey = signal<unknown>(TestLeafA);
-  const gate = signal(true);
+  const renderReady = signal(true);
+  const hidden = signal(false);
   const fieldInputs = signal<WrapperFieldInputs | undefined>(undefined);
 
   const injector = TestBed.inject(Injector);
@@ -140,7 +142,8 @@ function setupController(
     slot,
     wrappers,
     rebuildKey,
-    gate,
+    renderReady,
+    hidden,
     fieldInputs,
     innermostCalls: 0,
     lastInnermostSlot: undefined,
@@ -152,9 +155,10 @@ function setupController(
     createWrapperChainController({
       vcr: slotSignal,
       wrappers,
-      gate,
+      renderReady,
+      hidden,
       rebuildKey,
-      fieldInputs,
+      fieldInputs: fieldInputs as unknown as import('@angular/core').Signal<WrapperFieldInputs>,
       renderInnermost: (s) => {
         ref.innermostCalls++;
         ref.lastInnermostSlot = s;
@@ -184,26 +188,26 @@ describe('createWrapperChainController', () => {
     f.destroy();
   });
 
-  it('blocks the initial render when gate=false, renders once gate flips true', async () => {
+  it('blocks the initial render when renderReady=false, renders once renderReady flips true', async () => {
     const f = setupController();
-    f.gate.set(false);
+    f.renderReady.set(false);
     await flush();
     expect(f.innermostCalls).toBe(0);
 
-    f.gate.set(true);
+    f.renderReady.set(true);
     await flush();
     expect(f.innermostCalls).toBe(1);
     f.destroy();
   });
 
-  it('ignores a gate flicker after mount — does NOT rebuild', async () => {
+  it('ignores a renderReady flicker after mount — does NOT rebuild', async () => {
     const f = setupController();
     await flush();
     expect(f.innermostCalls).toBe(1);
 
-    f.gate.set(false);
+    f.renderReady.set(false);
     await flush();
-    f.gate.set(true);
+    f.renderReady.set(true);
     await flush();
 
     expect(f.innermostCalls).toBe(1);
@@ -376,7 +380,7 @@ describe('createWrapperChainController', () => {
     let beforeRebuildCount = 0;
     const wrappers = signal<readonly WrapperConfig[]>([{ type: 'x' } as WrapperConfig]);
     const rebuildKey = signal<unknown>(TestLeafA);
-    const gate = signal(true);
+    const renderReady = signal(true);
 
     TestBed.configureTestingModule({
       providers: [
@@ -396,7 +400,7 @@ describe('createWrapperChainController', () => {
       createWrapperChainController({
         vcr: slotSignal,
         wrappers,
-        gate,
+        renderReady,
         rebuildKey,
         renderInnermost: (s) => {
           s.createComponent(rebuildKey() as Type<unknown>, { environmentInjector: envInjector, injector });
@@ -423,5 +427,125 @@ describe('createWrapperChainController', () => {
 
     f.destroy();
     expect(f.slot.length).toBe(0);
+  });
+
+  describe('hidden vs renderReady split', () => {
+    function setupWithWrapperX(): ControllerFixture {
+      const registry = new Map<string, WrapperTypeDefinition>([['x', def('x', () => TestWrapX)]]);
+      const cache = new Map<string, Type<unknown>>();
+      const f = setupController({ registry, cache });
+      f.wrappers.set([{ type: 'x' } as WrapperConfig]);
+      return f;
+    }
+
+    function getOuterWrapHost(slot: ViewContainerRef): HTMLElement | null {
+      // The outermost wrapper's HOST element is the `<test-wrap-x>` element
+      // (the component's selector tag), NOT the inner `.wrap-x` template div.
+      // `ComponentRef.location.nativeElement` is the host, so the hide-class
+      // lands on the host tag — assertions must query for it.
+      const parent = slot.element.nativeElement.parentElement;
+      return (parent?.querySelector('test-wrap-x') as HTMLElement | null) ?? null;
+    }
+
+    it('does NOT render the chain on initial mount when hidden=true (parity with renderReady=false)', async () => {
+      const f = setupController();
+      f.hidden.set(true);
+      await flush();
+      expect(f.innermostCalls).toBe(0);
+
+      // Flipping hidden back to false mounts the chain fresh.
+      f.hidden.set(false);
+      await flush();
+      expect(f.innermostCalls).toBe(1);
+      f.destroy();
+    });
+
+    it('preserves mounted wrappers when hidden flips true post-mount AND applies the hide effect', async () => {
+      const f = setupWithWrapperX();
+      await flush();
+      expect(f.innermostCalls).toBe(1);
+
+      const outer = getOuterWrapHost(f.slot);
+      expect(outer).toBeTruthy();
+      expect(outer!.classList.contains(CHAIN_HIDDEN_CLASS)).toBe(false);
+
+      f.hidden.set(true);
+      await flush();
+
+      // Chain stayed mounted — focus / caret survives a re-show.
+      expect(f.innermostCalls).toBe(1);
+      expect(f.beforeRebuildCalls).toBe(0);
+
+      // Visible chrome is suppressed by the controller's hide mechanism:
+      // class for diagnostic visibility, inline display:none for guaranteed effect.
+      const outerAfter = getOuterWrapHost(f.slot);
+      expect(outerAfter).toBeTruthy();
+      expect(outerAfter!.classList.contains(CHAIN_HIDDEN_CLASS)).toBe(true);
+      expect(outerAfter!.style.display).toBe('none');
+
+      f.destroy();
+    });
+
+    it('removes the hide effect when hidden flips back to false — chain stays mounted', async () => {
+      const f = setupWithWrapperX();
+      await flush();
+      f.hidden.set(true);
+      await flush();
+      f.hidden.set(false);
+      await flush();
+
+      const outer = getOuterWrapHost(f.slot);
+      expect(outer).toBeTruthy();
+      expect(outer!.classList.contains(CHAIN_HIDDEN_CLASS)).toBe(false);
+      expect(outer!.style.display).toBe('');
+      expect(f.innermostCalls).toBe(1); // never rebuilt
+      expect(f.beforeRebuildCalls).toBe(0);
+
+      f.destroy();
+    });
+
+    it('renderReady flicker (false → true) with hidden=false leaves the hide effect untouched', async () => {
+      // Mirrors the existing flicker-tolerance test but expressed under the
+      // split-signal API. The chain stays mounted; no hide class applied.
+      const f = setupWithWrapperX();
+      await flush();
+      expect(f.innermostCalls).toBe(1);
+
+      f.renderReady.set(false);
+      await flush();
+      f.renderReady.set(true);
+      await flush();
+
+      expect(f.innermostCalls).toBe(1);
+      expect(f.beforeRebuildCalls).toBe(0);
+      const outer = getOuterWrapHost(f.slot);
+      expect(outer!.classList.contains(CHAIN_HIDDEN_CLASS)).toBe(false);
+      expect(outer!.style.display).toBe('');
+
+      f.destroy();
+    });
+
+    it('no-op hide effect when there are no wrappers (innermost handles its own hidden state)', async () => {
+      // Sanity: when refs is empty (bare innermost field, no wrappers), the
+      // controller doesn't touch any host element — the innermost field is
+      // expected to manage its own host-binding hidden state.
+      const f = setupController();
+      await flush();
+      expect(f.innermostCalls).toBe(1);
+
+      // The leaf component's host is what's mounted at the slot.
+      const leafEl = f.slot.element.nativeElement.parentElement?.querySelector('test-leaf-a') as HTMLElement | null;
+      expect(leafEl).toBeTruthy();
+
+      f.hidden.set(true);
+      await flush();
+
+      // The controller didn't add the chain-hidden class to the leaf — refs
+      // tracks WRAPPER refs only, and there are no wrappers here.
+      expect(leafEl!.classList.contains(CHAIN_HIDDEN_CLASS)).toBe(false);
+      expect(leafEl!.style.display).toBe('');
+
+      f.destroy();
+    });
   });
 });

--- a/packages/dynamic-forms/src/lib/utils/wrapper-chain/wrapper-chain-controller.ts
+++ b/packages/dynamic-forms/src/lib/utils/wrapper-chain/wrapper-chain-controller.ts
@@ -9,6 +9,9 @@ import { WrapperFieldInputs } from '../../wrappers/wrapper-field-inputs';
 import { isSameWrapperChain } from '../resolve-wrappers/resolve-wrappers';
 import { LoadedWrapper, loadWrapperComponents, renderWrapperChain, setInputIfDeclared } from './wrapper-chain';
 
+/** Class applied to the outermost wrapper host while `hidden` is true post-mount. */
+export const CHAIN_HIDDEN_CLASS = 'df-chain-hidden';
+
 export interface WrapperChainControllerOptions {
   /**
    * The outer slot where the wrapper chain is mounted. Sampled only at render
@@ -22,11 +25,25 @@ export interface WrapperChainControllerOptions {
    */
   readonly wrappers: Signal<readonly WrapperConfig[]>;
   /**
-   * Optional gating signal. When `false`, the chain is not mounted (initial)
-   * or left untouched (post-mount flicker). `DfFieldOutlet` passes
-   * `renderReady`; containers omit the gate.
+   * Optional render-readiness signal. When `false` BEFORE first mount the chain
+   * is not mounted; when `false` AFTER mount the chain is preserved (transient
+   * flicker tolerance — keeps focus/caret/scroll on value-bearing fields).
+   * `DfFieldOutlet` passes `field.renderReady()`; containers omit this.
    */
-  readonly gate?: Signal<boolean>;
+  readonly renderReady?: Signal<boolean>;
+  /**
+   * Optional hidden signal. When `true` BEFORE first mount the chain is not
+   * mounted. When `true` AFTER first mount the chain is PRESERVED but the
+   * outermost wrapper's host element is visually hidden (class +
+   * `display: none`) so wrapper chrome (section headers, icons, hint copy)
+   * doesn't leak through when only the innermost field has its own
+   * hide-styling.
+   *
+   * Distinct from `renderReady` because flickers and intentional hiding need
+   * different behaviour: flicker preserves the chain unchanged, hide preserves
+   * the chain AND suppresses its visible output.
+   */
+  readonly hidden?: Signal<boolean>;
   /**
    * Optional mapper-outputs signal. When present, the controller pushes it to
    * each wrapper's `fieldInputs` input at render time AND on every subsequent
@@ -64,8 +81,9 @@ export interface WrapperChainControllerOptions {
 /**
  * Owns the wrapper-chain lifecycle for a field or container: async component
  * loading, switchMap-based cancellation of stale loads, flicker-tolerant
- * rebuilds (only structural changes tear down), and `fieldInputs` push-through.
- * Must be called from a DI injection context.
+ * rebuilds (only structural changes tear down), `fieldInputs` push-through,
+ * and post-mount hide via the outermost host (chain stays alive so focus /
+ * caret survive a hide → show flip). Must be called from a DI injection context.
  */
 export function createWrapperChainController(opts: WrapperChainControllerOptions): void {
   const deps = injectChainDeps();
@@ -106,7 +124,10 @@ interface ChainDeps {
 }
 
 interface ChainState {
-  readonly open: boolean;
+  /** True when the mapper has produced required inputs (`field.renderReady()`). */
+  readonly renderReady: boolean;
+  /** True when the field is intentionally hidden via `logic.hidden` or `hidden: true`. */
+  readonly hidden: boolean;
   readonly wrappers: readonly WrapperConfig[];
   readonly rebuildKey: unknown;
 }
@@ -141,11 +162,18 @@ function injectChainDeps(): ChainDeps {
 function createStateSignal(opts: WrapperChainControllerOptions): Signal<ChainState> {
   return computed(
     () => ({
-      open: opts.gate?.() ?? true,
+      renderReady: opts.renderReady?.() ?? true,
+      hidden: opts.hidden?.() ?? false,
       wrappers: opts.wrappers(),
       rebuildKey: opts.rebuildKey?.(),
     }),
-    { equal: (a, b) => a.open === b.open && a.rebuildKey === b.rebuildKey && isSameWrapperChain(a.wrappers, b.wrappers) },
+    {
+      equal: (a, b) =>
+        a.renderReady === b.renderReady &&
+        a.hidden === b.hidden &&
+        a.rebuildKey === b.rebuildKey &&
+        isSameWrapperChain(a.wrappers, b.wrappers),
+    },
   );
 }
 
@@ -158,7 +186,10 @@ function buildEmissionStream(state: Signal<ChainState>, deps: ChainDeps): Observ
 }
 
 function resolveLoadedWrappers(state: ChainState, deps: ChainDeps): Observable<ChainEmission> {
-  if (!state.open) {
+  // Skip wrapper loading when we won't be mounting — renderReady=false is the
+  // flicker path; hidden=true skips the initial mount (post-mount hidden is
+  // handled in applyEmission via the hide-class without needing fresh loads).
+  if (!state.renderReady || state.hidden) {
     return of({ state, loaded: null });
   }
 
@@ -174,9 +205,11 @@ function resolveLoadedWrappers(state: ChainState, deps: ChainDeps): Observable<C
 
 /**
  * Diff what's mounted against the next state and act:
- *   - Gate-only flicker → no-op (preserve the mounted chain)
- *   - Structural change → beforeRebuild → vcr.clear → render fresh
- *   - Idempotent re-emission → no-op
+ *   - Same structure, already mounted → just sync the hide-class to `state.hidden`
+ *     (covers both renderReady flicker and hidden toggle; idempotent re-emissions
+ *     redundantly re-apply the same class, which is cheap)
+ *   - Structural change → beforeRebuild → vcr.clear → render fresh (or skip if
+ *     renderReady=false or hidden=true)
  *
  * Returns the (possibly new) wrapper refs so the caller can track them for
  * `fieldInputs` push-through.
@@ -186,24 +219,31 @@ function applyEmission({ state, loaded }: ChainEmission, ctx: EmissionApplyConte
   const vcr = opts.vcr();
   const structurallyChanged = isStructurallyDifferent(mounted.value, state);
 
-  // Gate-only flicker after first mount — keep the chain alive so the user's
-  // focus / caret / scroll survive. The caller's rawInputs effect continues
-  // to push live mapper outputs through the still-mounted innermost.
-  if (!structurallyChanged && !state.open) return refs;
+  // Non-structural emission with chain already mounted — preserve the chain
+  // (focus/caret/scroll survive) and just reconcile the hide-class to the
+  // current `state.hidden`. Covers:
+  //   - renderReady flicker false→true→false (state.hidden stays false → class cleared)
+  //   - hidden flip true (class + display:none applied)
+  //   - hidden flip back to false (class removed; chain re-appears)
+  if (!structurallyChanged) {
+    applyHideEffect(refs, state.hidden);
+    return refs;
+  }
 
   // Real structural change — tear down. Angular cascades destroy through
   // every nested ComponentRef, so walking `refs` manually is redundant.
   // `beforeRebuild` gives the caller a chance to detach views it wants to
   // preserve (e.g. the innermost field when only wrappers changed).
-  if (structurallyChanged && mounted.value !== null) {
+  if (mounted.value !== null) {
     opts.beforeRebuild?.();
     vcr.clear();
     mounted.value = null;
   }
 
-  if (!state.open || loaded === null) return [];
-  // Same structure + already mounted — idempotent re-emission, nothing to do.
-  if (mounted.value !== null) return refs;
+  // Don't mount when not renderReady, when intentionally hidden, or when
+  // wrapper loading was aborted. Each path is independent — a later state
+  // emission flips the relevant signal and we re-enter applyEmission.
+  if (!state.renderReady || state.hidden || loaded === null) return [];
 
   const newRefs = renderWrapperChain({
     outerContainer: vcr,
@@ -222,6 +262,35 @@ function isStructurallyDifferent(mounted: MountedChain | null, next: ChainState)
   if (mounted === null) return true;
   if (mounted.rebuildKey !== next.rebuildKey) return true;
   return !isSameWrapperChain(mounted.wrappers, next.wrappers);
+}
+
+/**
+ * Apply or remove the hide effect on the outermost wrapper's host element.
+ *
+ * When `hidden=true` we set both a class (for diagnostic visibility / overrides
+ * in app SCSS) AND inline `display: none` — the inline style wins regardless
+ * of what the wrapper component declared via `:host { display: ... }`, so we
+ * don't have to ship a global stylesheet to make this work for user-defined
+ * wrappers. Removing inline display restores whatever the wrapper's own host
+ * styling produces.
+ *
+ * No-op when there are no wrapper refs: a bare innermost field is expected to
+ * manage its own host-binding hidden state (e.g. `ContainerFieldComponent`'s
+ * `:host.df-container-hidden { display: none }`).
+ */
+function applyHideEffect(refs: readonly ComponentRef<unknown>[], hidden: boolean): void {
+  if (refs.length === 0) return;
+  const host = refs[0].location.nativeElement as HTMLElement | null;
+  if (host === null) return;
+  if (hidden) {
+    host.classList.add(CHAIN_HIDDEN_CLASS);
+    host.style.display = 'none';
+  } else {
+    host.classList.remove(CHAIN_HIDDEN_CLASS);
+    // Clear only inline display — restores whatever the wrapper's component
+    // SCSS specifies (most use `:host { display: block }` or similar).
+    host.style.display = '';
+  }
 }
 
 /**

--- a/packages/dynamic-forms/src/lib/utils/wrapper-chain/wrapper-chain.bench.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/wrapper-chain/wrapper-chain.bench.spec.ts
@@ -407,14 +407,14 @@ describe('wrapper-chain perf baseline', () => {
       const chainB: WrapperConfig[] = [{ type: 'c' } as WrapperConfig, { type: 'a' } as WrapperConfig, { type: 'b' } as WrapperConfig];
 
       const wrappersSig: WritableSignal<readonly WrapperConfig[]> = signal(chainA);
-      const gate = signal(true);
+      const renderReady = signal(true);
       const slotSig = signal(host.slot()).asReadonly();
 
       runInInjectionContext(fixture.componentRef.injector, () => {
         createWrapperChainController({
           vcr: slotSig,
           wrappers: wrappersSig,
-          gate,
+          renderReady,
           renderInnermost: (s) => s.createComponent(BenchLeaf, { environmentInjector: envInjector, injector }),
         });
       });
@@ -437,12 +437,13 @@ describe('wrapper-chain perf baseline', () => {
       });
       results.push(rebuildStat);
 
-      // (b) Gate flicker: off → on. Should NOT rebuild (controller preserves
-      // the mounted chain). This is the path the comment promises is "free".
-      const flickerStat = await benchAsync('flicker (gate false→true)', async () => {
-        gate.set(false);
+      // (b) renderReady flicker: off → on. Should NOT rebuild (controller
+      // preserves the mounted chain). This is the path the comment promises
+      // is "free".
+      const flickerStat = await benchAsync('flicker (renderReady false→true)', async () => {
+        renderReady.set(false);
         await microFlush();
-        gate.set(true);
+        renderReady.set(true);
         await microFlush();
       });
       results.push(flickerStat);


### PR DESCRIPTION
# Pull Request

## Description

When a field's `hidden` state flips `false → true` after the wrapper chain has already mounted, `createWrapperChainController` preserved the chain (intentional flicker tolerance so focus/caret/scroll survive on value-bearing fields) but only the innermost field component received `display: none` via its own host bindings. Every wrapper around it stayed visibly mounted — section headers, icons, hint copy all leaked through. Most visible on a `container({ fields: [], wrappers: [...] })` whose entire visible output **is** the wrapper chrome.

This PR splits the controller's single `gate` signal into two orthogonal signals — `renderReady` (existing flicker semantics) and `hidden` (new post-mount hide via the outermost host) — so the controller can distinguish "transient renderReady flicker" from "field became hidden on purpose." It also closes the initial-render race in `applyHiddenLogic` where wrapper chrome flashed for one tick before the root form registered.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Code style update (formatting, renaming)
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build/tooling update

## Related Issues

## Changes Made

**Core controller split (`wrapper-chain-controller.ts`)**

- Split the single `gate?: Signal<boolean>` controller option into two: `renderReady?` (existing flicker semantics — preserves the chain on transient false) and `hidden?` (new — when true post-mount, applies a `df-chain-hidden` class plus inline `display: none` to `refs[0].location.nativeElement`, the outermost wrapper host).
- Added `applyHideEffect` so the chain stays mounted on hide → show flips; focus/caret/scroll on value-bearing fields survive.
- Exported `CHAIN_HIDDEN_CLASS` constant; updated `ChainState`, `createStateSignal`, `resolveLoadedWrappers`, `applyEmission`, and `isStructurallyDifferent` to thread both signals.

**Outlet pass-through (`df-field-outlet.directive.ts`)**

- `renderReady` and `hidden` signals now flow through to the controller separately. Removed the previous `renderReady && !hidden && …` combo that conflated the two.

**Initial-render race (`apply-hidden-logic.ts` — "Option A")**

- When `rootFormRegistry.rootForm()` returns `null` AND the field declares hidden logic, default `inputs.hidden = true` so chrome doesn't flash during the one-tick window before root-form registration.

**Hide mechanism**

- Inline `display: none` + `df-chain-hidden` diagnostic class on the outermost wrapper host. Inline style wins regardless of the wrapper component's `:host { display: ... }`, so no shipped CSS is required.

## Breaking Changes

None for external consumers. `createWrapperChainController` is internal (not exported from the package index), so the `gate → renderReady` rename has no public-API impact.

## Testing

- [x] Unit tests added/updated
- [x] All tests pass locally
- [ ] Tested manually
- [ ] Tested edge cases

**New / migrated tests:**

- `wrapper-chain-controller.spec.ts` — migrated existing `gate` tests to `renderReady`; added a new **"hidden vs renderReady split"** describe block (5 tests) covering:
  - initial `hidden=true` → no render
  - post-mount hide-class + inline `display: none` applied to refs[0]
  - class + inline style removed on re-show
  - flicker tolerance (renderReady false transient ≠ hidden true)
  - no-op on a bare innermost (no wrappers)
- `df-field-outlet.directive.spec.ts` — integration test verifying the wrapper instance survives a post-mount hidden flip while chrome is suppressed.
- `container-field.component.spec.ts` — end-to-end HelloSubs-style repro: empty fields, section wrapper, `logic.hidden` keyed off a `fieldValue` condition, driving `formValue` post-mount.
- `apply-hidden-logic.spec.ts` *(new)* — 6 unit tests covering the null-`rootForm` default and normal evaluation paths.
- `wrapper-chain.bench.spec.ts` — migrated to the new `renderReady` API.

## Documentation

- [x] API documentation (TSDoc) added/updated — controller JSDoc reflects the `renderReady` / `hidden` split.
- [ ] Examples updated (if needed) — not needed; the public outlet API is unchanged.

## Checklist

- [x] Code follows the coding standards
- [x] No linting errors (`pnpm lint`)
- [x] Code is formatted (`pnpm lint:fix`)
- [x] Build succeeds (`pnpm build:libs`)
- [x] Commits follow conventional commit format
- [x] Self-review completed
- [x] No commented-out code or `console.log()` statements
- [x] Type safety maintained (no `any` types)

## Additional Notes

May not be needed anymore, as the issue appeared pre-0.9.0-next.12. Commit #ba77b21f seems to have resolved the issue though.