### PR TITLE
chore(release): bump version to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,63 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and uses [Conventional Commits](https://www.conventionalcommits.org/).
 
+## [0.9.0](https://github.com/ng-forge/ng-forge/compare/v0.8.0...v0.9.0) (2026-05-23)
+
+### 🚀 Features
+
+- ⚠️ added validateWhenHidden ([#392](https://github.com/ng-forge/ng-forge/pull/392))
+- ⚠️ **dynamic-forms:** add NgForgeField/NgForgeAction directives + migrate all 4 adapters ([#381](https://github.com/ng-forge/ng-forge/pull/381))
+- **dynamic-forms:** inline function alternatives for conditions, derivations, validators ([#400](https://github.com/ng-forge/ng-forge/pull/400))
+- ⚠️ **dynamic-forms:** allow overlapping leaf keys in different groups ([#401](https://github.com/ng-forge/ng-forge/pull/401), [#403](https://github.com/ng-forge/ng-forge/pull/403))
+- **dynamic-forms:** narrow FieldDef.type against RegisteredFieldTypes ([b8d5e93f3](https://github.com/ng-forge/ng-forge/commit/b8d5e93f3))
+- **dynamic-forms:** make renderReadyWhen explicit at registration sites ([ba77b21ff](https://github.com/ng-forge/ng-forge/commit/ba77b21ff))
+- **dynamic-forms:** add typed addon system across all 4 UI adapters ([8513e1683](https://github.com/ng-forge/ng-forge/commit/8513e1683))
+
+### 🐛 Bug Fixes
+
+- emit array minLength/maxLength as direct properties in openapi-generator ([#416](https://github.com/ng-forge/ng-forge/pull/416), [#417](https://github.com/ng-forge/ng-forge/pull/417))
+- handle circular schema references in openapi-generator ([#419](https://github.com/ng-forge/ng-forge/pull/419), [#420](https://github.com/ng-forge/ng-forge/pull/420))
+- **docs:** serve prerendered html on clean urls and prerender api reference ([#375](https://github.com/ng-forge/ng-forge/pull/375))
+- **docs:** prevent double adapter prefix on routerLink-resolved hrefs ([#395](https://github.com/ng-forge/ng-forge/pull/395))
+- **docs:** use vite-root-relative entry script in index.html ([98b126d34](https://github.com/ng-forge/ng-forge/commit/98b126d34))
+- **dynamic-forms:** preserve nested group defaults on partial value ([#387](https://github.com/ng-forge/ng-forge/pull/387))
+- **dynamic-forms:** preserve nested array-item defaults on partial value ([#389](https://github.com/ng-forge/ng-forge/pull/389))
+- **dynamic-forms:** refresh field props on same-key config changes ([#393](https://github.com/ng-forge/ng-forge/pull/393))
+- **dynamic-forms:** stop excludeValueIfHidden from leaking defaults into bound value ([#398](https://github.com/ng-forge/ng-forge/pull/398))
+- **dynamic-forms:** drop stale readonly DOM sync workaround ([#65897](https://github.com/ng-forge/ng-forge/issues/65897))
+- **dynamic-forms:** support nullable on checkbox/toggle fields ([#418](https://github.com/ng-forge/ng-forge/pull/418), [#415](https://github.com/ng-forge/ng-forge/issues/415))
+- **primeng:** clean up radio-group and multi-checkbox ([#399](https://github.com/ng-forge/ng-forge/pull/399))
+
+### ♻️ Code Refactoring
+
+- remove obsolete readonly + indeterminate dom workarounds ([#380](https://github.com/ng-forge/ng-forge/pull/380))
+- ⚠️ **dynamic-forms:** remove hidden fields from DOM + array state machine + registry ([#410](https://github.com/ng-forge/ng-forge/pull/410), [#413](https://github.com/ng-forge/ng-forge/pull/413))
+- ⚠️ **dynamic-forms:** per-adapter style defaults + opt-in signal forms compat classes ([#412](https://github.com/ng-forge/ng-forge/pull/412))
+
+### 📚 Documentation
+
+- add contributors section to README ([e0416c56c](https://github.com/ng-forge/ng-forge/commit/e0416c56c))
+- **docs:** migration guide + feature overview rework ([#378](https://github.com/ng-forge/ng-forge/pull/378))
+
+### ✅ Tests
+
+- **docs:** unbreak vite-plugin-search-index spec ([#388](https://github.com/ng-forge/ng-forge/pull/388))
+
+### ⚠️ Breaking Changes
+
+- **dynamic-forms:** per-adapter style defaults + opt-in signal forms compat classes ([#412](https://github.com/ng-forge/ng-forge/pull/412))
+- **dynamic-forms:** remove hidden fields from DOM + array state machine + registry ([#410](https://github.com/ng-forge/ng-forge/pull/410), [#413](https://github.com/ng-forge/ng-forge/pull/413))
+- **dynamic-forms:** allow overlapping leaf keys in different groups ([#401](https://github.com/ng-forge/ng-forge/pull/401), [#403](https://github.com/ng-forge/ng-forge/pull/403))
+- **dynamic-forms:** add NgForgeField/NgForgeAction directives + migrate all 4 adapters ([#381](https://github.com/ng-forge/ng-forge/pull/381))
+- added validateWhenHidden ([#392](https://github.com/ng-forge/ng-forge/pull/392))
+
+### ❤️ Thank You
+
+- Antim Prisacaru @antimprisacaru
+- antimprisacaru @antimprisacaru
+- Derek Burgman
+- Francesco Raso @0xfraso
+
 ## [0.8.0](https://github.com/ng-forge/ng-forge/compare/v0.7.0...v0.8.0) (2026-04-29)
 
 ### 🚀 Features

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ export class LoginComponent {
 
 | @ng-forge/dynamic-forms | Angular       |
 | ----------------------- | ------------- |
+| 0.9.x                   | >=21.2.0      |
 | 0.8.x                   | >=21.2.0      |
 | 0.7.x                   | >=21.2.0      |
 | 0.6.x                   | >=21.1.0      |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ng-forge/source",
   "type": "module",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "MIT",
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/packages/dynamic-form-mcp/package.json
+++ b/packages/dynamic-form-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-form-mcp",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "MCP server for ng-forge dynamic forms - AI-assisted form schema generation",
   "type": "module",
   "license": "MIT",
@@ -51,11 +51,11 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
-    "@ng-forge/dynamic-forms": "^0.8.0",
-    "@ng-forge/dynamic-forms-bootstrap": "^0.8.0",
-    "@ng-forge/dynamic-forms-ionic": "^0.8.0",
-    "@ng-forge/dynamic-forms-material": "^0.8.0",
-    "@ng-forge/dynamic-forms-primeng": "^0.8.0",
+    "@ng-forge/dynamic-forms": "^0.9.0",
+    "@ng-forge/dynamic-forms-bootstrap": "^0.9.0",
+    "@ng-forge/dynamic-forms-ionic": "^0.9.0",
+    "@ng-forge/dynamic-forms-material": "^0.9.0",
+    "@ng-forge/dynamic-forms-primeng": "^0.9.0",
     "tsx": "^4.19.0"
   }
 }

--- a/packages/dynamic-forms-bootstrap/README.md
+++ b/packages/dynamic-forms-bootstrap/README.md
@@ -20,6 +20,7 @@ Bootstrap 5 field components for [@ng-forge/dynamic-forms](https://www.npmjs.com
 
 | @ng-forge/dynamic-forms-bootstrap | @ng-forge/dynamic-forms | Angular       |
 | --------------------------------- | ----------------------- | ------------- |
+| 0.9.x                             | 0.9.x                   | >=21.2.0      |
 | 0.8.x                             | 0.8.x                   | >=21.2.0      |
 | 0.7.x                             | 0.7.x                   | >=21.2.0      |
 | 0.6.x                             | 0.6.x                   | >=21.1.0      |

--- a/packages/dynamic-forms-bootstrap/package.json
+++ b/packages/dynamic-forms-bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-bootstrap",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Bootstrap 5 integration for @ng-forge/dynamic-forms. Pre-built Bootstrap form components.",
   "type": "module",
   "license": "MIT",
@@ -37,7 +37,7 @@
     "@angular/common": "~21.2.0",
     "@angular/core": "~21.2.0",
     "@angular/forms": "~21.2.0",
-    "@ng-forge/dynamic-forms": "~0.8.0",
+    "@ng-forge/dynamic-forms": "~0.9.0",
     "rxjs": ">=7.0.0"
   }
 }

--- a/packages/dynamic-forms-ionic/README.md
+++ b/packages/dynamic-forms-ionic/README.md
@@ -20,6 +20,7 @@ Ionic field components for [@ng-forge/dynamic-forms](https://www.npmjs.com/packa
 
 | @ng-forge/dynamic-forms-ionic | @ng-forge/dynamic-forms | Angular       |
 | ----------------------------- | ----------------------- | ------------- |
+| 0.9.x                         | 0.9.x                   | >=21.2.0      |
 | 0.8.x                         | 0.8.x                   | >=21.2.0      |
 | 0.7.x                         | 0.7.x                   | >=21.2.0      |
 | 0.6.x                         | 0.6.x                   | >=21.1.0      |

--- a/packages/dynamic-forms-ionic/package.json
+++ b/packages/dynamic-forms-ionic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-ionic",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Ionic integration for @ng-forge/dynamic-forms. Pre-built Ionic form components for mobile and desktop.",
   "type": "module",
   "license": "MIT",
@@ -39,7 +39,7 @@
     "@angular/core": "~21.2.0",
     "@angular/forms": "~21.2.0",
     "@ionic/angular": ">=7.0.0",
-    "@ng-forge/dynamic-forms": "~0.8.0",
+    "@ng-forge/dynamic-forms": "~0.9.0",
     "rxjs": ">=7.0.0"
   },
   "dependencies": {

--- a/packages/dynamic-forms-material/README.md
+++ b/packages/dynamic-forms-material/README.md
@@ -20,6 +20,7 @@ Material Design field components for [@ng-forge/dynamic-forms](https://www.npmjs
 
 | @ng-forge/dynamic-forms-material | @ng-forge/dynamic-forms | Angular       |
 | -------------------------------- | ----------------------- | ------------- |
+| 0.9.x                            | 0.9.x                   | >=21.2.0      |
 | 0.8.x                            | 0.8.x                   | >=21.2.0      |
 | 0.7.x                            | 0.7.x                   | >=21.2.0      |
 | 0.6.x                            | 0.6.x                   | >=21.1.0      |

--- a/packages/dynamic-forms-material/package.json
+++ b/packages/dynamic-forms-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-material",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Angular Material integration for @ng-forge/dynamic-forms. Pre-built Material Design form components.",
   "type": "module",
   "license": "MIT",
@@ -38,7 +38,7 @@
     "@angular/core": "~21.2.0",
     "@angular/forms": "~21.2.0",
     "@angular/material": "~21.2.0",
-    "@ng-forge/dynamic-forms": "~0.8.0",
+    "@ng-forge/dynamic-forms": "~0.9.0",
     "rxjs": ">=7.0.0"
   }
 }

--- a/packages/dynamic-forms-primeng/README.md
+++ b/packages/dynamic-forms-primeng/README.md
@@ -20,6 +20,7 @@ PrimeNG field components for [@ng-forge/dynamic-forms](https://www.npmjs.com/pac
 
 | @ng-forge/dynamic-forms-primeng | @ng-forge/dynamic-forms | Angular       |
 | ------------------------------- | ----------------------- | ------------- |
+| 0.9.x                           | 0.9.x                   | >=21.2.0      |
 | 0.8.x                           | 0.8.x                   | >=21.2.0      |
 | 0.7.x                           | 0.7.x                   | >=21.2.0      |
 | 0.6.x                           | 0.6.x                   | >=21.1.0      |

--- a/packages/dynamic-forms-primeng/package.json
+++ b/packages/dynamic-forms-primeng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-primeng",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "PrimeNG integration for @ng-forge/dynamic-forms. Pre-built PrimeNG form components.",
   "type": "module",
   "license": "MIT",
@@ -37,7 +37,7 @@
     "@angular/common": "~21.2.0",
     "@angular/core": "~21.2.0",
     "@angular/forms": "~21.2.0",
-    "@ng-forge/dynamic-forms": "~0.8.0",
+    "@ng-forge/dynamic-forms": "~0.9.0",
     "primeng": ">=17.0.0",
     "rxjs": ">=7.0.0"
   }

--- a/packages/dynamic-forms/README.md
+++ b/packages/dynamic-forms/README.md
@@ -20,6 +20,7 @@ Core library for building type-safe, dynamic Angular forms with signal forms int
 
 | @ng-forge/dynamic-forms | Angular       |
 | ----------------------- | ------------- |
+| 0.9.x                   | >=21.2.0      |
 | 0.8.x                   | >=21.2.0      |
 | 0.7.x                   | >=21.2.0      |
 | 0.6.x                   | >=21.1.0      |

--- a/packages/dynamic-forms/package.json
+++ b/packages/dynamic-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Type-safe, signal-powered dynamic forms for Angular. Build complex forms from configuration with full TypeScript inference.",
   "type": "module",
   "license": "MIT",

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/openapi-generator",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Generate @ng-forge/dynamic-forms configurations from OpenAPI specs",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump all package versions to 0.9.0
- Update inter-package peerDependencies and MCP devDependencies to `~0.9.0` / `^0.9.0`
- Generate changelog from v0.8.0

## Packages Updated
- @ng-forge/dynamic-forms: 0.8.0 -> 0.9.0
- @ng-forge/dynamic-forms-bootstrap: 0.8.0 -> 0.9.0
- @ng-forge/dynamic-forms-ionic: 0.8.0 -> 0.9.0
- @ng-forge/dynamic-forms-material: 0.8.0 -> 0.9.0
- @ng-forge/dynamic-forms-primeng: 0.8.0 -> 0.9.0
- @ng-forge/dynamic-form-mcp: 0.8.0 -> 0.9.0
- @ng-forge/openapi-generator: 0.8.0 -> 0.9.0

## Changelog Highlights

### Features
- ⚠️ `validateWhenHidden` (#392)
- ⚠️ NgForgeField/NgForgeAction directives + 4-adapter migration (#381)
- Inline function alternatives for conditions/derivations/validators (#400)
- ⚠️ Allow overlapping leaf keys in different groups (#401, #403)
- Typed addon system across all 4 UI adapters (8513e1683)

### Bug Fixes
- openapi-generator: array minLength/maxLength + circular schema refs (#416, #417, #419, #420)
- nullable on checkbox/toggle (#418)
- preserve nested group/array defaults on partial value (#387, #389)
- stop excludeValueIfHidden from leaking defaults (#398)
- refresh field props on same-key config changes (#393)

### Code Refactoring
- ⚠️ Per-adapter style defaults + opt-in signal forms compat classes (#412)
- ⚠️ Hidden fields removed from DOM + array state machine + registry (#410, #413)
- Drop obsolete readonly + indeterminate DOM workarounds (#380)

### Breaking Changes
See `### ⚠️ Breaking Changes` block in `CHANGELOG.md` — five items including the per-adapter style defaults refactor, hidden field DOM removal, overlapping leaf keys, NgForgeField/NgForgeAction migration, and `validateWhenHidden`.

## Next Steps
After merging, trigger the **Release** workflow manually from GitHub Actions to create the tag, GitHub release, and publish to npm.