### PR TITLE
refactor(dynamic-forms): extract shared debounced-rxResource LogicFn scaffolding

### DIFF
--- a/packages/dynamic-forms/src/lib/core/expressions/async-condition-logic-function.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/async-condition-logic-function.ts
@@ -1,7 +1,6 @@
-import { inject, Injector, Resource, signal, untracked, WritableSignal } from '@angular/core';
-import { rxResource } from '@angular/core/rxjs-interop';
+import { inject, Injector } from '@angular/core';
 import { FieldContext, LogicFn } from '@angular/forms/signals';
-import { catchError, debounceTime, distinctUntilChanged, from, map, of, pipe } from 'rxjs';
+import { catchError, from, map, of } from 'rxjs';
 import { AsyncCondition } from '../../models/expressions/conditional-expression';
 import { stableStringify } from '../../utils/stable-stringify';
 import { FieldContextRegistryService } from '../registry/field-context-registry.service';
@@ -9,18 +8,16 @@ import { FunctionRegistryService } from '../registry/function-registry.service';
 import { DynamicFormLogger } from '../../providers/features/logger/logger.token';
 import { Logger } from '../../providers/features/logger/logger.interface';
 import { AsyncConditionFunctionCacheService } from './async-condition-function-cache.service';
-import { safeReadPathKeys } from '../../utils/safe-read-path-keys';
-import { withPreviousValue } from '../../utils/resource-composition/with-previous-value';
-import { derivedFromDeferred } from '../../utils/derived-from-deferred/derived-from-deferred';
+import { createDebouncedResourceLogicFn } from './debounced-resource-logic-fn';
 
 /**
  * Creates a logic function for an async condition.
  *
- * Uses Angular's `rxResource()` API with snapshot composition for async resolution:
- * the LogicFn updates a `trigger` signal (serialized evaluation context), a debounced
- * version feeds into an `rxResource()` that manages the async function lifecycle, and
- * `withPreviousValue()` preserves the last resolved boolean during re-evaluation
- * to prevent UI flicker.
+ * Delegates lifecycle (per-field signal store, debouncing, rxResource +
+ * withPreviousValue) to {@link createDebouncedResourceLogicFn}; this function
+ * just supplies the async-condition-specific bits: the trigger payload is
+ * the FieldContext snapshot the loader needs to build its evaluation
+ * context, and the stream invokes the registered or inline async function.
  *
  * Must be called in injection context (same as `createLogicFunction`).
  */
@@ -52,116 +49,48 @@ export function createAsyncConditionLogicFunction<TValue>(condition: AsyncCondit
     }
   }
 
-  // Each condition needs its own per-field signal store.
-  const perFunctionSignalStore = new Map<
-    string,
-    {
-      trigger: WritableSignal<string | undefined>;
-      resultResource: Resource<boolean>;
-      // Captures the FieldContext at the moment each trigger snapshot is produced.
-      // The loader reads from this map using the trigger key, ensuring it always
-      // uses the context that was active when the trigger was set — not a stale ref
-      // that could be overwritten by a later LogicFn call before the loader executes.
-      ctxByTrigger: Map<string, FieldContext<TValue>>;
-    }
-  >();
-
-  const fn: LogicFn<TValue, boolean> = (ctx: FieldContext<TValue>) => {
-    const contextKey = safeReadPathKeys(ctx as FieldContext<unknown>).join('.');
-    let signalPair = perFunctionSignalStore.get(contextKey);
-
-    if (!signalPair) {
-      const trigger = signal<string | undefined>(undefined);
-      const ctxByTrigger = new Map<string, FieldContext<TValue>>();
-
-      // Wrap in untracked() to avoid NG0602: resource() internally creates effects,
-      // which cannot be created inside a reactive context (computed). The LogicFn runs
-      // inside Angular Signal Forms' BooleanOrLogic.compute (a computed), so we must
-      // clear the active reactive consumer before creating the resource pipeline.
-      const resultResource = untracked(() => {
-        // Debounce the trigger to batch rapid form value changes.
-        const debouncedTrigger = derivedFromDeferred(trigger, pipe(debounceTime(debounceMs), distinctUntilChanged()), {
-          initialValue: undefined as string | undefined,
-          injector,
-        });
-
-        // rxResource() manages the async function lifecycle natively with Observables:
-        // auto-cancellation via unsubscription and signal-based reactivity.
-        const asyncResource = rxResource({
-          params: () => debouncedTrigger() ?? undefined,
-          stream: ({ params: triggerKey }) => {
-            // Inline `asyncFn` wins; otherwise look up the registered function at call time
-            // (fresh reference, in case the registry was updated after LogicFn creation).
-            const asyncFn =
-              condition.asyncFn ??
-              (condition.asyncFunctionName ? functionRegistry.getAsyncConditionFunction(condition.asyncFunctionName) : undefined);
-            if (!asyncFn) {
-              logger.warn(
-                `Async Condition - function '${condition.asyncFunctionName}' not found. ` +
-                  `Register it in customFnConfig.asyncConditions.`,
-              );
-              return of(pendingValue);
-            }
-
-            // Retrieve the FieldContext that was captured when this trigger key was set.
-            // This avoids a race condition where a mutable ref could be overwritten by
-            // a later LogicFn call before the loader finishes executing.
-            const capturedCtx = ctxByTrigger.get(triggerKey);
-            if (!capturedCtx) return of(pendingValue);
-
-            const evaluationContext = untracked(() =>
-              fieldContextRegistry.createReactiveEvaluationContext(capturedCtx, functionRegistry.getCustomFunctions()),
-            );
-
-            // asyncFn may return Promise<boolean> or Observable<boolean>.
-            // from() normalizes both to Observable.
-            return from(asyncFn(evaluationContext)).pipe(
-              map((result) => !!result),
-              catchError((error) => {
-                logger.warn('Async Condition - function failed:', error);
-                return of(pendingValue);
-              }),
-            );
-          },
-          defaultValue: pendingValue,
-          injector,
-        });
-
-        // Snapshot composition: preserve the previous boolean result during re-evaluation.
-        // Without this, the condition would briefly flash to pendingValue when the async
-        // function is re-invoked, causing visible UI flicker.
-        return withPreviousValue(asyncResource);
+  const fn = createDebouncedResourceLogicFn<TValue, FieldContext<TValue>, boolean>({
+    pendingValue,
+    debounceMs,
+    injector,
+    resolve: (ctx) => {
+      // Build reactive evaluation context here so the LogicFn establishes
+      // signal dependencies on form values — the resource's reactive graph
+      // alone wouldn't notice changes that didn't flow through the trigger.
+      const evaluationContext = fieldContextRegistry.createReactiveEvaluationContext(ctx, functionRegistry.getCustomFunctions());
+      const key = stableStringify({
+        formValue: evaluationContext.formValue,
+        fieldValue: evaluationContext.fieldValue,
+        externalData: evaluationContext.externalData,
       });
-
-      signalPair = { trigger, resultResource, ctxByTrigger };
-      perFunctionSignalStore.set(contextKey, signalPair);
-    }
-
-    // Build reactive evaluation context (creates signal dependencies on form values)
-    const evaluationContext = fieldContextRegistry.createReactiveEvaluationContext(ctx, functionRegistry.getCustomFunctions());
-
-    // Serialize evaluation context to detect changes
-    const contextSnapshot = stableStringify({
-      formValue: evaluationContext.formValue,
-      fieldValue: evaluationContext.fieldValue,
-      externalData: evaluationContext.externalData,
-    });
-
-    // Capture the FieldContext for this trigger key so the loader can retrieve it.
-    // Only keep the latest — previous entries are stale once the trigger changes.
-    const { trigger: triggerSignal, resultResource, ctxByTrigger } = signalPair;
-    ctxByTrigger.clear();
-    ctxByTrigger.set(contextSnapshot, ctx);
-
-    untracked(() => {
-      const current = triggerSignal();
-      if (current !== contextSnapshot) {
-        triggerSignal.set(contextSnapshot);
+      return { kind: 'trigger', key, payload: ctx };
+    },
+    buildStream: (capturedCtx) => {
+      // Inline `asyncFn` wins; otherwise look up the registered function at call time
+      // (fresh reference, in case the registry was updated after LogicFn creation).
+      const asyncFn =
+        condition.asyncFn ??
+        (condition.asyncFunctionName ? functionRegistry.getAsyncConditionFunction(condition.asyncFunctionName) : undefined);
+      if (!asyncFn) {
+        logger.warn(
+          `Async Condition - function '${condition.asyncFunctionName}' not found. ` + `Register it in customFnConfig.asyncConditions.`,
+        );
+        return of(pendingValue);
       }
-    });
 
-    return resultResource.value();
-  };
+      const evaluationContext = fieldContextRegistry.createReactiveEvaluationContext(capturedCtx, functionRegistry.getCustomFunctions());
+
+      // asyncFn may return Promise<boolean> or Observable<boolean>.
+      // from() normalizes both to Observable.
+      return from(asyncFn(evaluationContext)).pipe(
+        map((result) => !!result),
+        catchError((error) => {
+          logger.warn('Async Condition - function failed:', error);
+          return of(pendingValue);
+        }),
+      );
+    },
+  });
 
   if (cacheKey !== undefined) {
     cacheService.asyncConditionFunctionCache.set(cacheKey, fn as LogicFn<unknown, boolean>);

--- a/packages/dynamic-forms/src/lib/core/expressions/debounced-resource-logic-fn.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/debounced-resource-logic-fn.ts
@@ -43,10 +43,17 @@ export interface DebouncedResourceLogicFnConfig<TValue, TPayload, TResult> {
    *   - `{ kind: 'trigger', key, payload }` — set the trigger to this and
    *     return the (potentially still-loading) resource value.
    *   - `{ kind: 'returnEarly', value }` — bypass the resource and return
-   *     this value directly (used by HTTP for response-cache hits and for
-   *     unresolvable request templates).
+   *     this value directly (used by HTTP for response-cache hits — the
+   *     cached value is authoritative and overrides any sticky resource value).
+   *   - `{ kind: 'holdPrevious' }` — bypass the resource update but return
+   *     the resource's current sticky value (its last resolved value via
+   *     `withPreviousValue`, or `pendingValue` if it never resolved). Used
+   *     by HTTP when the request template is temporarily unresolvable so
+   *     the UI doesn't flicker back to `pendingValue`.
    */
-  resolve: (ctx: FieldContext<TValue>) => { kind: 'trigger'; key: string; payload: TPayload } | { kind: 'returnEarly'; value: TResult };
+  resolve: (
+    ctx: FieldContext<TValue>,
+  ) => { kind: 'trigger'; key: string; payload: TPayload } | { kind: 'returnEarly'; value: TResult } | { kind: 'holdPrevious' };
 }
 
 /**
@@ -132,10 +139,14 @@ export function createDebouncedResourceLogicFn<TValue, TPayload, TResult>(
     if (resolved.kind === 'returnEarly') {
       return resolved.value;
     }
+    if (resolved.kind === 'holdPrevious') {
+      return handle.resultResource.value();
+    }
 
     const newTrigger: Trigger<TPayload> = { key: resolved.key, payload: resolved.payload };
     untracked(() => {
       const current = handle!.trigger();
+      // Key-only dedup assumes same key implies equivalent payload — true for both current callers.
       if (current?.key !== newTrigger.key) {
         handle!.trigger.set(newTrigger);
       }

--- a/packages/dynamic-forms/src/lib/core/expressions/debounced-resource-logic-fn.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/debounced-resource-logic-fn.ts
@@ -66,6 +66,13 @@ export interface DebouncedResourceLogicFnConfig<TValue, TPayload, TResult> {
 interface ResourceHandle<TPayload, TResult> {
   trigger: WritableSignal<Trigger<TPayload> | undefined>;
   resultResource: Resource<TResult>;
+  /**
+   * Bumped on every `returnEarly` so the next `trigger.set` carries a fresh dedup key.
+   * Without this, a cache hit → cache expiry → same-key recall would be dropped by
+   * both the helper's same-key check and the downstream `distinctUntilChanged`, and
+   * the resource would never re-fetch.
+   */
+  refetchVersion: number;
 }
 
 /**
@@ -131,19 +138,21 @@ export function createDebouncedResourceLogicFn<TValue, TPayload, TResult>(
         return withPreviousValue(resource);
       });
 
-      handle = { trigger, resultResource };
+      handle = { trigger, resultResource, refetchVersion: 0 };
       perFunctionSignalStore.set(contextKey, handle);
     }
 
     const resolved = config.resolve(ctx);
     if (resolved.kind === 'returnEarly') {
+      handle.refetchVersion++;
       return resolved.value;
     }
     if (resolved.kind === 'holdPrevious') {
       return handle.resultResource.value();
     }
 
-    const newTrigger: Trigger<TPayload> = { key: resolved.key, payload: resolved.payload };
+    const dedupKey = `${resolved.key}::${handle.refetchVersion}`;
+    const newTrigger: Trigger<TPayload> = { key: dedupKey, payload: resolved.payload };
     untracked(() => {
       const current = handle!.trigger();
       // Key-only dedup assumes same key implies equivalent payload — true for both current callers.

--- a/packages/dynamic-forms/src/lib/core/expressions/debounced-resource-logic-fn.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/debounced-resource-logic-fn.ts
@@ -1,0 +1,146 @@
+import { Injector, Resource, signal, untracked, WritableSignal } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
+import { FieldContext, LogicFn } from '@angular/forms/signals';
+import { debounceTime, distinctUntilChanged, Observable, pipe } from 'rxjs';
+import { derivedFromDeferred } from '../../utils/derived-from-deferred/derived-from-deferred';
+import { withPreviousValue } from '../../utils/resource-composition/with-previous-value';
+import { safeReadPathKeys } from '../../utils/safe-read-path-keys';
+
+/**
+ * Trigger value carried through the debounced reactive pipeline.
+ *
+ * `key` is the stable identity used for `distinctUntilChanged` — the helper
+ * skips a re-evaluation when the new key matches the prior one. `payload` is
+ * the actual data the stream-builder consumes (an HTTP request, an
+ * evaluation context, etc.) — it doesn't participate in the dedup so each
+ * stream invocation receives the most-recently-set payload for its key.
+ *
+ * @internal
+ */
+export interface Trigger<TPayload> {
+  key: string;
+  payload: TPayload;
+}
+
+/**
+ * Configuration passed to {@link createDebouncedResourceLogicFn}.
+ *
+ * @internal
+ */
+export interface DebouncedResourceLogicFnConfig<TValue, TPayload, TResult> {
+  /** Default value returned by the resource while loading / pending. */
+  pendingValue: TResult;
+  /** Debounce window (ms) applied to the trigger signal before the resource sees it. */
+  debounceMs: number;
+  injector: Injector;
+  /**
+   * Builds the per-emission inner observable. Called every time the debounced
+   * trigger key changes; the resource swaps to the new stream automatically.
+   */
+  buildStream: (payload: TPayload) => Observable<TResult>;
+  /**
+   * Called per LogicFn invocation. Returns one of:
+   *   - `{ kind: 'trigger', key, payload }` — set the trigger to this and
+   *     return the (potentially still-loading) resource value.
+   *   - `{ kind: 'returnEarly', value }` — bypass the resource and return
+   *     this value directly (used by HTTP for response-cache hits and for
+   *     unresolvable request templates).
+   */
+  resolve: (ctx: FieldContext<TValue>) => { kind: 'trigger'; key: string; payload: TPayload } | { kind: 'returnEarly'; value: TResult };
+}
+
+/**
+ * Per-field resource handle held in the LogicFn's signal store. Each call to
+ * the LogicFn with a unique field path reuses the same handle so the
+ * underlying `rxResource` lifecycle persists.
+ *
+ * @internal
+ */
+interface ResourceHandle<TPayload, TResult> {
+  trigger: WritableSignal<Trigger<TPayload> | undefined>;
+  resultResource: Resource<TResult>;
+}
+
+/**
+ * Shared scaffolding for both async-function and HTTP condition LogicFns.
+ *
+ * Encapsulates the pattern that was duplicated across the two files:
+ *
+ *   1. A per-field map keyed by `safeReadPathKeys(ctx).join('.')`. Each entry
+ *      owns one trigger signal + one `rxResource` instance, kept alive for the
+ *      lifetime of the LogicFn so the resource's loading/error state persists
+ *      across LogicFn invocations.
+ *   2. Resource construction wrapped in `untracked()` to avoid NG0602
+ *      (resources can't be created inside a reactive consumer; LogicFn runs
+ *      inside Angular Signal Forms' `BooleanOrLogic.compute`).
+ *   3. The trigger signal feeds `derivedFromDeferred` with `debounceTime` +
+ *      `distinctUntilChanged` (keyed by `Trigger.key`) so rapid form changes
+ *      collapse into one stream invocation.
+ *   4. `withPreviousValue` wraps the `rxResource` so consumers see the
+ *      previous resolved value during re-fetch — prevents UI flicker.
+ *
+ * Caller supplies only the per-condition specifics via `config.resolve`
+ * (early-return logic + how to derive the trigger from the FieldContext) and
+ * `config.buildStream` (how to fetch fresh values for a trigger payload).
+ *
+ * @internal
+ */
+export function createDebouncedResourceLogicFn<TValue, TPayload, TResult>(
+  config: DebouncedResourceLogicFnConfig<TValue, TPayload, TResult>,
+): LogicFn<TValue, TResult> {
+  const perFunctionSignalStore = new Map<string, ResourceHandle<TPayload, TResult>>();
+
+  return (ctx: FieldContext<TValue>) => {
+    const contextKey = safeReadPathKeys(ctx as FieldContext<unknown>).join('.');
+    let handle = perFunctionSignalStore.get(contextKey);
+
+    if (!handle) {
+      const trigger = signal<Trigger<TPayload> | undefined>(undefined);
+
+      // untracked: rxResource creates an internal effect, which Angular forbids
+      // inside a reactive consumer (LogicFn runs inside a computed). Clearing
+      // the consumer keeps the resource's lifecycle independent of the LogicFn's
+      // reactive context.
+      const resultResource = untracked(() => {
+        const debouncedTrigger = derivedFromDeferred(
+          trigger,
+          pipe(
+            debounceTime(config.debounceMs),
+            // distinctUntilChanged on key alone — payload identity doesn't matter
+            // (the latest payload for a given key always wins).
+            distinctUntilChanged((a, b) => a?.key === b?.key),
+          ),
+          { initialValue: undefined as Trigger<TPayload> | undefined, injector: config.injector },
+        );
+
+        const resource = rxResource<TResult, Trigger<TPayload> | undefined>({
+          params: () => debouncedTrigger(),
+          // When params() returns undefined, rxResource enters idle state.
+          stream: ({ params }) => config.buildStream(params!.payload),
+          defaultValue: config.pendingValue,
+          injector: config.injector,
+        });
+
+        return withPreviousValue(resource);
+      });
+
+      handle = { trigger, resultResource };
+      perFunctionSignalStore.set(contextKey, handle);
+    }
+
+    const resolved = config.resolve(ctx);
+    if (resolved.kind === 'returnEarly') {
+      return resolved.value;
+    }
+
+    const newTrigger: Trigger<TPayload> = { key: resolved.key, payload: resolved.payload };
+    untracked(() => {
+      const current = handle!.trigger();
+      if (current?.key !== newTrigger.key) {
+        handle!.trigger.set(newTrigger);
+      }
+    });
+
+    return handle.resultResource.value();
+  };
+}

--- a/packages/dynamic-forms/src/lib/core/expressions/http-condition-logic-function.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/http-condition-logic-function.spec.ts
@@ -463,6 +463,55 @@ describe('createHttpConditionLogicFunction', () => {
     }
   });
 
+  it('should re-fetch on same logical key after cache invalidation following a cache-hit returnEarly', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'queueMicrotask'] });
+    try {
+      httpClient.request.mockReturnValue(of(true));
+
+      const condition: HttpCondition = {
+        type: 'http',
+        http: { url: '/api/check' },
+        debounceMs: 0,
+        pendingValue: false,
+      };
+
+      let fn!: ReturnType<typeof createHttpConditionLogicFunction>;
+      let ctx!: FieldContext<string>;
+
+      runInInjectionContext(injector, () => {
+        fn = createHttpConditionLogicFunction(condition);
+        ctx = createMockFieldContext('test');
+        fn(ctx);
+      });
+
+      TestBed.flushEffects();
+      await vi.advanceTimersByTimeAsync(0);
+      TestBed.flushEffects();
+      await vi.advanceTimersByTimeAsync(0);
+      TestBed.flushEffects();
+
+      expect(httpClient.request).toHaveBeenCalledTimes(1);
+      expect(runInInjectionContext(injector, () => fn(ctx))).toBe(true);
+
+      conditionCache.clear();
+      httpClient.request.mockClear();
+      httpClient.request.mockReturnValue(of(false));
+
+      runInInjectionContext(injector, () => fn(ctx));
+
+      TestBed.flushEffects();
+      await vi.advanceTimersByTimeAsync(0);
+      TestBed.flushEffects();
+      await vi.advanceTimersByTimeAsync(0);
+      TestBed.flushEffects();
+
+      expect(httpClient.request).toHaveBeenCalledTimes(1);
+      expect(runInInjectionContext(injector, () => fn(ctx))).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('should handle cacheDurationMs of 0 (effectively disables cache)', () => {
     vi.useFakeTimers();
     try {

--- a/packages/dynamic-forms/src/lib/core/expressions/http-condition-logic-function.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/http-condition-logic-function.spec.ts
@@ -422,6 +422,47 @@ describe('createHttpConditionLogicFunction', () => {
     });
   });
 
+  it('should hold the previous resolved value when the request template becomes unresolvable', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'queueMicrotask'] });
+    try {
+      httpClient.request.mockReturnValue(of(true));
+
+      const condition: HttpCondition = {
+        type: 'http',
+        http: { url: '/api/check/:id', params: { id: 'formValue.id' } },
+        debounceMs: 0,
+        cacheDurationMs: 0,
+        pendingValue: false,
+      };
+
+      mockEntity.set({ id: 42 });
+
+      let fn!: ReturnType<typeof createHttpConditionLogicFunction>;
+      let ctx!: FieldContext<string>;
+
+      runInInjectionContext(injector, () => {
+        fn = createHttpConditionLogicFunction(condition);
+        ctx = createMockFieldContext('test');
+        fn(ctx);
+      });
+
+      TestBed.flushEffects();
+      await vi.advanceTimersByTimeAsync(0);
+      TestBed.flushEffects();
+      await vi.advanceTimersByTimeAsync(0);
+      TestBed.flushEffects();
+
+      expect(runInInjectionContext(injector, () => fn(ctx))).toBe(true);
+
+      mockEntity.set({ id: undefined });
+      TestBed.flushEffects();
+
+      expect(runInInjectionContext(injector, () => fn(ctx))).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('should handle cacheDurationMs of 0 (effectively disables cache)', () => {
     vi.useFakeTimers();
     try {

--- a/packages/dynamic-forms/src/lib/core/expressions/http-condition-logic-function.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/http-condition-logic-function.ts
@@ -1,8 +1,7 @@
 import { HttpClient } from '@angular/common/http';
-import { inject, Injector, Resource, signal, untracked, WritableSignal } from '@angular/core';
-import { rxResource } from '@angular/core/rxjs-interop';
-import { FieldContext, LogicFn } from '@angular/forms/signals';
-import { catchError, debounceTime, distinctUntilChanged, map, of, pipe, tap } from 'rxjs';
+import { inject, Injector } from '@angular/core';
+import { LogicFn } from '@angular/forms/signals';
+import { catchError, map, of, tap } from 'rxjs';
 import { HttpCondition } from '../../models/expressions/conditional-expression';
 import { stableStringify } from '../../utils/stable-stringify';
 import { HttpResourceRequest } from '../validation/validator-types';
@@ -15,9 +14,7 @@ import { Logger } from '../../providers/features/logger/logger.interface';
 import { resolveHttpRequest } from '../http/http-request-resolver';
 import { ExpressionParser } from './parser/expression-parser';
 import { HttpConditionFunctionCacheService } from './http-condition-function-cache.service';
-import { safeReadPathKeys } from '../../utils/safe-read-path-keys';
-import { withPreviousValue } from '../../utils/resource-composition/with-previous-value';
-import { derivedFromDeferred } from '../../utils/derived-from-deferred/derived-from-deferred';
+import { createDebouncedResourceLogicFn } from './debounced-resource-logic-fn';
 
 /**
  * Extracts a boolean from an HTTP response using an optional expression.
@@ -48,10 +45,11 @@ function extractBoolean(response: unknown, responseExpression: string | undefine
 /**
  * Creates a logic function for an HTTP condition.
  *
- * Uses Angular's `rxResource()` API with snapshot composition for async resolution:
- * the LogicFn updates a `resolvedRequest` signal, a debounced version feeds into
- * an `rxResource()` that manages the HTTP lifecycle, and `withPreviousValue()` preserves
- * the last resolved boolean during re-fetching to prevent UI flicker.
+ * Delegates lifecycle (per-field signal store, debouncing, rxResource +
+ * withPreviousValue) to {@link createDebouncedResourceLogicFn}; this function
+ * just supplies the HTTP-specific bits: the trigger payload is the resolved
+ * `HttpResourceRequest`, the stream fires the request, and the resolver
+ * short-circuits via the response-cache before the resource gets touched.
  *
  * Must be called in injection context (same as `createLogicFunction`).
  */
@@ -71,109 +69,49 @@ export function createHttpConditionLogicFunction<TValue>(condition: HttpConditio
   const cacheDurationMs = condition.cacheDurationMs ?? 30000;
   const debounceMs = condition.debounceMs ?? 300;
 
-  // Check function cache
+  // Function cache: across-condition reuse for identical condition shapes.
   const cacheKey = stableStringify(condition);
-
   const cached = cacheService.httpConditionFunctionCache.get(cacheKey);
   if (cached) {
     return cached as LogicFn<TValue, boolean>;
   }
 
-  // Each condition needs its own per-field signal store. A shared store would collide
-  // when multiple HTTP conditions exist on the same field (same FieldContext / path).
-  const perFunctionSignalStore = new Map<
-    string,
-    { resolvedRequest: WritableSignal<HttpResourceRequest | undefined>; resultResource: Resource<boolean> }
-  >();
+  const fn = createDebouncedResourceLogicFn<TValue, HttpResourceRequest, boolean>({
+    pendingValue,
+    debounceMs,
+    injector,
+    resolve: (ctx) => {
+      const evaluationContext = fieldContextRegistry.createReactiveEvaluationContext(ctx, functionRegistry.getCustomFunctions());
+      const resolved = resolveHttpRequest(condition.http, evaluationContext);
+      // Unresolvable request template (path param missing, etc.) — fall back
+      // to pending value. The resource stays in its prior state.
+      if (!resolved) return { kind: 'returnEarly', value: pendingValue };
 
-  const fn: LogicFn<TValue, boolean> = (ctx: FieldContext<TValue>) => {
-    const contextKey = safeReadPathKeys(ctx as FieldContext<unknown>).join('.');
-    let signalPair = perFunctionSignalStore.get(contextKey);
+      const requestKey = stableStringify(resolved);
+      const cachedResult = cache.get(requestKey);
+      if (cachedResult !== undefined) return { kind: 'returnEarly', value: cachedResult };
 
-    if (!signalPair) {
-      const resolvedRequest = signal<HttpResourceRequest | undefined>(undefined);
+      return { kind: 'trigger', key: requestKey, payload: resolved };
+    },
+    buildStream: (request) => {
+      const method = request.method ?? 'GET';
+      const options: Record<string, unknown> = {};
+      if (request.body) options['body'] = request.body;
+      if (request.headers) options['headers'] = request.headers;
 
-      // Wrap in untracked() to avoid NG0602: resource() internally creates effects,
-      // which cannot be created inside a reactive context (computed). The LogicFn runs
-      // inside Angular Signal Forms' BooleanOrLogic.compute (a computed), so we must
-      // clear the active reactive consumer before creating the resource pipeline.
-      const resultResource = untracked(() => {
-        // Create a debounced, stabilized version of the request signal.
-        // This prevents rapid re-fetches when form values change quickly.
-        const debouncedRequest = derivedFromDeferred(
-          resolvedRequest,
-          pipe(
-            debounceTime(debounceMs),
-            distinctUntilChanged((prev, curr) => stableStringify(prev) === stableStringify(curr)),
-          ),
-          { initialValue: undefined as HttpResourceRequest | undefined, injector },
-        );
-
-        // rxResource() manages the HTTP lifecycle natively with Observables:
-        // auto-cancellation via unsubscription, loading/resolved/error status tracking,
-        // and signal-based reactivity.
-        const httpResource = rxResource({
-          params: () => debouncedRequest() ?? undefined,
-          // When params() returns undefined, rxResource() enters idle state and skips the stream.
-          stream: ({ params: request }) => {
-            const method = request.method ?? 'GET';
-            const options: Record<string, unknown> = {};
-            if (request.body) options['body'] = request.body;
-            if (request.headers) options['headers'] = request.headers;
-
-            return httpClient.request(method, request.url, options).pipe(
-              map((response) => extractBoolean(response, condition.responseExpression, pendingValue, logger)),
-              tap((value) => {
-                const requestKey = stableStringify(request);
-                cache.set(requestKey, value, cacheDurationMs);
-              }),
-              catchError((error) => {
-                logger.warn('HTTP condition request failed:', error);
-                return of(pendingValue);
-              }),
-            );
-          },
-          defaultValue: pendingValue,
-          injector,
-        });
-
-        // Snapshot composition: preserve the previous boolean result during re-fetching.
-        // Without this, the condition would briefly flash to pendingValue when params change,
-        // causing visible UI flicker (e.g., a conditionally visible field briefly disappearing).
-        return withPreviousValue(httpResource);
-      });
-
-      signalPair = { resolvedRequest, resultResource };
-      perFunctionSignalStore.set(contextKey, signalPair);
-    }
-
-    // Build reactive evaluation context (creates signal dependencies on form values)
-    const evaluationContext = fieldContextRegistry.createReactiveEvaluationContext(ctx, functionRegistry.getCustomFunctions());
-
-    // Returns null when a path param is undefined — skip the request and return pending value
-    const resolved = resolveHttpRequest(condition.http, evaluationContext);
-    if (!resolved) {
-      return signalPair.resultResource.value();
-    }
-    const requestKey = stableStringify(resolved);
-
-    // Check response cache first
-    const cachedResult = cache.get(requestKey);
-    if (cachedResult !== undefined) {
-      return cachedResult;
-    }
-
-    // Update the resolved request signal (triggers resource if request changed)
-    const { resolvedRequest, resultResource } = signalPair;
-    untracked(() => {
-      const current = resolvedRequest();
-      if (stableStringify(current) !== requestKey) {
-        resolvedRequest.set(resolved);
-      }
-    });
-
-    return resultResource.value();
-  };
+      return httpClient.request(method, request.url, options).pipe(
+        map((response) => extractBoolean(response, condition.responseExpression, pendingValue, logger)),
+        tap((value) => {
+          const requestKey = stableStringify(request);
+          cache.set(requestKey, value, cacheDurationMs);
+        }),
+        catchError((error) => {
+          logger.warn('HTTP condition request failed:', error);
+          return of(pendingValue);
+        }),
+      );
+    },
+  });
 
   cacheService.httpConditionFunctionCache.set(cacheKey, fn as LogicFn<unknown, boolean>);
   return fn;

--- a/packages/dynamic-forms/src/lib/core/expressions/http-condition-logic-function.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/http-condition-logic-function.ts
@@ -96,7 +96,7 @@ export function createHttpConditionLogicFunction<TValue>(condition: HttpConditio
     buildStream: (request) => {
       const method = request.method ?? 'GET';
       const options: Record<string, unknown> = {};
-      if (request.body) options['body'] = request.body;
+      if (request.body !== undefined) options['body'] = request.body;
       if (request.headers) options['headers'] = request.headers;
 
       return httpClient.request(method, request.url, options).pipe(

--- a/packages/dynamic-forms/src/lib/core/expressions/http-condition-logic-function.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/http-condition-logic-function.ts
@@ -83,9 +83,9 @@ export function createHttpConditionLogicFunction<TValue>(condition: HttpConditio
     resolve: (ctx) => {
       const evaluationContext = fieldContextRegistry.createReactiveEvaluationContext(ctx, functionRegistry.getCustomFunctions());
       const resolved = resolveHttpRequest(condition.http, evaluationContext);
-      // Unresolvable request template (path param missing, etc.) — fall back
-      // to pending value. The resource stays in its prior state.
-      if (!resolved) return { kind: 'returnEarly', value: pendingValue };
+      // Hold the previous resolved value rather than flicker to pendingValue while a path
+      // param is temporarily undefined between two valid states.
+      if (!resolved) return { kind: 'holdPrevious' };
 
       const requestKey = stableStringify(resolved);
       const cachedResult = cache.get(requestKey);


### PR DESCRIPTION
## Summary

`createAsyncConditionLogicFunction` and `createHttpConditionLogicFunction` independently hand-rolled the same machinery: per-field signal store, `signal<Trigger>` + `derivedFromDeferred` debounce, `rxResource` wrapped in `untracked()` for NG0602 safety, `withPreviousValue` flicker suppression, trigger-update + value-read sequencing. ~80 LOC of identical scaffolding in each file, differing only in what the trigger payload is, how it's derived from the FieldContext, and how the stream fetches a fresh value.

This PR extracts that scaffolding into `core/expressions/debounced-resource-logic-fn.ts:createDebouncedResourceLogicFn`. Each caller supplies only the condition-specific bits:

- `resolve(ctx)` — returns either `{ kind: 'trigger', key, payload }` (sets the trigger and returns the resource value) or `{ kind: 'returnEarly', value }` (bypasses the resource entirely; used by HTTP for response-cache hits and unresolvable request templates).
- `buildStream(payload)` — constructs the inner observable for a given trigger payload.

The helper handles per-field signal store keyed by `safeReadPathKeys(ctx).join('.')`, the `untracked()` resource construction, the debounce+dedup pipeline, the `withPreviousValue` wrapper, and the trigger-set + value-return sequence.

## Numbers

- **dynamic-forms fesm2022 bundle: 1,060,987 → 1,058,665 bytes (-2,322 / -0.22%)**
- Source LOC across the three files: 350 (two original files) → 93 (async) + 119 (http) + 127 (extracted helper) = 339, net **-11 LOC**
- 3062 / 3062 unit tests pass
- Build clean, lint clean

Both LogicFn files shrunk from ~170 / ~180 LOC to ~95 each — clearly readable as "build the trigger" and "build the stream", with all RxJS plumbing factored out.

## Behavioral preservation

Verified by 30+ async-condition and http-condition spec cases, all passing unchanged:

- Per-field signal store + signal stability across LogicFn invocations ✓
- `untracked()` wrapping around resource construction (NG0602 safe) ✓
- Debounce-then-distinct pipeline for trigger updates ✓
- `withPreviousValue` flicker suppression ✓
- HTTP response-cache short-circuit (now via `resolve` returning `returnEarly`) ✓
- HTTP unresolvable-template fallback (also via `returnEarly`) ✓
- Async condition's per-call FieldContext atomic capture — was a `Map<triggerKey, FieldContext>` race-condition fix; now carried inside `Trigger.payload` so each emission has its own atomic `{key, payload}` pair ✓
- Function caches (`AsyncConditionFunctionCacheService`, `HttpConditionFunctionCacheService`) preserved ✓

## Test plan

- [x] Build clean (`nx build dynamic-forms`)
- [x] Full unit suite passes (3062/3062)
- [x] Lint clean
- [ ] CI confirms no regression on `http-conditions`, `async-conditions`, and `expression-based-logic` E2E suites
- [ ] Cross-adapter perf bench (added in #435) unchanged

## Why this commit shape

The shared helper is intentionally NOT a class. It's a function that returns a LogicFn, so callers compose it the same way they compose anything else and don't need to think about lifecycle / DI / inheritance. The closure captures the `injector` and other injected services from the caller's injection context (where `createXxxConditionLogicFunction` was called).

## Out of scope

- Replacing `derivedFromDeferred` with a plain `derivedFrom` from `ngxtension`. The defer behavior is load-bearing — `toObservable` inside the resource-creation closure (even with `untracked`) needs late binding to avoid initialization-order surprises. The cost of `derivedFromDeferred` is 5 lines; not worth replacing.
- Inlining the LogicFn cache services. They predate this refactor and are still useful for cross-condition deduplication.