### PR TITLE
build(docs): export NODE_OPTIONS via wrapper script for Vercel build

### DIFF
--- a/scripts/vercel-build.sh
+++ b/scripts/vercel-build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Vercel build entrypoint.
+# Exports NODE_OPTIONS so child processes (vite SSR worker, etc.) inherit it
+# reliably — inline `KEY=val cmd` in vercel.json's buildCommand did not
+# propagate to the SSR transform step and caused OOM during docs prerender.
+
+set -e
+
+export NODE_OPTIONS=--max-old-space-size=8192
+export NX_DAEMON=false
+
+git fetch --unshallow --quiet 2>/dev/null || true
+
+exec pnpm run deploy:prep

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "git fetch --unshallow --quiet 2>/dev/null || true && NX_DAEMON=false NODE_OPTIONS=--max-old-space-size=8192 pnpm run deploy:prep",
+  "buildCommand": "bash scripts/vercel-build.sh",
   "outputDirectory": "dist/deploy",
   "cleanUrls": true,
   "trailingSlash": false,


### PR DESCRIPTION
## Summary

- Move `NODE_OPTIONS=--max-old-space-size=8192` (and `NX_DAEMON=false`) out of `vercel.json`'s inline `buildCommand` prefix and into a small `scripts/vercel-build.sh` wrapper that `export`s them.
- `vercel.json`'s `buildCommand` becomes `bash scripts/vercel-build.sh`.

## Why

PR #430 (a dependabot bump that nudged docs SSR memory up slightly) reproduced an OOM on Vercel at ~4130 MB during `vite building ssr environment for production... transforming...`. The setting `--max-old-space-size=8192` was already present inline in `buildCommand` (#892de21e1), but on Vercel that inline `KEY=val cmd` form did not propagate to the Vite SSR worker subprocess — only the immediate child saw the var, and the OOM matches the 4 GB default Node heap.

Locally reproduced both the failure (default heap) and the fix (`NODE_OPTIONS=--max-old-space-size=8192 pnpm nx run docs:build` succeeds on both `main` and PR #430). The wrapper script forces `export`, so every fork inherits the setting regardless of how Vercel invokes the shell.

Avoids the deprecated `build.env` / `env` fields in `vercel.json`.

## Test plan

- [ ] Vercel preview deploy on this PR succeeds (docs SSR build completes, no OOM).
- [ ] After merging, re-run the dependabot PR #430 build and confirm it now passes too.