### PR TITLE
chore(config): CLAUDE.md defaults, push-to-main hook, MCP trim, /verify-e2e

### DIFF
--- a/.claude/hooks/block-push-to-main.sh
+++ b/.claude/hooks/block-push-to-main.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Block direct `git push` to main. Encoded as a hook rather than only a CLAUDE.md
+# rule because the cost of an unwanted push to main is high.
+#
+# To override (e.g. for hotfixes the user has approved), invoke git directly
+# yourself rather than via Claude, or temporarily disable this hook.
+set -uo pipefail
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || true)
+
+case "$cmd" in
+  *"git push"*)
+    branch=$(git branch --show-current 2>/dev/null || echo "")
+    if [ "$branch" = "main" ] \
+       || printf '%s' "$cmd" | grep -qE '(^|[[:space:]])(\+|[^[:space:]]+:)?main([[:space:]]|$)'; then
+      echo "BLOCKED: direct push to main. Create a feature branch (or worktree) first." >&2
+      exit 2
+    fi
+    ;;
+esac
+exit 0

--- a/.claude/hooks/block-push-to-main.sh
+++ b/.claude/hooks/block-push-to-main.sh
@@ -9,14 +9,27 @@ set -uo pipefail
 input=$(cat)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || true)
 
-case "$cmd" in
-  *"git push"*)
-    branch=$(git branch --show-current 2>/dev/null || echo "")
-    if [ "$branch" = "main" ] \
-       || printf '%s' "$cmd" | grep -qE '(^|[[:space:]])(\+|[^[:space:]]+:)?main([[:space:]]|$)'; then
-      echo "BLOCKED: direct push to main. Create a feature branch (or worktree) first." >&2
-      exit 2
-    fi
-    ;;
-esac
+# Only fire when the command actually invokes `git push` at a command position
+# (start of line or after a shell separator). This avoids false positives when
+# "git push" or "main" appear inside argument strings (heredocs, PR bodies, etc).
+if ! printf '%s' "$cmd" | grep -qE '(^|[;&|][[:space:]]*)git[[:space:]]+push\b'; then
+  exit 0
+fi
+
+# Case 1: explicit `main` destination in the push command (e.g. `git push origin main`,
+# `git push origin HEAD:main`, `git push --force origin +main`).
+if printf '%s' "$cmd" | grep -qE 'git[[:space:]]+push[^;&|]*\b(\+|[^[:space:]]+:)?main([[:space:]]|$|[;&|])'; then
+  echo "BLOCKED: direct push to main. Create a feature branch (or worktree) first." >&2
+  exit 2
+fi
+
+# Case 2: bare `git push` (only flags, no refspec) while on main branch.
+if printf '%s' "$cmd" | grep -qE '(^|[;&|][[:space:]]*)git[[:space:]]+push([[:space:]]+-[^[:space:]]+)*([[:space:]]*$|[[:space:]]*[;&|])'; then
+  branch=$(git branch --show-current 2>/dev/null || echo "")
+  if [ "$branch" = "main" ]; then
+    echo "BLOCKED: bare 'git push' from main branch. Create a feature branch (or worktree) first." >&2
+    exit 2
+  fi
+fi
+
 exit 0

--- a/.claude/hooks/block-push-to-main.sh
+++ b/.claude/hooks/block-push-to-main.sh
@@ -6,19 +6,31 @@
 # yourself rather than via Claude, or temporarily disable this hook.
 set -uo pipefail
 
+# Fail-closed if jq is missing. Without it the tool_input is unparseable and a
+# silent pass would give a false sense of safety.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "BLOCKED: push-to-main hook requires jq. Install jq or remove this hook from .claude/settings.json." >&2
+  exit 2
+fi
+
 input=$(cat)
-cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || true)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
 
 # Only fire when the command actually invokes `git push` at a command position
-# (start of line or after a shell separator). This avoids false positives when
-# "git push" or "main" appear inside argument strings (heredocs, PR bodies, etc).
+# (start of line or after a shell separator). Prevents false positives when
+# "git push" appears inside argument strings (heredocs, PR bodies, etc).
 if ! printf '%s' "$cmd" | grep -qE '(^|[;&|][[:space:]]*)git[[:space:]]+push\b'; then
   exit 0
 fi
 
-# Case 1: explicit `main` destination in the push command (e.g. `git push origin main`,
-# `git push origin HEAD:main`, `git push --force origin +main`).
-if printf '%s' "$cmd" | grep -qE 'git[[:space:]]+push[^;&|]*\b(\+|[^[:space:]]+:)?main([[:space:]]|$|[;&|])'; then
+# Strip trailing inline shell comments. Best-effort: does not parse quote context,
+# so `git push origin "topic#1"` would be truncated. Rare enough to accept.
+cmd=$(printf '%s' "$cmd" | sed -E 's/[[:space:]]+#.*$//')
+
+# Case 1: explicit `main` as a refspec destination. The prefix must be
+# whitespace, `:`, or `+` so we do not match slashed/hyphenated/dotted branch
+# names (`release/main`, `feature-main`, `topic.main`, `user/main`).
+if printf '%s' "$cmd" | grep -qE 'git[[:space:]]+push[^;&|]*([[:space:]]|:)\+?main([[:space:]]|$|[;&|])'; then
   echo "BLOCKED: direct push to main. Create a feature branch (or worktree) first." >&2
   exit 2
 fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,6 +32,15 @@
             "command": "[ -f graphify-out/graph.json ] && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files.\"}}' || true"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/block-push-to-main.sh"
+          }
+        ]
       }
     ]
   }

--- a/.claude/skills/verify-e2e.md
+++ b/.claude/skills/verify-e2e.md
@@ -1,0 +1,68 @@
+---
+name: verify-e2e
+description: Run Playwright E2E suites via Nx CLI for scripted, repeatable verification instead of driving a browser interactively through an MCP
+---
+
+# Run E2E Tests
+
+For behavior-level verification of form fields, container components, validation flows, or any change touching the sandbox examples, run the existing Playwright suites via Nx rather than driving a browser via MCP. CLI output is targeted (pass/fail + failure traces) and avoids the token bleed of interactive MCP browser sessions.
+
+## When to use
+
+- After changes to field components, form state, container components, or validation logic
+- Regression checks before opening a PR
+- When the same scenario will be re-verified multiple times
+- When you only need to know "does it still work?" not "does it look right?"
+
+## When NOT to use
+
+- Ad-hoc visual checks of styling, theming, mobile layout — use `/verify` with `chrome-devtools` MCP
+- Live debugging of hydration, SSR mismatches, or runtime issues — use `/verify`
+- Generating new screenshots for unmounted scenarios — write the spec first, then `pnpm e2e:<adapter>:update`
+
+## Required User Input
+
+- **Adapter(s)**: `material`, `bootstrap`, `primeng`, `ionic`, or `core` (default: the one most relevant to the change)
+- **Scope** (optional): a specific suite (`array-fields`, `validation`, etc.) or scenario name to grep
+
+## Workflow
+
+### 1. Pick the runner
+
+- **Local, fast iteration** (screenshots may differ from CI — fine for behavior checks):
+  ```bash
+  nx run sandbox-examples:e2e-<adapter>
+  ```
+- **CI-equivalent screenshots** (Docker):
+  ```bash
+  pnpm e2e:<adapter>
+  ```
+- **Single scenario only** (faster feedback):
+  ```bash
+  nx run sandbox-examples:e2e-<adapter> -- --grep "<scenario name or suite>"
+  ```
+
+### 2. Run + capture output
+
+Run the command and capture the **actual** output. Do not claim "tests pass" without the run output in this session. If a test fails, paste the failing test name, error excerpt, and any new screenshot diff path.
+
+### 3. Snapshot updates only in Docker
+
+If screenshots need regenerating:
+
+```bash
+pnpm e2e:<adapter>:update     # Docker, matches CI
+```
+
+Never run `--update-snapshots` locally outside Docker — produces platform-specific screenshots that fail in CI.
+
+### 4. Firefox flakiness
+
+Firefox has pre-existing flakiness across `array-fields`, `row-fields`, `group-fields`, `multi-page`, and `expression-logic`. Don't spend time debugging Firefox-only failures unless explicitly asked.
+
+## Checklist
+
+- [ ] Picked the correct adapter for the change
+- [ ] Used local runner unless updating snapshots
+- [ ] Captured real test output before claiming verified
+- [ ] Reported failing scenarios with error excerpts, not just counts

--- a/.claude/skills/verify.md
+++ b/.claude/skills/verify.md
@@ -48,13 +48,16 @@ Wait for the server to be ready before proceeding.
 
 ### 3. Visual inspection
 
-Use Playwright MCP tools to verify:
+Use the `chrome-devtools` MCP to verify (preferred over Playwright MCP because it does not auto-dump a full a11y tree on every step, keeping token use lower):
 
-1. **Navigate** to each affected page
-2. **Take a snapshot** and inspect the DOM state
-3. **Check both light and dark mode** if styling was changed (toggle via the theme switcher or by evaluating `document.documentElement.classList.toggle('dark')`)
-4. **Check mobile viewport** if layout/responsive changes were made (resize to 375px width)
-5. **Look for regressions** on related pages (e.g., if sidebar was changed, check multiple doc pages)
+1. **Navigate** to each affected page via `navigate_page`
+2. **Take a screenshot** with `take_screenshot`
+3. **Check both light and dark mode** if styling was changed — toggle via the theme switcher or by running `document.documentElement.classList.toggle('dark')` through `evaluate`
+4. **Check mobile viewport** if layout/responsive changes were made — resize to 375px width
+5. **Inspect console** with `list_console_messages` for hydration warnings or runtime errors
+6. **Look for regressions** on related pages (e.g., if sidebar was changed, check multiple doc pages)
+
+For scripted, repeatable verification of behavior (not just visuals), use `/verify-e2e` instead.
 
 ### 4. Report findings
 

--- a/.claude/skills/verify.md
+++ b/.claude/skills/verify.md
@@ -52,7 +52,7 @@ Use the `chrome-devtools` MCP to verify (preferred over Playwright MCP because i
 
 1. **Navigate** to each affected page via `navigate_page`
 2. **Take a screenshot** with `take_screenshot`
-3. **Check both light and dark mode** if styling was changed — toggle via the theme switcher or by running `document.documentElement.classList.toggle('dark')` through `evaluate`
+3. **Check both light and dark mode** if styling was changed — toggle via the theme switcher or by running `document.documentElement.classList.toggle('dark')` through `evaluate_script`
 4. **Check mobile viewport** if layout/responsive changes were made — resize to 375px width
 5. **Inspect console** with `list_console_messages` for hydration warnings or runtime errors
 6. **Look for regressions** on related pages (e.g., if sidebar was changed, check multiple doc pages)

--- a/.mcp.json
+++ b/.mcp.json
@@ -5,14 +5,6 @@
       "command": "npx",
       "args": ["nx", "mcp"]
     },
-    "angular-cli": {
-      "command": "npx",
-      "args": ["-y", "@angular/cli", "mcp"]
-    },
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
-    },
     "chrome-devtools": {
       "command": "npx",
       "args": ["chrome-devtools-mcp@latest"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,13 @@
 
 # ng-forge Development Guidelines
 
+## Defaults (non-negotiable)
+
+- **Simplest solution that works.** No speculative abstractions, no "while I'm here" cleanup, no designing for hypothetical futures. If asked to simplify, actually simplify. Don't rewrite with similar complexity
+- **No verification claims without evidence.** Never say "verified", "tested", "ready to merge", or "CI green" unless you ran the command this session. Paste the actual output, or say "not verified"
+- **No direct push to `main`.** Always a feature branch or worktree. Show the commit message for review before pushing
+- **No AI-style prose in PRs, replies, or docs.** No em-dashes, no arrows (→), no "It's not X, it's Y" constructions. Don't post unsolicited PR comments. Don't cross-reference external repos' issues in PR descriptions (creates permanent backlinks)
+
 ## Working Style
 
 - **Spawn subagents if you believe the task is better to be divided**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 - **Simplest solution that works.** No speculative abstractions, no "while I'm here" cleanup, no designing for hypothetical futures. If asked to simplify, actually simplify. Don't rewrite with similar complexity
 - **No verification claims without evidence.** Never say "verified", "tested", "ready to merge", or "CI green" unless you ran the command this session. Paste the actual output, or say "not verified"
 - **No direct push to `main`.** Always a feature branch or worktree. Show the commit message for review before pushing
-- **No AI-style prose in PRs, replies, or docs.** No em-dashes, no arrows (→), no "It's not X, it's Y" constructions. Don't post unsolicited PR comments. Don't cross-reference external repos' issues in PR descriptions (creates permanent backlinks)
+- **No AI-style prose in user-facing output** (PR descriptions and comments, code review replies, commit messages, docs site content, announcements). No em-dashes, no arrows, no "It's not X, it's Y" constructions. Don't post unsolicited PR comments. Don't cross-reference external repos' issues in PR descriptions (creates permanent backlinks). This rule does not apply to internal config files like CLAUDE.md or skills, which predate it
 
 ## Working Style
 


### PR DESCRIPTION
## Summary

Encodes recurring corrections into project guardrails and trims the MCP surface to reduce token overhead in browser/docs lookup workflows.

## Changes

**CLAUDE.md** — adds a "Defaults (non-negotiable)" section at the top with four rules:

- **Simplest solution that works** — no speculative abstractions or "while I'm here" cleanup; if asked to simplify, actually simplify
- **No verification claims without evidence** — never say "verified/tested/ready" without pasting the command output, or say "not verified"
- **No direct push to `main`** — always a feature branch or worktree
- **No AI-style prose in user-facing output** (PR descriptions/comments, code review replies, commit messages, docs site, announcements). Excludes internal config files like CLAUDE.md and skills, which predate the rule

**Hook** — adds `.claude/hooks/block-push-to-main.sh` and registers it as a PreToolUse Bash hook in `.claude/settings.json`. Fires only on actual `git push` invocations (start of command or after a shell separator) and blocks when `main` is the destination, or when on the `main` branch with a bare push. Fails closed if `jq` is missing.

**MCP surface** — `.mcp.json` drops two servers:

- `playwright` — heavy snapshot/screenshot output per call. Replaced by `chrome-devtools` MCP for ad-hoc visual checks and Nx CLI for scripted E2E runs
- `angular-cli` — overlaps with Angular skills and `nx-mcp` for project metadata

Remaining: `nx-mcp`, `chrome-devtools`, `context7`, `ng-forge`.

**Skills**

- `/verify` — updated to use `chrome-devtools` MCP (`evaluate_script`, `take_screenshot`, etc.) instead of Playwright MCP
- `/verify-e2e` (new) — runs E2E suites via `nx run sandbox-examples:e2e-<adapter>` or `pnpm e2e:<adapter>` for behavior-level verification without driving a browser interactively

## Test plan

Hook tested locally against 15 cases:

**Blocks (6):**

- [x] `git push origin main`
- [x] `git push origin :main` (delete remote main)
- [x] `git push origin HEAD:main`
- [x] `git push origin +main` (force-push refspec)
- [x] `git push --force origin main`
- [x] `git push origin main foo` (main as one of multiple refs)

**Allows (9):**

- [x] `git push origin release/main` (slashed branch)
- [x] `git push origin user/main` (slashed branch)
- [x] `git push origin feature-main` (hyphenated)
- [x] `git push origin topic.main` (dotted)
- [x] `git push origin foo # comment about main` (trailing comment)
- [x] `git push origin main:feature` (main as source, not destination)
- [x] `git push origin docs/claude-md-defaults` (feature branch)
- [x] `gh pr edit ... --body "no direct push to main"` (string in argument)
- [x] `git status` (unrelated command)

Other:

- [x] commitlint passes on all commits
- [x] `.mcp.json` parses as valid JSON after edits
- [x] No content changes to existing CLAUDE.md sections beyond the new top block
