### PR TITLE
fix(openapi-generator): drop description hint on container field types

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -35,6 +35,8 @@ export default {
         'ionic',
         // MCP server
         'mcp',
+        // OpenAPI generator
+        'openapi-generator',
         // Apps
         'docs',
         'examples',

--- a/packages/openapi-generator/src/mapper/schema-to-fields.spec.ts
+++ b/packages/openapi-generator/src/mapper/schema-to-fields.spec.ts
@@ -1201,6 +1201,81 @@ describe('mapSchemaToFields', () => {
     });
   });
 
+  // Container types declare `props?: never`. Emitting any `props` (including the
+  // `description → hint` mapping) trips TS2322 under `as const satisfies FormConfig`.
+  describe('container types: no props.hint emitted (#425)', () => {
+    it('should not emit props on array fields with description (object items)', () => {
+      const schema: SchemaObject = {
+        type: 'object',
+        properties: {
+          fields: {
+            type: 'array',
+            description: 'Form fields of the form.',
+            items: {
+              type: 'object',
+              properties: { id: { type: 'string' } },
+            },
+          } as unknown as SchemaObject,
+        },
+      };
+
+      const result = mapSchemaToFields(schema, []);
+      expect(result.fields[0].type).toBe('array');
+      expect(result.fields[0].props).toBeUndefined();
+    });
+
+    it('should not emit props on array fields with description (primitive items)', () => {
+      const schema: SchemaObject = {
+        type: 'object',
+        properties: {
+          tags: {
+            type: 'array',
+            description: 'Free-form tags.',
+            items: { type: 'string' },
+          } as unknown as SchemaObject,
+        },
+      };
+
+      const result = mapSchemaToFields(schema, []);
+      expect(result.fields[0].type).toBe('array');
+      expect(result.fields[0].props).toBeUndefined();
+    });
+
+    it('should not emit props on group fields with description', () => {
+      const schema: SchemaObject = {
+        type: 'object',
+        properties: {
+          address: {
+            type: 'object',
+            description: 'Mailing address block.',
+            properties: { street: { type: 'string' } },
+          } as unknown as SchemaObject,
+        },
+      };
+
+      const result = mapSchemaToFields(schema, []);
+      expect(result.fields[0].type).toBe('group');
+      expect(result.fields[0].props).toBeUndefined();
+    });
+
+    it('should not emit props when x-ng-forge-type overrides to a container type with description', () => {
+      const schema: SchemaObject = {
+        type: 'object',
+        properties: {
+          custom: {
+            type: 'string',
+            description: 'Custom container.',
+            'x-ng-forge-type': 'container',
+          } as unknown as SchemaObject,
+        },
+      };
+
+      const result = mapSchemaToFields(schema, []);
+      expect(result.fields[0].type).toBe('container');
+      expect(result.fields[0].props).toBeUndefined();
+    });
+  });
+
   // Issue #419: dereferenced specs with $ref cycles produce literal cyclic JS object
   // graphs at runtime. Verify cycle detection terminates instead of blowing the stack.
   describe('circular schema references (issue #419)', () => {

--- a/packages/openapi-generator/src/mapper/schema-to-fields.spec.ts
+++ b/packages/openapi-generator/src/mapper/schema-to-fields.spec.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { mapSchemaToFields } from './schema-to-fields.js';
 import type { SchemaObject } from '../parser/schema-walker.js';
+import { logger } from '../utils/logger.js';
 
 describe('mapSchemaToFields', () => {
   it('should map a simple flat object schema', () => {
@@ -1204,6 +1205,10 @@ describe('mapSchemaToFields', () => {
   // Container types declare `props?: never`. Emitting any `props` (including the
   // `description → hint` mapping) trips TS2322 under `as const satisfies FormConfig`.
   describe('container types: no props.hint emitted (#425)', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
     it('should not emit props on array fields with description (object items)', () => {
       const schema: SchemaObject = {
         type: 'object',
@@ -1258,21 +1263,56 @@ describe('mapSchemaToFields', () => {
       expect(result.fields[0].props).toBeUndefined();
     });
 
-    it('should not emit props when x-ng-forge-type overrides to a container type with description', () => {
-      const schema: SchemaObject = {
-        type: 'object',
-        properties: {
-          custom: {
-            type: 'string',
-            description: 'Custom container.',
-            'x-ng-forge-type': 'container',
-          } as unknown as SchemaObject,
-        },
-      };
+    // Cover every member of CONTAINER_FIELD_TYPES so adding/removing one without
+    // updating the description-hint guard fails loudly here.
+    it.each(['group', 'array', 'row', 'page', 'container'] as const)(
+      'should not emit props on %s fields when description is set via x-ng-forge-type override',
+      (containerType) => {
+        const schema: SchemaObject = {
+          type: 'object',
+          properties: {
+            custom: {
+              type: 'string',
+              description: `Custom ${containerType}.`,
+              'x-ng-forge-type': containerType,
+            } as unknown as SchemaObject,
+          },
+        };
 
-      const result = mapSchemaToFields(schema, []);
-      expect(result.fields[0].type).toBe('container');
-      expect(result.fields[0].props).toBeUndefined();
+        const result = mapSchemaToFields(schema, []);
+        expect(result.fields[0].type).toBe(containerType);
+        expect(result.fields[0].props).toBeUndefined();
+      },
+    );
+
+    // Pin the recovery message — users rely on it to discover the manual workaround
+    // (sibling 'text' field). Wording changes here should be intentional.
+    it('should log a verbose message naming the field, the container type, and the recovery workaround', () => {
+      const verboseSpy = vi.spyOn(logger, 'verbose').mockImplementation(() => {
+        // suppress console output in tests
+      });
+
+      mapSchemaToFields(
+        {
+          type: 'object',
+          properties: {
+            fields: {
+              type: 'array',
+              description: 'Form fields of the form.',
+              items: { type: 'string' },
+            } as unknown as SchemaObject,
+          },
+        },
+        [],
+      );
+
+      const matching = verboseSpy.mock.calls.find(([msg]) => typeof msg === 'string' && msg.includes('dropped description hint'));
+      expect(matching, 'expected a verbose log mentioning the dropped description hint').toBeDefined();
+      const message = matching![0] as string;
+      expect(message).toContain("Field 'fields'");
+      expect(message).toContain("'array'");
+      expect(message).toContain('container fields do not accept props');
+      expect(message).toContain("sibling 'text' field");
     });
   });
 

--- a/packages/openapi-generator/src/mapper/schema-to-fields.ts
+++ b/packages/openapi-generator/src/mapper/schema-to-fields.ts
@@ -304,8 +304,17 @@ function mapPropertyToField(
     field.value = prop.schema.default;
   }
 
-  // Add props if present (only when not using x-ng-forge-type and type wasn't overridden by a decision)
-  if (!ngForgeType && finalType === typeResult.fieldType && typeResult.props && Object.keys(typeResult.props).length > 0) {
+  // Add props if present (only when not using x-ng-forge-type and type wasn't overridden by a decision).
+  // Container types are guarded explicitly: today `mapSchemaToFieldType` never returns props for
+  // container branches, but the extra check keeps the invariant local so a future addition of a
+  // container-applicable prop in type-mapping.ts can't silently emit `props` on a container field.
+  if (
+    !ngForgeType &&
+    finalType === typeResult.fieldType &&
+    typeResult.props &&
+    Object.keys(typeResult.props).length > 0 &&
+    !CONTAINER_FIELD_TYPES.has(finalType)
+  ) {
     field.props = typeResult.props;
   }
 

--- a/packages/openapi-generator/src/mapper/schema-to-fields.ts
+++ b/packages/openapi-generator/src/mapper/schema-to-fields.ts
@@ -309,9 +309,18 @@ function mapPropertyToField(
     field.props = typeResult.props;
   }
 
-  // description → hint (descriptions can be paragraphs, not suitable as placeholders)
+  // description → hint (descriptions can be paragraphs, not suitable as placeholders).
+  // Container field types declare `props?: never` — under `as const satisfies FormConfig`,
+  // emitting any `props` on these types triggers TS2322 (issue #425). Drop with a verbose
+  // log telling users how to recover the intent manually.
   if (prop.schema.description) {
-    field.props = { ...field.props, hint: prop.schema.description };
+    if (CONTAINER_FIELD_TYPES.has(finalType)) {
+      logger.verbose(
+        `Field '${fieldPath}': '${finalType}' container fields do not accept props — dropped description hint. Add a sibling 'text' field manually if you want to render this description.`,
+      );
+    } else {
+      field.props = { ...field.props, hint: prop.schema.description };
+    }
   }
 
   // Add enum options for select/radio/multi-checkbox.

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "git fetch --unshallow --quiet 2>/dev/null || true && NX_DAEMON=false pnpm run deploy:prep",
+  "buildCommand": "git fetch --unshallow --quiet 2>/dev/null || true && NX_DAEMON=false NODE_OPTIONS=--max-old-space-size=8192 pnpm run deploy:prep",
   "outputDirectory": "dist/deploy",
   "cleanUrls": true,
   "trailingSlash": false,


### PR DESCRIPTION
## Summary

Fixes #425.

- `mapPropertyToField` was setting `props: { hint: <description> }` on every field, including container types (`array`, `group`, `row`, `page`, `container`) whose interfaces declare `props?: never`.
- Result: any OpenAPI schema with a `description` on an array/group property produced TS2322 errors when consumers applied `as const satisfies FormConfig` to the generated code.

The fix gates the `description → props.hint` mapping behind `CONTAINER_FIELD_TYPES`. On container types we drop the hint and emit a `logger.verbose` line naming the field, the container type, and the manual recovery (add a sibling `text` field). This mirrors the existing drop-with-verbose-log pattern used for `validators` (#416) and `nullable` (#415) on container types.

A synthetic `text` sibling field was considered (per the issue's suggestion) but deferred — auto-generating keys risks collisions, depends on `text` being registered in the consumer's adapter, and would diverge from the rest of the generator's drop-with-log behaviour. Users can apply the workaround manually if they want it.

Includes a defensive symmetry guard on the value-bearing `props` assignment above the new gate: today `mapSchemaToFieldType` never returns props for container branches, but the explicit `!CONTAINER_FIELD_TYPES.has(finalType)` check keeps the invariant local so a future container-applicable prop in `type-mapping.ts` can't silently leak.

## Out-of-scope but bundled

- `commitlint.config.js`: adds `openapi-generator` to `scope-enum` so package-scoped commits and PR titles are valid. Past PRs for this package used the empty scope by necessity.
- `vercel.json`: bumps Node old-space to 8GB via `NODE_OPTIONS=--max-old-space-size=8192`. Required because `deploy:prep` OOMs at the default ~4GB heap during the Analog prerender (V8 GC stack trace). Local repro confirms; previous preview deploys on unrelated branches also intermittently errored on the same step. Inline next to the existing `NX_DAEMON=false` so no `build.env` block is introduced.

## Test plan

- [x] `nx test openapi-generator` — 375 tests pass. New cases under `container types: no props.hint emitted (#425)`:
  - array (object items), array (primitive items), and group with `description`.
  - Parameterised `it.each` across all five `CONTAINER_FIELD_TYPES` members via `x-ng-forge-type` override — adding or removing a container type without updating the guard will fail loudly.
  - Recovery-message spy that pins the field name, container type, and the literal `sibling 'text' field` phrase so the documented workaround can't drift silently.
- [x] `nx build openapi-generator` — clean.
- [x] `nx lint openapi-generator` — no new errors (25 pre-existing warnings unchanged).
- [x] `nx build docs --configuration=production` with `NODE_OPTIONS=--max-old-space-size=8192` — clean.
- [x] Existing `description → props.hint` tests for value-bearing fields still pass.