### PR TITLE
docs: trim verbose JSDoc and @example blocks from shipped libraries

### DIFF
--- a/packages/dynamic-form-mcp/bin/ng-forge-mcp.ts
+++ b/packages/dynamic-form-mcp/bin/ng-forge-mcp.ts
@@ -1,9 +1,5 @@
 #!/usr/bin/env node
-/**
- * ng-forge MCP Server CLI
- *
- * This is the entry point for the MCP server when invoked via npx or as a CLI tool.
- */
+/** ng-forge MCP Server CLI */
 
 import { runStdioServer } from '../src/server.js';
 

--- a/packages/dynamic-form-mcp/src/index.ts
+++ b/packages/dynamic-form-mcp/src/index.ts
@@ -2,7 +2,6 @@
  * @ng-forge/dynamic-form-mcp
  *
  * MCP server for ng-forge dynamic forms - AI-assisted form schema generation
- *
  * @packageDocumentation
  */
 

--- a/packages/dynamic-form-mcp/src/registry/addons.ts
+++ b/packages/dynamic-form-mcp/src/registry/addons.ts
@@ -1,13 +1,4 @@
-/**
- * Addon Registry Data
- *
- * Canonical source of addon kind metadata for the MCP server. Addons render
- * inside a field's slot (typically `prefix` / `suffix`) — icons, buttons,
- * inline text, custom templates, custom components.
- *
- * Manually authored for MVP; auto-extraction from `AddonKindDefinition.schema`
- * fragments is a follow-up.
- */
+/** Addon Registry Data */
 
 import type { PropertyInfo } from './index.js';
 

--- a/packages/dynamic-form-mcp/src/registry/documentation.ts
+++ b/packages/dynamic-form-mcp/src/registry/documentation.ts
@@ -1,9 +1,4 @@
-/**
- * Documentation Registry Data
- *
- * Maps documentation topics to their online URLs at ng-forge.com.
- * Replaces the previously bundled docs.json with links to the live documentation site.
- */
+/** Documentation Registry Data */
 
 const BASE_URL = 'https://ng-forge.com/dynamic-forms';
 

--- a/packages/dynamic-form-mcp/src/registry/field-types.ts
+++ b/packages/dynamic-form-mcp/src/registry/field-types.ts
@@ -1,9 +1,4 @@
-/**
- * Field Type Registry Data
- *
- * Canonical source of field type metadata for the MCP server.
- * Previously generated as field-types.json by generate-registry.ts.
- */
+/** Field Type Registry Data */
 
 import type { FieldTypeInfo } from './index.js';
 

--- a/packages/dynamic-form-mcp/src/registry/index.ts
+++ b/packages/dynamic-form-mcp/src/registry/index.ts
@@ -1,9 +1,4 @@
-/**
- * Registry module for field type, validator, and UI adapter metadata
- *
- * This module provides access to field types, validators, and UI adapters
- * defined as TypeScript data in the registry source files.
- */
+/** Registry module for field type, validator, and UI adapter metadata */
 
 export interface PropertyInfo {
   name: string;
@@ -94,65 +89,47 @@ export { WRAPPER_AUTHORING_CONTRACT };
 
 export type { DocPage };
 
-/**
- * Get all available field types
- */
+/** Get all available field types */
 export function getFieldTypes(): FieldTypeInfo[] {
   return FIELD_TYPES;
 }
 
-/**
- * Get a specific field type by name
- */
+/** Get a specific field type by name */
 export function getFieldType(type: string): FieldTypeInfo | undefined {
   return FIELD_TYPES.find((ft) => ft.type === type);
 }
 
-/**
- * Get field types by category
- */
+/** Get field types by category */
 export function getFieldTypesByCategory(category: 'value' | 'container' | 'button' | 'display'): FieldTypeInfo[] {
   return FIELD_TYPES.filter((ft) => ft.category === category);
 }
 
-/**
- * Get all available validators
- */
+/** Get all available validators */
 export function getValidators(): ValidatorInfo[] {
   return VALIDATORS;
 }
 
-/**
- * Get a specific validator by type
- */
+/** Get a specific validator by type */
 export function getValidator(type: string): ValidatorInfo | undefined {
   return VALIDATORS.find((v) => v.type === type);
 }
 
-/**
- * Get validators by category
- */
+/** Get validators by category */
 export function getValidatorsByCategory(category: 'built-in' | 'custom' | 'async' | 'http'): ValidatorInfo[] {
   return VALIDATORS.filter((v) => v.category === category);
 }
 
-/**
- * Get all UI adapters
- */
+/** Get all UI adapters */
 export function getUIAdapters(): UIAdapterInfo[] {
   return UI_ADAPTERS;
 }
 
-/**
- * Get a specific UI adapter by library name
- */
+/** Get a specific UI adapter by library name */
 export function getUIAdapter(library: 'material' | 'bootstrap' | 'primeng' | 'ionic'): UIAdapterInfo | undefined {
   return UI_ADAPTERS.find((a) => a.library === library);
 }
 
-/**
- * Get UI adapter field type configuration
- */
+/** Get UI adapter field type configuration */
 export function getUIAdapterFieldType(
   library: 'material' | 'bootstrap' | 'primeng' | 'ionic',
   fieldType: string,
@@ -161,44 +138,32 @@ export function getUIAdapterFieldType(
   return adapter?.fieldTypes.find((ft) => ft.type === fieldType);
 }
 
-/**
- * Get all wrappers
- */
+/** Get all wrappers */
 export function getWrappers(): WrapperInfo[] {
   return WRAPPERS;
 }
 
-/**
- * Get a specific wrapper by type
- */
+/** Get a specific wrapper by type */
 export function getWrapper(type: string): WrapperInfo | undefined {
   return WRAPPERS.find((w) => w.type === type);
 }
 
-/**
- * Get wrappers by category
- */
+/** Get wrappers by category */
 export function getWrappersByCategory(category: 'core' | 'demo' | 'adapter'): WrapperInfo[] {
   return WRAPPERS.filter((w) => w.category === category);
 }
 
-/**
- * Get all documentation pages
- */
+/** Get all documentation pages */
 export function getDocPages(): DocPage[] {
   return DOCUMENTATION;
 }
 
-/**
- * Get a specific documentation page by ID
- */
+/** Get a specific documentation page by ID */
 export function getDocPage(id: string): DocPage | undefined {
   return DOCUMENTATION.find((d) => d.id === id);
 }
 
-/**
- * Get documentation pages by category
- */
+/** Get documentation pages by category */
 export function getDocPagesByCategory(category: string): DocPage[] {
   return DOCUMENTATION.filter((d) => d.category === category);
 }

--- a/packages/dynamic-form-mcp/src/registry/instructions.ts
+++ b/packages/dynamic-form-mcp/src/registry/instructions.ts
@@ -1,9 +1,4 @@
-/**
- * ng-forge Best Practices
- *
- * This content is served via the ng-forge://instructions resource
- * to guide AI assistants in generating FormConfig objects.
- */
+/** ng-forge Best Practices */
 
 export const INSTRUCTIONS = `# ng-forge Dynamic Forms - Best Practices
 

--- a/packages/dynamic-form-mcp/src/registry/ui-adapters.ts
+++ b/packages/dynamic-form-mcp/src/registry/ui-adapters.ts
@@ -1,9 +1,4 @@
-/**
- * UI Adapter Registry Data
- *
- * Canonical source of UI adapter metadata for the MCP server.
- * Previously generated as ui-adapters.json by generate-registry.ts.
- */
+/** UI Adapter Registry Data */
 
 import type { UIAdapterInfo } from './index.js';
 

--- a/packages/dynamic-form-mcp/src/registry/validators.ts
+++ b/packages/dynamic-form-mcp/src/registry/validators.ts
@@ -1,9 +1,4 @@
-/**
- * Validator Registry Data
- *
- * Canonical source of validator metadata for the MCP server.
- * Previously generated as validators.json by generate-registry.ts.
- */
+/** Validator Registry Data */
 
 import type { ValidatorInfo } from './index.js';
 

--- a/packages/dynamic-form-mcp/src/registry/wrappers.ts
+++ b/packages/dynamic-form-mcp/src/registry/wrappers.ts
@@ -1,20 +1,4 @@
-/**
- * Wrapper Registry Data
- *
- * Canonical source of wrapper metadata for the MCP server.
- *
- * Wrappers decorate the rendered output of a field without changing the form
- * data structure. They are composed as a chain: each wrapper exposes a
- * `#fieldComponent` `ViewContainerRef` slot where the next wrapper (or the
- * field itself) is rendered.
- *
- * Categories:
- *   - core    — ships from `@ng-forge/dynamic-forms`, always available.
- *   - demo    — ships from `@internal/examples-shared-ui` for the docs
- *               sandbox. NOT a library primitive — use as a pattern, not
- *               a dependency.
- *   - adapter — (reserved) would ship from a UI adapter library.
- */
+/** Wrapper Registry Data */
 
 import type { WrapperInfo } from './index.js';
 

--- a/packages/dynamic-form-mcp/src/resources/documentation.resource.ts
+++ b/packages/dynamic-form-mcp/src/resources/documentation.resource.ts
@@ -1,9 +1,4 @@
-/**
- * Documentation Resource
- *
- * Exposes ng-forge documentation as MCP resources.
- * Fetches live content from ng-forge.com with fallback to static links.
- */
+/** Documentation Resource */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { getDocPages, getDocPage, getDocPagesByCategory } from '../registry/index.js';

--- a/packages/dynamic-form-mcp/src/resources/examples.resource.ts
+++ b/packages/dynamic-form-mcp/src/resources/examples.resource.ts
@@ -1,8 +1,4 @@
-/**
- * Examples Resource
- *
- * Provides curated FormConfig examples for common use cases.
- */
+/** Examples Resource */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import examplesData from '../registry/examples.json' with { type: 'json' };

--- a/packages/dynamic-form-mcp/src/resources/field-types.resource.ts
+++ b/packages/dynamic-form-mcp/src/resources/field-types.resource.ts
@@ -1,8 +1,4 @@
-/**
- * Field Types Resource
- *
- * Exposes available ng-forge field types and their configurations.
- */
+/** Field Types Resource */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { getFieldTypes, getFieldType, getFieldTypesByCategory } from '../registry/index.js';

--- a/packages/dynamic-form-mcp/src/resources/index.ts
+++ b/packages/dynamic-form-mcp/src/resources/index.ts
@@ -1,8 +1,4 @@
-/**
- * MCP Resources Registration
- *
- * Registers all available resources with the MCP server.
- */
+/** MCP Resources Registration */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerFieldTypesResource } from './field-types.resource.js';
@@ -14,9 +10,7 @@ import { registerExamplesResource } from './examples.resource.js';
 import { registerSchemasResource } from './schemas.resource.js';
 import { registerWrappersResource } from './wrappers.resource.js';
 
-/**
- * Register all MCP resources
- */
+/** Register all MCP resources */
 export function registerResources(server: McpServer): void {
   registerInstructionsResource(server);
   registerExamplesResource(server);

--- a/packages/dynamic-form-mcp/src/resources/instructions.resource.ts
+++ b/packages/dynamic-form-mcp/src/resources/instructions.resource.ts
@@ -1,8 +1,4 @@
-/**
- * Instructions Resource
- *
- * Exposes ng-forge best practices and usage guidelines for AI assistants.
- */
+/** Instructions Resource */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { INSTRUCTIONS } from '../registry/instructions.js';

--- a/packages/dynamic-form-mcp/src/resources/schemas.resource.ts
+++ b/packages/dynamic-form-mcp/src/resources/schemas.resource.ts
@@ -1,9 +1,4 @@
-/**
- * Schemas Resource
- *
- * Provides a lightweight index pointing to tools for schema access.
- * Actual schemas are accessed via tools to control context size.
- */
+/** Schemas Resource */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { getSupportedFieldTypes } from '@ng-forge/dynamic-forms-zod/mcp';

--- a/packages/dynamic-form-mcp/src/resources/ui-adapters.resource.ts
+++ b/packages/dynamic-form-mcp/src/resources/ui-adapters.resource.ts
@@ -1,8 +1,4 @@
-/**
- * UI Adapters Resource
- *
- * Exposes UI library-specific field configurations for Material, Bootstrap, PrimeNG, and Ionic.
- */
+/** UI Adapters Resource */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { getUIAdapters, getUIAdapter } from '../registry/index.js';

--- a/packages/dynamic-form-mcp/src/resources/validators.resource.ts
+++ b/packages/dynamic-form-mcp/src/resources/validators.resource.ts
@@ -1,8 +1,4 @@
-/**
- * Validators Resource
- *
- * Exposes available ng-forge validators and their configurations.
- */
+/** Validators Resource */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { getValidators, getValidator, getValidatorsByCategory } from '../registry/index.js';

--- a/packages/dynamic-form-mcp/src/resources/wrappers.resource.ts
+++ b/packages/dynamic-form-mcp/src/resources/wrappers.resource.ts
@@ -1,9 +1,4 @@
-/**
- * Wrappers Resource
- *
- * Exposes registered ng-forge wrappers (field decorators). Includes the built-in
- * core wrappers plus demo wrappers shipped with the examples-shared-ui package.
- */
+/** Wrappers Resource */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { getWrappers, getWrapper, getWrappersByCategory, WRAPPER_AUTHORING_CONTRACT } from '../registry/index.js';

--- a/packages/dynamic-form-mcp/src/server.ts
+++ b/packages/dynamic-form-mcp/src/server.ts
@@ -1,12 +1,4 @@
-/**
- * MCP Server for ng-forge dynamic forms
- *
- * Provides AI assistants with tools and resources for:
- * - Field type discovery
- * - Form schema generation
- * - Validation configuration
- * - Expression building
- */
+/** MCP Server for ng-forge dynamic forms */
 
 import { createRequire } from 'module';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -20,9 +12,7 @@ const packageJson = require('../package.json') as { name: string; version: strin
 const SERVER_NAME = 'ng-forge-mcp';
 const SERVER_VERSION = packageJson.version;
 
-/**
- * Create and configure the MCP server
- */
+/** Create and configure the MCP server */
 export function createServer(): McpServer {
   const server = new McpServer({
     name: SERVER_NAME,
@@ -38,9 +28,7 @@ export function createServer(): McpServer {
   return server;
 }
 
-/**
- * Run the MCP server with stdio transport
- */
+/** Run the MCP server with stdio transport */
 export async function runStdioServer(): Promise<void> {
   const server = createServer();
   const transport = new StdioServerTransport();

--- a/packages/dynamic-form-mcp/src/services/doc-fetcher.ts
+++ b/packages/dynamic-form-mcp/src/services/doc-fetcher.ts
@@ -1,13 +1,4 @@
-/**
- * Documentation Fetcher Service
- *
- * Fetches and caches live documentation from ng-forge.com.
- * Uses native fetch (Node >=20) with in-memory caching and TTL.
- *
- * Fetches:
- * - llms.txt: Documentation index
- * - llms-full.txt: Full documentation content, parsed into sections
- */
+/** Documentation Fetcher Service */
 
 const BASE_URL = 'https://ng-forge.com/dynamic-forms';
 const LLMS_TXT_URL = `${BASE_URL}/llms.txt`;
@@ -113,17 +104,13 @@ export async function fetchDocSection(path: string): Promise<string | null> {
   return sections?.get(path) ?? null;
 }
 
-/**
- * Clear all caches. Useful for testing or forcing a refresh.
- */
+/** Clear all caches. Useful for testing or forcing a refresh. */
 export function clearCache(): void {
   indexCache = null;
   sectionsCache = null;
 }
 
-/**
- * Set cache TTL in milliseconds.
- */
+/** Set cache TTL in milliseconds. */
 export function setCacheTtl(ttlMs: number): void {
   cacheTtlMs = ttlMs;
 }

--- a/packages/dynamic-form-mcp/src/services/topic-mapper.ts
+++ b/packages/dynamic-form-mcp/src/services/topic-mapper.ts
@@ -1,10 +1,4 @@
-/**
- * Topic-to-Section Mapper
- *
- * Maps MCP TOPICS keys to llms-full.txt section paths.
- * Some topics map to multiple sections (concatenated when fetched).
- * Topics with no website equivalent (MCP-specific patterns) return null.
- */
+/** Topic-to-Section Mapper */
 
 /**
  * Maps topic keys to one or more llms-full.txt section paths.
@@ -98,9 +92,7 @@ export function getTopicSections(topic: string): string[] | null | undefined {
   return TOPIC_SECTION_MAP[topic];
 }
 
-/**
- * Check if a topic is MCP-specific (no website equivalent).
- */
+/** Check if a topic is MCP-specific (no website equivalent). */
 export function isMcpOnlyTopic(topic: string): boolean {
   return MCP_ONLY_TOPICS.has(topic);
 }

--- a/packages/dynamic-form-mcp/src/tools/data/lookup-topics.ts
+++ b/packages/dynamic-form-mcp/src/tools/data/lookup-topics.ts
@@ -1,13 +1,6 @@
-/**
- * Lookup Topics Data
- *
- * Documentation content for the ngforge_lookup tool.
- * Extracted from lookup.tool.ts for better maintainability.
- */
+/** Lookup Topics Data */
 
-/**
- * Topic-specific documentation content.
- */
+/** Topic-specific documentation content. */
 export const TOPICS: Record<string, { brief: string; full: string }> = {
   // ========== FIELD TYPES ==========
   input: {
@@ -2614,9 +2607,7 @@ export const TOPIC_DESCRIPTIONS: Record<string, string> = {
   section: 'Demo wrapper — titled card around any field or container (examples-shared-ui)',
 };
 
-/**
- * Topic aliases for flexible lookup.
- */
+/** Topic aliases for flexible lookup. */
 export const TOPIC_ALIASES: Record<string, string> = {
   // Field type aliases
   textfield: 'input',

--- a/packages/dynamic-form-mcp/src/tools/examples.tool.ts
+++ b/packages/dynamic-form-mcp/src/tools/examples.tool.ts
@@ -1,19 +1,9 @@
-/**
- * Unified Examples Tool
- *
- * Consolidated working code patterns tool that absorbs:
- * - get-example.tool.ts (complete and mega examples)
- * - explain-feature.tool.ts (conceptual explanations)
- *
- * Single tool for "Show me how to do X"
- */
+/** Unified Examples Tool */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
-/**
- * Pattern definitions with minimal, brief, full, and explained content.
- */
+/** Pattern definitions with minimal, brief, full, and explained content. */
 export const PATTERNS: Record<
   string,
   {
@@ -1922,9 +1912,7 @@ PATTERNS.validation.brief = PATTERNS['minimal-validation'].brief;
 PATTERNS.validation.full = PATTERNS['minimal-validation'].full;
 PATTERNS.validation.explained = PATTERNS['minimal-validation'].explained;
 
-/**
- * Complete multi-page form example.
- */
+/** Complete multi-page form example. */
 export const COMPLETE_EXAMPLE = `# Complete Multi-Page Form Example
 
 This is a **complete, copy-pasteable** form configuration that demonstrates:
@@ -2067,9 +2055,7 @@ const formConfig = {
 }
 \`\`\``;
 
-/**
- * Mega kitchen sink example (abbreviated - full version exists in get-example.tool.ts).
- */
+/** Mega kitchen sink example (abbreviated - full version exists in get-example.tool.ts). */
 export const MEGA_EXAMPLE = `# Kitchen Sink Mega Example
 
 This example demonstrates **EVERY feature** of ng-forge dynamic forms.
@@ -2430,9 +2416,7 @@ Use depth="minimal" for code-only output (no markdown).`,
   );
 }
 
-/**
- * Extract just the code from markdown content.
- */
+/** Extract just the code from markdown content. */
 function extractCode(markdown: string): string {
   const codeBlocks: string[] = [];
   const regex = /```typescript\n([\s\S]*?)```/g;

--- a/packages/dynamic-form-mcp/src/tools/index.ts
+++ b/packages/dynamic-form-mcp/src/tools/index.ts
@@ -1,32 +1,4 @@
-/**
- * MCP Tools Registration
- *
- * Registers all available tools with the MCP server.
- *
- * 5 tools with zero overlap, each serving a single clear purpose:
- *
- * | Tool              | Purpose        | One-liner               |
- * |-------------------|----------------|-------------------------|
- * | ngforge_lookup    | Documentation  | "Tell me about X"       |
- * | ngforge_examples  | Working code   | "Show me how to do X"   |
- * | ngforge_validate  | Verification   | "Is my config correct?" |
- * | ngforge_scaffold  | Generation     | "Generate a skeleton"   |
- * | ngforge_search    | Discovery      | "Find topics about X"   |
- *
- * RECOMMENDED WORKFLOW:
- * 1. ngforge_lookup topic="workflow" - START HERE: tool usage guide
- * 2. ngforge_search query="your question" - Find relevant topics by keyword
- * 3. ngforge_lookup topic="golden-path" - Get form structure templates
- * 4. ngforge_lookup topic="<field-type>" - Get syntax for specific fields
- * 5. ngforge_validate - Validate your config (catches all errors)
- *
- * For working code examples:
- * - ngforge_examples pattern="complete" - Full multi-page form
- * - ngforge_examples pattern="minimal-conditional" - Minimal conditional example
- *
- * For generating skeletons:
- * - ngforge_scaffold pages=2 arrays=["contacts"] groups=["address"]
- */
+/** MCP Tools Registration */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerLookupTool } from './lookup.tool.js';
@@ -35,9 +7,7 @@ import { registerValidateTool } from './validate.tool.js';
 import { registerScaffoldTool } from './scaffold.tool.js';
 import { registerSearchTool } from './search.tool.js';
 
-/**
- * Register all MCP tools (5 total)
- */
+/** Register all MCP tools (5 total) */
 export function registerTools(server: McpServer): void {
   // 1. Lookup - unified documentation ("Tell me about X")
   registerLookupTool(server);

--- a/packages/dynamic-form-mcp/src/tools/lookup.tool.ts
+++ b/packages/dynamic-form-mcp/src/tools/lookup.tool.ts
@@ -1,15 +1,4 @@
-/**
- * Unified Lookup Tool
- *
- * Consolidated documentation tool that absorbs:
- * - quick-lookup.tool.ts (primary content source)
- * - get-field-info.tool.ts (field documentation + placement rules)
- * - get-api-reference.tool.ts (logic-matrix, context-api content)
- * - get-cheatsheet.tool.ts (comprehensive reference)
- * - get-field-schema.tool.ts (JSON schema for depth=schema)
- *
- * Single tool for "Tell me about X"
- */
+/** Unified Lookup Tool */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
@@ -50,9 +39,7 @@ const SCHEMA_SUPPORTED_FIELD_TYPES = [
   'previous',
 ] as const;
 
-/**
- * Get all available topics grouped by category.
- */
+/** Get all available topics grouped by category. */
 function formatTopicItem(key: string): string {
   const desc = TOPIC_DESCRIPTIONS[key];
   return desc ? `- **${key}**: ${desc}` : `- **${key}**`;
@@ -116,9 +103,7 @@ ${patterns.map(formatTopicItem).join('\n')}
 **Search:** \`ngforge_search query="your question"\` — find topics by keyword`;
 }
 
-/**
- * Format field info with placement rules (from get-field-info.tool.ts).
- */
+/** Format field info with placement rules (from get-field-info.tool.ts). */
 function formatFieldInfoFull(field: FieldTypeInfo, uiFieldType?: UIAdapterFieldType): string {
   const lines: string[] = [];
   const isContainer = ['row', 'group', 'array', 'page'].includes(field.type);
@@ -188,9 +173,7 @@ function formatFieldInfoFull(field: FieldTypeInfo, uiFieldType?: UIAdapterFieldT
   return lines.join('\n');
 }
 
-/**
- * Format a single wrapper registry entry.
- */
+/** Format a single wrapper registry entry. */
 function formatWrapperInfo(wrapper: WrapperInfo): string {
   const lines: string[] = [];
   lines.push(`# ${wrapper.type} wrapper`);
@@ -311,9 +294,7 @@ const config = {
   return lines.join('\n');
 }
 
-/**
- * Format a single addon-kind registry entry.
- */
+/** Format a single addon-kind registry entry. */
 function formatAddonInfo(addon: AddonKindInfo, depth: 'brief' | 'full' | 'schema'): string {
   if (depth === 'brief') {
     return [
@@ -363,9 +344,7 @@ function formatAddonInfo(addon: AddonKindInfo, depth: 'brief' | 'full' | 'schema
   return lines.join('\n');
 }
 
-/**
- * List every registered addon kind grouped by core vs adapter.
- */
+/** List every registered addon kind grouped by core vs adapter. */
 function formatAddonsOverview(): string {
   const kinds = getAddonKinds();
   const lines: string[] = [];
@@ -427,15 +406,7 @@ function formatAddonsOverview(): string {
   return lines.join('\n');
 }
 
-/**
- * Try to fetch live documentation for a topic, falling back to hardcoded content.
- *
- * Resolution order:
- * 1. Map topic → section path(s) via topic-mapper
- * 2. If mapped, fetch live content from llms-full.txt
- * 3. If fetch fails or topic is MCP-only, use hardcoded TOPICS content
- * 4. If not in TOPICS, try field type registry
- */
+/** Try to fetch live documentation for a topic, falling back to hardcoded content. */
 async function resolveTopicContent(
   resolvedTopic: string,
   depth: 'brief' | 'full' | 'schema',
@@ -634,9 +605,7 @@ const NEXT_STEPS: Record<string, string> = {
     '**Next:** `ngforge_lookup topic="wrappers"` for the wrapper overview · `ngforge_lookup topic="css"` for the shipping CSS wrapper',
 };
 
-/**
- * Get next-steps hint for a topic, if available.
- */
+/** Get next-steps hint for a topic, if available. */
 function getNextSteps(topic: string): string | undefined {
   return NEXT_STEPS[topic];
 }

--- a/packages/dynamic-form-mcp/src/tools/scaffold.tool.ts
+++ b/packages/dynamic-form-mcp/src/tools/scaffold.tool.ts
@@ -1,36 +1,23 @@
-/**
- * Scaffold Tool (NEW)
- *
- * Generates valid FormConfig skeletons based on parameters.
- * Produces copy-paste ready code with proper structure.
- *
- * Single tool for "Generate a skeleton for X"
- */
+/** Scaffold Tool (NEW) */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
 const UI_INTEGRATIONS = ['material', 'bootstrap', 'primeng', 'ionic'] as const;
 
-/**
- * Field definition from "name:type" string.
- */
+/** Field definition from "name:type" string. */
 interface FieldDef {
   name: string;
   type: string;
 }
 
-/**
- * Hidden field definition from "name:value" string.
- */
+/** Hidden field definition from "name:value" string. */
 interface HiddenDef {
   name: string;
   value: string;
 }
 
-/**
- * Parse "name:type" pairs.
- */
+/** Parse "name:type" pairs. */
 function parseFieldDefs(fields: string[]): FieldDef[] {
   return fields.map((f) => {
     const [name, type] = f.split(':');
@@ -41,9 +28,7 @@ function parseFieldDefs(fields: string[]): FieldDef[] {
   });
 }
 
-/**
- * Parse "name:value" pairs for hidden fields.
- */
+/** Parse "name:value" pairs for hidden fields. */
 function parseHiddenDefs(hiddens: string[]): HiddenDef[] {
   return hiddens.map((h) => {
     const colonIndex = h.indexOf(':');
@@ -57,9 +42,7 @@ function parseHiddenDefs(hiddens: string[]): HiddenDef[] {
   });
 }
 
-/**
- * Generate a basic field config.
- */
+/** Generate a basic field config. */
 function generateField(def: FieldDef, indent: string): string {
   const { name, type } = def;
 
@@ -109,9 +92,7 @@ ${indent}}`;
   }
 }
 
-/**
- * Generate a hidden field config.
- */
+/** Generate a hidden field config. */
 function generateHiddenField(def: HiddenDef, indent: string): string {
   const { name, value } = def;
   // Determine if value should be quoted
@@ -122,9 +103,7 @@ function generateHiddenField(def: HiddenDef, indent: string): string {
   return `${indent}{ key: '${name}', type: 'hidden', value: ${formattedValue} }`;
 }
 
-/**
- * Generate a group skeleton.
- */
+/** Generate a group skeleton. */
 function generateGroup(name: string, indent: string): string {
   return `${indent}{
 ${indent}  key: '${name}',
@@ -153,9 +132,7 @@ ${indent}  addButton: { label: 'Add ${capitalize(name)}' }
 ${indent}}`;
 }
 
-/**
- * Capitalize first letter.
- */
+/** Capitalize first letter. */
 function capitalize(s: string): string {
   return (
     s.charAt(0).toUpperCase() +
@@ -166,9 +143,7 @@ function capitalize(s: string): string {
   );
 }
 
-/**
- * Generate complete FormConfig skeleton.
- */
+/** Generate complete FormConfig skeleton. */
 function generateScaffold(options: { pages: number; arrays: string[]; groups: string[]; hidden: HiddenDef[]; fields: FieldDef[] }): string {
   const { pages, arrays, groups, hidden, fields } = options;
   const lines: string[] = [];
@@ -292,9 +267,7 @@ function generateScaffold(options: { pages: number; arrays: string[]; groups: st
   return lines.join('\n');
 }
 
-/**
- * Generate output shape preview.
- */
+/** Generate output shape preview. */
 function generateOutputShape(options: { groups: string[]; arrays: string[]; hidden: HiddenDef[]; fields: FieldDef[] }): string {
   const lines: string[] = [];
   lines.push('');
@@ -332,9 +305,7 @@ function generateOutputShape(options: { groups: string[]; arrays: string[]; hidd
   return lines.join('\n');
 }
 
-/**
- * Get TypeScript type for field type.
- */
+/** Get TypeScript type for field type. */
 function getTypeForFieldType(type: string): string {
   switch (type) {
     case 'input':

--- a/packages/dynamic-form-mcp/src/tools/search.tool.ts
+++ b/packages/dynamic-form-mcp/src/tools/search.tool.ts
@@ -1,9 +1,4 @@
-/**
- * Unified Search Tool
- *
- * Free-text keyword search across all TOPICS and PATTERNS.
- * Bridges the discoverability gap — find content without knowing exact topic names.
- */
+/** Unified Search Tool */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
@@ -25,9 +20,7 @@ interface SearchEntry {
 
 let searchIndex: SearchEntry[] | null = null;
 
-/**
- * Categorize a topic key into a subcategory for display.
- */
+/** Categorize a topic key into a subcategory for display. */
 function getTopicSubcategory(key: string): string {
   const fieldTypes = ['input', 'select', 'slider', 'radio', 'checkbox', 'textarea', 'datepicker', 'toggle', 'text', 'hidden'];
   const containers = ['group', 'row', 'array', 'simplified-array', 'page'];
@@ -50,9 +43,7 @@ function getTopicSubcategory(key: string): string {
   return 'Pattern';
 }
 
-/**
- * Build the search index from TOPICS and PATTERNS.
- */
+/** Build the search index from TOPICS and PATTERNS. */
 function buildIndex(): SearchEntry[] {
   if (searchIndex) return searchIndex;
 
@@ -127,9 +118,7 @@ function buildIndex(): SearchEntry[] {
   return entries;
 }
 
-/**
- * Score a search entry against query tokens.
- */
+/** Score a search entry against query tokens. */
 function scoreEntry(entry: SearchEntry, tokens: string[]): number {
   let score = 0;
   const idLower = entry.id.toLowerCase();
@@ -166,9 +155,7 @@ function scoreEntry(entry: SearchEntry, tokens: string[]): number {
   return score;
 }
 
-/**
- * Format search results.
- */
+/** Format search results. */
 function formatResults(results: Array<{ entry: SearchEntry; score: number }>): string {
   if (results.length === 0) {
     return `# No Results Found

--- a/packages/dynamic-form-mcp/src/tools/validate.tool.ts
+++ b/packages/dynamic-form-mcp/src/tools/validate.tool.ts
@@ -1,14 +1,4 @@
-/**
- * Unified Validation Tool
- *
- * Consolidated validation tool that absorbs:
- * - validate-file.tool.ts (TypeScript file validation with AST extraction)
- * - validate-form-config.tool.ts (JSON config validation)
- * - validate-field.tool.ts (single field validation)
- *
- * Single tool for "Is my config correct?"
- * Auto-detects if config is a file path or JSON object.
- */
+/** Unified Validation Tool */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
@@ -29,9 +19,7 @@ import {
 
 const UI_INTEGRATIONS = ['material', 'bootstrap', 'primeng', 'ionic'] as const;
 
-/**
- * Common fixes for validation errors.
- */
+/** Common fixes for validation errors. */
 const FIX_SUGGESTIONS: Record<string, string> = {
   options: 'Move `options` from `props: { options: [...] }` to field level: `{ key, type, options: [...] }`',
   label: 'Remove `label` from this container field (page/group/row/array). Use a `text` field inside for headings.',
@@ -90,9 +78,7 @@ const ERROR_TOPIC_HINTS: Array<{ pattern: RegExp; hint: string }> = [
   { pattern: /array/i, hint: '`ngforge_lookup topic="array"` — array field configuration' },
 ];
 
-/**
- * Collect unique topic hints based on validation errors.
- */
+/** Collect unique topic hints based on validation errors. */
 function collectErrorTopicHints(errors: FormattedValidationError[]): string[] {
   const seenHints = new Set<string>();
   const hints: string[] = [];
@@ -110,9 +96,7 @@ function collectErrorTopicHints(errors: FormattedValidationError[]): string[] {
   return hints;
 }
 
-/**
- * Get fix suggestion for an error.
- */
+/** Get fix suggestion for an error. */
 function getFixSuggestion(error: FormattedValidationError): string | undefined {
   const pathParts = error.path.split('.');
   const lastPart = pathParts[pathParts.length - 1];
@@ -132,9 +116,7 @@ function getFixSuggestion(error: FormattedValidationError): string | undefined {
   return undefined;
 }
 
-/**
- * Result of extracting and validating a single FormConfig from file.
- */
+/** Result of extracting and validating a single FormConfig from file. */
 interface ConfigValidationResult {
   name: string;
   line: number;
@@ -143,9 +125,7 @@ interface ConfigValidationResult {
   validation: ValidationResult;
 }
 
-/**
- * Format validation report for file validation.
- */
+/** Format validation report for file validation. */
 function formatFileReport(
   filePath: string,
   uiIntegration: string,
@@ -245,9 +225,7 @@ function formatFileReport(
   return lines.join('\n');
 }
 
-/**
- * Format validation report for JSON config validation.
- */
+/** Format validation report for JSON config validation. */
 function formatJsonReport(uiIntegration: string, result: ValidationResult): string {
   const lines: string[] = [];
 
@@ -291,9 +269,7 @@ function formatJsonReport(uiIntegration: string, result: ValidationResult): stri
   return lines.join('\n');
 }
 
-/**
- * Detect if a string is a file path.
- */
+/** Detect if a string is a file path. */
 function isFilePath(value: string): boolean {
   // Check for common file path patterns
   return (
@@ -309,9 +285,7 @@ function isFilePath(value: string): boolean {
   );
 }
 
-/**
- * Parse config input - handles string (file path or JSON) or object.
- */
+/** Parse config input - handles string (file path or JSON) or object. */
 async function parseConfigInput(
   config: string | Record<string, unknown>,
 ): Promise<

--- a/packages/dynamic-form-mcp/src/utils/ast-extractor.ts
+++ b/packages/dynamic-form-mcp/src/utils/ast-extractor.ts
@@ -1,14 +1,4 @@
-/**
- * AST Extractor Utility
- *
- * Uses ts-morph for robust TypeScript parsing to extract FormConfig objects.
- * Handles complex patterns that regex + new Function() cannot:
- * - new Date() constructors
- * - Function references and arrow functions
- * - Regex literals
- * - External variable references
- * - Method calls like Math.floor()
- */
+/** AST Extractor Utility */
 
 /**
  * Placeholder date used when encountering `new Date()` expressions.
@@ -33,9 +23,7 @@ import {
   SatisfiesExpression,
 } from 'ts-morph';
 
-/**
- * A candidate FormConfig object found in the source file.
- */
+/** A candidate FormConfig object found in the source file. */
 export interface FormConfigCandidate {
   /** Variable or property name */
   name: string;
@@ -47,9 +35,7 @@ export interface FormConfigCandidate {
   matchReason: 'type-annotation' | 'satisfies' | 'as-cast' | 'structural';
 }
 
-/**
- * Warning about a non-serializable value that was replaced with a placeholder.
- */
+/** Warning about a non-serializable value that was replaced with a placeholder. */
 export interface ExtractionWarning {
   /** Path to the property, e.g., "fields[0].props.maxDate" */
   path: string;
@@ -61,9 +47,7 @@ export interface ExtractionWarning {
   placeholder: string | number | boolean | null;
 }
 
-/**
- * Error that occurred during extraction.
- */
+/** Error that occurred during extraction. */
 export interface ExtractionError {
   /** Path to the property */
   path: string;
@@ -71,9 +55,7 @@ export interface ExtractionError {
   message: string;
 }
 
-/**
- * Result of extracting an AST node to JSON.
- */
+/** Result of extracting an AST node to JSON. */
 export interface ExtractionResult {
   /** The extracted JSON-safe object */
   value: unknown;
@@ -83,23 +65,13 @@ export interface ExtractionResult {
   errors: ExtractionError[];
 }
 
-/**
- * Create a ts-morph Project and parse source code.
- */
+/** Create a ts-morph Project and parse source code. */
 export function createSourceFile(source: string, fileName = 'temp.ts'): SourceFile {
   const project = new Project({ useInMemoryFileSystem: true });
   return project.createSourceFile(fileName, source);
 }
 
-/**
- * Find all potential FormConfig objects in a source file.
- *
- * Uses multiple detection strategies (in order of precedence):
- * 1. Type annotation: `const x: FormConfig = {...}` or `const x: SomeFormConfig = {...}`
- * 2. Satisfies: `const x = {...} satisfies FormConfig` or `{...} as const satisfies SomeConfig`
- * 3. As cast: `const x = {...} as FormConfig`
- * 4. Structural: Any object with `fields` array containing form-like objects
- */
+/** Find all potential FormConfig objects in a source file. */
 export function findFormConfigCandidates(sourceFile: SourceFile): FormConfigCandidate[] {
   const candidates: FormConfigCandidate[] = [];
   const foundNames = new Set<string>();
@@ -215,9 +187,7 @@ function findSatisfiesExpression(node: Node | undefined): SatisfiesExpression | 
   return undefined;
 }
 
-/**
- * Find object literal within a satisfies expression.
- */
+/** Find object literal within a satisfies expression. */
 function findObjectLiteralInSatisfies(satisfiesExpr: SatisfiesExpression): ObjectLiteralExpression | undefined {
   const expression = satisfiesExpr.getExpression();
   if (!expression) return undefined;
@@ -237,9 +207,7 @@ function findObjectLiteralInSatisfies(satisfiesExpr: SatisfiesExpression): Objec
   return undefined;
 }
 
-/**
- * Find an ObjectLiteralExpression in a node (handles as const, parentheses, etc.)
- */
+/** Find an ObjectLiteralExpression in a node (handles as const, parentheses, etc.) */
 function findObjectLiteral(node: Node | undefined): ObjectLiteralExpression | undefined {
   if (!node) return undefined;
 
@@ -314,9 +282,7 @@ export function extractToJson(node: Node, path = ''): ExtractionResult {
   return { value, warnings, errors };
 }
 
-/**
- * Recursively extract a node to a JSON-safe value.
- */
+/** Recursively extract a node to a JSON-safe value. */
 function extractNode(node: Node, path: string, warnings: ExtractionWarning[], errors: ExtractionError[]): unknown {
   // String literals
   if (Node.isStringLiteral(node)) {

--- a/packages/dynamic-forms-bootstrap/src/lib/addons/bs-button-addon.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/addons/bs-button-addon.component.ts
@@ -4,14 +4,7 @@ import { DynamicTextPipe } from '@ng-forge/dynamic-forms';
 import { injectNgForgeAddonAction, NgForgeAddonAction } from '@ng-forge/dynamic-forms/integration';
 import type { BsButtonAddon } from '../types/addons';
 
-/**
- * Renderer for the `bs-button` addon kind.
- *
- * Renders a Bootstrap `btn-outline-{severity}` button. Click dispatch
- * (preset / actionRef / action precedence, multi-set warning, `disabled` /
- * `loading` resolution) lives on `NgForgeAddonAction`; this component
- * focuses on the visual layer.
- */
+/** Renderer for the `bs-button` addon kind. */
 @Component({
   selector: 'df-bs-button-addon',
   imports: [DynamicTextPipe, AsyncPipe],

--- a/packages/dynamic-forms-bootstrap/src/lib/addons/bs-icon-addon.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/addons/bs-icon-addon.component.ts
@@ -3,13 +3,7 @@ import { ChangeDetectionStrategy, Component, computed, input } from '@angular/co
 import { DynamicTextPipe, WrapperFieldInputs } from '@ng-forge/dynamic-forms';
 import type { BsIconAddon } from '../types/addons';
 
-/**
- * Renderer for the `bs-icon` addon kind.
- *
- * Outputs `<i class="bi bi-{icon}">`. The host is set `aria-hidden="true"`
- * by default; if the addon supplies an `ariaLabel`, it is applied so the
- * icon is announced by screen readers.
- */
+/** Renderer for the `bs-icon` addon kind. */
 @Component({
   selector: 'df-bs-icon-addon',
   imports: [AsyncPipe, DynamicTextPipe],

--- a/packages/dynamic-forms-bootstrap/src/lib/directives/input-constraints.directive.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/directives/input-constraints.directive.ts
@@ -1,9 +1,7 @@
 import { Directive, ElementRef, inject, input } from '@angular/core';
 import { explicitEffect } from 'ngxtension/explicit-effect';
 
-/**
- * Directive to set min, max, and step attributes on form inputs
- */
+/** Directive to set min, max, and step attributes on form inputs */
 @Directive({
   selector: '[dfBsInputConstraints]',
 })

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/button/bs-button.mapper.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/button/bs-button.mapper.ts
@@ -6,9 +6,6 @@ import { ARRAY_CONTEXT, buildBaseInputs, DEFAULT_PROPS, FieldDef } from '@ng-for
  * For specific button types (submit, next, prev, add/remove array items),
  * use the dedicated field types and their specific mappers.
  *
- * Supports template property for array events (AppendArrayItemEvent, PrependArrayItemEvent, InsertArrayItemEvent)
- * which enables the $template token in eventArgs.
- *
  * @param fieldDef The button field definition
  * @returns Signal containing Record of input names to values for ngComponentOutlet
  */

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/button/bs-button.type.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/button/bs-button.type.ts
@@ -25,9 +25,7 @@ export interface BsButtonProps {
 export type BsButtonField<TEvent extends FormEvent> = ButtonField<BsButtonProps, TEvent>;
 export type BsButtonComponent<TEvent extends FormEvent> = FieldComponent<BsButtonField<TEvent>>;
 
-/**
- * Specific button field types with preconfigured events
- */
+/** Specific button field types with preconfigured events */
 
 /** Submit button field - automatically disabled when form is invalid */
 export type BsSubmitButtonField = Omit<BsButtonField<SubmitEvent>, 'event' | 'type' | 'eventArgs'> & {
@@ -87,9 +85,7 @@ export type InsertArrayItemButtonField = Omit<BsButtonField<InsertArrayItemEvent
    * When inside an array, this is automatically determined from context.
    */
   arrayKey?: string;
-  /**
-   * The index at which to insert the new item.
-   */
+  /** The index at which to insert the new item. */
   index: number;
   /**
    * Template for the new array item. REQUIRED.

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/button/bs-specific-button.mapper.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/button/bs-specific-button.mapper.ts
@@ -1,7 +1,2 @@
-/**
- * Navigation button mappers for Bootstrap - re-exported from integration package.
- *
- * These mappers handle submit, next, and previous buttons with proper
- * disabled state resolution based on form validity and options.
- */
+/** Navigation button mappers for Bootstrap - re-exported from integration package. */
 export { submitButtonFieldMapper, nextButtonFieldMapper, previousButtonFieldMapper } from '@ng-forge/dynamic-forms/integration';

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/input/bs-input.type.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/input/bs-input.type.ts
@@ -15,33 +15,13 @@ export interface BsInputProps extends InputProps {
 /**
  * Module-augmentable seam for adding custom addon kinds to `bs-input` at
  * the type level. Pair with `withCustomAddon(...)` for the runtime side:
- *
- * ```ts
- * declare module '@ng-forge/dynamic-forms-bootstrap' {
- *   interface BsAddonExtensions {
- *     'my-rating': MyRatingAddon;
- *   }
- * }
- * ```
- *
- * Empty by default — the extension lookup resolves to `never` and contributes
- * nothing to the union.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type -- Intentionally empty: module-augmentation seam
 export interface BsAddonExtensions {}
 
 type BsAddonExtension = BsAddonExtensions[keyof BsAddonExtensions];
 
-/**
- * Addon kinds accepted by `bs-input`.
- *
- * Bootstrap-specific kinds (`bs-icon`, `bs-button`) plus the universal `text`
- * and `template` kinds. `component` is permitted at runtime via the broader
- * `BaseAddon` union (and dropped in JSON-derived configs by the validator)
- * but excluded here so the IDE narrows tightly to declarative shapes.
- *
- * To extend with custom kinds, augment `BsAddonExtensions`.
- */
+/** Addon kinds accepted by `bs-input`. */
 export type BsInputAddon = BsIconAddon | BsButtonAddon | TextAddon | TemplateAddon | BsAddonExtension;
 
 export type BsInputField = InputField<BsInputProps> & {

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/radio/bs-radio-group.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/radio/bs-radio-group.component.ts
@@ -5,25 +5,15 @@ import { NgForgeControl } from '@ng-forge/dynamic-forms/integration';
 import { AsyncPipe } from '@angular/common';
 
 export interface BsRadioGroupProps {
-  /**
-   * Display radio buttons inline (horizontal)
-   */
+  /** Display radio buttons inline (horizontal) */
   inline?: boolean;
-  /**
-   * Reverse the position of the radio button and label
-   */
+  /** Reverse the position of the radio button and label */
   reverse?: boolean;
-  /**
-   * Display as button group instead of radio buttons
-   */
+  /** Display as button group instead of radio buttons */
   buttonGroup?: boolean;
-  /**
-   * Button size when using button group
-   */
+  /** Button size when using button group */
   buttonSize?: 'sm' | 'lg';
-  /**
-   * Hint text to display below the radio group
-   */
+  /** Hint text to display below the radio group */
   hint?: DynamicText;
 }
 
@@ -106,9 +96,7 @@ export class BsRadioGroupComponent implements FormValueControl<ValueType | undef
   readonly options = input.required<FieldOption<ValueType>[]>();
   readonly properties = input<BsRadioGroupProps>();
 
-  /**
-   * Handle radio button change event
-   */
+  /** Handle radio button change event */
   protected onRadioChange(newValue: ValueType): void {
     if (!this.disabled() && !this.readonly()) {
       this.value.set(newValue);

--- a/packages/dynamic-forms-bootstrap/src/lib/models/bootstrap-config.token.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/models/bootstrap-config.token.ts
@@ -4,22 +4,5 @@ import { BootstrapConfig } from './bootstrap-config';
 /**
  * Injection token for Bootstrap form configuration.
  * Use this to provide global configuration for Bootstrap form fields.
- *
- * @example
- * ```typescript
- * import { provideDynamicForm } from '@ng-forge/dynamic-forms';
- * import { withBootstrapFields } from '@ng-forge/dynamic-forms-bootstrap';
- *
- * export const appConfig: ApplicationConfig = {
- *   providers: [
- *     provideDynamicForm(
- *       ...withBootstrapFields({
- *         floatingLabel: true,
- *         size: 'lg'
- *       })
- *     )
- *   ]
- * };
- * ```
  */
 export const BOOTSTRAP_CONFIG = new InjectionToken<BootstrapConfig>('BOOTSTRAP_CONFIG');

--- a/packages/dynamic-forms-bootstrap/src/lib/models/bootstrap-config.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/models/bootstrap-config.ts
@@ -1,51 +1,36 @@
-/**
- * Configuration options for Bootstrap form fields.
- *
- * These settings can be applied at two levels:
- * - **Library-level**: Via `withBootstrapFields({ ... })` - applies to all forms
- * - **Form-level**: Via `defaultProps` in form config - applies to a specific form
- *
- * The cascade hierarchy is: Library-level → Form-level → Field-level
- *
- * @example
- * ```typescript
- * // Library-level (in app config)
- * provideDynamicForms(withBootstrapFields({ size: 'sm', floatingLabel: true }))
- *
- * // Form-level (in form config)
- * const config: BsFormConfig = {
- *   defaultProps: { size: 'lg' },
- *   fields: [...]
- * };
- * ```
- */
+/** Configuration options for Bootstrap form fields. */
 export interface BootstrapConfig {
   /**
    * Default size for form controls
+   *
    * @default undefined
    */
   size?: 'sm' | 'lg';
 
   /**
    * Whether to use floating labels by default for inputs
+   *
    * @default false
    */
   floatingLabel?: boolean;
 
   /**
    * Default variant for buttons
+   *
    * @default 'primary'
    */
   variant?: 'primary' | 'secondary' | 'success' | 'danger' | 'warning' | 'info' | 'light' | 'dark' | 'link';
 
   /**
    * Whether buttons should be outlined by default
+   *
    * @default false
    */
   outline?: boolean;
 
   /**
    * Whether buttons should be block-level by default
+   *
    * @default false
    */
   block?: boolean;

--- a/packages/dynamic-forms-bootstrap/src/lib/providers/bootstrap-providers.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/providers/bootstrap-providers.ts
@@ -5,9 +5,7 @@ import { BootstrapConfig } from '../models/bootstrap-config';
 import { BOOTSTRAP_CONFIG } from '../models/bootstrap-config.token';
 import type { BsButtonAddon, BsIconAddon } from '../types/addons';
 
-/**
- * Field type definitions for Bootstrap components.
- */
+/** Field type definitions for Bootstrap components. */
 export type BootstrapFieldTypes = FieldTypeDefinition[];
 
 type BootstrapConfigFeature = {
@@ -28,40 +26,7 @@ type BootstrapFieldsWithConfig = [...BootstrapFieldTypes, BootstrapAddonsFeature
  * with Bootstrap-shipped addon kinds (`bs-icon`, `bs-button`) auto-included
  * so addons work out of the box.
  *
- * If you want addons WITHOUT the field types (rare — e.g., adding addons to
- * a form that uses custom fields), call `withBootstrapAddons()` standalone.
- *
  * @param config - Optional global configuration for Bootstrap form fields
- *
- * @example
- * ```typescript
- * // Application-level setup — addons (bs-icon, bs-button) ship in automatically
- * import { ApplicationConfig } from '@angular/core';
- * import { provideDynamicForm } from '@ng-forge/dynamic-forms';
- * import { withBootstrapFields } from '@ng-forge/dynamic-forms-bootstrap';
- *
- * export const appConfig: ApplicationConfig = {
- *   providers: [
- *     provideDynamicForm(...withBootstrapFields())
- *   ]
- * };
- * ```
- *
- * @example
- * ```typescript
- * // With global configuration
- * export const appConfig: ApplicationConfig = {
- *   providers: [
- *     provideDynamicForm(
- *       ...withBootstrapFields({
- *         floatingLabel: true,
- *         size: 'lg'
- *       })
- *     )
- *   ]
- * };
- * ```
- *
  * @returns Tuple of field type definitions, the addons feature, and
  *   optionally a config feature.
  */
@@ -125,27 +90,7 @@ type BootstrapAddonsFeature = {
   ɵproviders: Provider[];
 };
 
-/**
- * Register Bootstrap-shipped addon kinds (`bs-icon`, `bs-button`) standalone.
- *
- * **Most users don't need this** — `withBootstrapFields()` auto-includes
- * these kinds. Call `withBootstrapAddons()` directly only when you want
- * Bootstrap addon kinds without the Bootstrap field types (e.g., a custom
- * field set that wants to render `bs-icon` prefixes), or when you're
- * stitching addons through a different DI scope.
- *
- * @example
- * ```typescript
- * // Custom field types + Bootstrap addon kinds.
- * provideDynamicForm(
- *   ...myCustomFields(),
- *   withBootstrapAddons(),
- * );
- * ```
- *
- * Adapter authors who need to override a kind with a customised renderer
- * should call `withCustomAddon(...)` directly instead.
- */
+/** Register Bootstrap-shipped addon kinds (`bs-icon`, `bs-button`) standalone. */
 export function withBootstrapAddons(): BootstrapAddonsFeature {
   return {
     ɵkind: 'addons',

--- a/packages/dynamic-forms-bootstrap/src/lib/testing/bootstrap-test-utils.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/testing/bootstrap-test-utils.ts
@@ -16,26 +16,20 @@ import { BsButtonField } from '../fields/button/bs-button.type';
 import { BsMultiCheckboxField } from '../fields/multi-checkbox/bs-multi-checkbox.type';
 import { BsField } from '../types/types';
 
-/**
- * Configuration for creating a Bootstrap dynamic form test
- */
+/** Configuration for creating a Bootstrap dynamic form test */
 export interface BootstrapFormTestConfig {
   config: FormConfig;
   initialValue?: Record<string, unknown>;
   providers?: unknown[];
 }
 
-/**
- * Result of creating a Bootstrap dynamic form test
- */
+/** Result of creating a Bootstrap dynamic form test */
 export interface BootstrapFormTestResult {
   component: DynamicForm;
   fixture: ComponentFixture<DynamicForm<RegisteredFieldTypes[]>>;
 }
 
-/**
- * Fluent API for building Bootstrap form configurations
- */
+/** Fluent API for building Bootstrap form configurations */
 export class BootstrapFormConfigBuilder {
   private fields: unknown[] = [];
 
@@ -119,20 +113,14 @@ export class BootstrapFormConfigBuilder {
   }
 }
 
-/**
- * Utility class for testing Bootstrap dynamic forms
- */
+/** Utility class for testing Bootstrap dynamic forms */
 export class BootstrapFormTestUtils {
-  /**
-   * Creates a new Bootstrap form config builder
-   */
+  /** Creates a new Bootstrap form config builder */
   static builder(): BootstrapFormConfigBuilder {
     return new BootstrapFormConfigBuilder();
   }
 
-  /**
-   * Creates a Bootstrap dynamic form test setup with proper providers
-   */
+  /** Creates a Bootstrap dynamic form test setup with proper providers */
   static async createTest(testConfig: BootstrapFormTestConfig): Promise<BootstrapFormTestResult> {
     await TestBed.configureTestingModule({
       imports: [DynamicForm],
@@ -160,9 +148,7 @@ export class BootstrapFormTestUtils {
     };
   }
 
-  /**
-   * Waits for the Bootstrap dynamic form to initialize
-   */
+  /** Waits for the Bootstrap dynamic form to initialize */
   static async waitForInit(fixture: ComponentFixture<DynamicForm>): Promise<void> {
     await waitForDFInit(fixture.componentInstance, fixture);
 
@@ -184,9 +170,7 @@ export class BootstrapFormTestUtils {
     fixture.detectChanges();
   }
 
-  /**
-   * Simulates user input on a Bootstrap input field
-   */
+  /** Simulates user input on a Bootstrap input field */
   static async simulateBsInput(fixture: ComponentFixture<DynamicForm>, selector: string, value: string): Promise<void> {
     const input = fixture.nativeElement.querySelector(selector) as HTMLInputElement;
     if (!input) {
@@ -200,9 +184,7 @@ export class BootstrapFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates user selection on a Bootstrap select
-   */
+  /** Simulates user selection on a Bootstrap select */
   static async simulateBsSelect(fixture: ComponentFixture<DynamicForm>, selectSelector: string, value: string | string[]): Promise<void> {
     const select = fixture.nativeElement.querySelector(selectSelector) as HTMLSelectElement;
     if (!select) {
@@ -226,9 +208,7 @@ export class BootstrapFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates Bootstrap checkbox toggle
-   */
+  /** Simulates Bootstrap checkbox toggle */
   static async simulateBsCheckbox(fixture: ComponentFixture<DynamicForm>, selector: string, checked: boolean): Promise<void> {
     let checkboxElement: Element | null = null;
 
@@ -288,9 +268,7 @@ export class BootstrapFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates Bootstrap toggle switch
-   */
+  /** Simulates Bootstrap toggle switch */
   static async simulateBsToggle(fixture: ComponentFixture<DynamicForm>, selector: string, checked: boolean): Promise<void> {
     const toggle = fixture.nativeElement.querySelector(selector) as HTMLInputElement;
     if (!toggle) {
@@ -309,9 +287,7 @@ export class BootstrapFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates Bootstrap button click
-   */
+  /** Simulates Bootstrap button click */
   static async simulateBsButtonClick(fixture: ComponentFixture<DynamicForm>, selector: string): Promise<void> {
     const button = fixture.nativeElement.querySelector(selector) as HTMLButtonElement;
     if (!button) {
@@ -323,9 +299,7 @@ export class BootstrapFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates Bootstrap radio button selection
-   */
+  /** Simulates Bootstrap radio button selection */
   static async simulateBsRadio(fixture: ComponentFixture<DynamicForm>, selector: string, value: string): Promise<void> {
     // Find all radio buttons in the group
     const radios = fixture.nativeElement.querySelectorAll(selector) as NodeListOf<HTMLInputElement>;
@@ -353,9 +327,7 @@ export class BootstrapFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates Bootstrap slider (range) input (.form-range)
-   */
+  /** Simulates Bootstrap slider (range) input (.form-range) */
   static async simulateBsSlider(fixture: ComponentFixture<DynamicForm>, selector: string, value: number): Promise<void> {
     const slider = fixture.nativeElement.querySelector(selector) as HTMLInputElement;
     if (!slider) {
@@ -369,37 +341,27 @@ export class BootstrapFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Gets the current form value from the component
-   */
+  /** Gets the current form value from the component */
   static getFormValue(component: DynamicForm): Record<string, unknown> {
     return component.formValue();
   }
 
-  /**
-   * Gets validation errors from the component
-   */
+  /** Gets validation errors from the component */
   static getFormErrors(component: DynamicForm): unknown[] {
     return component.errors();
   }
 
-  /**
-   * Checks if the form is valid
-   */
+  /** Checks if the form is valid */
   static isFormValid(component: DynamicForm): boolean {
     return component.valid();
   }
 
-  /**
-   * Gets all Bootstrap field elements from the fixture
-   */
+  /** Gets all Bootstrap field elements from the fixture */
   static getBsFieldElements(fixture: ComponentFixture<DynamicForm>, fieldType: string): NodeListOf<Element> {
     return fixture.nativeElement.querySelectorAll(`df-bs-${fieldType}`);
   }
 
-  /**
-   * Asserts that a Bootstrap field has a specific value
-   */
+  /** Asserts that a Bootstrap field has a specific value */
   static assertBsFieldValue(fixture: ComponentFixture<DynamicForm>, fieldSelector: string, expectedValue: string): void {
     const element = fixture.nativeElement.querySelector(fieldSelector);
     if (!element) {
@@ -427,9 +389,7 @@ export class BootstrapFormTestUtils {
     }
   }
 
-  /**
-   * Asserts that the form has a specific value
-   */
+  /** Asserts that the form has a specific value */
   static assertFormValue(component: DynamicForm, expectedValue: Record<string, unknown>): void {
     const actualValue = component.formValue();
     if (JSON.stringify(actualValue) !== JSON.stringify(expectedValue)) {
@@ -437,9 +397,7 @@ export class BootstrapFormTestUtils {
     }
   }
 
-  /**
-   * Asserts that a Bootstrap field shows an error message
-   */
+  /** Asserts that a Bootstrap field shows an error message */
   static assertBsFieldError(fixture: ComponentFixture<DynamicForm>, fieldSelector: string, expectedError?: string): void {
     const fieldContainer = fixture.nativeElement.querySelector(fieldSelector);
     if (!fieldContainer) {
@@ -456,9 +414,7 @@ export class BootstrapFormTestUtils {
     }
   }
 
-  /**
-   * Asserts that an element has a specific Bootstrap class
-   */
+  /** Asserts that an element has a specific Bootstrap class */
   static assertHasClass(fixture: ComponentFixture<DynamicForm>, selector: string, className: string): void {
     const element = fixture.nativeElement.querySelector(selector);
     if (!element) {

--- a/packages/dynamic-forms-bootstrap/src/lib/testing/wait-for-df.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/testing/wait-for-df.ts
@@ -2,20 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DynamicForm } from '@ng-forge/dynamic-forms';
 import { firstValueFrom } from 'rxjs';
 
-/**
- * Waits for all dynamic form definitions to be initialized and ready
- *
- * Hybrid approach:
- * 1. Event-based: Wait for initialized$ (tracks container components + field loading cascade)
- * 2. DOM verification: Short poll to ensure Bootstrap components fully rendered
- *
- * The initialized$ observable tracks page/row/group containers. Each container waits
- * for its children via forkJoin + afterNextRender before emitting its initialized event.
- * This creates a cascade where parent containers only emit after all descendants are ready.
- *
- * The short poll handles edge cases where Bootstrap component templates need additional
- * change detection cycles before DOM elements match test selectors.
- */
+/** Waits for all dynamic form definitions to be initialized and ready */
 export async function waitForDFInit(component: DynamicForm, fixture: ComponentFixture<unknown>): Promise<void> {
   fixture.detectChanges();
 
@@ -38,13 +25,7 @@ export async function waitForDFInit(component: DynamicForm, fixture: ComponentFi
   await fixture.whenStable();
 }
 
-/**
- * Deterministic DOM stability check
- *
- * Waits until Bootstrap component count stabilizes for 3 consecutive checks
- * and no loading placeholders remain. Uses timeout-based safety net instead
- * of arbitrary iteration limits.
- */
+/** Deterministic DOM stability check */
 async function waitForFieldComponents(fixture: ComponentFixture<any>, timeoutMs = 500, debug = false): Promise<void> {
   const formElement = fixture.nativeElement.querySelector('.df-form, form');
   if (!formElement) return;

--- a/packages/dynamic-forms-bootstrap/src/lib/tokens/input-type-override.token.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/tokens/input-type-override.token.ts
@@ -1,14 +1,4 @@
 import { InjectionToken, WritableSignal } from '@angular/core';
 
-/**
- * Per-field writable signal that overrides the input's `type` attribute.
- *
- * Provided at the `bs-input` field component level. The button addon's
- * `'toggle-password-visibility'` preset writes to it; the field component
- * reads it to compute its effective `type`.
- *
- * Optional from a button's perspective — when the button is hosted inside a
- * field that doesn't provide this token (e.g., textarea or a future
- * non-input field), the toggle preset is a no-op.
- */
+/** Per-field writable signal that overrides the input's `type` attribute. */
 export const BS_INPUT_TYPE_OVERRIDE = new InjectionToken<WritableSignal<string | undefined>>('BS_INPUT_TYPE_OVERRIDE');

--- a/packages/dynamic-forms-bootstrap/src/lib/types/addons.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/types/addons.ts
@@ -7,15 +7,7 @@ import type {
   RegisteredActionRef,
 } from '@ng-forge/dynamic-forms';
 
-/**
- * Decorative icon addon for Bootstrap fields.
- *
- * Renders `<i class="bi bi-{icon}">` (Bootstrap Icons). The `icon` string is the
- * bare suffix — e.g., `'search'` produces `<i class="bi bi-search">`.
- *
- * Add `ariaLabel` for icons that convey meaning (search, error, success);
- * leave it omitted for purely decorative icons (will be `aria-hidden="true"`).
- */
+/** Decorative icon addon for Bootstrap fields. */
 export interface BsIconAddon extends BaseAddon {
   readonly kind: 'bs-icon';
   /** Bootstrap Icons name without the `bi-` prefix (e.g., `'search'`, `'x'`). */
@@ -40,11 +32,6 @@ interface BsButtonBase extends BaseAddon {
  * Click axis — XOR enforced at type level so configurations that combine
  * two click handlers (e.g., `preset` AND `actionRef`) are rejected by
  * TypeScript. The four shapes:
- *
- * - `Preset`    — built-in preset action.
- * - `ActionRef` — typed reference to a handler registered via `provideAddonActions(...)`.
- * - `Action`    — inline handler (code-only; dropped from JSON-derived configs).
- * - `None`      — decorative button with no handler.
  */
 type BsButtonClickPreset = {
   /** Built-in preset action (e.g., `'clear'`, `'toggle-password-visibility'`). JSON-safe. */
@@ -101,19 +88,7 @@ type BsButtonContentDecorative = {
 };
 type BsButtonContent = BsButtonContentIconOnly | BsButtonContentLabeled | BsButtonContentDecorative;
 
-/**
- * Interactive button addon for Bootstrap fields.
- *
- * Renders `<button class="btn btn-outline-{severity}">` with optional icon,
- * label, severity, and reactive loading state.
- *
- * Type-level guarantees:
- *
- * - **Content axis (XOR):** `IconOnly` (icon + required ariaLabel) |
- *   `Labeled` (label, icon optional) | `Decorative` (neither).
- * - **Click axis (XOR):** exactly one of `preset` / `actionRef` / `action`,
- *   or none.
- */
+/** Interactive button addon for Bootstrap fields. */
 export type BsButtonAddon = BsButtonBase & BsButtonContent & BsButtonClick;
 
 /** Union of all Bootstrap-shipped addon kinds. */

--- a/packages/dynamic-forms-bootstrap/src/lib/types/form-config.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/types/form-config.ts
@@ -1,50 +1,10 @@
 import { FormConfig, InferFormValue, NarrowFields, RegisteredFieldTypes } from '@ng-forge/dynamic-forms';
 import { BootstrapConfig } from '../models/bootstrap-config';
 
-/**
- * Bootstrap-specific props that can be set at form level and cascade to all fields.
- *
- * This is the same type as `BootstrapConfig` used in `withBootstrapFields()`.
- * Using a single type ensures consistency between library-level and form-level configuration.
- *
- * The cascade hierarchy is: Library-level → Form-level → Field-level
- *
- * @example
- * ```typescript
- * const config: BsFormConfig = {
- *   defaultProps: {
- *     size: 'sm',
- *     floatingLabel: true,
- *   },
- *   fields: [
- *     { type: 'bs-input', key: 'name', label: 'Name' },
- *   ],
- * };
- * ```
- */
+/** Bootstrap-specific props that can be set at form level and cascade to all fields. */
 export type BsFormProps = BootstrapConfig;
 
-/**
- * Bootstrap-specific FormConfig with type-safe defaultProps.
- *
- * Use this type alias when defining form configurations with Bootstrap components
- * to get IDE autocomplete and type checking for `defaultProps`.
- *
- * @example
- * ```typescript
- * const formConfig: BsFormConfig = {
- *   defaultProps: {
- *     size: 'sm',
- *     floatingLabel: true,
- *     variant: 'primary',
- *   },
- *   fields: [
- *     { type: 'bs-input', key: 'name', label: 'Name' },  // Uses form defaultProps
- *     { type: 'bs-input', key: 'email', props: { size: 'lg' } },  // Override
- *   ],
- * };
- * ```
- */
+/** Bootstrap-specific FormConfig with type-safe defaultProps. */
 export type BsFormConfig<
   TFields extends NarrowFields | RegisteredFieldTypes[] = RegisteredFieldTypes[],
   TValue = InferFormValue<TFields extends readonly RegisteredFieldTypes[] ? TFields : RegisteredFieldTypes[]>,

--- a/packages/dynamic-forms-bootstrap/testing/index.ts
+++ b/packages/dynamic-forms-bootstrap/testing/index.ts
@@ -1,8 +1,3 @@
-/**
- * Testing utilities for @ng-forge/dynamic-form-bootstrap
- *
- * This secondary entry point provides testing utilities for Bootstrap dynamic forms.
- * Import from '@ng-forge/dynamic-form-bootstrap/testing' to access these utilities.
- */
+/** Testing utilities for @ng-forge/dynamic-form-bootstrap */
 
 export * from '../src/lib/testing';

--- a/packages/dynamic-forms-ionic/src/lib/addons/ion-button-addon.component.ts
+++ b/packages/dynamic-forms-ionic/src/lib/addons/ion-button-addon.component.ts
@@ -5,15 +5,7 @@ import { DynamicTextPipe } from '@ng-forge/dynamic-forms';
 import { injectNgForgeAddonAction, NgForgeAddonAction } from '@ng-forge/dynamic-forms/integration';
 import type { IonButtonAddon } from '../types/addons';
 
-/**
- * Renderer for the `ion-button` addon kind.
- *
- * Wraps Ionic's `<ion-button>`. Click dispatch (preset / actionRef /
- * action precedence, multi-set warning, `disabled` / `loading`
- * resolution) lives on `NgForgeAddonAction`; this component focuses on
- * the visual layer. While `action.loading()`, an `<ion-spinner>` is
- * rendered in place of the icon and the button is disabled.
- */
+/** Renderer for the `ion-button` addon kind. */
 @Component({
   selector: 'df-ion-button-addon',
   imports: [IonButton, IonIcon, IonSpinner, DynamicTextPipe, AsyncPipe],

--- a/packages/dynamic-forms-ionic/src/lib/addons/ion-icon-addon.component.ts
+++ b/packages/dynamic-forms-ionic/src/lib/addons/ion-icon-addon.component.ts
@@ -4,13 +4,7 @@ import { IonIcon } from '@ionic/angular/standalone';
 import { DynamicTextPipe, WrapperFieldInputs } from '@ng-forge/dynamic-forms';
 import type { IonIconAddon } from '../types/addons';
 
-/**
- * Renderer for the `ion-icon` addon kind.
- *
- * Outputs `<ion-icon [name]="icon">`. The host is set `aria-hidden="true"`
- * by default; if the addon supplies an `ariaLabel`, it is applied so the
- * icon is announced by screen readers.
- */
+/** Renderer for the `ion-icon` addon kind. */
 @Component({
   selector: 'df-ion-icon-addon',
   imports: [IonIcon, AsyncPipe, DynamicTextPipe],

--- a/packages/dynamic-forms-ionic/src/lib/fields/button/ionic-button.mapper.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/button/ionic-button.mapper.ts
@@ -6,9 +6,6 @@ import { ARRAY_CONTEXT, buildBaseInputs, DEFAULT_PROPS, FieldDef } from '@ng-for
  * For specific button types (submit, next, prev, add/remove array items),
  * use the dedicated field types and their specific mappers.
  *
- * Supports template property for array events (AppendArrayItemEvent, PrependArrayItemEvent, InsertArrayItemEvent)
- * which enables the $template token in eventArgs.
- *
  * @param fieldDef The button field definition
  * @returns Signal containing Record of input names to values for ngComponentOutlet
  */

--- a/packages/dynamic-forms-ionic/src/lib/fields/button/ionic-button.type.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/button/ionic-button.type.ts
@@ -26,9 +26,7 @@ export interface IonicButtonProps {
 export type IonicButtonField<TEvent extends FormEvent> = ButtonField<IonicButtonProps, TEvent>;
 export type IonicButtonComponent<TEvent extends FormEvent> = FieldComponent<IonicButtonField<TEvent>>;
 
-/**
- * Specific button field types with preconfigured events
- */
+/** Specific button field types with preconfigured events */
 
 /** Submit button field - automatically disabled when form is invalid */
 export type IonicSubmitButtonField = Omit<IonicButtonField<SubmitEvent>, 'event' | 'type' | 'eventArgs'> & {
@@ -88,9 +86,7 @@ export type InsertArrayItemButtonField = Omit<IonicButtonField<InsertArrayItemEv
    * When inside an array, this is automatically determined from context.
    */
   arrayKey?: string;
-  /**
-   * The index at which to insert the new item.
-   */
+  /** The index at which to insert the new item. */
   index: number;
   /**
    * Template for the new array item. REQUIRED.

--- a/packages/dynamic-forms-ionic/src/lib/fields/button/ionic-specific-button.mapper.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/button/ionic-specific-button.mapper.ts
@@ -1,7 +1,2 @@
-/**
- * Navigation button mappers for Ionic - re-exported from integration package.
- *
- * These mappers handle submit, next, and previous buttons with proper
- * disabled state resolution based on form validity and options.
- */
+/** Navigation button mappers for Ionic - re-exported from integration package. */
 export { submitButtonFieldMapper, nextButtonFieldMapper, previousButtonFieldMapper } from '@ng-forge/dynamic-forms/integration';

--- a/packages/dynamic-forms-ionic/src/lib/fields/input/ionic-input.component.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/input/ionic-input.component.ts
@@ -182,9 +182,7 @@ export default class IonicInputFieldComponent {
 
   protected readonly fill = computed(() => this.props()?.fill ?? this.ionicConfig?.fill ?? 'solid');
   protected readonly shape = computed(() => this.props()?.shape ?? this.ionicConfig?.shape);
-  /** Default 'stacked' (label above the input) for adapter parity with Material /
-   *  Bootstrap / PrimeNG. Consumers can opt into Ionic's native inline 'start'
-   *  or 'fixed' via props.labelPlacement or the IONIC_CONFIG token. */
+  /**  Bootstrap / PrimeNG. Consumers can opt into Ionic's native inline 'start' */
   protected readonly labelPlacement = computed(() => this.props()?.labelPlacement ?? this.ionicConfig?.labelPlacement ?? 'stacked');
   protected readonly color = computed(() => this.props()?.color ?? this.ionicConfig?.color);
 

--- a/packages/dynamic-forms-ionic/src/lib/fields/input/ionic-input.type.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/input/ionic-input.type.ts
@@ -16,33 +16,13 @@ export interface IonicInputProps extends InputProps {
 /**
  * Module-augmentable seam for adding custom addon kinds to `ion-input` at
  * the type level. Pair with `withCustomAddon(...)` for the runtime side:
- *
- * ```ts
- * declare module '@ng-forge/dynamic-forms-ionic' {
- *   interface IonAddonExtensions {
- *     'my-rating': MyRatingAddon;
- *   }
- * }
- * ```
- *
- * Empty by default — the extension lookup resolves to `never` and contributes
- * nothing to the union.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type -- Intentionally empty: module-augmentation seam
 export interface IonAddonExtensions {}
 
 type IonAddonExtension = IonAddonExtensions[keyof IonAddonExtensions];
 
-/**
- * Addon kinds accepted by `ion-input`.
- *
- * Ionic-specific kinds (`ion-icon`, `ion-button`) plus the universal `text`
- * and `template` kinds. `component` is permitted at runtime via the broader
- * `BaseAddon` union (and dropped in JSON-derived configs by the validator)
- * but excluded here so the IDE narrows tightly to declarative shapes.
- *
- * To extend with custom kinds, augment `IonAddonExtensions`.
- */
+/** Addon kinds accepted by `ion-input`. */
 export type IonInputAddon = IonIconAddon | IonButtonAddon | TextAddon | TemplateAddon | IonAddonExtension;
 
 export type IonicInputField = InputField<IonicInputProps> & {

--- a/packages/dynamic-forms-ionic/src/lib/models/ionic-config.token.ts
+++ b/packages/dynamic-forms-ionic/src/lib/models/ionic-config.token.ts
@@ -4,22 +4,5 @@ import { IonicConfig } from './ionic-config';
 /**
  * Injection token for Ionic form configuration.
  * Use this to provide global configuration for Ionic form fields.
- *
- * @example
- * ```typescript
- * import { provideDynamicForm } from '@ng-forge/dynamic-forms';
- * import { withIonicFields } from '@ng-forge/dynamic-forms-ionic';
- *
- * export const appConfig: ApplicationConfig = {
- *   providers: [
- *     provideDynamicForm(
- *       ...withIonicFields({
- *         fill: 'outline',
- *         labelPlacement: 'floating'
- *       })
- *     )
- *   ]
- * };
- * ```
  */
 export const IONIC_CONFIG = new InjectionToken<IonicConfig>('IONIC_CONFIG');

--- a/packages/dynamic-forms-ionic/src/lib/models/ionic-config.ts
+++ b/packages/dynamic-forms-ionic/src/lib/models/ionic-config.ts
@@ -1,69 +1,57 @@
-/**
- * Configuration options for Ionic form fields.
- *
- * These settings can be applied at two levels:
- * - **Library-level**: Via `withIonicFields({ ... })` - applies to all forms
- * - **Form-level**: Via `defaultProps` in form config - applies to a specific form
- *
- * The cascade hierarchy is: Library-level → Form-level → Field-level
- *
- * @example
- * ```typescript
- * // Library-level (in app config)
- * provideDynamicForms(withIonicFields({ fill: 'outline', labelPlacement: 'floating' }))
- *
- * // Form-level (in form config)
- * const config: IonicFormConfig = {
- *   defaultProps: { color: 'tertiary' },
- *   fields: [...]
- * };
- * ```
- */
+/** Configuration options for Ionic form fields. */
 export interface IonicConfig {
   /**
    * Default fill style for form inputs
+   *
    * @default 'solid'
    */
   fill?: 'solid' | 'outline';
 
   /**
    * Default shape for form controls
+   *
    * @default undefined
    */
   shape?: 'round';
 
   /**
    * Default label placement for form inputs
+   *
    * @default 'start'
    */
   labelPlacement?: 'start' | 'end' | 'fixed' | 'stacked' | 'floating';
 
   /**
    * Default color theme for form controls
+   *
    * @default 'primary'
    */
   color?: 'primary' | 'secondary' | 'tertiary' | 'success' | 'warning' | 'danger' | 'light' | 'medium' | 'dark';
 
   /**
    * Default size for buttons
+   *
    * @default 'default'
    */
   size?: 'small' | 'default' | 'large';
 
   /**
    * Default expand behavior for buttons
+   *
    * @default undefined
    */
   expand?: 'full' | 'block';
 
   /**
    * Default fill style for buttons (overrides general fill if set)
+   *
    * @default 'solid'
    */
   buttonFill?: 'clear' | 'outline' | 'solid' | 'default';
 
   /**
    * Whether buttons should be strong (bold) by default
+   *
    * @default false
    */
   strong?: boolean;

--- a/packages/dynamic-forms-ionic/src/lib/providers/ionic-providers.ts
+++ b/packages/dynamic-forms-ionic/src/lib/providers/ionic-providers.ts
@@ -5,9 +5,7 @@ import { IonicConfig } from '../models/ionic-config';
 import { IONIC_CONFIG } from '../models/ionic-config.token';
 import type { IonButtonAddon, IonIconAddon } from '../types/addons';
 
-/**
- * Field type definitions for Ionic components.
- */
+/** Field type definitions for Ionic components. */
 export type IonicFieldTypes = FieldTypeDefinition[];
 
 type IonicConfigFeature = {
@@ -28,42 +26,7 @@ type IonicFieldsWithConfig = [...IonicFieldTypes, IonicAddonsFeature, IonicConfi
  * with Ionic-shipped addon kinds (`ion-icon`, `ion-button`) auto-included
  * so addons work out of the box.
  *
- * If you want field types WITHOUT addons (rare), pass them through
- * `provideDynamicForm` directly and skip this helper. If you want addons
- * WITHOUT the field types (also rare — e.g., adding addons to a form that
- * uses custom fields), call `withIonicAddons()` standalone.
- *
  * @param config - Optional global configuration for Ionic form fields
- *
- * @example
- * ```typescript
- * // Application-level setup — addons (ion-icon, ion-button) ship in automatically
- * import { ApplicationConfig } from '@angular/core';
- * import { provideDynamicForm } from '@ng-forge/dynamic-forms';
- * import { withIonicFields } from '@ng-forge/dynamic-forms-ionic';
- *
- * export const appConfig: ApplicationConfig = {
- *   providers: [
- *     provideDynamicForm(...withIonicFields())
- *   ]
- * };
- * ```
- *
- * @example
- * ```typescript
- * // With global configuration
- * export const appConfig: ApplicationConfig = {
- *   providers: [
- *     provideDynamicForm(
- *       ...withIonicFields({
- *         fill: 'outline',
- *         labelPlacement: 'floating'
- *       })
- *     )
- *   ]
- * };
- * ```
- *
  * @returns Tuple of field type definitions, the addons feature, and
  *   optionally a config feature.
  */
@@ -127,27 +90,7 @@ type IonicAddonsFeature = {
   ɵproviders: Provider[];
 };
 
-/**
- * Register Ionic-shipped addon kinds (`ion-icon`, `ion-button`) standalone.
- *
- * **Most users don't need this** — `withIonicFields()` auto-includes
- * these kinds. Call `withIonicAddons()` directly only when you want
- * Ionic addon kinds without the Ionic field types (e.g., a custom
- * field set that wants to render `ion-icon` prefixes), or when you're
- * stitching addons through a different DI scope.
- *
- * @example
- * ```typescript
- * // Custom field types + Ionic addon kinds.
- * provideDynamicForm(
- *   ...myCustomFields(),
- *   withIonicAddons(),
- * );
- * ```
- *
- * Adapter authors who need to override a kind with a customised renderer
- * should call `withCustomAddon(...)` directly instead.
- */
+/** Register Ionic-shipped addon kinds (`ion-icon`, `ion-button`) standalone. */
 export function withIonicAddons(): IonicAddonsFeature {
   return {
     ɵkind: 'addons',

--- a/packages/dynamic-forms-ionic/src/lib/testing/ionic-test-utils.ts
+++ b/packages/dynamic-forms-ionic/src/lib/testing/ionic-test-utils.ts
@@ -18,26 +18,20 @@ import {
 } from '../fields';
 import { IonicField } from '../types/types';
 
-/**
- * Configuration for creating an Ionic dynamic form test
- */
+/** Configuration for creating an Ionic dynamic form test */
 export interface IonicFormTestConfig {
   config: FormConfig;
   initialValue?: Record<string, unknown>;
   providers?: unknown[];
 }
 
-/**
- * Result of creating an Ionic dynamic form test
- */
+/** Result of creating an Ionic dynamic form test */
 export interface IonicFormTestResult {
   component: DynamicForm;
   fixture: ComponentFixture<DynamicForm<readonly RegisteredFieldTypes[]>>;
 }
 
-/**
- * Fluent API for building Ionic form configurations
- */
+/** Fluent API for building Ionic form configurations */
 export class IonicFormConfigBuilder {
   private fields: unknown[] = [];
 
@@ -121,20 +115,14 @@ export class IonicFormConfigBuilder {
   }
 }
 
-/**
- * Utility class for testing Ionic dynamic forms
- */
+/** Utility class for testing Ionic dynamic forms */
 export class IonicFormTestUtils {
-  /**
-   * Creates a new Ionic form config builder
-   */
+  /** Creates a new Ionic form config builder */
   static builder(): IonicFormConfigBuilder {
     return new IonicFormConfigBuilder();
   }
 
-  /**
-   * Creates an Ionic dynamic form test setup with proper providers
-   */
+  /** Creates an Ionic dynamic form test setup with proper providers */
   static async createTest(testConfig: IonicFormTestConfig): Promise<IonicFormTestResult> {
     await TestBed.configureTestingModule({
       imports: [DynamicForm],
@@ -161,9 +149,7 @@ export class IonicFormTestUtils {
     };
   }
 
-  /**
-   * Waits for the Ionic dynamic form to initialize
-   */
+  /** Waits for the Ionic dynamic form to initialize */
   static async waitForInit(fixture: ComponentFixture<DynamicForm>): Promise<void> {
     await waitForDFInit(fixture.componentInstance, fixture);
 
@@ -185,9 +171,7 @@ export class IonicFormTestUtils {
     fixture.detectChanges();
   }
 
-  /**
-   * Helper to query into Shadow DOM
-   */
+  /** Helper to query into Shadow DOM */
   private static queryShadowDom(element: Element, selector: string): Element | null {
     // Try to find in shadow root first
     if (element.shadowRoot) {
@@ -230,9 +214,7 @@ export class IonicFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates user selection on an Ionic select
-   */
+  /** Simulates user selection on an Ionic select */
   static async simulateIonicSelect(fixture: ComponentFixture<DynamicForm>, selectSelector: string, value: string): Promise<void> {
     // Find the ion-select component
     const ionSelect = fixture.nativeElement.querySelector(selectSelector);
@@ -372,37 +354,27 @@ export class IonicFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Gets the current form value from the component
-   */
+  /** Gets the current form value from the component */
   static getFormValue(component: DynamicForm): Record<string, unknown> {
     return component.formValue();
   }
 
-  /**
-   * Gets validation errors from the component
-   */
+  /** Gets validation errors from the component */
   static getFormErrors(component: DynamicForm): unknown[] {
     return component.errors() as unknown[];
   }
 
-  /**
-   * Checks if the form is valid
-   */
+  /** Checks if the form is valid */
   static isFormValid(component: DynamicForm): boolean {
     return component.valid();
   }
 
-  /**
-   * Gets all Ionic field elements from the fixture
-   */
+  /** Gets all Ionic field elements from the fixture */
   static getIonicFieldElements(fixture: ComponentFixture<DynamicForm>, fieldType: string): NodeListOf<Element> {
     return fixture.nativeElement.querySelectorAll(`df-ion-${fieldType}`);
   }
 
-  /**
-   * Asserts that an Ionic field has a specific value
-   */
+  /** Asserts that an Ionic field has a specific value */
   static assertIonicFieldValue(fixture: ComponentFixture<DynamicForm>, fieldSelector: string, expectedValue: string): void {
     // Try to find the input element directly first
     let element = fixture.nativeElement.querySelector(fieldSelector);
@@ -432,9 +404,7 @@ export class IonicFormTestUtils {
     }
   }
 
-  /**
-   * Asserts that the form has a specific value
-   */
+  /** Asserts that the form has a specific value */
   static assertFormValue(component: DynamicForm, expectedValue: Record<string, unknown>): void {
     const actualValue = component.formValue();
     if (JSON.stringify(actualValue) !== JSON.stringify(expectedValue)) {
@@ -442,9 +412,7 @@ export class IonicFormTestUtils {
     }
   }
 
-  /**
-   * Asserts that an Ionic field shows an error message
-   */
+  /** Asserts that an Ionic field shows an error message */
   static assertIonicFieldError(fixture: ComponentFixture<DynamicForm>, fieldSelector: string, expectedError?: string): void {
     const ionItem = fixture.nativeElement.querySelector(`${fieldSelector} ion-item`);
     if (!ionItem) {

--- a/packages/dynamic-forms-ionic/src/lib/testing/wait-for-df.ts
+++ b/packages/dynamic-forms-ionic/src/lib/testing/wait-for-df.ts
@@ -2,20 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DynamicForm } from '@ng-forge/dynamic-forms';
 import { firstValueFrom } from 'rxjs';
 
-/**
- * Waits for all dynamic form definitions to be initialized and ready
- *
- * Hybrid approach:
- * 1. Event-based: Wait for initialized$ (tracks container components + field loading cascade)
- * 2. DOM verification: Short poll to ensure Ionic components fully rendered
- *
- * The initialized$ observable tracks page/row/group containers. Each container waits
- * for its children via forkJoin + afterNextRender before emitting its initialized event.
- * This creates a cascade where parent containers only emit after all descendants are ready.
- *
- * The short poll handles edge cases where Ionic component templates need additional
- * change detection cycles before DOM elements match test selectors.
- */
+/** Waits for all dynamic form definitions to be initialized and ready */
 export async function waitForDFInit(component: DynamicForm, fixture: ComponentFixture<DynamicForm>): Promise<void> {
   fixture.detectChanges();
 
@@ -38,17 +25,7 @@ export async function waitForDFInit(component: DynamicForm, fixture: ComponentFi
   await fixture.whenStable();
 }
 
-/**
- * Deterministic DOM stability check
- *
- * Waits until Ionic component count stabilizes for 3 consecutive checks
- * and no loading placeholders remain. Uses timeout-based safety net instead
- * of arbitrary iteration limits.
- *
- * Note: Timeout is set to 500ms to leave margin for test assertions within
- * the 1000ms test timeout. Ionic web components with shadow DOM typically
- * stabilize well within this window.
- */
+/** Deterministic DOM stability check */
 async function waitForFieldComponents(fixture: ComponentFixture<DynamicForm>, timeoutMs = 500): Promise<void> {
   const formElement = fixture.nativeElement.querySelector('.df-form, form');
   if (!formElement) return;

--- a/packages/dynamic-forms-ionic/src/lib/tokens/input-type-override.token.ts
+++ b/packages/dynamic-forms-ionic/src/lib/tokens/input-type-override.token.ts
@@ -1,14 +1,4 @@
 import { InjectionToken, WritableSignal } from '@angular/core';
 
-/**
- * Per-field writable signal that overrides the input's `type` attribute.
- *
- * Provided at the `ion-input` field component level. The button addon's
- * `'toggle-password-visibility'` preset writes to it; the field component
- * reads it to compute its effective `type`.
- *
- * Optional from a button's perspective — when the button is hosted inside a
- * field that doesn't provide this token (e.g., textarea or a future
- * non-input field), the toggle preset is a no-op.
- */
+/** Per-field writable signal that overrides the input's `type` attribute. */
 export const IONIC_INPUT_TYPE_OVERRIDE = new InjectionToken<WritableSignal<string | undefined>>('IONIC_INPUT_TYPE_OVERRIDE');

--- a/packages/dynamic-forms-ionic/src/lib/types/addons.ts
+++ b/packages/dynamic-forms-ionic/src/lib/types/addons.ts
@@ -7,16 +7,7 @@ import type {
   RegisteredActionRef,
 } from '@ng-forge/dynamic-forms';
 
-/**
- * Decorative icon addon for Ion fields.
- *
- * Renders `<ion-icon name="{icon}">` (Ionons). The `icon` string is the
- * Ionons name — e.g., `'search-outline'` produces
- * `<ion-icon name="search-outline">`.
- *
- * Add `ariaLabel` for icons that convey meaning; leave it omitted for
- * purely decorative icons (will be `aria-hidden="true"`).
- */
+/** Decorative icon addon for Ion fields. */
 export interface IonIconAddon extends BaseAddon {
   readonly kind: 'ion-icon';
   /** Ionons name (e.g., `'search-outline'`, `'close-outline'`). */
@@ -25,14 +16,10 @@ export interface IonIconAddon extends BaseAddon {
   readonly ariaLabel?: DynamicText;
 }
 
-/**
- * Ionic-supported button colour palette.
- */
+/** Ionic-supported button colour palette. */
 type IonButtonColor = 'primary' | 'secondary' | 'tertiary' | 'success' | 'warning' | 'danger' | 'light' | 'medium' | 'dark';
 
-/**
- * Ionic-supported button fill variants.
- */
+/** Ionic-supported button fill variants. */
 type IonButtonFill = 'clear' | 'outline' | 'solid' | 'default';
 
 /**
@@ -53,14 +40,6 @@ interface IonButtonBase extends BaseAddon {
  * Click axis — XOR enforced at type level so configurations that combine
  * two click handlers (e.g., `preset` AND `actionRef`) are rejected by
  * TypeScript. The four shapes:
- *
- * - `Preset`    — built-in preset action.
- * - `ActionRef` — typed reference to a handler registered via `provideAddonActions(...)`.
- * - `Action`    — inline handler (code-only; dropped from JSON-derived configs).
- * - `None`      — decorative button with no handler.
- *
- * Runtime XOR validation stays as defence-in-depth for JSON-source configs
- * that bypass the type checker.
  */
 type IonButtonClickPreset = {
   /** Built-in preset action (e.g., `'clear'`, `'toggle-password-visibility'`). JSON-safe. */
@@ -99,13 +78,6 @@ type IonButtonClick = IonButtonClickPreset | IonButtonClickActionRef | IonButton
 /**
  * Content axis — XOR enforced at type level so an icon-only button is
  * forced to declare `ariaLabel`. The three shapes:
- *
- * - `IconOnly`   — just `icon`; `ariaLabel` is REQUIRED
- * - `Labeled`    — `label` set; `icon` and `ariaLabel` optional
- * - `Decorative` — neither icon nor label (e.g., custom-rendered child)
- *
- * Combining keys is rejected by TypeScript — `icon: 'x'` without either
- * `label` or `ariaLabel` doesn't satisfy any branch.
  */
 type IonButtonContentIconOnly = {
   readonly icon: string;
@@ -125,23 +97,7 @@ type IonButtonContentDecorative = {
 };
 type IonButtonContent = IonButtonContentIconOnly | IonButtonContentLabeled | IonButtonContentDecorative;
 
-/**
- * Interactive button addon for Ion fields.
- *
- * Renders `<ion-button>` with optional icon (via `<ion-icon>`), label,
- * colour / fill variants, and a reactive loading state (rendered as
- * `<ion-spinner>`).
- *
- * Type-level guarantees:
- *
- * - **Content axis (XOR):** `IconOnly` (icon + required ariaLabel) |
- *   `Labeled` (label, icon optional) | `Decorative` (neither). The IDE
- *   rejects icon-only configs that omit `ariaLabel`.
- * - **Click axis (XOR):** exactly one of `preset` / `actionRef` / `action`,
- *   or none. Combining two is rejected by TypeScript at the call site;
- *   the runtime validator still drops the addon with a clear warning when
- *   JSON-source configs slip a multi-set past the type checker.
- */
+/** Interactive button addon for Ion fields. */
 export type IonButtonAddon = IonButtonBase & IonButtonContent & IonButtonClick;
 
 /** Union of all Ion-shipped addon kinds. */

--- a/packages/dynamic-forms-ionic/src/lib/types/form-config.ts
+++ b/packages/dynamic-forms-ionic/src/lib/types/form-config.ts
@@ -1,51 +1,10 @@
 import { FormConfig, InferFormValue, NarrowFields, RegisteredFieldTypes } from '@ng-forge/dynamic-forms';
 import { IonicConfig } from '../models/ionic-config';
 
-/**
- * Ionic-specific props that can be set at form level and cascade to all fields.
- *
- * This is the same type as `IonicConfig` used in `withIonicFields()`.
- * Using a single type ensures consistency between library-level and form-level configuration.
- *
- * The cascade hierarchy is: Library-level → Form-level → Field-level
- *
- * @example
- * ```typescript
- * const config: IonicFormConfig = {
- *   defaultProps: {
- *     fill: 'outline',
- *     labelPlacement: 'floating',
- *     color: 'tertiary',
- *   },
- *   fields: [
- *     { type: 'ionic-input', key: 'name', label: 'Name' },
- *   ],
- * };
- * ```
- */
+/** Ionic-specific props that can be set at form level and cascade to all fields. */
 export type IonicFormProps = IonicConfig;
 
-/**
- * Ionic-specific FormConfig with type-safe defaultProps.
- *
- * Use this type alias when defining form configurations with Ionic components
- * to get IDE autocomplete and type checking for `defaultProps`.
- *
- * @example
- * ```typescript
- * const formConfig: IonicFormConfig = {
- *   defaultProps: {
- *     fill: 'outline',
- *     labelPlacement: 'floating',
- *     color: 'primary',
- *   },
- *   fields: [
- *     { type: 'ionic-input', key: 'name', label: 'Name' },  // Uses form defaultProps
- *     { type: 'ionic-input', key: 'email', props: { fill: 'solid' } },  // Override
- *   ],
- * };
- * ```
- */
+/** Ionic-specific FormConfig with type-safe defaultProps. */
 export type IonicFormConfig<
   TFields extends NarrowFields | RegisteredFieldTypes[] = RegisteredFieldTypes[],
   TValue = InferFormValue<TFields extends readonly RegisteredFieldTypes[] ? TFields : RegisteredFieldTypes[]>,

--- a/packages/dynamic-forms-material/src/lib/addons/mat-button-addon.component.ts
+++ b/packages/dynamic-forms-material/src/lib/addons/mat-button-addon.component.ts
@@ -7,14 +7,7 @@ import { DynamicTextPipe } from '@ng-forge/dynamic-forms';
 import { injectNgForgeAddonAction, NgForgeAddonAction } from '@ng-forge/dynamic-forms/integration';
 import type { MatButtonAddon } from '../types/addons';
 
-/**
- * Renderer for the `mat-button` addon kind.
- *
- * Renders `<button mat-icon-button>` when icon-only (no label), or
- * `<button mat-button>` when labeled. Click dispatch (preset / actionRef /
- * action precedence, multi-set warning, `disabled` / `loading` resolution)
- * lives on `NgForgeAddonAction`; this component focuses on the visual layer.
- */
+/** Renderer for the `mat-button` addon kind. */
 @Component({
   selector: 'df-mat-button-addon',
   imports: [MatButton, MatIconButton, MatIcon, MatProgressSpinner, DynamicTextPipe, AsyncPipe],

--- a/packages/dynamic-forms-material/src/lib/addons/mat-icon-addon.component.ts
+++ b/packages/dynamic-forms-material/src/lib/addons/mat-icon-addon.component.ts
@@ -4,13 +4,7 @@ import { MatIcon } from '@angular/material/icon';
 import { DynamicTextPipe, WrapperFieldInputs } from '@ng-forge/dynamic-forms';
 import type { MatIconAddon } from '../types/addons';
 
-/**
- * Renderer for the `mat-icon` addon kind.
- *
- * Outputs `<mat-icon>{icon}</mat-icon>` using Material Icons ligatures. The
- * host is set `aria-hidden="true"` by default; if the addon supplies an
- * `ariaLabel`, it is applied so the icon is announced by screen readers.
- */
+/** Renderer for the `mat-icon` addon kind. */
 @Component({
   selector: 'df-mat-icon-addon',
   imports: [MatIcon, AsyncPipe, DynamicTextPipe],

--- a/packages/dynamic-forms-material/src/lib/fields/button/mat-button.mapper.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/button/mat-button.mapper.ts
@@ -6,9 +6,6 @@ import { ARRAY_CONTEXT, buildBaseInputs, DEFAULT_PROPS, FieldDef } from '@ng-for
  * For specific button types (submit, next, prev, add/remove array items),
  * use the dedicated field types and their specific mappers.
  *
- * Supports template property for array events (AppendArrayItemEvent, PrependArrayItemEvent, InsertArrayItemEvent)
- * which enables the $template token in eventArgs.
- *
  * @param fieldDef The button field definition
  * @returns Signal containing Record of input names to values for ngComponentOutlet
  */

--- a/packages/dynamic-forms-material/src/lib/fields/button/mat-button.type.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/button/mat-button.type.ts
@@ -21,9 +21,7 @@ export interface MatButtonProps {
 export type MatButtonField<TEvent extends FormEvent> = ButtonField<MatButtonProps, TEvent>;
 export type MatButtonComponent<TEvent extends FormEvent> = FieldComponent<MatButtonField<TEvent>>;
 
-/**
- * Specific button field types with preconfigured events
- */
+/** Specific button field types with preconfigured events */
 
 /** Submit button field - automatically disabled when form is invalid */
 export type MatSubmitButtonField = Omit<MatButtonField<SubmitEvent>, 'event' | 'type' | 'eventArgs'> & {
@@ -83,9 +81,7 @@ export type InsertArrayItemButtonField = Omit<MatButtonField<InsertArrayItemEven
    * When inside an array, this is automatically determined from context.
    */
   arrayKey?: string;
-  /**
-   * The index at which to insert the new item.
-   */
+  /** The index at which to insert the new item. */
   index: number;
   /**
    * Template for the new array item. REQUIRED.

--- a/packages/dynamic-forms-material/src/lib/fields/button/mat-specific-button.mapper.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/button/mat-specific-button.mapper.ts
@@ -1,7 +1,2 @@
-/**
- * Navigation button mappers for Material - re-exported from integration package.
- *
- * These mappers handle submit, next, and previous buttons with proper
- * disabled state resolution based on form validity and options.
- */
+/** Navigation button mappers for Material - re-exported from integration package. */
 export { submitButtonFieldMapper, nextButtonFieldMapper, previousButtonFieldMapper } from '@ng-forge/dynamic-forms/integration';

--- a/packages/dynamic-forms-material/src/lib/fields/input/mat-input.type.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/input/mat-input.type.ts
@@ -16,34 +16,13 @@ export interface MatInputProps extends InputProps {
 /**
  * Module-augmentable seam for adding custom addon kinds to `mat-input` at
  * the type level. Pair with `withCustomAddon(...)` for the runtime side:
- *
- * ```ts
- * declare module '@ng-forge/dynamic-forms-material' {
- *   interface MatAddonExtensions {
- *     'my-rating': MyRatingAddon;
- *   }
- * }
- * ```
- *
- * Empty by default — the extension lookup resolves to `never` and contributes
- * nothing to the union.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type -- Intentionally empty: module-augmentation seam
 export interface MatAddonExtensions {}
 
 type MatAddonExtension = MatAddonExtensions[keyof MatAddonExtensions];
 
-/**
- * Addon kinds accepted by `mat-input`.
- *
- * Material-specific kinds (`mat-icon`, `mat-button`) plus the universal
- * `text` and `template` kinds. `component` is permitted at runtime via the
- * broader `BaseAddon` union (and dropped in JSON-derived configs by the
- * validator) but excluded here so the IDE narrows tightly to declarative
- * shapes.
- *
- * To extend with custom kinds, augment `MatAddonExtensions`.
- */
+/** Addon kinds accepted by `mat-input`. */
 export type MatInputAddon = MatIconAddon | MatButtonAddon | TextAddon | TemplateAddon | MatAddonExtension;
 
 export type MatInputField = InputField<MatInputProps> & {

--- a/packages/dynamic-forms-material/src/lib/models/material-config.token.ts
+++ b/packages/dynamic-forms-material/src/lib/models/material-config.token.ts
@@ -4,22 +4,5 @@ import { MaterialConfig } from './material-config';
 /**
  * Injection token for Material Design form configuration.
  * Use this to provide global configuration for Material form fields.
- *
- * @example
- * ```typescript
- * import { provideDynamicForm } from '@ng-forge/dynamic-forms';
- * import { withMaterialFields } from '@ng-forge/dynamic-forms-material';
- *
- * export const appConfig: ApplicationConfig = {
- *   providers: [
- *     provideDynamicForm(
- *       ...withMaterialFields({
- *         appearance: 'fill',
- *         subscriptSizing: 'fixed'
- *       })
- *     )
- *   ]
- * };
- * ```
  */
 export const MATERIAL_CONFIG = new InjectionToken<MaterialConfig>('MATERIAL_CONFIG');

--- a/packages/dynamic-forms-material/src/lib/models/material-config.ts
+++ b/packages/dynamic-forms-material/src/lib/models/material-config.ts
@@ -1,66 +1,53 @@
 import { FloatLabelType, MatFormFieldAppearance, SubscriptSizing } from '@angular/material/form-field';
 import { ThemePalette } from '@angular/material/core';
 
-/**
- * Configuration options for Material Design form fields.
- *
- * These settings can be applied at two levels:
- * - **Library-level**: Via `withMaterialFields({ ... })` - applies to all forms
- * - **Form-level**: Via `defaultProps` in form config - applies to a specific form
- *
- * The cascade hierarchy is: Library-level → Form-level → Field-level
- *
- * @example
- * ```typescript
- * // Library-level (in app config)
- * provideDynamicForms(withMaterialFields({ appearance: 'outline' }))
- *
- * // Form-level (in form config)
- * const config: MatFormConfig = {
- *   defaultProps: { appearance: 'fill' },
- *   fields: [...]
- * };
- * ```
- */
+/** Configuration options for Material Design form fields. */
 export interface MaterialConfig {
   /**
    * Default appearance for Material form fields
+   *
    * @default 'outline'
    */
   appearance?: MatFormFieldAppearance;
 
   /**
    * Default subscript sizing for Material form fields
+   *
    * @default 'dynamic'
    */
   subscriptSizing?: SubscriptSizing;
 
   /**
    * Whether to disable ripple effects by default
+   *
    * @default false
    */
   disableRipple?: boolean;
 
   /**
    * Default color theme for form controls (checkboxes, radios, sliders, toggles)
+   *
    * @default 'primary'
    */
   color?: ThemePalette;
 
   /**
    * Default label position for checkboxes and radios
+   *
    * @default 'after'
    */
   labelPosition?: 'before' | 'after';
 
   /**
    * Default float label behavior for form fields
+   *
    * @default 'auto'
    */
   floatLabel?: FloatLabelType;
 
   /**
    * Whether to hide the required marker by default
+   *
    * @default false
    */
   hideRequiredMarker?: boolean;

--- a/packages/dynamic-forms-material/src/lib/providers/material-providers.ts
+++ b/packages/dynamic-forms-material/src/lib/providers/material-providers.ts
@@ -5,9 +5,7 @@ import { MaterialConfig } from '../models/material-config';
 import { MATERIAL_CONFIG } from '../models/material-config.token';
 import type { MatButtonAddon, MatIconAddon } from '../types/addons';
 
-/**
- * Field type definitions for Material Design components.
- */
+/** Field type definitions for Material Design components. */
 export type MaterialFieldTypes = FieldTypeDefinition[];
 
 type MaterialConfigFeature = {
@@ -28,41 +26,7 @@ type MaterialFieldsWithConfig = [...MaterialFieldTypes, MaterialAddonsFeature, M
  * Material-shipped addon kinds (`mat-icon`, `mat-button`) auto-included so
  * addons work out of the box.
  *
- * If you want field types WITHOUT addons (rare), pass them through
- * `provideDynamicForm` directly and skip this helper. If you want addons
- * WITHOUT the field types (also rare), call `withMaterialAddons()` standalone.
- *
  * @param config - Optional global configuration for Material form fields
- *
- * @example
- * ```typescript
- * // Application-level setup — addons (mat-icon, mat-button) ship in automatically
- * import { ApplicationConfig } from '@angular/core';
- * import { provideDynamicForm } from '@ng-forge/dynamic-forms';
- * import { withMaterialFields } from '@ng-forge/dynamic-forms-material';
- *
- * export const appConfig: ApplicationConfig = {
- *   providers: [
- *     provideDynamicForm(...withMaterialFields())
- *   ]
- * };
- * ```
- *
- * @example
- * ```typescript
- * // With global configuration
- * export const appConfig: ApplicationConfig = {
- *   providers: [
- *     provideDynamicForm(
- *       ...withMaterialFields({
- *         appearance: 'fill',
- *         subscriptSizing: 'fixed'
- *       })
- *     )
- *   ]
- * };
- * ```
- *
  * @returns Tuple of field type definitions, the addons feature, and
  *   optionally a config feature.
  */
@@ -126,27 +90,7 @@ type MaterialAddonsFeature = {
   ɵproviders: Provider[];
 };
 
-/**
- * Register Material-shipped addon kinds (`mat-icon`, `mat-button`) standalone.
- *
- * **Most users don't need this** — `withMaterialFields()` auto-includes
- * these kinds. Call `withMaterialAddons()` directly only when you want
- * Material addon kinds without the Material field types (e.g., a custom
- * field set that wants to render `mat-icon` prefixes), or when you're
- * stitching addons through a different DI scope.
- *
- * @example
- * ```typescript
- * // Custom field types + Material addon kinds.
- * provideDynamicForm(
- *   ...myCustomFields(),
- *   withMaterialAddons(),
- * );
- * ```
- *
- * Adapter authors who need to override a kind with a customised renderer
- * should call `withCustomAddon(...)` directly instead.
- */
+/** Register Material-shipped addon kinds (`mat-icon`, `mat-button`) standalone. */
 export function withMaterialAddons(): MaterialAddonsFeature {
   return {
     ɵkind: 'addons',

--- a/packages/dynamic-forms-material/src/lib/testing/material-test-utils.ts
+++ b/packages/dynamic-forms-material/src/lib/testing/material-test-utils.ts
@@ -16,26 +16,20 @@ import { MatButtonField } from '../fields/button/mat-button.type';
 import { MatMultiCheckboxField } from '../fields/multi-checkbox/mat-multi-checkbox.type';
 import { MatField } from '../types/types';
 
-/**
- * Configuration for creating a material dynamic form test
- */
+/** Configuration for creating a material dynamic form test */
 export interface MaterialFormTestConfig {
   config: FormConfig;
   initialValue?: Record<string, unknown>;
   providers?: unknown[];
 }
 
-/**
- * Result of creating a material dynamic form test
- */
+/** Result of creating a material dynamic form test */
 export interface MaterialFormTestResult {
   component: DynamicForm;
   fixture: ComponentFixture<DynamicForm>;
 }
 
-/**
- * Fluent API for building material form configurations
- */
+/** Fluent API for building material form configurations */
 export class MaterialFormConfigBuilder {
   private fields: unknown[] = [];
 
@@ -119,20 +113,14 @@ export class MaterialFormConfigBuilder {
   }
 }
 
-/**
- * Utility class for testing material dynamic forms
- */
+/** Utility class for testing material dynamic forms */
 export class MaterialFormTestUtils {
-  /**
-   * Creates a new material form config builder
-   */
+  /** Creates a new material form config builder */
   static builder(): MaterialFormConfigBuilder {
     return new MaterialFormConfigBuilder();
   }
 
-  /**
-   * Creates a material dynamic form test setup with proper providers
-   */
+  /** Creates a material dynamic form test setup with proper providers */
   static async createTest(testConfig: MaterialFormTestConfig): Promise<MaterialFormTestResult> {
     await TestBed.configureTestingModule({
       imports: [DynamicForm],
@@ -159,9 +147,7 @@ export class MaterialFormTestUtils {
     };
   }
 
-  /**
-   * Waits for the material dynamic form to initialize
-   */
+  /** Waits for the material dynamic form to initialize */
   static async waitForInit(fixture: ComponentFixture<DynamicForm>): Promise<void> {
     await waitForDFInit(fixture.componentInstance, fixture);
 
@@ -183,9 +169,7 @@ export class MaterialFormTestUtils {
     fixture.detectChanges();
   }
 
-  /**
-   * Simulates user input on a material input field
-   */
+  /** Simulates user input on a material input field */
   static async simulateMatInput(fixture: ComponentFixture<DynamicForm>, selector: string, value: string): Promise<void> {
     const input = fixture.nativeElement.querySelector(selector) as HTMLInputElement;
     if (!input) {
@@ -199,9 +183,7 @@ export class MaterialFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates user selection on a material select
-   */
+  /** Simulates user selection on a material select */
   static async simulateMatSelect(fixture: ComponentFixture<DynamicForm>, selectSelector: string, value: string): Promise<void> {
     // Find the mat-select component
     const matSelect = fixture.nativeElement.querySelector(selectSelector);
@@ -224,9 +206,7 @@ export class MaterialFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates material checkbox toggle
-   */
+  /** Simulates material checkbox toggle */
   static async simulateMatCheckbox(fixture: ComponentFixture<DynamicForm>, selector: string, checked: boolean): Promise<void> {
     let checkboxElement: Element | null = null;
 
@@ -279,9 +259,7 @@ export class MaterialFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates material toggle switch
-   */
+  /** Simulates material toggle switch */
   static async simulateMatToggle(fixture: ComponentFixture<DynamicForm>, selector: string, checked: boolean): Promise<void> {
     const toggle = fixture.nativeElement.querySelector(selector);
     if (!toggle) {
@@ -302,9 +280,7 @@ export class MaterialFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates material button click
-   */
+  /** Simulates material button click */
   static async simulateMatButtonClick(fixture: ComponentFixture<DynamicForm>, selector: string): Promise<void> {
     const button = fixture.nativeElement.querySelector(selector) as HTMLButtonElement;
     if (!button) {
@@ -316,37 +292,27 @@ export class MaterialFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Gets the current form value from the component
-   */
+  /** Gets the current form value from the component */
   static getFormValue(component: DynamicForm): Record<string, unknown> {
     return component.formValue();
   }
 
-  /**
-   * Gets validation errors from the component
-   */
+  /** Gets validation errors from the component */
   static getFormErrors(component: DynamicForm): unknown[] {
     return component.errors() as unknown[];
   }
 
-  /**
-   * Checks if the form is valid
-   */
+  /** Checks if the form is valid */
   static isFormValid(component: DynamicForm): boolean {
     return component.valid();
   }
 
-  /**
-   * Gets all material field elements from the fixture
-   */
+  /** Gets all material field elements from the fixture */
   static getMatFieldElements(fixture: ComponentFixture<DynamicForm>, fieldType: string): NodeListOf<Element> {
     return fixture.nativeElement.querySelectorAll(`df-mat-${fieldType}`);
   }
 
-  /**
-   * Asserts that a material field has a specific value
-   */
+  /** Asserts that a material field has a specific value */
   static assertMatFieldValue(fixture: ComponentFixture<DynamicForm>, fieldSelector: string, expectedValue: string): void {
     // Try to find the input element directly first
     let element = fixture.nativeElement.querySelector(fieldSelector);
@@ -376,9 +342,7 @@ export class MaterialFormTestUtils {
     }
   }
 
-  /**
-   * Asserts that the form has a specific value
-   */
+  /** Asserts that the form has a specific value */
   static assertFormValue(component: DynamicForm, expectedValue: Record<string, unknown>): void {
     const actualValue = component.formValue();
     if (JSON.stringify(actualValue) !== JSON.stringify(expectedValue)) {
@@ -386,9 +350,7 @@ export class MaterialFormTestUtils {
     }
   }
 
-  /**
-   * Asserts that a material form field has the correct appearance
-   */
+  /** Asserts that a material form field has the correct appearance */
   static assertMatFormFieldAppearance(fixture: ComponentFixture<DynamicForm>, fieldSelector: string, appearance: string): void {
     // Try both new and legacy selectors
     let formField = fixture.nativeElement.querySelector(`${fieldSelector} mat-form-field`);
@@ -405,9 +367,7 @@ export class MaterialFormTestUtils {
     }
   }
 
-  /**
-   * Asserts that a material field shows an error message
-   */
+  /** Asserts that a material field shows an error message */
   static assertMatFieldError(fixture: ComponentFixture<DynamicForm>, fieldSelector: string, expectedError?: string): void {
     const formField = fixture.nativeElement.querySelector(`${fieldSelector} mat-form-field`);
     if (!formField) {

--- a/packages/dynamic-forms-material/src/lib/testing/minimal-test-builders.ts
+++ b/packages/dynamic-forms-material/src/lib/testing/minimal-test-builders.ts
@@ -1,17 +1,7 @@
 import { FieldOption } from '@ng-forge/dynamic-forms';
 import { MaterialFormTestUtils } from './material-test-utils';
 
-/**
- * MINIMAL TEST DATA BUILDERS
- *
- * Philosophy: Only create what you're testing
- *
- * Benefits:
- * - Clear intent (builder name matches test purpose)
- * - Fast execution (no unnecessary fields/data)
- * - Reusable (consistent patterns across tests)
- * - Maintainable (change in one place)
- */
+/** MINIMAL TEST DATA BUILDERS */
 
 export class MinimalTestBuilder {
   /**
@@ -146,9 +136,7 @@ export class MinimalTestBuilder {
     return { config, initialValue };
   }
 
-  /**
-   * Get default value for field type
-   */
+  /** Get default value for field type */
   private static getDefaultValue(fieldType: string): string | number | boolean | null {
     switch (fieldType) {
       case 'checkbox':
@@ -497,27 +485,4 @@ export class MinimalTestBuilder {
   }
 }
 
-/**
- * USAGE EXAMPLES:
- *
- * // Test input type rendering
- * it('should render email type', async () => {
- *   const { config, initialValue } = MinimalTestBuilder.withInputType('email');
- *   const { fixture } = await MaterialFormTestUtils.createTest({ config, initialValue });
- *   // Assert type attribute
- * });
- *
- * // Test label rendering
- * it('should render label', async () => {
- *   const { config, initialValue } = MinimalTestBuilder.withLabel('Email Address');
- *   const { fixture } = await MaterialFormTestUtils.createTest({ config, initialValue });
- *   // Assert label text
- * });
- *
- * // Test multiple fields
- * it('should render 5 inputs', async () => {
- *   const { config, initialValue } = MinimalTestBuilder.withMultipleFields(5);
- *   const { fixture } = await MaterialFormTestUtils.createTest({ config, initialValue });
- *   // Assert count
- * });
- */
+/** USAGE EXAMPLES: */

--- a/packages/dynamic-forms-material/src/lib/testing/wait-for-df.ts
+++ b/packages/dynamic-forms-material/src/lib/testing/wait-for-df.ts
@@ -2,20 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DynamicForm } from '@ng-forge/dynamic-forms';
 import { firstValueFrom } from 'rxjs';
 
-/**
- * Waits for all dynamic form definitions to be initialized and ready
- *
- * Deterministic approach:
- * 1. Event-based: Wait for initialized$ (tracks container components + field loading cascade)
- * 2. Stabilization: Ensure effects/change detection complete
- * 3. DOM stability check: Wait until component count stops changing
- *
- * The initialized$ observable tracks page/row/group containers. Each container waits
- * for its children via forkJoin + afterNextRender before emitting its initialized event.
- *
- * The page orchestration refactoring introduced reactive primitives that require additional
- * stabilization cycles for UI component templates to fully hydrate.
- */
+/** Waits for all dynamic form definitions to be initialized and ready */
 export async function waitForDFInit(component: DynamicForm, fixture: ComponentFixture<DynamicForm>): Promise<void> {
   fixture.detectChanges();
 
@@ -38,13 +25,7 @@ export async function waitForDFInit(component: DynamicForm, fixture: ComponentFi
   await fixture.whenStable();
 }
 
-/**
- * Deterministic DOM stability check
- *
- * Waits until Material component count stabilizes for 3 consecutive checks
- * and no loading placeholders remain. Uses timeout-based safety net instead
- * of arbitrary iteration limits.
- */
+/** Deterministic DOM stability check */
 async function waitForFieldComponents(fixture: ComponentFixture<DynamicForm>, timeoutMs = 500): Promise<void> {
   const formElement = fixture.nativeElement.querySelector('.df-form');
   if (!formElement) return;

--- a/packages/dynamic-forms-material/src/lib/tokens/input-type-override.token.ts
+++ b/packages/dynamic-forms-material/src/lib/tokens/input-type-override.token.ts
@@ -3,16 +3,6 @@ import { InjectionToken, WritableSignal } from '@angular/core';
 /**
  * Per-field writable signal that overrides the input's `type` attribute.
  *
- * Provided at the `mat-input` field component level. The button addon's
- * `'toggle-password-visibility'` preset writes to it; the field component
- * reads it to compute its effective `type`.
- *
- * Optional from a button's perspective — when the button is hosted inside a
- * field that doesn't provide this token (e.g., textarea or a future
- * non-input field), the toggle preset is a no-op.
- *
- * @example provided per-field:
- * ```typescript
  * @Component({
  *   providers: [{ provide: MAT_INPUT_TYPE_OVERRIDE, useValue: signal(undefined) }],
  * })

--- a/packages/dynamic-forms-material/src/lib/types/addons.ts
+++ b/packages/dynamic-forms-material/src/lib/types/addons.ts
@@ -7,15 +7,7 @@ import type {
   RegisteredActionRef,
 } from '@ng-forge/dynamic-forms';
 
-/**
- * Decorative icon addon for Material fields.
- *
- * Renders `<mat-icon>{icon}</mat-icon>` using Material Icons ligatures —
- * `icon: 'search'` produces `<mat-icon>search</mat-icon>`.
- *
- * Add `ariaLabel` for icons that convey meaning (search, error, success);
- * leave it omitted for purely decorative icons (will be `aria-hidden="true"`).
- */
+/** Decorative icon addon for Material fields. */
 export interface MatIconAddon extends BaseAddon {
   readonly kind: 'mat-icon';
   /** Material Icons name (ligature, e.g., `'search'`, `'close'`). */
@@ -79,10 +71,6 @@ type MatButtonClick = MatButtonClickPreset | MatButtonClickActionRef | MatButton
 /**
  * Content axis — XOR enforced at type level so an icon-only button is
  * forced to declare `ariaLabel`. The three shapes:
- *
- * - `IconOnly`   — just `icon`; `ariaLabel` is REQUIRED
- * - `Labeled`    — `label` set; `icon` and `ariaLabel` optional
- * - `Decorative` — neither icon nor label
  */
 type MatButtonContentIconOnly = {
   readonly icon: string;
@@ -102,21 +90,7 @@ type MatButtonContentDecorative = {
 };
 type MatButtonContent = MatButtonContentIconOnly | MatButtonContentLabeled | MatButtonContentDecorative;
 
-/**
- * Interactive button addon for Material fields.
- *
- * Renders `<button mat-icon-button>` (icon-only) or `<button mat-button>`
- * (labeled). Click dispatch (preset / actionRef / action precedence) lives
- * on `NgForgeAddonAction`; this addon shape focuses on configuration.
- *
- * Type-level guarantees:
- *
- * - **Content axis (XOR):** `IconOnly` (icon + required ariaLabel) |
- *   `Labeled` (label, icon optional) | `Decorative` (neither). The IDE
- *   rejects icon-only configs that omit `ariaLabel`.
- * - **Click axis (XOR):** exactly one of `preset` / `actionRef` / `action`,
- *   or none.
- */
+/** Interactive button addon for Material fields. */
 export type MatButtonAddon = MatButtonBase & MatButtonContent & MatButtonClick;
 
 /** Union of all Material-shipped addon kinds. */

--- a/packages/dynamic-forms-material/src/lib/types/form-config.ts
+++ b/packages/dynamic-forms-material/src/lib/types/form-config.ts
@@ -1,50 +1,10 @@
 import { FormConfig, NarrowFields, RegisteredFieldTypes, InferFormValue } from '@ng-forge/dynamic-forms';
 import { MaterialConfig } from '../models/material-config';
 
-/**
- * Material-specific props that can be set at form level and cascade to all fields.
- *
- * This is the same type as `MaterialConfig` used in `withMaterialFields()`.
- * Using a single type ensures consistency between library-level and form-level configuration.
- *
- * The cascade hierarchy is: Library-level → Form-level → Field-level
- *
- * @example
- * ```typescript
- * const config: MatFormConfig = {
- *   defaultProps: {
- *     appearance: 'outline',
- *     subscriptSizing: 'dynamic',
- *     color: 'accent',
- *   },
- *   fields: [
- *     { type: 'mat-input', key: 'name', label: 'Name' },
- *   ],
- * };
- * ```
- */
+/** Material-specific props that can be set at form level and cascade to all fields. */
 export type MatFormProps = MaterialConfig;
 
-/**
- * Material-specific FormConfig with type-safe defaultProps.
- *
- * Use this type alias when defining form configurations with Material Design components
- * to get IDE autocomplete and type checking for `defaultProps`.
- *
- * @example
- * ```typescript
- * const formConfig: MatFormConfig = {
- *   defaultProps: {
- *     appearance: 'outline',
- *     subscriptSizing: 'dynamic',
- *   },
- *   fields: [
- *     { type: 'mat-input', key: 'name', label: 'Name' },  // Uses form defaultProps
- *     { type: 'mat-input', key: 'email', props: { appearance: 'fill' } },  // Override
- *   ],
- * };
- * ```
- */
+/** Material-specific FormConfig with type-safe defaultProps. */
 export type MatFormConfig<
   TFields extends NarrowFields | RegisteredFieldTypes[] = RegisteredFieldTypes[],
   TValue = InferFormValue<TFields extends readonly RegisteredFieldTypes[] ? TFields : RegisteredFieldTypes[]>,

--- a/packages/dynamic-forms-material/testing/index.ts
+++ b/packages/dynamic-forms-material/testing/index.ts
@@ -1,8 +1,3 @@
-/**
- * Testing utilities for @ng-forge/dynamic-form-material
- *
- * This secondary entry point provides testing utilities for material dynamic forms.
- * Import from '@ng-forge/dynamic-form-material/testing' to access these utilities.
- */
+/** Testing utilities for @ng-forge/dynamic-form-material */
 
 export * from '../src/lib/testing';

--- a/packages/dynamic-forms-primeng/src/lib/addons/prime-button-addon.component.ts
+++ b/packages/dynamic-forms-primeng/src/lib/addons/prime-button-addon.component.ts
@@ -5,14 +5,7 @@ import { injectNgForgeAddonAction, NgForgeAddonAction } from '@ng-forge/dynamic-
 import { ButtonModule } from 'primeng/button';
 import type { PrimeButtonAddon } from '../types/addons';
 
-/**
- * Renderer for the `prime-button` addon kind.
- *
- * Wraps PrimeNG's `<p-button>`. Click dispatch (preset / actionRef /
- * action precedence, multi-set warning, `disabled` / `loading`
- * resolution) lives on `NgForgeAddonAction`; this component focuses on
- * the visual layer.
- */
+/** Renderer for the `prime-button` addon kind. */
 @Component({
   selector: 'df-prime-button-addon',
   imports: [ButtonModule, DynamicTextPipe, AsyncPipe],

--- a/packages/dynamic-forms-primeng/src/lib/addons/prime-icon-addon.component.ts
+++ b/packages/dynamic-forms-primeng/src/lib/addons/prime-icon-addon.component.ts
@@ -3,13 +3,7 @@ import { ChangeDetectionStrategy, Component, computed, input } from '@angular/co
 import { DynamicTextPipe, WrapperFieldInputs } from '@ng-forge/dynamic-forms';
 import type { PrimeIconAddon } from '../types/addons';
 
-/**
- * Renderer for the `prime-icon` addon kind.
- *
- * Outputs `<i class="pi pi-{icon}">`. The host is set `aria-hidden="true"`
- * by default; if the addon supplies an `ariaLabel`, it is applied so the
- * icon is announced by screen readers.
- */
+/** Renderer for the `prime-icon` addon kind. */
 @Component({
   selector: 'df-prime-icon-addon',
   imports: [AsyncPipe, DynamicTextPipe],

--- a/packages/dynamic-forms-primeng/src/lib/fields/button/prime-button.mapper.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/button/prime-button.mapper.ts
@@ -6,9 +6,6 @@ import { ARRAY_CONTEXT, buildBaseInputs, DEFAULT_PROPS, FieldDef } from '@ng-for
  * For specific button types (submit, next, prev, add/remove array items),
  * use the dedicated field types and their specific mappers.
  *
- * Supports template property for array events (AppendArrayItemEvent, PrependArrayItemEvent, InsertArrayItemEvent)
- * which enables the $template token in eventArgs.
- *
  * @param fieldDef The button field definition
  * @returns Signal containing Record of input names to values for ngComponentOutlet
  */

--- a/packages/dynamic-forms-primeng/src/lib/fields/button/prime-button.type.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/button/prime-button.type.ts
@@ -27,9 +27,7 @@ export interface PrimeButtonProps {
 export type PrimeButtonField<TEvent extends FormEvent = FormEvent> = ButtonField<PrimeButtonProps, TEvent>;
 export type PrimeButtonComponent<TEvent extends FormEvent = FormEvent> = FieldComponent<PrimeButtonField<TEvent>>;
 
-/**
- * Specific button field types with preconfigured events
- */
+/** Specific button field types with preconfigured events */
 
 /** Submit button field - automatically disabled when form is invalid */
 export type PrimeSubmitButtonField = Omit<PrimeButtonField<SubmitEvent>, 'event' | 'type' | 'eventArgs'> & {
@@ -89,9 +87,7 @@ export type InsertArrayItemButtonField = Omit<PrimeButtonField<InsertArrayItemEv
    * When inside an array, this is automatically determined from context.
    */
   arrayKey?: string;
-  /**
-   * The index at which to insert the new item.
-   */
+  /** The index at which to insert the new item. */
   index: number;
   /**
    * Template for the new array item. REQUIRED.

--- a/packages/dynamic-forms-primeng/src/lib/fields/button/prime-specific-button.mapper.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/button/prime-specific-button.mapper.ts
@@ -1,7 +1,2 @@
-/**
- * Navigation button mappers for PrimeNG - re-exported from integration package.
- *
- * These mappers handle submit, next, and previous buttons with proper
- * disabled state resolution based on form validity and options.
- */
+/** Navigation button mappers for PrimeNG - re-exported from integration package. */
 export { submitButtonFieldMapper, nextButtonFieldMapper, previousButtonFieldMapper } from '@ng-forge/dynamic-forms/integration';

--- a/packages/dynamic-forms-primeng/src/lib/fields/checkbox/prime-checkbox.type.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/checkbox/prime-checkbox.type.ts
@@ -2,25 +2,15 @@ import { CheckedFieldComponent, DynamicText } from '@ng-forge/dynamic-forms';
 import { CheckboxField } from '@ng-forge/dynamic-forms/integration';
 
 export interface PrimeCheckboxProps {
-  /**
-   * Binary mode for boolean values.
-   */
+  /** Binary mode for boolean values. */
   binary?: boolean;
-  /**
-   * CSS class to apply to the checkbox element.
-   */
+  /** CSS class to apply to the checkbox element. */
   styleClass?: string;
-  /**
-   * Value to use when checked.
-   */
+  /** Value to use when checked. */
   trueValue?: unknown;
-  /**
-   * Value to use when unchecked.
-   */
+  /** Value to use when unchecked. */
   falseValue?: unknown;
-  /**
-   * Hint text displayed below the checkbox.
-   */
+  /** Hint text displayed below the checkbox. */
   hint?: DynamicText;
 }
 

--- a/packages/dynamic-forms-primeng/src/lib/fields/datepicker/prime-datepicker.type.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/datepicker/prime-datepicker.type.ts
@@ -2,41 +2,23 @@ import { DynamicText, ValueFieldComponent } from '@ng-forge/dynamic-forms';
 import { DatepickerField, DatepickerProps } from '@ng-forge/dynamic-forms/integration';
 
 export interface PrimeDatepickerProps extends DatepickerProps {
-  /**
-   * Format string for displaying dates.
-   */
+  /** Format string for displaying dates. */
   dateFormat?: string;
-  /**
-   * Display calendar inline instead of overlay.
-   */
+  /** Display calendar inline instead of overlay. */
   inline?: boolean;
-  /**
-   * Show calendar icon button.
-   */
+  /** Show calendar icon button. */
   showIcon?: boolean;
-  /**
-   * Show button bar with today/clear buttons.
-   */
+  /** Show button bar with today/clear buttons. */
   showButtonBar?: boolean;
-  /**
-   * Selection mode (single date, multiple dates, or range).
-   */
+  /** Selection mode (single date, multiple dates, or range). */
   selectionMode?: 'single' | 'multiple' | 'range';
-  /**
-   * Enable touch-optimized UI for mobile devices.
-   */
+  /** Enable touch-optimized UI for mobile devices. */
   touchUI?: boolean;
-  /**
-   * Initial view to display (date, month, or year).
-   */
+  /** Initial view to display (date, month, or year). */
   view?: 'date' | 'month' | 'year';
-  /**
-   * Hint text displayed below the datepicker.
-   */
+  /** Hint text displayed below the datepicker. */
   hint?: DynamicText;
-  /**
-   * CSS class to apply to the calendar element.
-   */
+  /** CSS class to apply to the calendar element. */
   styleClass?: string;
 }
 

--- a/packages/dynamic-forms-primeng/src/lib/fields/input/prime-input.type.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/input/prime-input.type.ts
@@ -3,58 +3,28 @@ import { InputField, InputProps } from '@ng-forge/dynamic-forms/integration';
 import type { PrimeButtonAddon, PrimeIconAddon } from '../../types/addons';
 
 export interface PrimeInputProps extends InputProps {
-  /**
-   * CSS class to apply to the input element.
-   */
+  /** CSS class to apply to the input element. */
   styleClass?: string;
-  /**
-   * Hint text displayed below the input.
-   */
+  /** Hint text displayed below the input. */
   hint?: DynamicText;
-  /**
-   * Size variant of the input.
-   */
+  /** Size variant of the input. */
   size?: 'small' | 'large';
-  /**
-   * Visual variant of the input.
-   */
+  /** Visual variant of the input. */
   variant?: 'outlined' | 'filled';
-  /**
-   * Type of the input element.
-   */
+  /** Type of the input element. */
   type?: 'text' | 'email' | 'password' | 'number' | 'tel' | 'url';
 }
 
 /**
  * Module-augmentable seam for adding custom addon kinds to `prime-input` at
  * the type level. Pair with `withCustomAddon(...)` for the runtime side:
- *
- * ```ts
- * declare module '@ng-forge/dynamic-forms-primeng' {
- *   interface PrimeAddonExtensions {
- *     'my-rating': MyRatingAddon;
- *   }
- * }
- * ```
- *
- * Empty by default — the extension lookup resolves to `never` and contributes
- * nothing to the union.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type -- Intentionally empty: module-augmentation seam
 export interface PrimeAddonExtensions {}
 
 type PrimeAddonExtension = PrimeAddonExtensions[keyof PrimeAddonExtensions];
 
-/**
- * Addon kinds accepted by `prime-input`.
- *
- * PrimeNG-specific kinds (`prime-icon`, `prime-button`) plus the universal `text`
- * and `template` kinds. `component` is permitted at runtime via the broader
- * `BaseAddon` union (and dropped in JSON-derived configs by the validator)
- * but excluded here so the IDE narrows tightly to declarative shapes.
- *
- * To extend with custom kinds, augment `PrimeAddonExtensions`.
- */
+/** Addon kinds accepted by `prime-input`. */
 export type PrimeInputAddon = PrimeIconAddon | PrimeButtonAddon | TextAddon | TemplateAddon | PrimeAddonExtension;
 
 export type PrimeInputField = InputField<PrimeInputProps> & {

--- a/packages/dynamic-forms-primeng/src/lib/fields/multi-checkbox/prime-multi-checkbox.type.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/multi-checkbox/prime-multi-checkbox.type.ts
@@ -2,13 +2,9 @@ import { DynamicText, ValueFieldComponent, ValueType } from '@ng-forge/dynamic-f
 import { MultiCheckboxField } from '@ng-forge/dynamic-forms/integration';
 
 export interface PrimeMultiCheckboxProps {
-  /**
-   * CSS class to apply to the checkbox group.
-   */
+  /** CSS class to apply to the checkbox group. */
   styleClass?: string;
-  /**
-   * Hint text displayed below the checkbox group.
-   */
+  /** Hint text displayed below the checkbox group. */
   hint?: DynamicText;
 }
 

--- a/packages/dynamic-forms-primeng/src/lib/fields/radio/prime-radio-group.component.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/radio/prime-radio-group.component.ts
@@ -7,9 +7,7 @@ import { AsyncPipe } from '@angular/common';
 import { RadioButton } from 'primeng/radiobutton';
 
 export interface PrimeRadioGroupProps {
-  /**
-   * Custom CSS class for the radio buttons
-   */
+  /** Custom CSS class for the radio buttons */
   styleClass?: string;
 }
 

--- a/packages/dynamic-forms-primeng/src/lib/fields/radio/prime-radio.type.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/radio/prime-radio.type.ts
@@ -2,17 +2,11 @@ import { DynamicText, ValueFieldComponent, ValueType } from '@ng-forge/dynamic-f
 import { RadioField } from '@ng-forge/dynamic-forms/integration';
 
 export interface PrimeRadioProps {
-  /**
-   * Name of the radio button group.
-   */
+  /** Name of the radio button group. */
   name?: string;
-  /**
-   * CSS class to apply to the radio button.
-   */
+  /** CSS class to apply to the radio button. */
   styleClass?: string;
-  /**
-   * Hint text displayed below the radio group.
-   */
+  /** Hint text displayed below the radio group. */
   hint?: DynamicText;
 }
 

--- a/packages/dynamic-forms-primeng/src/lib/fields/select/prime-select.type.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/select/prime-select.type.ts
@@ -1,33 +1,19 @@
 import { DynamicText, ValueFieldComponent, ValueType } from '@ng-forge/dynamic-forms';
 import { SelectField, SelectProps } from '@ng-forge/dynamic-forms/integration';
 
-/**
- * Configuration props for PrimeNG select field component.
- */
+/** Configuration props for PrimeNG select field component. */
 export interface PrimeSelectProps extends SelectProps {
-  /**
-   * Enable multiple selection mode.
-   */
+  /** Enable multiple selection mode. */
   multiple?: boolean;
-  /**
-   * Enable filtering/search functionality.
-   */
+  /** Enable filtering/search functionality. */
   filter?: boolean;
-  /**
-   * Show clear button to deselect value.
-   */
+  /** Show clear button to deselect value. */
   showClear?: boolean;
-  /**
-   * CSS class to apply to the dropdown element.
-   */
+  /** CSS class to apply to the dropdown element. */
   styleClass?: string;
-  /**
-   * Hint text displayed below the select.
-   */
+  /** Hint text displayed below the select. */
   hint?: DynamicText;
-  /**
-   * Custom comparison function for determining equality of option values.
-   */
+  /** Custom comparison function for determining equality of option values. */
   compareWith?: (o1: ValueType, o2: ValueType) => boolean;
 }
 

--- a/packages/dynamic-forms-primeng/src/lib/fields/slider/prime-slider.type.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/slider/prime-slider.type.ts
@@ -2,43 +2,19 @@ import { DynamicText, ValueFieldComponent } from '@ng-forge/dynamic-forms';
 import { SliderField } from '@ng-forge/dynamic-forms/integration';
 
 export interface PrimeSliderProps {
-  /**
-   * Minimum value of the slider.
-   *
-   * Adapter-level override. Field-level `minValue` (or the validator `min`) takes
-   * precedence — set this only when you need a render-only override that should
-   * not flow into form validation.
-   */
+  /** Minimum value of the slider. */
   min?: number;
-  /**
-   * Maximum value of the slider.
-   *
-   * Adapter-level override. Field-level `maxValue` (or the validator `max`) takes
-   * precedence — set this only when you need a render-only override that should
-   * not flow into form validation.
-   */
+  /** Maximum value of the slider. */
   max?: number;
-  /**
-   * Step increment for slider values.
-   *
-   * Adapter-level override. Field-level `step` on `SliderField` takes precedence.
-   */
+  /** Step increment for slider values. */
   step?: number;
-  /**
-   * Enable range mode with two handles.
-   */
+  /** Enable range mode with two handles. */
   range?: boolean;
-  /**
-   * Orientation of the slider.
-   */
+  /** Orientation of the slider. */
   orientation?: 'horizontal' | 'vertical';
-  /**
-   * CSS class to apply to the slider element.
-   */
+  /** CSS class to apply to the slider element. */
   styleClass?: string;
-  /**
-   * Hint text displayed below the slider.
-   */
+  /** Hint text displayed below the slider. */
   hint?: DynamicText;
 }
 

--- a/packages/dynamic-forms-primeng/src/lib/fields/textarea/prime-textarea.type.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/textarea/prime-textarea.type.ts
@@ -1,27 +1,17 @@
 import { DynamicText, ValueFieldComponent } from '@ng-forge/dynamic-forms';
 import { TextareaField, TextareaProps } from '@ng-forge/dynamic-forms/integration';
 
-/**
- * Configuration props for PrimeNG textarea field component.
- */
+/** Configuration props for PrimeNG textarea field component. */
 export interface PrimeTextareaProps extends TextareaProps {
-  /**
-   * Enable automatic resizing based on content.
-   */
+  /** Enable automatic resizing based on content. */
   autoResize?: boolean;
-  /**
-   * CSS class to apply to the textarea element.
-   */
+  /** CSS class to apply to the textarea element. */
   styleClass?: string;
-  /**
-   * Hint text displayed below the textarea.
-   */
+  /** Hint text displayed below the textarea. */
   hint?: DynamicText;
 }
 
-/**
- * PrimeNG textarea field type definition.
- */
+/** PrimeNG textarea field type definition. */
 export type PrimeTextareaField = TextareaField<PrimeTextareaProps>;
 
 /** @deprecated Scheduled for removal in v1. Use `injectNgForgeField<T>()` for typed access to a field component's directive instance. */

--- a/packages/dynamic-forms-primeng/src/lib/fields/toggle/prime-toggle.type.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/toggle/prime-toggle.type.ts
@@ -2,13 +2,9 @@ import { CheckedFieldComponent, DynamicText } from '@ng-forge/dynamic-forms';
 import { ToggleField } from '@ng-forge/dynamic-forms/integration';
 
 export interface PrimeToggleProps {
-  /**
-   * CSS class to apply to the toggle element.
-   */
+  /** CSS class to apply to the toggle element. */
   styleClass?: string;
-  /**
-   * Hint text displayed below the toggle.
-   */
+  /** Hint text displayed below the toggle. */
   hint?: DynamicText;
 }
 

--- a/packages/dynamic-forms-primeng/src/lib/models/primeng-config.token.ts
+++ b/packages/dynamic-forms-primeng/src/lib/models/primeng-config.token.ts
@@ -4,22 +4,5 @@ import { PrimeNGConfig } from './primeng-config';
 /**
  * Injection token for PrimeNG form configuration.
  * Use this to provide global configuration for PrimeNG form fields.
- *
- * @example
- * ```typescript
- * import { provideDynamicForm } from '@ng-forge/dynamic-forms';
- * import { withPrimeNGFields } from '@ng-forge/dynamic-forms-primeng';
- *
- * export const appConfig: ApplicationConfig = {
- *   providers: [
- *     provideDynamicForm(
- *       ...withPrimeNGFields({
- *         variant: 'filled',
- *         size: 'large'
- *       })
- *     )
- *   ]
- * };
- * ```
  */
 export const PRIMENG_CONFIG = new InjectionToken<PrimeNGConfig>('PRIMENG_CONFIG');

--- a/packages/dynamic-forms-primeng/src/lib/models/primeng-config.ts
+++ b/packages/dynamic-forms-primeng/src/lib/models/primeng-config.ts
@@ -1,63 +1,50 @@
-/**
- * Configuration options for PrimeNG form fields.
- *
- * These settings can be applied at two levels:
- * - **Library-level**: Via `withPrimeNGFields({ ... })` - applies to all forms
- * - **Form-level**: Via `defaultProps` in form config - applies to a specific form
- *
- * The cascade hierarchy is: Library-level → Form-level → Field-level
- *
- * @example
- * ```typescript
- * // Library-level (in app config)
- * provideDynamicForms(withPrimeNGFields({ size: 'small', variant: 'filled' }))
- *
- * // Form-level (in form config)
- * const config: PrimeFormConfig = {
- *   defaultProps: { variant: 'outlined' },
- *   fields: [...]
- * };
- * ```
- */
+/** Configuration options for PrimeNG form fields. */
 export interface PrimeNGConfig {
   /**
    * Default size variant for form inputs
+   *
    * @default undefined
    */
   size?: 'small' | 'large';
 
   /**
    * Default visual variant for form inputs
+   *
    * @default 'outlined'
    */
   variant?: 'outlined' | 'filled';
 
   /**
    * Default severity for buttons
+   *
    * @default 'primary'
    */
   severity?: 'primary' | 'secondary' | 'success' | 'info' | 'warn' | 'danger' | 'help' | 'contrast';
 
   /**
    * Whether buttons should be text-only by default
+   *
    * @default false
    */
   text?: boolean;
 
   /**
    * Whether buttons should be outlined by default
+   *
    * @default false
    */
   outlined?: boolean;
 
   /**
    * Whether buttons should be raised by default
+   *
    * @default false
    */
   raised?: boolean;
 
   /**
    * Whether buttons should be rounded by default
+   *
    * @default false
    */
   rounded?: boolean;

--- a/packages/dynamic-forms-primeng/src/lib/providers/primeng-providers.ts
+++ b/packages/dynamic-forms-primeng/src/lib/providers/primeng-providers.ts
@@ -5,9 +5,7 @@ import { PrimeNGConfig } from '../models/primeng-config';
 import { PRIMENG_CONFIG } from '../models/primeng-config.token';
 import type { PrimeButtonAddon, PrimeIconAddon } from '../types/addons';
 
-/**
- * Field type definitions for PrimeNG components.
- */
+/** Field type definitions for PrimeNG components. */
 export type PrimeNGFieldTypes = FieldTypeDefinition[];
 
 type PrimeNGConfigFeature = {
@@ -28,42 +26,7 @@ type PrimeNGFieldsWithConfig = [...PrimeNGFieldTypes, PrimeNGAddonsFeature, Prim
  * with PrimeNG-shipped addon kinds (`prime-icon`, `prime-button`) auto-included
  * so addons work out of the box.
  *
- * If you want field types WITHOUT addons (rare), pass them through
- * `provideDynamicForm` directly and skip this helper. If you want addons
- * WITHOUT the field types (also rare — e.g., adding addons to a form that
- * uses custom fields), call `withPrimeNGAddons()` standalone.
- *
  * @param config - Optional global configuration for PrimeNG form fields
- *
- * @example
- * ```typescript
- * // Application-level setup — addons (prime-icon, prime-button) ship in automatically
- * import { ApplicationConfig } from '@angular/core';
- * import { provideDynamicForm } from '@ng-forge/dynamic-forms';
- * import { withPrimeNGFields } from '@ng-forge/dynamic-forms-primeng';
- *
- * export const appConfig: ApplicationConfig = {
- *   providers: [
- *     provideDynamicForm(...withPrimeNGFields())
- *   ]
- * };
- * ```
- *
- * @example
- * ```typescript
- * // With global configuration
- * export const appConfig: ApplicationConfig = {
- *   providers: [
- *     provideDynamicForm(
- *       ...withPrimeNGFields({
- *         variant: 'filled',
- *         size: 'large'
- *       })
- *     )
- *   ]
- * };
- * ```
- *
  * @returns Tuple of field type definitions, the addons feature, and
  *   optionally a config feature.
  */
@@ -127,27 +90,7 @@ type PrimeNGAddonsFeature = {
   ɵproviders: Provider[];
 };
 
-/**
- * Register PrimeNG-shipped addon kinds (`prime-icon`, `prime-button`) standalone.
- *
- * **Most users don't need this** — `withPrimeNGFields()` auto-includes
- * these kinds. Call `withPrimeNGAddons()` directly only when you want
- * PrimeNG addon kinds without the PrimeNG field types (e.g., a custom
- * field set that wants to render `prime-icon` prefixes), or when you're
- * stitching addons through a different DI scope.
- *
- * @example
- * ```typescript
- * // Custom field types + PrimeNG addon kinds.
- * provideDynamicForm(
- *   ...myCustomFields(),
- *   withPrimeNGAddons(),
- * );
- * ```
- *
- * Adapter authors who need to override a kind with a customised renderer
- * should call `withCustomAddon(...)` directly instead.
- */
+/** Register PrimeNG-shipped addon kinds (`prime-icon`, `prime-button`) standalone. */
 export function withPrimeNGAddons(): PrimeNGAddonsFeature {
   return {
     ɵkind: 'addons',

--- a/packages/dynamic-forms-primeng/src/lib/testing/primeng-test-utils.ts
+++ b/packages/dynamic-forms-primeng/src/lib/testing/primeng-test-utils.ts
@@ -20,26 +20,20 @@ import {
   PrimeToggleField,
 } from '../fields';
 
-/**
- * Configuration for creating a PrimeNG dynamic form test
- */
+/** Configuration for creating a PrimeNG dynamic form test */
 export interface PrimeNGFormTestConfig {
   config: FormConfig;
   initialValue?: Record<string, unknown>;
   providers?: unknown[];
 }
 
-/**
- * Result of creating a PrimeNG dynamic form test
- */
+/** Result of creating a PrimeNG dynamic form test */
 export interface PrimeNGFormTestResult {
   component: DynamicForm;
   fixture: ComponentFixture<DynamicForm>;
 }
 
-/**
- * Fluent API for building PrimeNG form configurations
- */
+/** Fluent API for building PrimeNG form configurations */
 export class PrimeNGFormConfigBuilder {
   private fields: unknown[] = [];
 
@@ -123,20 +117,14 @@ export class PrimeNGFormConfigBuilder {
   }
 }
 
-/**
- * Utility class for testing PrimeNG dynamic forms
- */
+/** Utility class for testing PrimeNG dynamic forms */
 export class PrimeNGFormTestUtils {
-  /**
-   * Creates a new PrimeNG form config builder
-   */
+  /** Creates a new PrimeNG form config builder */
   static builder(): PrimeNGFormConfigBuilder {
     return new PrimeNGFormConfigBuilder();
   }
 
-  /**
-   * Creates a PrimeNG dynamic form test setup with proper providers
-   */
+  /** Creates a PrimeNG dynamic form test setup with proper providers */
   static async createTest(testConfig: PrimeNGFormTestConfig): Promise<PrimeNGFormTestResult> {
     await TestBed.configureTestingModule({
       imports: [DynamicForm],
@@ -169,9 +157,7 @@ export class PrimeNGFormTestUtils {
     };
   }
 
-  /**
-   * Waits for the PrimeNG dynamic form to initialize
-   */
+  /** Waits for the PrimeNG dynamic form to initialize */
   static async waitForInit(fixture: ComponentFixture<DynamicForm>): Promise<void> {
     await waitForDFInit(fixture.componentInstance, fixture);
 
@@ -209,9 +195,7 @@ export class PrimeNGFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates user input on a PrimeNG input field
-   */
+  /** Simulates user input on a PrimeNG input field */
   static async simulatePrimeInput(fixture: ComponentFixture<DynamicForm>, selector: string, value: string): Promise<void> {
     const input = fixture.nativeElement.querySelector(selector) as HTMLInputElement;
     if (!input) {
@@ -225,9 +209,7 @@ export class PrimeNGFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates user selection on a PrimeNG dropdown/select
-   */
+  /** Simulates user selection on a PrimeNG dropdown/select */
   static async simulatePrimeDropdown(
     fixture: ComponentFixture<DynamicForm>,
     selectSelector: string,
@@ -256,9 +238,7 @@ export class PrimeNGFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates PrimeNG checkbox toggle
-   */
+  /** Simulates PrimeNG checkbox toggle */
   static async simulatePrimeCheckbox(fixture: ComponentFixture<DynamicForm>, selector: string, checked: boolean): Promise<void> {
     let checkboxElement: Element | null = null;
 
@@ -339,9 +319,7 @@ export class PrimeNGFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates PrimeNG toggle switch (InputSwitch)
-   */
+  /** Simulates PrimeNG toggle switch (InputSwitch) */
   static async simulatePrimeToggle(fixture: ComponentFixture<DynamicForm>, selector: string, checked: boolean): Promise<void> {
     const toggle = fixture.nativeElement.querySelector(selector);
     if (!toggle) {
@@ -362,9 +340,7 @@ export class PrimeNGFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates PrimeNG button click
-   */
+  /** Simulates PrimeNG button click */
   static async simulatePrimeButtonClick(fixture: ComponentFixture<DynamicForm>, selector: string): Promise<void> {
     const button = fixture.nativeElement.querySelector(selector) as HTMLButtonElement;
     if (!button) {
@@ -376,37 +352,27 @@ export class PrimeNGFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Gets the current form value from the component
-   */
+  /** Gets the current form value from the component */
   static getFormValue(component: DynamicForm): Record<string, unknown> {
     return component.formValue();
   }
 
-  /**
-   * Gets validation errors from the component
-   */
+  /** Gets validation errors from the component */
   static getFormErrors(component: DynamicForm): unknown[] {
     return component.errors();
   }
 
-  /**
-   * Checks if the form is valid
-   */
+  /** Checks if the form is valid */
   static isFormValid(component: DynamicForm): boolean {
     return component.valid();
   }
 
-  /**
-   * Gets all PrimeNG field elements from the fixture
-   */
+  /** Gets all PrimeNG field elements from the fixture */
   static getPrimeFieldElements(fixture: ComponentFixture<DynamicForm>, fieldType: string): NodeListOf<Element> {
     return fixture.nativeElement.querySelectorAll(`df-prime-${fieldType}`);
   }
 
-  /**
-   * Asserts that a PrimeNG field has a specific value
-   */
+  /** Asserts that a PrimeNG field has a specific value */
   static assertPrimeFieldValue(fixture: ComponentFixture<DynamicForm>, fieldSelector: string, expectedValue: string): void {
     // Try to find the input element directly first
     let element = fixture.nativeElement.querySelector(fieldSelector);
@@ -436,9 +402,7 @@ export class PrimeNGFormTestUtils {
     }
   }
 
-  /**
-   * Asserts that the form has a specific value
-   */
+  /** Asserts that the form has a specific value */
   static assertFormValue(component: DynamicForm, expectedValue: Record<string, unknown>): void {
     const actualValue = component.formValue();
     if (JSON.stringify(actualValue) !== JSON.stringify(expectedValue)) {
@@ -446,9 +410,7 @@ export class PrimeNGFormTestUtils {
     }
   }
 
-  /**
-   * Asserts that a PrimeNG field shows an error message
-   */
+  /** Asserts that a PrimeNG field shows an error message */
   static assertPrimeFieldError(fixture: ComponentFixture<DynamicForm>, fieldSelector: string, expectedError?: string): void {
     const fieldWrapper = fixture.nativeElement.querySelector(fieldSelector);
     if (!fieldWrapper) {
@@ -466,9 +428,7 @@ export class PrimeNGFormTestUtils {
     }
   }
 
-  /**
-   * Gets a PrimeNG input text element
-   */
+  /** Gets a PrimeNG input text element */
   static getPInputText(fixture: ComponentFixture<DynamicForm>, selector: string): HTMLInputElement {
     const input = fixture.nativeElement.querySelector(selector) as HTMLInputElement;
     if (!input) {
@@ -477,9 +437,7 @@ export class PrimeNGFormTestUtils {
     return input;
   }
 
-  /**
-   * Gets a PrimeNG dropdown element
-   */
+  /** Gets a PrimeNG dropdown element */
   static getPDropdown(fixture: ComponentFixture<DynamicForm>, selector: string): Element {
     const dropdown = fixture.nativeElement.querySelector(selector);
     if (!dropdown) {
@@ -488,9 +446,7 @@ export class PrimeNGFormTestUtils {
     return dropdown;
   }
 
-  /**
-   * Gets a PrimeNG checkbox element
-   */
+  /** Gets a PrimeNG checkbox element */
   static getPCheckbox(fixture: ComponentFixture<DynamicForm>, selector: string): Element {
     const checkbox = fixture.nativeElement.querySelector(selector);
     if (!checkbox) {
@@ -499,9 +455,7 @@ export class PrimeNGFormTestUtils {
     return checkbox;
   }
 
-  /**
-   * Gets a PrimeNG radio button element
-   */
+  /** Gets a PrimeNG radio button element */
   static getPRadioButton(fixture: ComponentFixture<DynamicForm>, selector: string): Element {
     const radio = fixture.nativeElement.querySelector(selector);
     if (!radio) {
@@ -510,9 +464,7 @@ export class PrimeNGFormTestUtils {
     return radio;
   }
 
-  /**
-   * Gets a PrimeNG InputSwitch (toggle) element
-   */
+  /** Gets a PrimeNG InputSwitch (toggle) element */
   static getPInputSwitch(fixture: ComponentFixture<DynamicForm>, selector: string): Element {
     const toggle = fixture.nativeElement.querySelector(selector);
     if (!toggle) {
@@ -521,9 +473,7 @@ export class PrimeNGFormTestUtils {
     return toggle;
   }
 
-  /**
-   * Gets a PrimeNG textarea element
-   */
+  /** Gets a PrimeNG textarea element */
   static getPTextarea(fixture: ComponentFixture<DynamicForm>, selector: string): HTMLTextAreaElement {
     const textarea = fixture.nativeElement.querySelector(selector) as HTMLTextAreaElement;
     if (!textarea) {
@@ -532,9 +482,7 @@ export class PrimeNGFormTestUtils {
     return textarea;
   }
 
-  /**
-   * Gets a PrimeNG calendar (datepicker) element
-   */
+  /** Gets a PrimeNG calendar (datepicker) element */
   static getPCalendar(fixture: ComponentFixture<DynamicForm>, selector: string): Element {
     const calendar = fixture.nativeElement.querySelector(selector);
     if (!calendar) {
@@ -543,9 +491,7 @@ export class PrimeNGFormTestUtils {
     return calendar;
   }
 
-  /**
-   * Gets a PrimeNG slider element
-   */
+  /** Gets a PrimeNG slider element */
   static getPSlider(fixture: ComponentFixture<DynamicForm>, selector: string): Element {
     const slider = fixture.nativeElement.querySelector(selector);
     if (!slider) {
@@ -554,9 +500,7 @@ export class PrimeNGFormTestUtils {
     return slider;
   }
 
-  /**
-   * Gets a PrimeNG button element
-   */
+  /** Gets a PrimeNG button element */
   static getPButton(fixture: ComponentFixture<DynamicForm>, selector: string): HTMLButtonElement {
     const button = fixture.nativeElement.querySelector(selector) as HTMLButtonElement;
     if (!button) {

--- a/packages/dynamic-forms-primeng/src/lib/testing/wait-for-df.ts
+++ b/packages/dynamic-forms-primeng/src/lib/testing/wait-for-df.ts
@@ -3,20 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DynamicForm } from '@ng-forge/dynamic-forms';
 import { firstValueFrom } from 'rxjs';
 
-/**
- * Waits for all dynamic form definitions to be initialized and ready
- *
- * Hybrid approach:
- * 1. Event-based: Wait for initialized$ (tracks container components + field loading cascade)
- * 2. DOM verification: Short poll to ensure PrimeNG components fully rendered
- *
- * The initialized$ observable tracks page/row/group containers. Each container waits
- * for its children via forkJoin + afterNextRender before emitting its initialized event.
- * This creates a cascade where parent containers only emit after all descendants are ready.
- *
- * The short poll handles edge cases where PrimeNG component templates need additional
- * change detection cycles before DOM elements match test selectors.
- */
+/** Waits for all dynamic form definitions to be initialized and ready */
 export async function waitForDFInit(component: DynamicForm, fixture: ComponentFixture<DynamicForm>): Promise<void> {
   untracked(() => fixture.detectChanges());
 
@@ -39,13 +26,7 @@ export async function waitForDFInit(component: DynamicForm, fixture: ComponentFi
   await fixture.whenStable();
 }
 
-/**
- * Deterministic DOM stability check
- *
- * Waits until PrimeNG component count stabilizes for 3 consecutive checks
- * and no loading placeholders remain. Uses timeout-based safety net instead
- * of arbitrary iteration limits.
- */
+/** Deterministic DOM stability check */
 async function waitForFieldComponents(fixture: ComponentFixture<any>, timeoutMs = 500): Promise<void> {
   const formElement = fixture.nativeElement.querySelector('.df-form, form');
   if (!formElement) return;

--- a/packages/dynamic-forms-primeng/src/lib/tokens/input-type-override.token.ts
+++ b/packages/dynamic-forms-primeng/src/lib/tokens/input-type-override.token.ts
@@ -3,16 +3,6 @@ import { InjectionToken, WritableSignal } from '@angular/core';
 /**
  * Per-field writable signal that overrides the input's `type` attribute.
  *
- * Provided at the `prime-input` field component level. The button addon's
- * `'toggle-password-visibility'` preset writes to it; the field component
- * reads it to compute its effective `type`.
- *
- * Optional from a button's perspective — when the button is hosted inside a
- * field that doesn't provide this token (e.g., textarea or a future
- * non-input field), the toggle preset is a no-op.
- *
- * @example provided per-field:
- * ```typescript
  * @Component({
  *   providers: [{ provide: PRIME_INPUT_TYPE_OVERRIDE, useValue: signal(undefined) }],
  * })

--- a/packages/dynamic-forms-primeng/src/lib/types/addons.ts
+++ b/packages/dynamic-forms-primeng/src/lib/types/addons.ts
@@ -7,15 +7,7 @@ import type {
   RegisteredActionRef,
 } from '@ng-forge/dynamic-forms';
 
-/**
- * Decorative icon addon for PrimeNG fields.
- *
- * Renders `<i class="pi pi-{icon}">`. The `icon` string is the bare PrimeIcons
- * suffix — e.g., `'search'` produces `<i class="pi pi-search">`.
- *
- * Add `ariaLabel` for icons that convey meaning (search, error, success);
- * leave it omitted for purely decorative icons (will be `aria-hidden="true"`).
- */
+/** Decorative icon addon for PrimeNG fields. */
 export interface PrimeIconAddon extends BaseAddon {
   readonly kind: 'prime-icon';
   /** PrimeIcons name without the `pi-` prefix (e.g., `'search'`, `'times'`). */
@@ -40,14 +32,6 @@ interface PiButtonBase extends BaseAddon {
  * Click axis — XOR enforced at type level so configurations that combine
  * two click handlers (e.g., `preset` AND `actionRef`) are rejected by
  * TypeScript. The four shapes:
- *
- * - `Preset`    — built-in preset action.
- * - `ActionRef` — typed reference to a handler registered via `provideAddonActions(...)`.
- * - `Action`    — inline handler (code-only; dropped from JSON-derived configs).
- * - `None`      — decorative button with no handler.
- *
- * Runtime XOR validation stays as defence-in-depth for JSON-source configs
- * that bypass the type checker.
  */
 type PiButtonClickPreset = {
   /** Built-in preset action (e.g., `'clear'`, `'toggle-password-visibility'`). JSON-safe. */
@@ -86,13 +70,6 @@ type PiButtonClick = PiButtonClickPreset | PiButtonClickActionRef | PiButtonClic
 /**
  * Content axis — XOR enforced at type level so an icon-only button is
  * forced to declare `ariaLabel`. The three shapes:
- *
- * - `IconOnly`   — just `icon`; `ariaLabel` is REQUIRED
- * - `Labeled`    — `label` set; `icon` and `ariaLabel` optional
- * - `Decorative` — neither icon nor label (e.g., custom-rendered child)
- *
- * Combining keys is rejected by TypeScript — `icon: 'x'` without either
- * `label` or `ariaLabel` doesn't satisfy any branch.
  */
 type PiButtonContentIconOnly = {
   readonly icon: string;
@@ -112,22 +89,7 @@ type PiButtonContentDecorative = {
 };
 type PiButtonContent = PiButtonContentIconOnly | PiButtonContentLabeled | PiButtonContentDecorative;
 
-/**
- * Interactive button addon for PrimeNG fields.
- *
- * Renders `<p-button>` with optional icon, label, severity, and reactive
- * loading state.
- *
- * Type-level guarantees:
- *
- * - **Content axis (XOR):** `IconOnly` (icon + required ariaLabel) |
- *   `Labeled` (label, icon optional) | `Decorative` (neither). The IDE
- *   rejects icon-only configs that omit `ariaLabel`.
- * - **Click axis (XOR):** exactly one of `preset` / `actionRef` / `action`,
- *   or none. Combining two is rejected by TypeScript at the call site;
- *   the runtime validator still drops the addon with a clear warning when
- *   JSON-source configs slip a multi-set past the type checker.
- */
+/** Interactive button addon for PrimeNG fields. */
 export type PrimeButtonAddon = PiButtonBase & PiButtonContent & PiButtonClick;
 
 /** Union of all PrimeNG-shipped addon kinds. */

--- a/packages/dynamic-forms-primeng/src/lib/types/form-config.ts
+++ b/packages/dynamic-forms-primeng/src/lib/types/form-config.ts
@@ -1,50 +1,10 @@
 import { FormConfig, InferFormValue, NarrowFields, RegisteredFieldTypes } from '@ng-forge/dynamic-forms';
 import { PrimeNGConfig } from '../models/primeng-config';
 
-/**
- * PrimeNG-specific props that can be set at form level and cascade to all fields.
- *
- * This is the same type as `PrimeNGConfig` used in `withPrimeNGFields()`.
- * Using a single type ensures consistency between library-level and form-level configuration.
- *
- * The cascade hierarchy is: Library-level → Form-level → Field-level
- *
- * @example
- * ```typescript
- * const config: PrimeFormConfig = {
- *   defaultProps: {
- *     size: 'small',
- *     variant: 'filled',
- *   },
- *   fields: [
- *     { type: 'prime-input', key: 'name', label: 'Name' },
- *   ],
- * };
- * ```
- */
+/** PrimeNG-specific props that can be set at form level and cascade to all fields. */
 export type PrimeFormProps = PrimeNGConfig;
 
-/**
- * PrimeNG-specific FormConfig with type-safe defaultProps.
- *
- * Use this type alias when defining form configurations with PrimeNG components
- * to get IDE autocomplete and type checking for `defaultProps`.
- *
- * @example
- * ```typescript
- * const formConfig: PrimeFormConfig = {
- *   defaultProps: {
- *     size: 'small',
- *     variant: 'filled',
- *     severity: 'secondary',
- *   },
- *   fields: [
- *     { type: 'prime-input', key: 'name', label: 'Name' },  // Uses form defaultProps
- *     { type: 'prime-input', key: 'email', props: { variant: 'outlined' } },  // Override
- *   ],
- * };
- * ```
- */
+/** PrimeNG-specific FormConfig with type-safe defaultProps. */
 export type PrimeFormConfig<
   TFields extends NarrowFields | RegisteredFieldTypes[] = RegisteredFieldTypes[],
   TValue = InferFormValue<TFields extends readonly RegisteredFieldTypes[] ? TFields : RegisteredFieldTypes[]>,

--- a/packages/dynamic-forms-primeng/src/lib/types/registry-augmentation.ts
+++ b/packages/dynamic-forms-primeng/src/lib/types/registry-augmentation.ts
@@ -1,9 +1,4 @@
-/**
- * Module augmentation for @ng-forge/dynamic-form to add PrimeNG field types to the global registry.
- *
- * This file augments the FieldRegistryLeaves interface to include PrimeNG-specific field types.
- * Import this file in your main entry point to get global type safety for PrimeNG fields.
- */
+/** Module augmentation for @ng-forge/dynamic-form to add PrimeNG field types to the global registry. */
 
 import type { FormEvent } from '@ng-forge/dynamic-forms';
 import type {

--- a/packages/dynamic-forms/integration/src/definitions/button-field.ts
+++ b/packages/dynamic-forms/integration/src/definitions/button-field.ts
@@ -3,18 +3,10 @@ import { FieldDef, FormEvent, FormEventConstructor, StateLogicConfig } from '@ng
 /**
  * Event arguments that can contain static values or tokens to be resolved at runtime.
  * Tokens supported: $key, $index, $arrayKey, $template, formValue
- *
- * Used by the generic button type when manually configuring events.
  */
 export type EventArgs = readonly (string | number | boolean | null | undefined)[];
 
-/**
- * Base interface for button fields.
- *
- * This is used by the generic 'button' type which requires explicit event configuration.
- * For specific button types (submit, next, previous, array buttons), use the
- * pre-configured types from the UI library instead.
- */
+/** Base interface for button fields. */
 export interface ButtonField<TProps, TEvent extends FormEvent> extends FieldDef<TProps> {
   type: 'button';
   event: FormEventConstructor<TEvent>;
@@ -26,10 +18,6 @@ export interface ButtonField<TProps, TEvent extends FormEvent> extends FieldDef<
    * - $arrayKey: The parent array field key (if inside an array field)
    * - $template: The template for array item creation (for array add buttons)
    * - formValue: Access to the current form value for indexing
-   *
-   * @example
-   * eventArgs: ['$arrayKey', '$index']
-   * eventArgs: ['contacts', 0]
    */
   eventArgs?: EventArgs;
   /** Logic rules for dynamic disabled state (overrides form-level defaults) */

--- a/packages/dynamic-forms/integration/src/definitions/input-field.ts
+++ b/packages/dynamic-forms/integration/src/definitions/input-field.ts
@@ -3,6 +3,7 @@ import { InputMeta } from './input-meta';
 
 /**
  * All valid HTML input types per MDN specification.
+ *
  * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types
  */
 export type HtmlInputType =
@@ -40,14 +41,7 @@ export type HtmlInputType =
  */
 export type InputType = Extract<HtmlInputType, 'text' | 'email' | 'password' | 'number' | 'tel' | 'url' | 'search'>;
 
-/**
- * Infers the TypeScript value type for a given input type.
- *
- * @example
- * type NumberValue = InferInputValue<'number'>; // number
- * type TextValue = InferInputValue<'text'>; // string
- * type DateValue = InferInputValue<'date'>; // string (extended types)
- */
+/** Infers the TypeScript value type for a given input type. */
 export type InferInputValue<T extends HtmlInputType> = T extends 'number' ? number : string;
 
 /**
@@ -58,14 +52,6 @@ export type InputTypeToValueType<T extends InputType> = InferInputValue<T>;
 /**
  * Props for input fields with optional type specification.
  * Generic parameter allows extending InputType with additional HtmlInputType values.
- *
- * @example
- * // Default usage
- * interface MyProps extends InputProps { ... }
- *
- * // Extended input types (e.g., supporting date inputs)
- * type ExtendedType = InputType | 'date' | 'time';
- * interface ExtendedProps extends InputProps<ExtendedType> { ... }
  */
 export interface InputProps<T extends HtmlInputType = InputType> {
   /**
@@ -83,18 +69,10 @@ export interface InputProps<T extends HtmlInputType = InputType> {
 /**
  * Input types that produce numeric values.
  * Currently only 'number' produces a numeric value in HTML inputs.
- *
- * @example
- * type Numeric = NumericInputType; // 'number'
  */
 export type NumericInputType<T extends HtmlInputType = InputType> = Extract<T, 'number'>;
 
-/**
- * Input types that produce string values.
- *
- * @example
- * type Strings = StringInputType; // Exclude<InputType, 'number'>
- */
+/** Input types that produce string values. */
 export type StringInputType<T extends HtmlInputType = InputType> = Exclude<T, 'number'>;
 
 // ============================================================================
@@ -143,30 +121,6 @@ type BuildInputFieldUnion<TProps extends { type?: string }, TNullable extends bo
 /**
  * Input field with automatic type-safe value inference.
  * TypeScript automatically infers the correct value type based on props.type.
- *
- * @example
- * // Direct usage - automatic strict type safety
- * const numberField: InputField = {
- *   type: 'input',
- *   key: 'age',
- *   props: { type: 'number' },
- *   value: 25 // ✓ number only (string is type error!)
- * };
- *
- * const textField: InputField = {
- *   type: 'input',
- *   key: 'name',
- *   props: { type: 'text' },
- *   value: 'hello' // ✓ string only (number is type error!)
- * };
- *
- * @example
- * // Framework usage - extend with custom props
- * interface MatInputProps extends InputProps {
- *   appearance?: 'fill' | 'outline';
- *   hint?: string;
- * }
- * type MatInputField = InputField<MatInputProps>; // Automatically gets discriminated union
  */
 export type InputField<TProps extends { type?: string } = InputProps, TNullable extends boolean = boolean> = BuildInputFieldUnion<
   TProps,

--- a/packages/dynamic-forms/integration/src/definitions/input-meta.ts
+++ b/packages/dynamic-forms/integration/src/definitions/input-meta.ts
@@ -83,73 +83,32 @@ export type EnterKeyHint = 'enter' | 'done' | 'go' | 'next' | 'previous' | 'sear
  */
 export type Autocapitalize = 'off' | 'none' | 'on' | 'sentences' | 'words' | 'characters';
 
-/**
- * Meta attributes specific to HTML input elements.
- *
- * Extends FieldMeta with input-specific native attributes that can be passed through
- * to the underlying input element.
- *
- * @example
- * ```typescript
- * // Input field with meta attributes
- * {
- *   type: 'input',
- *   key: 'email',
- *   meta: {
- *     autocomplete: 'email',
- *     inputmode: 'email',
- *     enterkeyhint: 'next',
- *     spellcheck: false,
- *     'data-testid': 'email-input'
- *   }
- * }
- * ```
- *
- * @public
- */
+/** Meta attributes specific to HTML input elements. */
 export interface InputMeta extends FieldMeta {
-  /**
-   * Hint for form autofill behavior.
-   */
+  /** Hint for form autofill behavior. */
   autocomplete?: AutocompleteValue;
 
-  /**
-   * Hint for virtual keyboard type on mobile devices.
-   */
+  /** Hint for virtual keyboard type on mobile devices. */
   inputmode?: InputMode;
 
-  /**
-   * Hint for the enter key label on virtual keyboards.
-   */
+  /** Hint for the enter key label on virtual keyboards. */
   enterkeyhint?: EnterKeyHint;
 
-  /**
-   * Whether to enable spellchecking for the input.
-   */
+  /** Whether to enable spellchecking for the input. */
   spellcheck?: boolean;
 
-  /**
-   * Hint for autocapitalization behavior on virtual keyboards.
-   */
+  /** Hint for autocapitalization behavior on virtual keyboards. */
   autocapitalize?: Autocapitalize;
 
-  /**
-   * Pattern for client-side validation (regex).
-   */
+  /** Pattern for client-side validation (regex). */
   pattern?: string;
 
-  /**
-   * Size hint for the input element (character count).
-   */
+  /** Size hint for the input element (character count). */
   size?: number;
 
-  /**
-   * Maximum number of characters allowed.
-   */
+  /** Maximum number of characters allowed. */
   maxlength?: number;
 
-  /**
-   * Minimum number of characters required.
-   */
+  /** Minimum number of characters required. */
   minlength?: number;
 }

--- a/packages/dynamic-forms/integration/src/definitions/multi-checkbox-field.ts
+++ b/packages/dynamic-forms/integration/src/definitions/multi-checkbox-field.ts
@@ -3,18 +3,6 @@ import { BaseValueField, FieldMeta, FieldOption } from '@ng-forge/dynamic-forms'
 /**
  * Multi-checkbox field for selecting multiple values from a list of options.
  * The value is an array of selected option values.
- *
- * @example
- * const tagsField: MultiCheckboxField<string> = {
- *   type: 'multi-checkbox',
- *   key: 'tags',
- *   value: ['tag1', 'tag2'], // Array of selected values
- *   options: [
- *     { label: 'Tag 1', value: 'tag1' },
- *     { label: 'Tag 2', value: 'tag2' },
- *     { label: 'Tag 3', value: 'tag3' }
- *   ]
- * };
  */
 export interface MultiCheckboxField<TValue, TProps = object, TNullable extends boolean = boolean> extends BaseValueField<
   TProps,

--- a/packages/dynamic-forms/integration/src/definitions/textarea-meta.ts
+++ b/packages/dynamic-forms/integration/src/definitions/textarea-meta.ts
@@ -8,29 +8,7 @@ import { Autocapitalize, AutocompleteValue, EnterKeyHint } from './input-meta';
  */
 export type TextareaWrap = 'hard' | 'soft' | 'off';
 
-/**
- * Meta attributes specific to HTML textarea elements.
- *
- * Extends FieldMeta with textarea-specific native attributes that can be passed through
- * to the underlying textarea element.
- *
- * @example
- * ```typescript
- * // Textarea field with meta attributes
- * {
- *   type: 'textarea',
- *   key: 'description',
- *   meta: {
- *     wrap: 'soft',
- *     spellcheck: true,
- *     autocomplete: 'off',
- *     'data-testid': 'description-textarea'
- *   }
- * }
- * ```
- *
- * @public
- */
+/** Meta attributes specific to HTML textarea elements. */
 export interface TextareaMeta extends FieldMeta {
   /**
    * How text should wrap when submitted.
@@ -40,33 +18,21 @@ export interface TextareaMeta extends FieldMeta {
    */
   wrap?: TextareaWrap;
 
-  /**
-   * Whether to enable spellchecking for the textarea.
-   */
+  /** Whether to enable spellchecking for the textarea. */
   spellcheck?: boolean;
 
-  /**
-   * Hint for form autofill behavior.
-   */
+  /** Hint for form autofill behavior. */
   autocomplete?: AutocompleteValue;
 
-  /**
-   * Hint for autocapitalization behavior on virtual keyboards.
-   */
+  /** Hint for autocapitalization behavior on virtual keyboards. */
   autocapitalize?: Autocapitalize;
 
-  /**
-   * Hint for the enter key label on virtual keyboards.
-   */
+  /** Hint for the enter key label on virtual keyboards. */
   enterkeyhint?: EnterKeyHint;
 
-  /**
-   * Maximum number of characters allowed.
-   */
+  /** Maximum number of characters allowed. */
   maxlength?: number;
 
-  /**
-   * Minimum number of characters required.
-   */
+  /** Minimum number of characters required. */
   minlength?: number;
 }

--- a/packages/dynamic-forms/integration/src/directives/addon-preset-handler.token.ts
+++ b/packages/dynamic-forms/integration/src/directives/addon-preset-handler.token.ts
@@ -7,10 +7,6 @@ import { AddonActionContext } from '@ng-forge/dynamic-forms';
  * (`NgForgeAddonAction`) delegates to this when an addon configures a
  * `preset`; the adapter wires concrete preset semantics in its own
  * provider scope.
- *
- * `NgForgeAddonAction` injects this with `{ optional: true }`. Addons that
- * configure a preset on an adapter that hasn't registered a handler get a
- * lenient warning at click time.
  */
 export interface AddonPresetHandler {
   run(preset: string, ctx: AddonActionContext): void | Promise<void>;

--- a/packages/dynamic-forms/integration/src/directives/host-directive-presets.ts
+++ b/packages/dynamic-forms/integration/src/directives/host-directive-presets.ts
@@ -8,26 +8,6 @@ import { NgForgeField, NG_FORGE_VALUE_FIELD_INPUTS } from './ng-forge-field.dire
  * identity) with `NgForgeField` (value + validation + aria + meta-tracking)
  * in a single host-directive entry, so consumer components compose just one
  * directive instead of two.
- *
- * Why a directive instead of a `const` preset: cross-package partial
- * compilation can't resolve a const reference inside `hostDirectives:`, so
- * an exported const array doesn't work for library consumers. A wrapper
- * directive's own `hostDirectives` IS a literal at compile time (in this
- * file), so it works everywhere.
- *
- * Authoring shape for adapter components:
- * ```ts
- * \@Component({
- *   hostDirectives: [NgForgeFieldHost],
- *   ...
- * })
- * export class MyInputField {
- *   protected readonly ngf = injectNgForgeField<string>();
- * }
- * ```
- *
- * Pattern reference: Taiga UI uses the same wrapper-directive technique
- * for the same reason. See https://www.angularspace.com/host-directives-decomposition-unleashed/
  */
 @Directive({
   hostDirectives: [
@@ -41,17 +21,6 @@ export class NgForgeFieldHost {}
  * Action / button host wrapper. Composes `NgForgeFieldShell` with
  * `NgForgeAction` (event dispatch + aria-disabled) for button-shaped
  * components.
- *
- * Authoring shape:
- * ```ts
- * \@Component({
- *   hostDirectives: [NgForgeActionHost],
- *   ...
- * })
- * export class MyButton {
- *   protected readonly action = injectNgForgeAction();
- * }
- * ```
  */
 @Directive({
   hostDirectives: [

--- a/packages/dynamic-forms/integration/src/directives/ng-forge-action.directive.ts
+++ b/packages/dynamic-forms/integration/src/directives/ng-forge-action.directive.ts
@@ -18,24 +18,6 @@ import { NgForgeFieldShell } from './ng-forge-field-shell.directive';
  * action component needs (label, disabled, event, eventArgs, …) plus the
  * `[attr.hidden]` / `[attr.aria-disabled]` host bindings driven by its own
  * inputs (no field tree).
- *
- * Components call `action.dispatch()` from their click handler; this
- * directive resolves any `eventArgs` tokens via the optional `ARRAY_CONTEXT`
- * and dispatches the configured `event` through the `EventBus`.
- *
- * @example
- * ```ts
- * \@Component({
- *   hostDirectives: NG_FORGE_ACTION,
- *   template: `<button (click)="action.dispatch()" [disabled]="action.disabled()">{{ action.label() }}</button>`,
- * })
- * export class MyButton {
- *   protected readonly action = inject(NgForgeAction);
- * }
- * ```
- *
- * Selectorless — usage is exclusively via `hostDirectives`. Prefer the
- * `NG_FORGE_ACTION` preset over composing this directive manually.
  */
 @Directive({
   host: {
@@ -116,11 +98,6 @@ void _NG_FORGE_ACTION_INPUTS_LOCKSTEP;
 /**
  * Typed wrapper around `inject(NgForgeAction)`. The generic narrows the
  * `event` input to a specific FormEvent subclass.
- *
- * @example
- * ```ts
- * protected readonly action = injectNgForgeAction<SubmitEvent>();
- * ```
  */
 export function injectNgForgeAction<TEvent extends FormEvent = FormEvent>(): NgForgeAction<TEvent> {
   return inject(NgForgeAction) as unknown as NgForgeAction<TEvent>;

--- a/packages/dynamic-forms/integration/src/directives/ng-forge-addon-action.directive.ts
+++ b/packages/dynamic-forms/integration/src/directives/ng-forge-addon-action.directive.ts
@@ -32,11 +32,6 @@ interface ActionAddonShape extends BaseAddon {
  * labelled buttons, etc.): `disabled` / `loading` resolution from
  * `DynamicValue<boolean>`, action context construction, and the
  * `preset / actionRef / action` precedence dispatcher.
- *
- * Adapter button kinds (e.g., `prime-button`) compose `NgForgeAddonAction`
- * and read state via `injectNgForgeAddonAction<TAddon>()`. Preset semantics
- * are adapter-specific — register an `ADDON_PRESET_HANDLER` at the host
- * field scope to receive preset dispatches.
  */
 @Directive({})
 export class NgForgeAddonActionBase {
@@ -141,22 +136,6 @@ export class NgForgeAddonActionBase {
    * Build an `AddonActionContext` for handlers from the wrapper-style
    * `fieldInputs` bag. Returns the field-bound variant when a host field
    * is reachable, or the orphan variant otherwise.
-   *
-   * Resolution order for `setValue`:
-   * 1. `inputs.setValue` from the forwarded bag (preferred — populated by
-   *    `buildFieldInputs` in `DfFieldOutlet`).
-   * 2. Fallback reconstructed from `inputs.field` itself: although
-   *    `ReadonlyFieldTree.value` is type-narrowed to `Signal<T>`, the
-   *    underlying runtime object is the same `WritableSignal<T>` created
-   *    by Signal Forms (the read-only wrapping is type-level only, see
-   *    `toReadonlyFieldTree`). Casting back at the writer boundary
-   *    produces a working setValue for ANY field depth — top-level OR
-   *    nested under groups. This avoids the previous FSC-key navigation
-   *    that broke for grouped fields, where `inputs.key` is DOM-mangled
-   *    (`'user_address_street'`) and `fsc.form[key]` returns undefined.
-   *
-   * The orphan variant fires only when the bag carries no field tree at
-   * all — genuine "rendered outside a field" scenario.
    */
   buildActionContext(): AddonActionContext {
     const inputs = this.fieldInputs();
@@ -193,22 +172,7 @@ const _NG_FORGE_ADDON_ACTION_INPUTS_LOCKSTEP: AssertTupleLockstep<
 > = true;
 void _NG_FORGE_ADDON_ACTION_INPUTS_LOCKSTEP;
 
-/**
- * Host wrapper for `NgForgeAddonActionBase`. Consumers compose this directly:
- *
- * ```ts
- * \@Component({
- *   hostDirectives: [NgForgeAddonAction],
- *   template: `
- *     <p-button [loading]="action.loading()" [disabled]="action.disabled()"
- *               (onClick)="action.dispatch()" />
- *   `,
- * })
- * export class MyButtonAddon {
- *   protected readonly action = injectNgForgeAddonAction<MyButtonAddon>();
- * }
- * ```
- */
+/** Host wrapper for `NgForgeAddonActionBase`. Consumers compose this directly: */
 @Directive({
   hostDirectives: [{ directive: NgForgeAddonActionBase, inputs: [...NG_FORGE_ADDON_ACTION_INPUTS] }],
 })

--- a/packages/dynamic-forms/integration/src/directives/ng-forge-addons.directive.ts
+++ b/packages/dynamic-forms/integration/src/directives/ng-forge-addons.directive.ts
@@ -93,10 +93,6 @@ void _NG_FORGE_ADDONS_INPUTS_LOCKSTEP;
 /**
  * Host wrapper for `NgForgeAddonsBase`. Consumers compose this directly:
  *
- * ```ts
- * \@Component({
- *   hostDirectives: [NgForgeFieldHost, NgForgeAddons],
- *   template: `
  *     @if (ngfa.hasAddons()) {
  *       <p-inputgroup>
  *         @for (a of ngfa.prefixAddons(); track $index) {

--- a/packages/dynamic-forms/integration/src/directives/ng-forge-controls.ts
+++ b/packages/dynamic-forms/integration/src/directives/ng-forge-controls.ts
@@ -8,26 +8,6 @@ import { NgForgeField } from './ng-forge-field.directive';
  * parent-derived aria signals (`aria-invalid`, `aria-required`,
  * `aria-describedby`) onto a target element.
  *
- * By default attributes land on the directive's own host. For wrapped
- * controls (e.g. `<mat-checkbox>`, `<p-toggleSwitch>`) where the canonical
- * native input is rendered as a descendant inside the wrapper, pass a CSS
- * selector through the input alias — the directive caches the resolved
- * descendant set and re-resolves only when the selector changes.
- *
- * @example Bare native control
- * ```html
- * <input ngForgeControl [formField]="ngf.field()" />
- * ```
- *
- * @example Wrapped control with inner native input
- * ```html
- * <mat-checkbox ngForgeControl="input[type='checkbox']" [formField]="ngf.field()">
- *   {{ ngf.label() }}
- * </mat-checkbox>
- * ```
- *
- * @example Dynamic option list (radios rendered in @for)
- * ```html
  * @for (option of options(); track option.value) {
  *   <input type="radio" ngForgeControl [value]="option.value" />
  * }
@@ -52,24 +32,6 @@ export class NgForgeControl {
  * (PrimeNG `p-select`, Ionic web components, etc.) where no light-DOM child
  * is the canonical control. Added to the component's `hostDirectives` so the
  * field's `meta` + parent aria land on the component's own host element.
- *
- * For split parent/control components (e.g. `df-prime-select` rendering
- * `df-prime-select-control` internally), place `NgForgeHostControl` on the
- * INNER control component's `hostDirectives` — the inner element is the
- * canonical control, and the marker's `inject(NgForgeField)` walks up the
- * element-injector tree to find the parent's directive instance.
- *
- * @example
- * ```ts
- * \@Component({
- *   hostDirectives: [
- *     { directive: NgForgeField, inputs: [...NG_FORGE_FIELD_INPUTS] },
- *     NgForgeHostControl,
- *   ],
- *   template: `...`,
- * })
- * export class IonicInputField { ... }
- * ```
  */
 // Empty `@Directive({})` is intentional — selectorless; used only via `hostDirectives`.
 @Directive({})

--- a/packages/dynamic-forms/integration/src/directives/ng-forge-field-shell.directive.ts
+++ b/packages/dynamic-forms/integration/src/directives/ng-forge-field-shell.directive.ts
@@ -5,16 +5,6 @@ import { Directive, input } from '@angular/core';
  * Owns the universal identity inputs (`key`, `className`) and the host
  * bindings that every field shape — value-bearing, action, future container —
  * shares: `[id]`, `[attr.data-testid]`, `[class]`.
- *
- * Shape-specific add-ons (`NgForgeField` for value fields, `NgForgeAction`
- * for actions) inject this directive and read `key()` / `className()` from
- * it. Source-of-truth concerns like `hidden` / `disabled` live on the add-on
- * because they vary by shape (value fields derive from `field()()`; actions
- * receive direct inputs).
- *
- * Selectorless — usage is exclusively via `hostDirectives`. Prefer the
- * `NG_FORGE_FIELD` / `NG_FORGE_ACTION` presets rather than composing Shell
- * directly.
  */
 @Directive({
   host: {

--- a/packages/dynamic-forms/integration/src/directives/ng-forge-field.directive.ts
+++ b/packages/dynamic-forms/integration/src/directives/ng-forge-field.directive.ts
@@ -12,21 +12,6 @@ import { NgForgeFieldShell } from './ng-forge-field-shell.directive';
  * the `NG_FORGE_FIELD` preset. Owns the value/validation/aria plumbing every
  * value-bearing field needs.
  *
- * The Shell owns universal identity (`key`, `className`, `[id]`,
- * `[attr.data-testid]`, `[class]`); this directive injects Shell and adds
- * field-driven bindings (`[attr.hidden]`, `[attr.aria-disabled]`), the
- * standard value-field inputs (`field`, `label`, `placeholder`, `tabIndex`,
- * `props`, `meta`, `validationMessages`), the derived error/aria signals,
- * and the meta-tracking claim contract.
- *
- * @example
- * ```ts
- * \@Component({
- *   hostDirectives: NG_FORGE_FIELD,
- *   imports: [NgForgeControl, FormField],
- *   template: `
- *     <label [for]="ngf.key() + '-input'">{{ ngf.label() | dynamicText | async }}</label>
- *     <input ngForgeControl [id]="ngf.key() + '-input'" [formField]="ngf.field()" />
  *     @if (ngf.errorsToDisplay()[0]; as e) {
  *       <span [id]="ngf.errorId()">{{ e.message }}</span>
  *     }
@@ -185,12 +170,6 @@ export type TypedNgForgeField<T> = Omit<NgForgeField, 'field'> & {
  * `field` signal to `Signal<FieldTree<T>>` for the calling component's value
  * type. The cast is unchecked — the runtime contract is that mappers only
  * forward a `field` whose value type matches the field-type definition.
- *
- * @example
- * ```ts
- * protected readonly ngf = injectNgForgeField<string>();
- * // ngf.field() is Signal<FieldTree<string>>; ngf.errors() etc. unchanged
- * ```
  */
 export function injectNgForgeField<T = unknown>(): TypedNgForgeField<T> {
   return inject(NgForgeField) as unknown as TypedNgForgeField<T>;

--- a/packages/dynamic-forms/integration/src/mappers/button/array-button.utils.ts
+++ b/packages/dynamic-forms/integration/src/mappers/button/array-button.utils.ts
@@ -16,9 +16,7 @@ export interface ArrayButtonContext {
   isInsideArray: boolean;
 }
 
-/**
- * Event context passed to button components for array operations.
- */
+/** Event context passed to button components for array operations. */
 export interface ArrayButtonEventContext {
   /** The button field key */
   key: string;
@@ -37,11 +35,6 @@ export interface ArrayButtonEventContext {
 
 /**
  * Resolves array button context for button mappers.
- *
- * Handles both inside-array (context from ARRAY_CONTEXT) and
- * outside-array (explicit arrayKey) placements.
- *
- * Must be called in injection context.
  *
  * @param fieldKey The button field key (for logging)
  * @param buttonType The button type name (for logging)
@@ -78,8 +71,6 @@ export function resolveArrayButtonContext(fieldKey: string, buttonType: string, 
 
 /**
  * Builds the event context passed to the button component.
- *
- * Should be called inside a computed to track index signal changes.
  *
  * @param fieldKey The button field key
  * @param ctx The resolved array button context

--- a/packages/dynamic-forms/integration/src/mappers/button/button-field-mapper.ts
+++ b/packages/dynamic-forms/integration/src/mappers/button/button-field-mapper.ts
@@ -6,17 +6,6 @@ import { applyNonFieldLogic } from './non-field-logic.utils';
 /**
  * Maps a button field to component inputs.
  *
- * Unlike value field mappers, button fields do not participate in form values
- * and do not need field tree resolution or validation messages.
- *
- * Button-specific properties:
- * - event: The FormEvent constructor to emit when clicked
- * - eventArgs: Optional arguments to pass to the event constructor
- *
- * Hidden and disabled states are resolved using non-field logic resolvers which consider:
- * 1. Explicit `hidden: true` / `disabled: true` on the field definition
- * 2. Field-level `logic` array with `type: 'hidden'` or `type: 'disabled'` conditions
- *
  * @param fieldDef The button field definition
  * @returns Signal containing Record of input names to values for ngComponentOutlet
  */

--- a/packages/dynamic-forms/integration/src/mappers/button/navigation-button.mapper.ts
+++ b/packages/dynamic-forms/integration/src/mappers/button/navigation-button.mapper.ts
@@ -19,9 +19,7 @@ import { resolveHiddenValue } from './non-field-logic.utils';
 // Base Interfaces
 // =============================================================================
 
-/**
- * Base interface for navigation button fields (submit, next, previous).
- */
+/** Base interface for navigation button fields (submit, next, previous). */
 export type BaseNavigationButtonField<TProps = unknown> = ButtonField<TProps, SubmitEvent | NextPageEvent | PreviousPageEvent> & {
   type: string;
   /** Logic rules for dynamic disabled state */

--- a/packages/dynamic-forms/integration/src/mappers/button/non-field-logic.utils.ts
+++ b/packages/dynamic-forms/integration/src/mappers/button/non-field-logic.utils.ts
@@ -70,12 +70,6 @@ export function applyNonFieldLogic(rootFormRegistry: RootFormRegistryService, fi
 /**
  * Applies hidden logic to a non-form-bound field.
  *
- * This is a focused utility for fields that only need hidden state resolution.
- * Use this when you need hidden logic but handle disabled separately
- * (e.g., navigation buttons with custom disabled logic).
- *
- * NOTE: This function must be called inside a computed() context.
- *
  * @param rootForm The root form FieldTree (can be undefined)
  * @param fieldDef The field definition with optional hidden/logic
  * @returns The resolved hidden boolean value, or undefined if no hidden logic

--- a/packages/dynamic-forms/integration/src/mappers/checkbox/checkbox-field-mapper.ts
+++ b/packages/dynamic-forms/integration/src/mappers/checkbox/checkbox-field-mapper.ts
@@ -9,9 +9,6 @@ import { omit } from '@ng-forge/dynamic-forms';
 /**
  * Maps a checkbox/toggle field definition to component inputs.
  *
- * Checkbox fields are checked fields that contribute to the form's value as boolean.
- * This mapper injects FIELD_SIGNAL_CONTEXT to access the form structure and retrieve the field tree.
- *
  * @param fieldDef The checkbox field definition
  * @returns Signal containing Record of input names to values for ngComponentOutlet
  */

--- a/packages/dynamic-forms/integration/src/mappers/datepicker/datepicker-field-mapper.ts
+++ b/packages/dynamic-forms/integration/src/mappers/datepicker/datepicker-field-mapper.ts
@@ -22,14 +22,6 @@ function toDate(value: Date | string | null | undefined): Date | null {
 /**
  * Maps a datepicker field to component inputs.
  *
- * Extends the base value field mapper by adding datepicker-specific properties:
- * - minDate: Minimum selectable date
- * - maxDate: Maximum selectable date
- * - startAt: Initial date to display when opening the picker
- *
- * Date values are automatically converted from strings to Date objects
- * since UI libraries (Material, PrimeNG, etc.) expect Date objects.
- *
  * @param fieldDef The datepicker field definition
  * @returns Signal containing Record of input names to values for ngComponentOutlet
  */

--- a/packages/dynamic-forms/integration/src/mappers/select/options-field-mapper.ts
+++ b/packages/dynamic-forms/integration/src/mappers/select/options-field-mapper.ts
@@ -5,9 +5,7 @@ import { MultiCheckboxField } from '../../definitions';
 import { BaseValueField, DEFAULT_PROPS, FieldMeta } from '@ng-forge/dynamic-forms';
 import { resolveValueFieldContext, buildValueFieldInputs } from '../value/value-field.mapper';
 
-/**
- * Field types that have an options property.
- */
+/** Field types that have an options property. */
 export type FieldWithOptions<T = unknown, TProps = unknown> =
   | SelectField<T, TProps>
   | RadioField<T, TProps>
@@ -15,8 +13,6 @@ export type FieldWithOptions<T = unknown, TProps = unknown> =
 
 /**
  * Maps a field with options (select, radio, multi-checkbox) to component inputs.
- *
- * Extends the base value field mapper by adding the options property.
  *
  * @param fieldDef The field definition with options
  * @returns Signal containing Record of input names to values for ngComponentOutlet

--- a/packages/dynamic-forms/integration/src/mappers/slider/slider-field-mapper.ts
+++ b/packages/dynamic-forms/integration/src/mappers/slider/slider-field-mapper.ts
@@ -6,11 +6,6 @@ import { resolveValueFieldContext, buildValueFieldInputs } from '../value/value-
 /**
  * Maps a slider field to component inputs.
  *
- * Extends the base value field mapper by adding slider-specific properties:
- * - minValue: Minimum slider value
- * - maxValue: Maximum slider value
- * - step: Step increment for the slider
- *
  * @param fieldDef The slider field definition
  * @returns Signal containing Record of input names to values for ngComponentOutlet
  */

--- a/packages/dynamic-forms/integration/src/mappers/value/value-field.mapper.ts
+++ b/packages/dynamic-forms/integration/src/mappers/value/value-field.mapper.ts
@@ -8,10 +8,6 @@ import { omit } from '@ng-forge/dynamic-forms';
 /**
  * Context for value field mapping, containing the injected context reference.
  * Used by specialized mappers to avoid duplicate injection.
- *
- * Note: The field tree is resolved lazily via getFieldTree() to support
- * reactive form access (e.g., for array items where the form structure
- * may not exist at injection time but becomes available later).
  */
 export interface ValueFieldContext {
   /**
@@ -25,14 +21,6 @@ export interface ValueFieldContext {
 /**
  * Creates a value field context from the injected FIELD_SIGNAL_CONTEXT.
  * Must be called within an injection context.
- *
- * With direct root form binding for array items, the FIELD_SIGNAL_CONTEXT.form
- * uses a getter that evaluates reactively. This means:
- * - For regular fields: direct access to the form's FieldTree
- * - For array items: the getter resolves rootForm['arrayKey'][index] dynamically
- *
- * The returned context provides a getFieldTree function that should be called
- * inside a computed to establish proper reactive dependencies.
  *
  * @returns The value field context with reactive field tree accessor
  */
@@ -58,9 +46,6 @@ export function resolveValueFieldContext(): ValueFieldContext {
 /**
  * Builds the base inputs for a value field.
  * This is a helper function used by valueFieldMapper and specialized mappers.
- *
- * Note: This function should be called inside a computed signal to ensure
- * proper reactive dependency tracking for the field tree resolution.
  *
  * @param fieldDef The value field definition
  * @param ctx The resolved value field context
@@ -96,20 +81,6 @@ export function buildValueFieldInputs<TProps, TValue = unknown>(
 
 /**
  * Maps a value field definition to component inputs.
- *
- * Value fields are input fields that contribute to the form's value (text, number, etc.).
- * This mapper injects FIELD_SIGNAL_CONTEXT to access the form structure and retrieve the field proxy.
- *
- * For array items, the FIELD_SIGNAL_CONTEXT.form uses a reactive getter that resolves
- * rootForm['arrayKey'][index] dynamically. This means:
- * - Zod/StandardSchema validation errors are automatically available
- * - The field tree updates reactively when the root form structure changes
- * - Newly added array items will get their field tree once the form value updates
- *
- * For fields with specific properties, use the specialized mappers:
- * - optionsFieldMapper: for fields with options (select, radio, multi-checkbox)
- * - datepickerFieldMapper: for fields with minDate, maxDate, startAt
- * - checkboxFieldMapper: for boolean fields (checkbox, toggle)
  *
  * @param fieldDef The value field definition
  * @returns Signal containing Record of input names to values for ngComponentOutlet

--- a/packages/dynamic-forms/integration/src/testing/create-field-fixture.ts
+++ b/packages/dynamic-forms/integration/src/testing/create-field-fixture.ts
@@ -36,9 +36,6 @@ export interface NgForgeFieldFixture<C, TValue = unknown> {
  * Builds a `ComponentFixture` for an `NgForgeField`-composing component with
  * `field` + `key` bound BEFORE `detectChanges()` — sidesteps the NG0950 that
  * Shell's required `key` and Field's required `field` would otherwise throw.
- *
- * The caller drives `detectChanges()` themselves (so they can `setInput`
- * additional component-specific props in between).
  */
 export function createNgForgeFieldFixture<C, TValue = unknown>(
   component: Type<C>,

--- a/packages/dynamic-forms/integration/src/utils/create-resolved-errors-signal.ts
+++ b/packages/dynamic-forms/integration/src/utils/create-resolved-errors-signal.ts
@@ -9,9 +9,7 @@ import { interpolateParams } from '@ng-forge/dynamic-forms';
 import { DynamicFormLogger } from '@ng-forge/dynamic-forms';
 import type { Logger } from '@ng-forge/dynamic-forms';
 
-/**
- * Resolved validation error with interpolated message
- */
+/** Resolved validation error with interpolated message */
 export interface ResolvedError {
   kind: string;
   message: string;
@@ -26,15 +24,6 @@ export interface ResolvedError {
  * @param defaultValidationMessages - Signal containing default validation messages (fallback)
  * @param injector - Optional injector for DynamicText resolution
  * @returns Signal<ResolvedError[]> - Reactively resolved error messages
- *
- * @example
- * ```typescript
- * readonly resolvedErrors = createResolvedErrorsSignal(
- *   this.field,
- *   this.validationMessages,
- *   this.defaultValidationMessages
- * );
- * ```
  */
 export function createResolvedErrorsSignal<T>(
   field: Signal<FieldTree<T>>,
@@ -87,10 +76,6 @@ export function createResolvedErrorsSignal<T>(
 /**
  * Resolves a single error message from DynamicText sources with fallback logic
  * Priority: field-level message → default message → error.message → no message (logs warning)
- *
- * The error.message fallback enables schema validation libraries (Zod, Valibot, etc.)
- * to provide their own messages without requiring explicit validationMessages configuration.
- * Users who want translations can still override by configuring validationMessages.
  *
  * @internal
  */

--- a/packages/dynamic-forms/integration/src/utils/setup-meta-tracking.ts
+++ b/packages/dynamic-forms/integration/src/utils/setup-meta-tracking.ts
@@ -1,30 +1,17 @@
 import { afterRenderEffect, ElementRef, isDevMode, Signal } from '@angular/core';
 import { applyMetaToElement, FieldMeta, isEqual } from '@ng-forge/dynamic-forms';
 
-/**
- * Configuration options for setupMetaTracking.
- */
+/** Configuration options for setupMetaTracking. */
 export interface MetaTrackingOptions {
   /**
    * CSS selector for target elements within the host.
    * If not provided, meta attributes are applied directly to the host element.
-   *
-   * @example
-   * // Apply to internal radio inputs
-   * selector: 'input[type="radio"]'
-   *
-   * // Apply to host element (for Shadow DOM components)
-   * selector: undefined
    */
   selector?: string;
 
   /**
    * Additional signals to track that should trigger re-application of meta.
    * Useful for components where DOM elements are dynamically created (e.g., radio options).
-   *
-   * @example
-   * // Re-apply when options change
-   * dependents: [this.options]
    */
   dependents?: Signal<unknown>[];
 }
@@ -41,6 +28,7 @@ interface ApplyAttrsOptions {
  * Target resolution is cached by selector identity — re-resolves only on
  * selector change or `dependents` change. afterRenderEffect is signal-tracked,
  * so the callback re-runs only when computeAttrs / dependents differ.
+ *
  * @internal
  */
 function applyTrackedAttrsToTargets(
@@ -107,39 +95,9 @@ function applyTrackedAttrsToTargets(
 /**
  * Sets up automatic meta attribute tracking and application for wrapped components.
  *
- * This utility creates an `afterRenderEffect` that applies meta attributes to DOM elements
- * after Angular's render cycle. It efficiently tracks signal dependencies and only re-applies
- * when the meta signal or any dependent signals change.
- *
- * Use this instead of MutationObserver for better performance and integration with Angular's
- * change detection.
- *
  * @param elementRef - Reference to the host element
  * @param meta - Signal containing meta attributes to apply
  * @param options - Configuration options
- *
- * @example
- * ```typescript
- * // For a radio group with dynamic options
- * constructor() {
- *   setupMetaTracking(inject(ElementRef), this.meta, {
- *     selector: 'input[type="radio"]',
- *     dependents: [this.options]
- *   });
- * }
- *
- * // For a simple checkbox
- * constructor() {
- *   setupMetaTracking(inject(ElementRef), this.meta, {
- *     selector: 'input[type="checkbox"]'
- *   });
- * }
- *
- * // For Shadow DOM components (apply to host)
- * constructor() {
- *   setupMetaTracking(inject(ElementRef), this.meta);
- * }
- * ```
  */
 export function setupMetaTracking(
   elementRef: ElementRef<HTMLElement>,
@@ -152,6 +110,7 @@ export function setupMetaTracking(
 /**
  * Marker-directive variant: writes parent meta + aria to resolved targets.
  * Parent aria wins on key collision. Internal to NgForgeControl/HostControl.
+ *
  * @internal
  */
 export function setupMarkerAttrTracking(

--- a/packages/dynamic-forms/schema/src/standard-schema-marker.ts
+++ b/packages/dynamic-forms/schema/src/standard-schema-marker.ts
@@ -11,35 +11,7 @@ export const STANDARD_SCHEMA_KIND = 'standardSchema' as const;
  * Angular schema callback function type.
  * This is the raw callback that Angular's schema() function accepts.
  *
- * Use this when you want to write Angular schema validation directly
- * without any wrapper. This is ideal for Angular-only projects that
- * want full access to Angular's form validation APIs.
- *
  * @typeParam T - The form value type
- *
- * @example
- * ```typescript
- * import { FormConfig } from '@ng-forge/dynamic-forms';
- * import { validateTree } from '@angular/forms/signals';
- *
- * const config = {
- *   // Raw callback - no wrapper needed!
- *   schema: (path) => {
- *     validateTree(path, (ctx) => {
- *       const { password, confirmPassword } = ctx.value();
- *       if (password !== confirmPassword) {
- *         return [{ kind: 'passwordMismatch', fieldTree: ctx.fieldTreeOf(path).confirmPassword }];
- *       }
- *       return null;
- *     });
- *   },
- *   fields: [
- *     { key: 'password', type: 'input', label: 'Password', required: true },
- *     { key: 'confirmPassword', type: 'input', label: 'Confirm', required: true,
- *       validationMessages: { passwordMismatch: 'Passwords must match' } },
- *   ],
- * } as const satisfies FormConfig;
- * ```
  */
 export type AngularSchemaCallback<T = unknown> = (path: SchemaPath<T> & SchemaPathTree<T>) => void;
 
@@ -48,36 +20,17 @@ export type AngularSchemaCallback<T = unknown> = (path: SchemaPath<T> & SchemaPa
  * This allows the dynamic forms system to identify and use standard-compliant schemas
  * for validation without coupling to any specific schema library.
  *
- * The `out` variance modifier makes this type covariant in T, meaning a
- * StandardSchemaMarker<SpecificType> is assignable to StandardSchemaMarker<BroaderType>.
- * This enables Zod/Valibot schemas to be used with FormConfig's inferred TValue.
- *
  * @typeParam T - The inferred type that the schema validates to (covariant)
- *
- * @example
- * ```typescript
- * import { z } from 'zod';
- * import { standardSchema } from '@ng-forge/dynamic-forms/schema';
- *
- * const userSchema = z.object({
- *   name: z.string(),
- *   email: z.string().email(),
- * });
- *
- * // Wrap the Zod schema with standardSchema marker
- * const formSchema = standardSchema(userSchema);
- * ```
  */
 export interface StandardSchemaMarker<out T = unknown> {
   /**
    * Internal marker identifying this as a standard schema wrapper.
+   *
    * @internal
    */
   readonly ɵkind: typeof STANDARD_SCHEMA_KIND;
 
-  /**
-   * The underlying schema that implements the Standard Schema spec.
-   */
+  /** The underlying schema that implements the Standard Schema spec. */
   readonly schema: StandardSchemaV1<T>;
 }
 
@@ -86,69 +39,16 @@ export interface StandardSchemaMarker<out T = unknown> {
  * Supports both Standard Schema compliant schemas (Zod, Valibot, ArkType)
  * and raw Angular schema callbacks.
  *
- * The covariance from StandardSchemaMarker flows through, allowing
- * schemas with specific types to be assigned to broader form value types.
- *
  * @typeParam T - The inferred type that the schema validates to
- *
- * @example Standard Schema (Zod)
- * ```typescript
- * import { z } from 'zod';
- * import { standardSchema } from '@ng-forge/dynamic-forms/schema';
- *
- * const config = {
- *   schema: standardSchema(z.object({ ... })),
- *   fields: [...],
- * };
- * ```
- *
- * @example Angular Schema Callback
- * ```typescript
- * import { validateTree } from '@angular/forms/signals';
- *
- * const config = {
- *   schema: (path) => {
- *     validateTree(path, (ctx) => { ... });
- *   },
- *   fields: [...],
- * };
- * ```
  */
 export type FormSchema<T = unknown> = StandardSchemaMarker<T> | AngularSchemaCallback<T>;
 
 /**
  * Wraps a Standard Schema compliant schema for use with dynamic forms.
  *
- * This function creates a marker wrapper around schemas that implement the
- * Standard Schema spec (Zod, Valibot, ArkType, etc.), allowing the dynamic
- * forms system to identify and use them for validation.
- *
  * @typeParam T - The inferred type that the schema validates to
  * @param schema - A schema implementing the Standard Schema V1 spec
  * @returns A wrapped schema marker that can be passed to dynamic form configuration
- *
- * @example
- * ```typescript
- * import { z } from 'zod';
- * import { standardSchema } from '@ng-forge/dynamic-forms/schema';
- *
- * const loginSchema = z.object({
- *   email: z.string().email('Invalid email format'),
- *   password: z.string().min(8, 'Password must be at least 8 characters'),
- * });
- *
- * // Wrap for use with dynamic forms
- * const formSchema = standardSchema(loginSchema);
- *
- * // Use in form configuration
- * const formConfig = {
- *   schema: formSchema,
- *   fields: [
- *     input({ key: 'email', label: 'Email' }),
- *     input({ key: 'password', label: 'Password', props: { type: 'password' } }),
- *   ],
- * };
- * ```
  */
 export function standardSchema<T>(schema: StandardSchemaV1<T>): StandardSchemaMarker<T> {
   return {
@@ -160,23 +60,8 @@ export function standardSchema<T>(schema: StandardSchemaV1<T>): StandardSchemaMa
 /**
  * Type guard to check if a value is a StandardSchemaMarker.
  *
- * This is useful when processing form configuration to determine if a schema
- * has been provided and should be used for validation.
- *
  * @param value - The value to check
  * @returns True if the value is a StandardSchemaMarker, false otherwise
- *
- * @example
- * ```typescript
- * import { isStandardSchemaMarker } from '@ng-forge/dynamic-forms/schema';
- *
- * function processFormConfig(config: FormConfig) {
- *   if (config.schema && isStandardSchemaMarker(config.schema)) {
- *     // Use the schema for validation
- *     const result = config.schema.schema['~standard'].validate(formValue);
- *   }
- * }
- * ```
  */
 export function isStandardSchemaMarker(value: unknown): value is StandardSchemaMarker {
   return (

--- a/packages/dynamic-forms/src/lib/addons/component-addon.component.ts
+++ b/packages/dynamic-forms/src/lib/addons/component-addon.component.ts
@@ -9,12 +9,6 @@ import type { WrapperFieldInputs } from '../wrappers/wrapper-field-inputs';
 /**
  * Renderer for the universal `component` addon kind.
  *
- * Loads the user-supplied component lazily (`addon.component()`) and renders
- * it via `NgComponentOutlet` with `addon.inputs` forwarded as input bindings.
- * The wrapper-style `fieldInputs` bag is not propagated — user components
- * receive only what `addon.inputs` declares. Authors that need field state
- * should switch to the `template` kind or build a wrapper.
- *
  * @codeOnly The `component` loader is a function; this kind is dropped in
  * lenient validation when the config originated from JSON.
  */

--- a/packages/dynamic-forms/src/lib/addons/run-preset-action.ts
+++ b/packages/dynamic-forms/src/lib/addons/run-preset-action.ts
@@ -5,14 +5,6 @@ import type { Logger } from '../providers/features/logger/logger.interface';
 /**
  * Optional collaborators a preset may need beyond the base context. Passed
  * by the button kind component which has access to its own DI scope.
- *
- * Adapter input components fill in the collaborators their preset semantics
- * require:
- * - `mat-input` / `bs-input` / `prime-input` / `ion-input` populate
- *   `typeOverride` + `fieldValueSetter` + `fieldDefaultValueGetter` +
- *   `baselineType` from their own DI scope.
- * - Addons rendered outside any input field receive `{ logger }` only and
- *   the input-specific presets warn-and-no-op.
  */
 export interface PresetCollaborators {
   /** Per-field input-type override signal — populated only inside an input field. */
@@ -33,16 +25,7 @@ export interface PresetCollaborators {
    * yet set.
    */
   readonly baselineType?: () => string | undefined;
-  /**
-   * Logger for warnings about presets that can't be fulfilled in this context.
-   *
-   * Passed via collaborators (rather than injected) because `runPresetAction`
-   * is a DI-free pure function shared across adapters — each adapter's
-   * `ADDON_PRESET_HANDLER` factory injects `DynamicFormLogger` itself and
-   * forwards it here. The `[Dynamic Forms]` prefix comes from
-   * `ConsoleLogger`'s implementation, so the final console line is identical
-   * to one logged directly via `inject(DynamicFormLogger)`.
-   */
+  /** Logger for warnings about presets that can't be fulfilled in this context. */
   readonly logger: Logger;
 }
 
@@ -50,11 +33,6 @@ export interface PresetCollaborators {
  * Apply a built-in preset action against the addon's host field. Shared
  * across all adapters — each adapter's `ADDON_PRESET_HANDLER` provider
  * delegates here.
- *
- * Presets that require adapter-specific UI mechanics (clipboard, type
- * override) are best-effort — they no-op with a warning when the necessary
- * collaborator isn't available (e.g., toggle-password-visibility outside an
- * input field).
  *
  * @param adapterLabel Used in warnings — `'Material'` / `'Bootstrap'` / etc.
  * @param fieldLabel   Used in warnings — `'mat-input'` / `'bs-input'` / etc.

--- a/packages/dynamic-forms/src/lib/addons/template-addon.component.ts
+++ b/packages/dynamic-forms/src/lib/addons/template-addon.component.ts
@@ -6,18 +6,7 @@ import { DF_FIELD_TEMPLATES } from '../models/addon/df-field-templates.token';
 import { DynamicFormLogger } from '../providers/features/logger/logger.token';
 import { WrapperFieldInputs } from '../wrappers/wrapper-field-inputs';
 
-/**
- * Renderer for the universal `template` addon kind.
- *
- * Resolves the addon's `templateKey` against {@link DF_FIELD_TEMPLATES}
- * (populated by `<df-dynamic-form>` from `<ng-template dfTemplate="...">`
- * children) and renders via `NgTemplateOutlet`. The wrapper-style host bag
- * (`fieldInputs`) is forwarded as the template's implicit context — author
- * the template as `<ng-template dfTemplate="..." let-fi>{{ fi.key }}</ng-template>`.
- *
- * If the key is unresolved, logs a warning and renders nothing — keeps the
- * form alive when a backend references a template the FE has not registered.
- */
+/** Renderer for the universal `template` addon kind. */
 @Component({
   selector: 'df-template-addon',
   imports: [NgTemplateOutlet],

--- a/packages/dynamic-forms/src/lib/addons/text-addon.component.ts
+++ b/packages/dynamic-forms/src/lib/addons/text-addon.component.ts
@@ -4,13 +4,7 @@ import { TextAddon } from '../models/addon/addon-def';
 import { DynamicTextPipe } from '../pipes/dynamic-text/dynamic-text.pipe';
 import { WrapperFieldInputs } from '../wrappers/wrapper-field-inputs';
 
-/**
- * Renderer for the universal `text` addon kind.
- *
- * Renders the addon's `text` (a `DynamicText`) inside a span. Decorative —
- * sets `aria-hidden="true"` on the host so screen readers skip it; users
- * who need announcement should use a `*-button` kind with `ariaLabel` instead.
- */
+/** Renderer for the universal `text` addon kind. */
 @Component({
   selector: 'df-text-addon',
   imports: [AsyncPipe, DynamicTextPipe],

--- a/packages/dynamic-forms/src/lib/components/df-addon-slot.component.ts
+++ b/packages/dynamic-forms/src/lib/components/df-addon-slot.component.ts
@@ -10,32 +10,6 @@ import { WrapperFieldInputs } from '../wrappers/wrapper-field-inputs';
 /**
  * Dispatcher component that renders an addon by looking up its `kind` in
  * `ADDON_KIND_REGISTRY` and instantiating the registered component.
- *
- * Used by every adapter's field component to render slot content:
- *
- * ```html
- * \@for (a of addonsAt('prefix'); track $index) {
- *   <df-addon-slot [addon]="a" />
- * }
- * ```
- *
- * Behaviour:
- * - Resolves and caches the kind's component asynchronously on first render.
- * - Forwards the `slot` HTML attribute on the host so Ionic shadow-DOM
- *   projection works (`<ion-input>` projects children with `slot="start"`
- *   into its native start slot).
- * - Honours the addon's reactive `hidden` flag — when `true`, the host is
- *   `display: none` so it occupies no layout but stays in DOM (cheaper than
- *   tearing down the component).
- * - Forwards `className` to the host element.
- * - ARIA semantics are owned by individual kind components — decorative
- *   kinds (icons, text) set `aria-hidden="true"` on themselves; interactive
- *   kinds (buttons) handle their own `aria-label`.
- *
- * If the kind cannot be resolved (registry miss, load failure), the
- * dispatcher logs a warning and renders nothing — never throws. The
- * runtime addon validator should have caught unknown kinds at config init,
- * but this provides a defence-in-depth fallback for misconfigured registries.
  */
 @Component({
   selector: 'df-addon-slot',
@@ -63,8 +37,6 @@ export class DfAddonSlot {
    * wrappers receive (`field?: ReadonlyFieldTree`, `key`, `props`, etc.).
    * Forwarded to kind components so they can read field state without
    * re-injecting `FIELD_SIGNAL_CONTEXT` and rebuilding context themselves.
-   *
-   * `undefined` when the addon is rendered outside a field (rare).
    */
   readonly fieldInputs = input<WrapperFieldInputs | undefined>();
   /**
@@ -88,11 +60,6 @@ export class DfAddonSlot {
    * context (NG0602). The WeakMap caches per `hidden`-value identity, so
    * swapping `addon` inputs that share the same Observable reuses the
    * subscription instead of leaking a fresh one per swap.
-   *
-   * Resolved unconditionally (not gated on host `hidden()` presence) so a
-   * transition from `host hidden = Signal` → `undefined` doesn't expose a
-   * brief window where neither value is current — the upstream effect
-   * re-runs eventually, but the computed read can happen in between.
    */
   private readonly _hiddenByValue = new WeakMap<object, Signal<boolean>>();
   private readonly _resolvedHidden = signal<Signal<boolean> | undefined>(undefined);

--- a/packages/dynamic-forms/src/lib/core/cross-field/cross-field-collector.ts
+++ b/packages/dynamic-forms/src/lib/core/cross-field/cross-field-collector.ts
@@ -140,12 +140,7 @@ function tryCreateValidatorEntry(fieldKey: string, config: ValidatorConfig): Cro
   return null;
 }
 
-/**
- * Returns a logic entry if cross-field state logic, null otherwise.
- *
- * Note: Derivation logic is handled separately by the derivation system
- * and is not collected here.
- */
+/** Returns a logic entry if cross-field state logic, null otherwise. */
 function tryCreateLogicEntry(fieldKey: string, config: LogicConfig): CrossFieldLogicEntry | null {
   // Only process state logic (hidden, readonly, disabled, required)
   // Derivation logic is handled by the derivation collector

--- a/packages/dynamic-forms/src/lib/core/cross-field/cross-field-detector.ts
+++ b/packages/dynamic-forms/src/lib/core/cross-field/cross-field-detector.ts
@@ -10,22 +10,10 @@ import { CustomFunctionScope } from '../expressions/custom-function-types';
  */
 const FORM_VALUE_ACCESS_PATTERN = /\bformValue\s*(?:\.|\[)/;
 
-/**
- * Combined regex for extracting field paths from formValue expressions.
- *
- * Captures one of three groups per match:
- * - group 1: dot notation (formValue.parent.child) — JS identifier chars only
- * - group 2: single-quoted bracket (formValue['field-name']) — allows `-`
- * - group 3: double-quoted bracket (formValue["field-name"]) — allows `-`
- *
- * Note: Computed property access (formValue[variableName]) is NOT supported
- * and must use explicit dependsOn configuration.
- */
+/** Combined regex for extracting field paths from formValue expressions. */
 const FORM_VALUE_PATTERN = /\bformValue\s*(?:\.([\w.]+)|\[\s*'([\w.-]+)'\s*\]|\[\s*"([\w.-]+)"\s*\])/g;
 
-/**
- * Context for cross-field detection, providing access to function scope information.
- */
+/** Context for cross-field detection, providing access to function scope information. */
 export interface CrossFieldDetectionContext {
   /**
    * Lookup function to get the scope of a registered custom function.
@@ -38,13 +26,6 @@ export interface CrossFieldDetectionContext {
 
 /**
  * Detects if a ConditionalExpression references other fields (cross-field).
- *
- * This is the core detection function that handles ALL expression types:
- * - `fieldValue` with `fieldPath` → Always cross-field
- * - `formValue` → Always cross-field
- * - `javascript` with `formValue.*` in expression → Cross-field
- * - `custom` → Checks registered function scope, defaults to cross-field if unknown
- * - `and`/`or` → Recursively check nested conditions
  *
  * @param expr The conditional expression to analyze
  * @param context Optional context providing function scope lookup
@@ -103,10 +84,6 @@ export function isCrossFieldExpression(
 /**
  * Extracts field dependencies from a ConditionalExpression.
  *
- * Returns an array of field keys that the expression depends on.
- * For `formValue` type without specific field, returns ['*'] to indicate
- * dependency on the entire form.
- *
  * @param expr The conditional expression to analyze
  * @returns Array of field keys that this expression depends on
  */
@@ -161,13 +138,7 @@ export function extractStringDependencies(expression: string): string[] {
   return Array.from(deps);
 }
 
-/**
- * Internal helper that populates a Set with dependencies from an expression string.
- *
- * Extracts both root fields and full nested paths for precise dependency tracking:
- * - 'formValue.parent.child' → adds 'parent' (root) and 'parent.child' (full path)
- * - 'formValue.simple' → adds 'simple'
- */
+/** Internal helper that populates a Set with dependencies from an expression string. */
 function extractFromExpressionString(expression: string, deps: Set<string>): void {
   for (const match of expression.matchAll(FORM_VALUE_PATTERN)) {
     const fullPath = match[1] ?? match[2] ?? match[3];
@@ -202,9 +173,6 @@ export function isCrossFieldValidator(config: CustomValidatorConfig): boolean {
 /**
  * Detects if a built-in validator has a dynamic expression that references formValue.
  *
- * Built-in validators (min, max, pattern, etc.) can have dynamic expressions
- * like `{ type: 'min', expression: 'formValue.minAge' }`.
- *
  * @param config The validator configuration to check
  * @returns true if the validator has a cross-field dynamic expression
  */
@@ -221,14 +189,7 @@ export function isCrossFieldBuiltInValidator(config: ValidatorConfig): boolean {
   return false;
 }
 
-/**
- * Checks if a validator uses Angular's resource API (validateHttp / validateAsync).
- *
- * Resource-based validators handle cross-field when-conditions internally
- * via their request/params callbacks returning `undefined`. They must NOT
- * be skipped by the cross-field early-return guard in `applyValidator`,
- * because they require field-level registration.
- */
+/** Checks if a validator uses Angular's resource API (validateHttp / validateAsync). */
 export function isResourceBasedValidator(config: ValidatorConfig): boolean {
   return config.type === 'async' || config.type === 'http';
 }
@@ -253,9 +214,6 @@ export function hasCrossFieldWhenCondition(config: ValidatorConfig, context?: Cr
 
 /**
  * Detects if a StateLogicConfig has a cross-field condition.
- *
- * Note: This function only handles state logic (hidden, readonly, disabled, required).
- * Derivation logic is handled separately by the derivation system.
  *
  * @param config The state logic configuration to check
  * @param context Optional context providing function scope lookup

--- a/packages/dynamic-forms/src/lib/core/cross-field/cross-field-types.ts
+++ b/packages/dynamic-forms/src/lib/core/cross-field/cross-field-types.ts
@@ -3,9 +3,7 @@ import { StateLogicConfig } from '../../models/logic/logic-config';
 import { ValidatorConfig } from '../../models/validation/validator-config';
 import { SchemaApplicationConfig } from '../../models/schemas/schema-definition';
 
-/**
- * Categories of cross-field configurations that need to be hoisted to form level.
- */
+/** Categories of cross-field configurations that need to be hoisted to form level. */
 export type CrossFieldCategory = 'validator' | 'logic' | 'schema';
 
 /**
@@ -26,10 +24,6 @@ export interface BaseCrossFieldEntry {
 /**
  * Cross-field validator entry.
  * Represents a validator that references formValue.* and needs form-level execution.
- *
- * Supports two types of validators:
- * 1. Custom validators with cross-field expressions (e.g., `formValue.password === formValue.confirmPassword`)
- * 2. Built-in validators with cross-field `when` conditions (e.g., `required` when `country === 'USA'`)
  */
 export interface CrossFieldValidatorEntry extends BaseCrossFieldEntry {
   category: 'validator';
@@ -48,16 +42,12 @@ export interface CrossFieldValidatorEntry extends BaseCrossFieldEntry {
   validatorType?: ValidatorConfig['type'];
 }
 
-/**
- * Logic types that can be controlled via cross-field conditions.
- */
+/** Logic types that can be controlled via cross-field conditions. */
 export type LogicType = 'hidden' | 'disabled' | 'readonly' | 'required';
 
 /**
  * Cross-field logic entry.
  * Represents a state logic condition that references other fields and needs form-level evaluation.
- *
- * Note: Derivation logic is handled separately by the derivation system.
  */
 export interface CrossFieldLogicEntry extends BaseCrossFieldEntry {
   category: 'logic';
@@ -86,9 +76,7 @@ export interface CrossFieldSchemaEntry extends BaseCrossFieldEntry {
   condition: ConditionalExpression;
 }
 
-/**
- * Union type of all cross-field entry types.
- */
+/** Union type of all cross-field entry types. */
 export type CrossFieldEntry = CrossFieldValidatorEntry | CrossFieldLogicEntry | CrossFieldSchemaEntry;
 
 /**
@@ -127,27 +115,18 @@ export interface CrossFieldSchemaResult {
   hasChanges: boolean;
 }
 
-/**
- * Combined result from the cross-field orchestrator.
- *
- * Note: Validation is handled separately by Angular's validateTree API.
- * The orchestrator only returns logic and schema results.
- */
+/** Combined result from the cross-field orchestrator. */
 export interface CrossFieldOrchestratorResult {
   logic: CrossFieldLogicResult;
   schemas: CrossFieldSchemaResult;
 }
 
-/**
- * Creates a unique key for a logic entry (fieldKey + logicType).
- */
+/** Creates a unique key for a logic entry (fieldKey + logicType). */
 export function createLogicStateKey(fieldKey: string, logicType: LogicType): string {
   return `${fieldKey}:${logicType}`;
 }
 
-/**
- * Parses a logic state key back into field key and logic type.
- */
+/** Parses a logic state key back into field key and logic type. */
 export function parseLogicStateKey(key: string): { fieldKey: string; logicType: LogicType } {
   const [fieldKey, logicType] = key.split(':');
   return { fieldKey, logicType: logicType as LogicType };

--- a/packages/dynamic-forms/src/lib/core/derivation/async-derivation-stream.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/async-derivation-stream.ts
@@ -54,16 +54,10 @@ const DEFAULT_ASYNC_DEBOUNCE_MS = 300;
 /**
  * Creates an RxJS Observable stream that processes an async derivation entry.
  *
- * Each async derivation gets its own stream with:
- * - `debounceTime` to batch rapid changes
- * - `switchMap` to auto-cancel in-flight async operations
- * - `catchError` inside the switchMap projection to prevent stream termination
- *
  * @param entry - The derivation entry with asyncFunctionName
  * @param formValue$ - Observable of form value changes
  * @param context - Context with logger, etc.
  * @returns Observable that applies async-derived values to the form
- *
  * @internal
  */
 export function createAsyncDerivationStream(

--- a/packages/dynamic-forms/src/lib/core/derivation/collection-context.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/collection-context.ts
@@ -4,16 +4,12 @@ import { DynamicFormError } from '../../errors/dynamic-form-error';
  * Tokens recognised by the dependency resolver. Exported so the few callers
  * that build `dependsOn` arrays programmatically (e.g. tests) don't have to
  * inline the string literal.
- *
- * @public
  */
 export const SELF_DEPENDENCY_TOKEN = '$self';
 
 /**
  * Token resolving to the absolute path of the field's nearest parent
  * container (group or array).
- *
- * @public
  */
 export const GROUP_DEPENDENCY_TOKEN = '$group';
 
@@ -39,15 +35,6 @@ export interface CollectionContext {
 /**
  * Builds the absolute field path for an entry whose enclosing context is
  * tracked by {@link CollectionContext}.
- *
- * Shape ladder:
- * - inside array AND groups: `${arrayPath}.$.${groupPath}.${fieldKey}`
- * - inside array only:       `${arrayPath}.$.${fieldKey}`
- * - inside groups only:      `${groupPath}.${fieldKey}`
- * - root:                    `${fieldKey}`
- *
- * Both value and property collectors used to compute this independently; they
- * produced identical strings, so the logic now lives here.
  *
  * @internal
  */
@@ -83,9 +70,6 @@ export function buildNearestGroupPath(context: CollectionContext): string | unde
  * `dependsOn` array with their resolved absolute paths. Non-token strings
  * pass through unchanged.
  *
- * Throws `DynamicFormError` when `$group` is used on a field at the form
- * root (no parent container exists).
- *
  * @internal
  */
 export function resolveTokenDependencies(deps: string[], effectiveFieldKey: string, context: CollectionContext): string[] {
@@ -114,23 +98,6 @@ export function resolveTokenDependencies(deps: string[], effectiveFieldKey: stri
 /**
  * Standard `traverseFieldsWithContext` step handlers for derivation
  * collection.
- *
- * **Array boundary intentionally drops enclosing `groupPath`.** Arrays act
- * as their own model root in the derivation key scheme: entries inside an
- * array item are keyed `<arrayKey>.$.<...>` regardless of whether the array
- * itself was nested under one or more groups. The `<arrayKey>` is the
- * array's own key alone, not a path prefixed with ancestor groups.
- * Downstream consumers (applicators, store, derivation sorter — see
- * `derivation-sorter.ts` for the `.$.` split logic) rely on this shape to
- * identify which array a per-item entry belongs to.
- *
- * Locked in by `derivation-collector.spec.ts`'s "should reset ancestor
- * groupPath at array boundaries" case. CodeRabbit flagged this on #438 as
- * potentially missing parent ancestry; the asymmetry is real but
- * load-bearing for the placeholder-key contract.
- *
- * Group descent appends the field's key to the ancestor `groupPath`;
- * layout containers leave context unchanged.
  *
  * @internal
  */

--- a/packages/dynamic-forms/src/lib/core/derivation/compute-derived-value.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/compute-derived-value.ts
@@ -10,9 +10,7 @@ import { BaseDerivationEntry } from './derivation-entry-base';
  * @internal
  */
 export interface ComputeValueOptions {
-  /**
-   * Registered derivation functions, used when the entry has `functionName`.
-   */
+  /** Registered derivation functions, used when the entry has `functionName`. */
   derivationFunctions?: Record<string, CustomFunction>;
 
   /**
@@ -32,9 +30,6 @@ export interface ComputeValueOptions {
 /**
  * Single dispatch over `value` / `expression` / `functionName` shared by both
  * the value-derivation and property-derivation applicators.
- *
- * Throws {@link DynamicFormError} on missing function or missing value source
- * so both pipelines surface the library's standard error type.
  *
  * @internal
  */

--- a/packages/dynamic-forms/src/lib/core/derivation/cycle-detector.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/cycle-detector.ts
@@ -35,25 +35,8 @@ const enum VisitState {
 /**
  * Detects cycles in the derivation dependency graph.
  *
- * Uses Kahn's algorithm variant with DFS to detect cycles.
- * Bidirectional sync patterns (A→B→A) are allowed because they stabilize
- * via the equality check at runtime.
- *
  * @param collection - The collected derivation entries
  * @returns Result indicating whether a cycle exists and details if found
- *
- * @example
- * ```typescript
- * const collection = collectDerivations(fields);
- * const result = detectCycles(collection);
- *
- * if (result.hasCycle) {
- *   console.error(`Cycle detected: ${result.cyclePath?.join(' -> ')}`);
- *   throw new Error(result.errorMessage);
- * }
- * ```
- *
- * @public
  */
 export function detectCycles(collection: DerivationCollection): CycleDetectionResult {
   // Build directed graph from derivation entries
@@ -80,33 +63,6 @@ export function detectCycles(collection: DerivationCollection): CycleDetectionRe
 
 /**
  * Detects bidirectional derivation pairs (A↔B patterns).
- *
- * These patterns are allowed because they stabilize via equality checks.
- * Example: USD/EUR conversion where both fields derive from each other.
- *
- * A bidirectional pair exists when:
- * - Field A derives its value from field B (A depends on B)
- * - Field B derives its value from field A (B depends on A)
- *
- * ## Floating-Point Precision Note
- *
- * Bidirectional derivations stabilize via equality checks using exact IEEE 754
- * comparison with no tolerance. This means:
- *
- * - **Integer math**: Safe (e.g., `A = B * 2`, `B = A / 2` where A is even)
- * - **Floating-point math**: May oscillate due to rounding errors
- *
- * For currency conversions or other floating-point operations, consider:
- * 1. Rounding values in your expression (e.g., `Math.round(value * 100) / 100`)
- * 2. Using integer cents instead of decimal dollars
- * 3. Using one-way derivation instead of bidirectional
- *
- * @example
- * ```typescript
- * // Bidirectional currency conversion
- * { key: 'amountUSD', derivation: 'formValue.amountEUR * 1.1' }
- * { key: 'amountEUR', derivation: 'formValue.amountUSD / 1.1' }
- * ```
  *
  * @internal
  */
@@ -164,13 +120,6 @@ function isBidirectionalCycle(cyclePath: string[], bidirectionalPairs: Set<strin
 /**
  * Builds a dependency graph from derivation entries.
  *
- * Creates nodes for each field involved in derivations and
- * edges representing the derivation dependencies.
- *
- * Edge direction is based on dependencies:
- * - If field A's derivation depends on field B, then B -> A (changing B triggers A)
- * - A cycle exists if: A -> B -> C -> A (circular dependency chain)
- *
  * @internal
  */
 function buildDependencyGraph(collection: DerivationCollection): Map<string, GraphNode> {
@@ -214,14 +163,6 @@ function buildDependencyGraph(collection: DerivationCollection): Map<string, Gra
 
 /**
  * Detects cycles using depth-first search.
- *
- * Uses three-color marking:
- * - Unvisited (white): Not yet processed
- * - InProgress (gray): Currently in the DFS stack
- * - Completed (black): Fully processed
- *
- * A cycle is detected when we visit a node that's InProgress,
- * unless it's a bidirectional sync pattern (allowed).
  *
  * @internal
  */
@@ -341,28 +282,9 @@ function formatCycleError(cyclePath: string[]): string {
 /**
  * Validates a derivation collection and throws if cycles are detected.
  *
- * This is the main entry point for cycle validation during form initialization.
- * Should be called after collecting derivations and before setting up effects.
- *
- * In dev mode, logs a warning when bidirectional derivation pairs are detected.
- * These patterns are allowed but may oscillate with floating-point values.
- *
  * @param collection - The collected derivation entries to validate
  * @param logger - Optional logger for dev-mode warnings
  * @throws Error if a cycle is detected, with details about the cycle
- *
- * @example
- * ```typescript
- * const collection = collectDerivations(fields);
- *
- * // This will throw if cycles exist
- * validateNoCycles(collection, logger);
- *
- * // Safe to set up derivation effects now
- * setupDerivationEffects(collection);
- * ```
- *
- * @public
  */
 export function validateNoCycles(collection: DerivationCollection, logger?: Logger): void {
   const result = detectCycles(collection);

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-applicator.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-applicator.ts
@@ -29,11 +29,7 @@ import { applyValueToForm, readFieldDirty, resetFieldState } from './field-value
 // Re-export for backwards compatibility
 export type { DerivationProcessingResult } from './derivation-types';
 
-/**
- * Context required for applying derivations.
- *
- * @public
- */
+/** Context required for applying derivations. */
 export interface DerivationApplicatorContext {
   /** The current form value (signal) */
   formValue: Signal<Record<string, unknown>>;
@@ -100,32 +96,10 @@ interface DerivationResult {
 /**
  * Applies all pending derivations from a collection.
  *
- * This function processes derivations in order, evaluating conditions
- * and computing values. It handles loop prevention through:
- * 1. Chain tracking (prevents same derivation from running twice in one cycle)
- * 2. Value equality checks (skips if target already has computed value)
- * 3. Max iteration limit (safety fallback)
- *
  * @param collection - The collected derivation entries
  * @param context - Context for applying derivations
  * @param changedFields - Set of field keys that changed (for filtering)
  * @returns Result of the derivation processing
- *
- * @example
- * ```typescript
- * const result = applyDerivations(collection, {
- *   formValue: formValueSignal,
- *   rootForm: form(),
- *   derivationFunctions: customFnConfig?.derivations,
- *   logger: inject(DynamicFormLogger),
- * });
- *
- * if (result.maxIterationsReached) {
- *   console.warn('Possible derivation loop detected');
- * }
- * ```
- *
- * @public
  */
 export function applyDerivations(
   collection: DerivationCollection,
@@ -199,19 +173,6 @@ export function applyDerivations(
 /**
  * Gets entries that should be processed based on changed fields.
  *
- * Filters entries by checking if any of their dependencies are in the changed fields set.
- * Also includes all wildcard (*) entries since they depend on any form change.
- *
- * **Parent-key matching:** Since `changedFields` contains root-level keys (e.g., `'address'`),
- * but derivation entries may target or depend on nested paths (e.g., `'address.city'`),
- * this function checks `startsWith(changed + '.')` to include entries whose field or
- * dependencies live under a changed parent. This is intentionally broad — false positives
- * are acceptable for filtering because entries are still guarded by value-equality checks
- * (`isEqual`) in `tryApplyDerivation` and will be skipped if the value hasn't changed.
- *
- * Note: Performance is O(n) where n = total entries. For large forms with many
- * derivations, consider optimizing with indexed lookup maps.
- *
  * @internal
  */
 function getEntriesForChangedFields(entries: DerivationEntry[], changedFields: Set<string>): DerivationEntry[] {
@@ -242,20 +203,6 @@ function getEntriesForChangedFields(entries: DerivationEntry[], changedFields: S
 
 /**
  * Attempts to apply a single derivation.
- *
- * **Important:** When a derivation's condition evaluates to `false`, the previously
- * derived value is NOT automatically cleared. If you need to reset a field when a
- * condition becomes false, use a separate derivation with an inverted condition
- * that sets the desired fallback value.
- *
- * @example
- * ```typescript
- * // Two derivations for conditional value with cleanup:
- * // When country is USA, set phonePrefix to '+1'
- * { key: 'phonePrefix', logic: [{ type: 'derivation', condition: { field: 'country', operator: '==', value: 'USA' }, value: '+1' }] }
- * // When country is NOT USA, clear phonePrefix
- * { key: 'phonePrefix', logic: [{ type: 'derivation', condition: { field: 'country', operator: '!=', value: 'USA' }, value: '' }] }
- * ```
  *
  * @internal
  */
@@ -400,9 +347,6 @@ function tryApplyDerivation(
 /**
  * Handles array field derivations with '$' placeholder.
  *
- * Iterates over all array items and applies the derivation for each,
- * resolving '$' to the actual index and creating scoped evaluation contexts.
- *
  * @internal
  */
 function tryApplyArrayDerivation(
@@ -526,9 +470,6 @@ function createEvaluationContext(
 /**
  * Creates an evaluation context scoped to a specific array item.
  *
- * For array derivations, `formValue` in the expression should reference
- * the current array item's values, not the root form values.
- *
  * @internal
  */
 function createArrayItemEvaluationContext(
@@ -615,12 +556,14 @@ function computeDerivedValue(
 
 /**
  * Error message prefix for derivation-related errors.
+ *
  * @internal
  */
 const ERROR_PREFIX = '[Derivation]';
 
 /**
  * Creates a standardized error message for derivation errors.
+ *
  * @internal
  */
 function formatDerivationError(entry: DerivationEntry, phase: 'compute' | 'apply' | 'condition', message: string): string {
@@ -640,18 +583,6 @@ function formatDerivationError(entry: DerivationEntry, phase: 'compute' | 'apply
 /**
  * Checks whether any of the entry's dependencies appear in the changed fields set.
  *
- * **Known limitation for array derivations:** `changedFields` contains root-level keys
- * (e.g., `'lineItems'`) produced by `getChangedKeys()`, but array derivation dependencies
- * use relative names (e.g., `['quantity', 'unitPrice']`). This means `reEngageOnDependencyChange`
- * only fires for root-level dependencies (e.g., `'discountRate'`) — NOT for intra-item
- * dependencies like `'quantity'` within the same array item.
- *
- * Adding parent-key matching (checking if `entry.fieldKey.startsWith(changed + '.')`)
- * was attempted but causes false positives: editing the TARGET field also triggers
- * `changedFields = {'lineItems'}`, which would reset dirty immediately and break
- * `stopOnUserOverride`. Fixing this requires per-field change tracking instead of
- * per-root-key tracking — a more significant architectural change.
- *
  * @internal
  */
 function hasDependencyChanged(entry: DerivationEntry, changedFields: Set<string>): boolean {
@@ -664,7 +595,6 @@ function hasDependencyChanged(entry: DerivationEntry, changedFields: Set<string>
  * is set and a dependency has changed.
  *
  * @returns `true` if the derivation should be skipped, `false` otherwise
- *
  * @internal
  */
 function shouldSkipForUserOverride(
@@ -699,15 +629,11 @@ function shouldSkipForUserOverride(
 /**
  * Processes derivations for a specific trigger type.
  *
- * Filters entries by trigger type and applies them.
- *
  * @param collection - The collected derivation entries
  * @param trigger - The trigger type to filter by
  * @param context - Context for applying derivations
  * @param changedFields - Set of field keys that changed (for filtering)
  * @returns Result of the derivation processing
- *
- * @public
  */
 export function applyDerivationsForTrigger(
   collection: DerivationCollection,
@@ -735,12 +661,8 @@ export function applyDerivationsForTrigger(
 /**
  * Gets all debounced derivation entries from a collection.
  *
- * Use this to extract debounced entries for separate processing with debounce timers.
- *
  * @param collection - The collected derivation entries
  * @returns Array of debounced derivation entries
- *
- * @public
  */
 export function getDebouncedDerivationEntries(collection: DerivationCollection): DerivationEntry[] {
   return collection.entries.filter((entry) => entry.trigger === 'debounced');

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-collector.ts
@@ -21,22 +21,8 @@ export { SELF_DEPENDENCY_TOKEN, GROUP_DEPENDENCY_TOKEN } from './collection-cont
 /**
  * Collects all VALUE derivation entries from field definitions.
  *
- * Traverses the field definition tree and extracts:
- * - Shorthand `derivation` properties on fields
- * - Full `logic` array entries with `type: 'derivation'` *without* `targetProperty`
- *   (entries WITH `targetProperty` are property derivations; see {@link collectAllDerivations}).
- *
- * The collected entries are sorted topologically so downstream processing
- * applies them in dependency order.
- *
- * Thin wrapper over {@link collectAllDerivations} that returns the value
- * slice. For forms that have both kinds of derivations, prefer the unified
- * collector — it walks the field tree once instead of twice.
- *
  * @param fields - Array of field definitions to traverse
  * @returns Collection containing sorted derivation entries
- *
- * @public
  */
 export function collectDerivations(fields: FieldDef<unknown>[]): DerivationCollection {
   const entries: DerivationEntry[] = [];
@@ -54,13 +40,6 @@ export function collectDerivations(fields: FieldDef<unknown>[]): DerivationColle
 /**
  * Single traversal that emits both value derivations (sorted topologically)
  * and property derivations (no sort — they don't chain among themselves).
- *
- * Walks the field tree once, dispatching each `type: 'derivation'` logic
- * entry to the right collection based on whether it carries a
- * `targetProperty`. Used internally by the `DerivationOrchestrator` when
- * both pipelines are active to share one walk across both collection
- * signals; external callers should use {@link collectDerivations} or
- * `collectPropertyDerivations` instead.
  *
  * @internal
  */
@@ -144,9 +123,6 @@ function collectPropertyEntriesFromField(field: FieldDef<unknown>, entries: Prop
 /**
  * Creates a value-derivation entry from a field's shorthand `derivation`
  * property.
- *
- * Shorthand derivations target the same field they're defined on, always
- * apply (condition `true`), and always trigger on change.
  *
  * @internal
  */
@@ -244,11 +220,6 @@ function createValueLogicEntry(fieldKey: string, config: DerivationLogicConfig, 
  * encoding as value entries via {@link buildEffectiveFieldKey} —
  * `buildPropertyOverrideKey` in the original property collector produced the
  * same shape.
- *
- * Includes the property-pipeline-specific runtime validation: source-vs-sync
- * field conflicts, HTTP/async cross-bleed, missing required HTTP fields, and
- * wildcard dependency guards. Mirrors the original
- * `createPropertyDerivationEntryFromDerivation` helper.
  *
  * @internal
  */

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-constants.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-constants.ts
@@ -1,58 +1,17 @@
 /**
  * Centralized constants for the derivation system.
  *
- * These constants configure the behavior of derivation processing,
- * caching, and path handling. Centralizing them enables:
- * - Easy configuration changes
- * - Consistent values across all derivation modules
- * - Clear documentation of magic numbers
- *
  * @module
  */
 
-/**
- * Maximum number of derivation iterations before stopping to prevent infinite loops.
- *
- * The value of 10 is chosen based on:
- * - Most derivation chains are 2-3 levels deep (A→B→C)
- * - Complex forms with conditional cascades rarely exceed 5-6 levels
- * - 10 provides headroom for bidirectional sync patterns (A↔B) which may need
- *   2 iterations per pair to stabilize
- * - Higher values delay detection of actual infinite loops
- * - Lower values risk false positives on legitimate deep chains
- *
- * If you hit this limit legitimately, consider:
- * 1. Restructuring derivations to reduce chain depth
- * 2. Using explicit `dependsOn` to control evaluation order
- * 3. Breaking complex derivations into computed signals outside the form
- */
+/** Maximum number of derivation iterations before stopping to prevent infinite loops. */
 export const MAX_DERIVATION_ITERATIONS = 10;
 
-/**
- * Placeholder string for array index in derivation paths.
- *
- * Used in paths like `items.$.quantity` to represent "each item in the array".
- * The `$` is resolved to actual indices at runtime during array derivation processing.
- */
+/** Placeholder string for array index in derivation paths. */
 export const ARRAY_PLACEHOLDER = '.$.';
 
-/**
- * Maximum size of the expression AST cache.
- *
- * Expressions are parsed into Abstract Syntax Trees (AST) once and cached
- * to avoid re-parsing on each evaluation. The cache uses LRU eviction.
- *
- * 1000 entries handles:
- * - Large forms with many derivation expressions
- * - Multiple form instances with different expressions
- * - Memory efficiency (AST nodes are relatively small)
- */
+/** Maximum size of the expression AST cache. */
 export const MAX_AST_CACHE_SIZE = 1000;
 
-/**
- * Delimiter used to create unique derivation keys from source and target field keys.
- *
- * Uses null character (\x00) which is extremely unlikely to appear in field names,
- * avoiding collision issues that could occur with common delimiters like ':'.
- */
+/** Delimiter used to create unique derivation keys from source and target field keys. */
 export const DERIVATION_KEY_DELIMITER = '\x00';

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-entry-base.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-entry-base.ts
@@ -2,43 +2,18 @@ import { ConditionalExpression } from '../../models/expressions/conditional-expr
 import { DerivationLogicConfig, LogicTrigger } from '../../models/logic/logic-config';
 import type { CustomFunction } from '../expressions/custom-function-types';
 
-/**
- * Common shape shared by `DerivationEntry` and `PropertyDerivationEntry`.
- *
- * Both entry types are produced by collecting `type: 'derivation'` logic from
- * field definitions; they diverge only in their write target (form value vs.
- * property override store) and a few specialized fields. Shared utilities
- * (`computeValueFromEntry`, `getDebouncePeriods`, etc.) operate on this shape
- * so they can be reused across both pipelines without casts.
- *
- * @public
- */
+/** Common shape shared by `DerivationEntry` and `PropertyDerivationEntry`. */
 export interface BaseDerivationEntry {
-  /**
-   * The key of the field where this derivation is defined and targets.
-   *
-   * For array fields, this may include a placeholder path like 'items.$.x'
-   * which is resolved to actual indices at runtime.
-   */
+  /** The key of the field where this derivation is defined and targets. */
   fieldKey: string;
 
-  /**
-   * Field keys that this derivation depends on.
-   *
-   * Extracted from explicit `dependsOn`, expressions, and conditions.
-   */
+  /** Field keys that this derivation depends on. */
   dependsOn: string[];
 
-  /**
-   * Condition that determines when this derivation applies.
-   *
-   * Defaults to `true` (always apply) if not specified in the config.
-   */
+  /** Condition that determines when this derivation applies. */
   condition: ConditionalExpression | boolean;
 
-  /**
-   * Static value. Mutually exclusive with `expression` and `functionName`.
-   */
+  /** Static value. Mutually exclusive with `expression` and `functionName`. */
   value?: unknown;
 
   /**
@@ -73,13 +48,9 @@ export interface BaseDerivationEntry {
    */
   debounceMs?: number;
 
-  /**
-   * Optional debug name for easier identification in logs.
-   */
+  /** Optional debug name for easier identification in logs. */
   debugName?: string;
 
-  /**
-   * The original logic config if this entry was created from a full logic config.
-   */
+  /** The original logic config if this entry was created from a full logic config. */
   originalConfig?: DerivationLogicConfig;
 }

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-logger.service.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-logger.service.ts
@@ -3,14 +3,7 @@ import { DerivationLogConfig, createDefaultDerivationLogConfig, shouldLog } from
 import { DerivationProcessingResult } from './derivation-types';
 import { DerivationLogEntry } from './derivation-logger';
 
-/**
- * Service interface for derivation logging.
- *
- * Provides methods to log derivation processing events at different verbosity levels.
- * Use `createDerivationLogger` factory to create an instance.
- *
- * @public
- */
+/** Service interface for derivation logging. */
 export interface DerivationLogger {
   /**
    * Logs the start of a derivation processing cycle.
@@ -36,9 +29,7 @@ export interface DerivationLogger {
    */
   summary(result: DerivationProcessingResult, trigger: 'onChange' | 'debounced'): void;
 
-  /**
-   * Logs when max iterations are reached (always logged as warning).
-   */
+  /** Logs when max iterations are reached (always logged as warning). */
   maxIterationsReached(result: DerivationProcessingResult, trigger: 'onChange' | 'debounced'): void;
 }
 
@@ -51,9 +42,7 @@ class ActiveDerivationLogger implements DerivationLogger {
   logger!: Logger;
   private config: DerivationLogConfig = createDefaultDerivationLogConfig();
 
-  /**
-   * Updates the log configuration.
-   */
+  /** Updates the log configuration. */
   setConfig(config: DerivationLogConfig): void {
     this.config = config;
   }
@@ -169,14 +158,9 @@ const NOOP_INSTANCE = new NoopDerivationLogger();
 /**
  * Factory function to create a DerivationLogger.
  *
- * Returns a no-op implementation if config level is 'none',
- * otherwise returns an active logger with the given config.
- *
  * @param config - The derivation log configuration
  * @param logger - The underlying logger instance
  * @returns A DerivationLogger instance
- *
- * @public
  */
 export function createDerivationLogger(config: DerivationLogConfig | undefined, logger: Logger): DerivationLogger {
   const effectiveConfig = config ?? createDefaultDerivationLogConfig();

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-logger.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-logger.ts
@@ -6,11 +6,7 @@ import { DerivationProcessingResult } from './derivation-types';
 export type { DerivationLogLevel, DerivationLogConfig } from '../../models/logic/logic-config';
 export { createDefaultDerivationLogConfig, shouldLog } from '../../models/logic/logic-config';
 
-/**
- * Information about a single derivation evaluation for logging.
- *
- * @public
- */
+/** Information about a single derivation evaluation for logging. */
 export interface DerivationLogEntry {
   /** Debug name if provided in the derivation config */
   debugName?: string;
@@ -32,6 +28,7 @@ export interface DerivationLogEntry {
 
 /**
  * Prefix for derivation debug log messages.
+ *
  * @internal
  */
 const LOG_PREFIX = '[Derivation]';
@@ -39,16 +36,10 @@ const LOG_PREFIX = '[Derivation]';
 /**
  * Logs a summary of derivation processing results.
  *
- * Only logs when:
- * - Config level is 'summary' or 'verbose'
- * - At least one derivation was applied or an error occurred
- *
  * @param result - The derivation processing result
  * @param trigger - The trigger type ('onChange' or 'debounced')
  * @param logger - Logger instance
  * @param config - Debug logging configuration
- *
- * @public
  */
 export function logDerivationSummary(
   result: DerivationProcessingResult,
@@ -75,8 +66,6 @@ export function logDerivationSummary(
  * @param result - The derivation processing result
  * @param trigger - The trigger type
  * @param logger - Logger instance
- *
- * @public
  */
 export function logMaxIterationsReached(result: DerivationProcessingResult, trigger: 'onChange' | 'debounced', logger: Logger): void {
   logger.warn(
@@ -89,12 +78,9 @@ export function logMaxIterationsReached(result: DerivationProcessingResult, trig
 /**
  * Logs a verbose entry for a single derivation evaluation.
  *
- * Only logs when config level is 'verbose'.
- *
  * @param entry - The derivation log entry with evaluation details
  * @param logger - Logger instance
  * @param config - Debug logging configuration
- *
  * @internal
  */
 export function logDerivationEvaluation(entry: DerivationLogEntry, logger: Logger, config: DerivationLogConfig): void {
@@ -151,13 +137,10 @@ function formatSkipReason(reason?: string): string {
 /**
  * Logs the start of a derivation processing cycle.
  *
- * Only logs when config level is 'verbose'.
- *
  * @param trigger - The trigger type ('onChange' or 'debounced')
  * @param entryCount - Number of derivations to process in this cycle
  * @param logger - Logger instance
  * @param config - Debug logging configuration
- *
  * @internal
  */
 export function logDerivationCycleStart(
@@ -174,12 +157,9 @@ export function logDerivationCycleStart(
 /**
  * Logs the start of a derivation iteration within a cycle.
  *
- * Only logs when config level is 'verbose'.
- *
  * @param iteration - Current iteration number (1-based)
  * @param logger - Logger instance
  * @param config - Debug logging configuration
- *
  * @internal
  */
 export function logDerivationIteration(iteration: number, logger: Logger, config: DerivationLogConfig): void {

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-orchestrator.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-orchestrator.ts
@@ -31,20 +31,6 @@ import { createAsyncPropertyDerivationStream } from '../property-derivation/asyn
 /**
  * Configuration for creating a DerivationOrchestrator. Both pipelines are
  * opt-in via their respective config fields:
- *
- * - **Value pipeline** (form-value derivations): activated when both `form`
- *   and `derivationLogger` are provided. Wires onChange/debounced/HTTP/async
- *   streams that write derived values into the Angular Signal-Form tree via
- *   `form()`.
- * - **Property pipeline** (hidden/disabled/readonly derivations): activated
- *   when `propertyStore` is provided. Wires the same four stream variants
- *   that write derived property overrides into the store.
- *
- * Both pipelines share the same `schemaFields` and `formValue` signals — the
- * collectors walk the same field tree but extract disjoint sets of entries
- * (value entries have no `targetProperty`; property entries have one).
- *
- * @public
  */
 export interface DerivationOrchestratorConfig {
   /** Signal containing the flattened schema fields */
@@ -82,13 +68,6 @@ export interface DerivationOrchestratorConfig {
  * (writes into a property override store). Each pipeline opts in via the
  * corresponding fields of {@link DerivationOrchestratorConfig}; an orchestrator
  * instance can run one, both, or (degenerately) neither.
- *
- * The streaming plumbing is shared between pipelines via
- * `pipeline-setup-utils` — both wire onChange + debounced + HTTP-entry-keyed +
- * async-function-entry-keyed streams via the same helpers, differing only in
- * collection, apply callback, and per-entry stream constructor.
- *
- * @public
  */
 export class DerivationOrchestrator {
   private readonly config: DerivationOrchestratorConfig;
@@ -604,18 +583,12 @@ function propertyAsyncEntrySignature(entry: PropertyDerivationEntry): string {
  *
  * @param config - Form-specific signals configuration
  * @returns The created DerivationOrchestrator
- *
- * @public
  */
 export function createDerivationOrchestrator(config: DerivationOrchestratorConfig): DerivationOrchestrator {
   return new DerivationOrchestrator(config);
 }
 
-/**
- * Injection token for the DerivationOrchestrator.
- *
- * @public
- */
+/** Injection token for the DerivationOrchestrator. */
 export const DERIVATION_ORCHESTRATOR = new InjectionToken<DerivationOrchestrator>('DERIVATION_ORCHESTRATOR');
 
 /**
@@ -624,8 +597,6 @@ export const DERIVATION_ORCHESTRATOR = new InjectionToken<DerivationOrchestrator
  * {@link DerivationOrchestrator}; the DI binding for this token uses
  * `useExisting: DERIVATION_ORCHESTRATOR`, so any consumer still calling
  * `inject(PROPERTY_DERIVATION_ORCHESTRATOR)` resolves to the same instance.
- *
- * New code should `inject(DERIVATION_ORCHESTRATOR)` directly.
  *
  * @deprecated Use {@link DERIVATION_ORCHESTRATOR}.
  */
@@ -636,8 +607,6 @@ export const PROPERTY_DERIVATION_ORCHESTRATOR = new InjectionToken<DerivationOrc
  *
  * @returns The DerivationOrchestrator instance
  * @throws Error if called outside of an injection context or if orchestrator is not provided
- *
- * @public
  */
 export function injectDerivationOrchestrator(): DerivationOrchestrator {
   return inject(DERIVATION_ORCHESTRATOR);

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-sorter.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-sorter.ts
@@ -3,30 +3,8 @@ import { DerivationEntry } from './derivation-types';
 /**
  * Sorts derivation entries in topological order based on their dependencies.
  *
- * This ensures that derivations are processed in the correct order:
- * if derivation B depends on field A, and derivation A->A' modifies A,
- * then A->A' is processed before B.
- *
- * Uses Kahn's algorithm for topological sorting, which also provides
- * natural handling of entries with no dependencies (they come first).
- *
  * @param entries - The derivation entries to sort
  * @returns A new array of entries in topological order
- *
- * @example
- * ```typescript
- * // Given derivations:
- * // 1. quantity -> lineTotal (depends on quantity, unitPrice)
- * // 2. unitPrice -> lineTotal (depends on quantity, unitPrice)
- * // 3. lineTotal -> grandTotal (depends on lineTotal)
- * //
- * // Topological sort ensures lineTotal is computed before grandTotal
- * const sorted = topologicalSort(entries);
- * // Result: [1, 2, 3] - derivations that produce lineTotal come before
- * // those that consume it
- * ```
- *
- * @public
  */
 export function topologicalSort(entries: DerivationEntry[]): DerivationEntry[] {
   if (entries.length <= 1) {

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-types.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-types.ts
@@ -3,52 +3,19 @@ import { HttpRequestConfig } from '../../models/http/http-request-config';
 import type { AsyncDerivationFunction } from '../expressions/async-custom-function-types';
 import { BaseDerivationEntry } from './derivation-entry-base';
 
-/**
- * Entry representing a collected derivation from field definitions.
- *
- * Unified across both write targets: when `targetProperty` is absent the entry
- * writes the derived value into the form's FieldTree (value derivation); when
- * `targetProperty` is set it writes into the PropertyOverrideStore under
- * `[fieldKey, targetProperty]` (property derivation — hidden/disabled/readonly).
- * The collectors emit entries of the appropriate shape; the orchestrator's
- * apply step routes by inspecting `targetProperty`.
- *
- * All derivations are self-targeting: the `fieldKey` is both where the
- * derivation is defined AND where the computed value will be set.
- *
- * Extends {@link BaseDerivationEntry} with the async source variants (HTTP,
- * async function) and value-pipeline-only authoring controls (shorthand flag,
- * user-override behavior). Property-pipeline entries simply leave the
- * value-only fields unset; see {@link PropertyDerivationEntry} for the
- * property-only variant.
- *
- * @public
- */
+/** Entry representing a collected derivation from field definitions. */
 export interface DerivationEntry extends BaseDerivationEntry {
   /**
    * Target property name when this entry feeds the property-override store
    * (one of `'hidden'`, `'disabled'`, `'readonly'`, ...). When absent, the
    * entry is a value derivation and writes into the FieldTree.
-   *
-   * Property derivations are distinguished from value derivations purely by
-   * the presence of this field.
    */
   targetProperty?: string;
 
-  /**
-   * HTTP request configuration for server-driven derivations.
-   *
-   * Mutually exclusive with `value`, `expression`, `functionName`, and `asyncFunctionName`.
-   * Processed asynchronously in a dedicated RxJS stream, not in the sync loop.
-   */
+  /** HTTP request configuration for server-driven derivations. */
   http?: HttpRequestConfig;
 
-  /**
-   * Name of a registered async derivation function.
-   *
-   * Mutually exclusive with `value`, `expression`, `functionName`, `asyncFn`, and `http`.
-   * Processed asynchronously in a dedicated RxJS stream, not in the sync loop.
-   */
+  /** Name of a registered async derivation function. */
   asyncFunctionName?: string;
 
   /**
@@ -58,19 +25,13 @@ export interface DerivationEntry extends BaseDerivationEntry {
    */
   asyncFn?: AsyncDerivationFunction;
 
-  /**
-   * Expression to extract the derived value from an HTTP response.
-   *
-   * Required when `http` is set.
-   */
+  /** Expression to extract the derived value from an HTTP response. */
   responseExpression?: string;
 
   /**
    * Whether this derivation was created from the shorthand `derivation` property.
    * Value-pipeline-only — property derivations are always created from full
    * logic configs and leave this unset.
-   *
-   * Shorthand derivations use a string expression directly on the field.
    */
   isShorthand?: boolean;
 
@@ -78,10 +39,6 @@ export interface DerivationEntry extends BaseDerivationEntry {
    * When true, the derivation stops running after the user manually
    * edits the target field. Value-pipeline-only — property derivations
    * always recompute on dependency change.
-   *
-   * Uses the field's `dirty()` signal — derivations write directly to
-   * `value.set()` which does not trigger `markAsDirty()`, so
-   * `dirty === true` reliably indicates user modification.
    */
   stopOnUserOverride?: boolean;
 
@@ -93,13 +50,7 @@ export interface DerivationEntry extends BaseDerivationEntry {
   reEngageOnDependencyChange?: boolean;
 }
 
-/**
- * Collection of all derivation entries from a form's field definitions.
- *
- * This interface is intentionally minimal - it contains only the core data.
- *
- * @public
- */
+/** Collection of all derivation entries from a form's field definitions. */
 export interface DerivationCollection {
   /**
    * All derivation entries collected from field definitions,
@@ -108,80 +59,37 @@ export interface DerivationCollection {
   entries: DerivationEntry[];
 }
 
-/**
- * Result of cycle detection in the derivation graph.
- *
- * @public
- */
+/** Result of cycle detection in the derivation graph. */
 export interface CycleDetectionResult {
-  /**
-   * Whether a cycle was detected.
-   */
+  /** Whether a cycle was detected. */
   hasCycle: boolean;
 
-  /**
-   * Field paths involved in the cycle, if one was detected.
-   *
-   * Example: ['country', 'currency', 'country'] for a country -> currency -> country cycle.
-   */
+  /** Field paths involved in the cycle, if one was detected. */
   cyclePath?: string[];
 
-  /**
-   * Bidirectional derivation pairs detected (A↔B patterns).
-   *
-   * These are allowed and stabilize via equality checks, but may oscillate
-   * with floating-point precision issues (e.g., currency conversions).
-   *
-   * Format: ['fieldA↔fieldB', 'fieldC↔fieldD']
-   */
+  /** Bidirectional derivation pairs detected (A↔B patterns). */
   bidirectionalPairs?: string[];
 
-  /**
-   * Human-readable error message describing the cycle.
-   */
+  /** Human-readable error message describing the cycle. */
   errorMessage?: string;
 }
 
 /**
  * Context for tracking derivation chain during runtime.
  *
- * Prevents infinite loops by tracking which derivations have already
- * been applied in the current update cycle.
- *
  * @internal
  */
 export interface DerivationChainContext {
-  /**
-   * Set of derivation keys that have already been applied.
-   *
-   * Key format: "fieldKey"
-   *
-   * For array derivations, the caller is responsible for resolving
-   * array placeholders (e.g., 'items.$.lineTotal' -> 'items.0.lineTotal')
-   * before adding to this set.
-   */
+  /** Set of derivation keys that have already been applied. */
   appliedDerivations: Set<string>;
 
-  /**
-   * Current iteration count in the derivation processing loop.
-   */
+  /** Current iteration count in the derivation processing loop. */
   iteration: number;
 
-  /**
-   * Set of field keys that changed in this cycle.
-   *
-   * Used by `reEngageOnDependencyChange` to determine whether to
-   * clear a user-override flag. `undefined` on initial onChange evaluation
-   * (when no prior value exists to compare against).
-   */
+  /** Set of field keys that changed in this cycle. */
   changedFields?: Set<string>;
 
-  /**
-   * Cached FormFieldStateMap for this cycle.
-   *
-   * Created once per `applyDerivations` call and reused across all entry
-   * evaluations to avoid allocating a new Proxy + Map per entry.
-   */
+  /** Cached FormFieldStateMap for this cycle. */
   formFieldState?: FormFieldStateMap;
 }
 
@@ -189,7 +97,6 @@ export interface DerivationChainContext {
  * Creates an empty derivation collection.
  *
  * @returns Empty collection ready for population
- *
  * @internal
  */
 export function createEmptyDerivationCollection(): DerivationCollection {
@@ -200,7 +107,6 @@ export function createEmptyDerivationCollection(): DerivationCollection {
  * Creates a new derivation chain context for tracking applied derivations.
  *
  * @returns Fresh context for a new derivation cycle
- *
  * @internal
  */
 export function createDerivationChainContext(): DerivationChainContext {
@@ -213,16 +119,8 @@ export function createDerivationChainContext(): DerivationChainContext {
 /**
  * Creates a unique key for a derivation entry.
  *
- * Since derivations are self-targeting, the key is simply the field key.
- * This function exists for semantic clarity and to provide a single point
- * of change if the key format needs to be extended in the future.
- *
- * Note: For array derivations, callers must resolve placeholders
- * (e.g., 'items.$.lineTotal' -> 'items.0.lineTotal') before calling this.
- *
  * @param fieldKey - The field key (with array index already resolved)
  * @returns Unique key for the derivation
- *
  * @internal
  */
 export function createDerivationKey(fieldKey: string): string {
@@ -234,18 +132,13 @@ export function createDerivationKey(fieldKey: string): string {
  *
  * @param key - The derivation key to parse
  * @returns Object containing the field key
- *
  * @internal
  */
 export function parseDerivationKey(key: string): { fieldKey: string } {
   return { fieldKey: key };
 }
 
-/**
- * Result of processing all pending derivations.
- *
- * @public
- */
+/** Result of processing all pending derivations. */
 export interface DerivationProcessingResult {
   /** Number of derivations successfully applied */
   appliedCount: number;
@@ -256,12 +149,7 @@ export interface DerivationProcessingResult {
   /** Number of derivations that failed with errors */
   errorCount: number;
 
-  /**
-   * Number of derivations that encountered warnings (e.g., missing target field).
-   *
-   * These are not counted as errors because they may be intentional (conditional fields)
-   * but indicate potential configuration issues if unexpected.
-   */
+  /** Number of derivations that encountered warnings (e.g., missing target field). */
   warnCount: number;
 
   /** Total iterations performed */

--- a/packages/dynamic-forms/src/lib/core/derivation/entry-set-utils.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/entry-set-utils.ts
@@ -6,13 +6,6 @@ import { EMPTY, Observable, distinctUntilChanged, map, switchMap, merge } from '
  * reorderings triggered by unrelated entries don't churn downstream stream
  * lifecycles.
  *
- * Multiset (not set) semantics: two distinct entries with identical signatures
- * are counted separately, so `[A, B]` does NOT equal `[A, A]` even though both
- * have length 2 and both contain `A` as a signature.
- *
- * Used by the value-derivation and property-derivation orchestrators to gate
- * `distinctUntilChanged` over HTTP- and async-function-entry sets.
- *
  * @internal
  */
 export function entrySetsEqual<T>(prev: T[], next: T[], sig: (item: T) => string): boolean {
@@ -55,24 +48,12 @@ export interface EntryStreamPipelineConfig<TCollection, TEntry> {
    * owned by the outer pipeline — when the entry set changes, the previous
    * merged inner stream is unsubscribed (cancelling in-flight work) and a
    * fresh batch is created from the new entries.
-   *
-   * Return `null` to skip an entry (e.g., when a prerequisite like
-   * `HttpClient` is unavailable and an error was already logged upstream).
    */
   createStream: (entry: TEntry) => Observable<unknown> | null;
 }
 
 /**
  * Declarative pipeline shared by both derivation orchestrators:
- *
- * 1. Project the collection down to a typed entry list.
- * 2. Skip rebuilds when the entry set hasn't changed (multiset comparison).
- * 3. `switchMap` cancels the previous merged inner streams and creates fresh
- *    ones from the new entries; in-flight HTTP / async work is cancelled via
- *    ordinary RxJS unsubscribe semantics.
- *
- * No mutable subscription bookkeeping; the caller pipes through
- * `takeUntilDestroyed` for unmount cleanup.
  *
  * @internal
  */

--- a/packages/dynamic-forms/src/lib/core/derivation/evaluation-scope.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/evaluation-scope.ts
@@ -6,13 +6,6 @@ import { ArrayPathInfo } from '../../utils/path-utils/path-utils';
  * `.`-delimited segment. Returns `undefined` when the field has no parent
  * in scope (single-segment root key).
  *
- * - `'address.state'` → `'address'`
- * - `'org.address.state'` → `'org.address'`
- * - `'state'` → `undefined`
- *
- * Used by the non-array evaluation context to populate `groupValue` from
- * the field's parent group on `formValue`.
- *
  * @internal
  */
 export function getParentPathInScope(fieldKey: string): string | undefined {
@@ -29,21 +22,12 @@ export function getParentPathInScope(fieldKey: string): string | undefined {
 export interface ArrayItemScope {
   /** Path within the array item (everything after `'.$.'`); `''` for non-array entries. */
   readonly relativePath: string;
-  /** Nearest parent of the leaf within the array item: the inner group's value when the leaf
-   *  is nested under a group, otherwise the array item itself. */
   readonly groupValue: unknown;
-  /** Leaf value addressed by `relativePath` within the array item, or the array item itself
-   *  when the leaf has no relative path. */
   readonly fieldValue: unknown;
 }
 
 /**
  * Resolves the per-array-item scope shared by both derivation applicators.
- *
- * Both `derivation-applicator.ts` and `property-derivation-applicator.ts`
- * need the same fan-out from `(pathInfo, arrayItem)` to `fieldValue`,
- * `groupValue`, and `relativePath` when building an evaluation context for
- * an array item. Centralising here keeps the two pipelines from drifting.
  *
  * @internal
  */

--- a/packages/dynamic-forms/src/lib/core/derivation/external-data-resolver.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/external-data-resolver.ts
@@ -4,10 +4,6 @@ import { isSignal, Signal, untracked } from '@angular/core';
  * Resolves a record of external-data signals to their current values without
  * establishing reactive dependencies.
  *
- * The orchestrators read external data per derivation cycle; using `untracked`
- * here ensures the orchestrator's own computed/effect graph isn't tied to the
- * external-data signal identities.
- *
  * @internal
  */
 export function resolveExternalData(

--- a/packages/dynamic-forms/src/lib/core/derivation/extract-dependencies.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/extract-dependencies.ts
@@ -4,12 +4,6 @@ import { extractExpressionDependencies, extractStringDependencies } from '../cro
 /**
  * Extracts the union of field dependencies declared by a derivation config.
  *
- * Combines:
- * - Explicit `dependsOn` (when provided, it takes precedence over auto-detection)
- * - Expression-detected dependencies (only used when `dependsOn` is empty)
- * - `'*'` wildcard for `functionName` / inline `fn` (only when `dependsOn` is empty)
- * - Condition expression dependencies (always included)
- *
  * @internal
  */
 export function extractDependenciesFromConfig(config: DerivationLogicConfig): string[] {

--- a/packages/dynamic-forms/src/lib/core/derivation/extract-inline-fn.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/extract-inline-fn.ts
@@ -4,11 +4,6 @@ import type { CustomFunction } from '../expressions/custom-function-types';
 /**
  * Reads the optional inline `fn` property off a derivation config.
  *
- * `fn` only appears on the function-mode branch of the discriminated union, so
- * call sites that need to copy it through unconditionally must widen via cast.
- * This helper centralises the cast and keeps it read-only — no widening, no
- * mutation. Returns `undefined` for any non-function-mode variant.
- *
  * @internal
  */
 export function extractInlineFn(config: object): CustomFunction | undefined {
@@ -17,10 +12,6 @@ export function extractInlineFn(config: object): CustomFunction | undefined {
 
 /**
  * Reads the optional inline `asyncFn` property off a derivation config.
- *
- * Same rationale as {@link extractInlineFn}: `asyncFn` only appears on the
- * `source: 'asyncFunction'` branch, so collectors that copy it through need a
- * cast. Read-only access, no widening.
  *
  * @internal
  */

--- a/packages/dynamic-forms/src/lib/core/derivation/field-state-extractor.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/field-state-extractor.ts
@@ -25,14 +25,6 @@ function readStateSignal(fieldState: FieldState<unknown>, prop: StateProperty, r
 /**
  * Resolves a field source (FieldTree or FieldState) to its FieldState.
  *
- * Accepts either:
- * - A FieldTree (signal or callable Proxy from form tree) — called to get the FieldState
- * - A direct FieldState object (from FieldContext) — used directly
- *
- * FieldTree accessors may be Angular signals (pass `isSignal()`) or Proxy-wrapped
- * callables (fail `isSignal()` but pass `typeof === 'function'`). Both are handled
- * by the callable check.
- *
  * @internal
  */
 function resolveFieldState(
@@ -57,20 +49,10 @@ function resolveFieldState(
 /**
  * Creates a lazy FieldStateInfo that only reads state properties when accessed.
  *
- * This prevents reactive cycles when fieldState/formFieldState is used inside
- * logic conditions (readonly, hidden, disabled). Eagerly reading all properties
- * (e.g., `valid`, `readonly`) would create circular dependencies when the
- * logic condition itself controls one of those properties.
- *
- * Accepts either:
- * - A FieldTree (signal accessor from form tree) — called to get the FieldState
- * - A direct FieldState object (from FieldContext) — used directly
- *
  * @param fieldSource - A FieldTree or direct FieldState instance
  * @param reactive - If true, reads signals reactively (creates dependencies).
  *                   If false, reads signals with `untracked()` (no dependencies).
  * @returns A FieldStateInfo proxy with lazy property access, or undefined if the source is invalid
- *
  * @internal
  */
 export function readFieldStateInfo(
@@ -101,17 +83,10 @@ export function readFieldStateInfo(
 /**
  * Creates a Proxy-based FormFieldStateMap for accessing any field's state by key.
  *
- * Property access like `[key]` navigates to `rootForm[key]` and returns
- * a FieldStateInfo snapshot for that field.
- *
- * Uses an internal Map cache for identity stability within a single
- * access chain (avoids redundant snapshot allocations).
- *
  * @param rootForm - The root FieldTree of the form
  * @param reactive - If true, reads signals reactively (creates dependencies).
  *                   If false, reads signals with `untracked()` (no dependencies).
  * @returns A FormFieldStateMap proxy
- *
  * @internal
  */
 export function createFormFieldStateMap(rootForm: FieldTree<unknown>, reactive: boolean): FormFieldStateMap {
@@ -136,10 +111,6 @@ export function createFormFieldStateMap(rootForm: FieldTree<unknown>, reactive: 
 
 /**
  * Navigates the form tree to find a field accessor (FieldTree) for the given key path.
- *
- * Supports dot-notation for nested paths (e.g., 'address.city').
- * Follows the same bracket-notation navigation pattern as `applyValueToForm`
- * in `derivation-applicator.ts`.
  *
  * @internal
  */

--- a/packages/dynamic-forms/src/lib/core/derivation/field-traversal.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/field-traversal.ts
@@ -13,11 +13,6 @@ export type FieldVisitor<TContext> = (field: FieldDef<unknown>, context: TContex
 /**
  * Hooks for mutating the traversal context when crossing container boundaries.
  *
- * Both hooks receive the parent context and the container field; they return
- * a partial object that is merged into a copy of the parent context to form
- * the child context. Layout containers (page, row, container) call
- * `onLayoutChild` and by default leave context unchanged.
- *
  * @internal
  */
 export interface FieldTraversalHooks<TContext> {
@@ -31,19 +26,6 @@ export interface FieldTraversalHooks<TContext> {
 
 /**
  * Recursively walks a field-definition tree, invoking `visitor` for each field.
- *
- * Owns the subtleties shared across derivation collectors:
- * - Detects container fields via `hasChildFields`.
- * - Falls back to the simplified-array Symbol-metadata template when an array
- *   field has empty `fields` (the case for arrays initialized without a
- *   starting `value` — only the metadata template carries their item shape).
- * - Flattens primitive (FieldDef) and object (FieldDef[]) array items into a
- *   single child list before recursing.
- *
- * Callers customize per-boundary context via {@link FieldTraversalHooks}: e.g.,
- * the value-derivation collector tracks an array path AND a group path (with
- * the group path reset at array boundaries), while the property-derivation
- * collector tracks only the array path.
  *
  * @internal
  */
@@ -74,9 +56,6 @@ export function traverseFieldsWithContext<TContext>(
 /**
  * Returns the flattened list of children for an array field, falling back
  * to the Symbol metadata template when `fields` is empty.
- *
- * Caller must ensure `field` is a container (passes `hasChildFields`); this
- * function reads `field.fields` directly and would error otherwise.
  *
  * @internal
  */

--- a/packages/dynamic-forms/src/lib/core/derivation/field-value-utils.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/field-value-utils.ts
@@ -7,12 +7,7 @@ import type { WarningTracker } from '../../utils/warning-tracker';
 /**
  * Navigates the form tree to resolve a field instance at the given path.
  *
- * Walks the tree following the same pattern as `setFieldValue`:
- * each segment is looked up on the current node, and signal accessors
- * are called to get the next level.
- *
  * @returns The field instance object, or `undefined` if the path is invalid
- *
  * @internal
  */
 export function resolveFieldInstance(rootForm: FieldTree<unknown>, fieldPath: string): FieldState<unknown> | undefined {
@@ -34,9 +29,6 @@ export function resolveFieldInstance(rootForm: FieldTree<unknown>, fieldPath: st
 /**
  * Reads the dirty() signal from a field at the given path.
  *
- * Returns `true` if the field is dirty, `false` if pristine,
- * or `undefined` if the field cannot be found.
- *
  * @internal
  */
 export function readFieldDirty(rootForm: FieldTree<unknown>, fieldPath: string): boolean | undefined {
@@ -48,12 +40,6 @@ export function readFieldDirty(rootForm: FieldTree<unknown>, fieldPath: string):
 /**
  * Resets a field's dirty/touched state at the given path.
  *
- * Used for re-engagement: when a dependency changes, clear the user override
- * so the derivation can re-apply.
- *
- * Uses the public `reset()` API on FieldState, which clears both
- * dirty and touched without changing the field's value.
- *
  * @internal
  */
 export function resetFieldState(rootForm: FieldTree<unknown>, fieldPath: string): void {
@@ -64,12 +50,6 @@ export function resetFieldState(rootForm: FieldTree<unknown>, fieldPath: string)
 
 /**
  * Applies a value to the form at the specified path.
- *
- * Uses bracket notation to access child FieldTrees, following the same pattern
- * as group-field and array-field components. Fields are accessed as signals
- * and their value is set via the `.value.set()` method.
- *
- * Handles nested paths and array paths with '$' placeholder.
  *
  * @internal
  */
@@ -116,16 +96,7 @@ export function applyValueToForm(
 /**
  * Sets a field value using the Angular Signal Forms pattern.
  *
- * Accesses the child field via bracket notation, drills down to find
- * the WritableSignal, and uses isWritableSignal for type-safe signal detection.
- *
- * Angular Signal Forms structure:
- * - form[key] is a callable function (field accessor)
- * - form[key]() returns the field instance with { value: WritableSignal<T> }
- * - form[key]().value.set(newValue) sets the value
- *
  * @returns true if the value was successfully set, false if field not found
- *
  * @internal
  */
 function setFieldValue(
@@ -167,9 +138,6 @@ function setFieldValue(
 
 /**
  * Logs a warning for a missing target field (once per field per form instance).
- *
- * Uses the provided warning tracker to avoid log spam. If no tracker is provided,
- * the warning will be logged every time.
  *
  * @internal
  */

--- a/packages/dynamic-forms/src/lib/core/derivation/http-derivation-stream.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/http-derivation-stream.ts
@@ -56,21 +56,10 @@ const DEFAULT_HTTP_DEBOUNCE_MS = 300;
 /**
  * Creates an RxJS Observable stream that processes an HTTP derivation entry.
  *
- * Each HTTP derivation gets its own stream with:
- * - `debounceTime` to batch rapid changes
- * - `switchMap` to auto-cancel in-flight requests
- * - `catchError` inside the switchMap projection to prevent stream termination
- *
- * **Note:** The stream uses `startWith(null) → pairwise()` to detect changed fields.
- * This means the first form value emission (initial load) will fire an HTTP request
- * for all `dependsOn` fields, since every field appears "changed" relative to `null`.
- * This is intentional — it ensures derived values are populated on initial form load.
- *
  * @param entry - The derivation entry with HTTP configuration
  * @param formValue$ - Observable of form value changes
  * @param context - Context with HttpClient, logger, etc.
  * @returns Observable that applies HTTP-derived values to the form
- *
  * @internal
  */
 export function createHttpDerivationStream(

--- a/packages/dynamic-forms/src/lib/core/derivation/pipeline-setup-utils.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/pipeline-setup-utils.ts
@@ -64,17 +64,6 @@ interface BaseReactiveStreamOptions<TCollection extends ReactiveDerivationCollec
 /**
  * Options for the **onChange** reactive stream.
  *
- * The stream re-fires whenever either the derivation collection OR the form
- * value emits, debounced to a microtask boundary via `auditTime(0)`. Each
- * emission invokes `applyOnChange` with the current collection and the set of
- * field keys that changed since the previous emission — value-derivation uses
- * the changed set for `reEngageOnDependencyChange`; property-derivation
- * ignores it.
- *
- * `additionalAwakeners` is an optional array of signals whose changes should
- * also wake the stream (used by the value pipeline to also react to form
- * accessor changes during config swaps).
- *
  * @internal
  */
 export interface OnChangeStreamOptions<TCollection extends ReactiveDerivationCollection> extends BaseReactiveStreamOptions<TCollection> {
@@ -85,16 +74,6 @@ export interface OnChangeStreamOptions<TCollection extends ReactiveDerivationCol
 /**
  * Subscribe to the onChange reactive stream and route emissions through
  * `applyOnChange`. The pipeline:
- *
- * 1. `combineLatestWith` collection + formValue (+ any additional awakeners).
- * 2. `auditTime(0)` to batch synchronous signal updates that fire in the same
- *    microtask (e.g., when an exhaustMap consumer calls `value.set()`).
- * 3. `startWith(null) + pairwise()` to expose the previous value-tuple so we
- *    can compute the changed-fields set per emission.
- * 4. `exhaustMap` so re-entrant emissions (caused by the apply step setting
- *    values that propagate back through the form-value signal) are dropped
- *    rather than queued or cancelled. `scheduled([null], queueScheduler)`
- *    ensures the inner observable completes in the next microtask.
  *
  * @internal
  */
@@ -131,13 +110,6 @@ export function setupOnChangeStream<TCollection extends ReactiveDerivationCollec
 
 /**
  * Options for the **debounced** reactive stream.
- *
- * The debounced stream waits until form value stops changing for
- * `DEFAULT_DEBOUNCE_MS`, computes the changed-fields set vs. the prior
- * emission, then for each unique `debounceMs` period present in the
- * collection's `'debounced'`-triggered entries, runs `applyDebouncedForPeriod`
- * after the additional wait. Per-period streams are `merge`d so different
- * debounce groups process concurrently.
  *
  * @internal
  */
@@ -204,10 +176,6 @@ export function setupDebouncedStream<TCollection extends ReactiveDerivationColle
  * {@link buildEntryStreamPipeline}, filter to entries of the relevant kind,
  * key each emission by a stable signature so unrelated topological reorderings
  * don't churn subscriptions, and per-entry call the caller's `createStream`.
- *
- * The outer pipeline (filter + signature dedup + merge) is the same in all
- * four call sites (value/property × http/async). The `selectEntries`,
- * `entrySignature`, and `createStream` callbacks carry the only differences.
  *
  * @internal
  */

--- a/packages/dynamic-forms/src/lib/core/expressions/async-condition-function-cache.service.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/async-condition-function-cache.service.ts
@@ -1,15 +1,6 @@
 import { LogicFn } from '@angular/forms/signals';
 
-/**
- * DI-scoped cache for async condition logic functions.
- *
- * Replaces module-scoped WeakMaps to ensure SSR safety.
- * Scoped to the DynamicForm component via `provideDynamicFormDI()`.
- *
- * Note: Per-field signal stores are closure-scoped per LogicFn, not shared here,
- * because multiple async conditions on the same field share the same FieldContext
- * reference and would collide in a shared WeakMap.
- */
+/** DI-scoped cache for async condition logic functions. */
 export class AsyncConditionFunctionCacheService {
   /** Cache for async condition logic functions, keyed by serialized condition. */
   readonly asyncConditionFunctionCache = new Map<string, LogicFn<unknown, boolean>>();

--- a/packages/dynamic-forms/src/lib/core/expressions/async-condition-logic-function.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/async-condition-logic-function.ts
@@ -10,17 +10,7 @@ import { Logger } from '../../providers/features/logger/logger.interface';
 import { AsyncConditionFunctionCacheService } from './async-condition-function-cache.service';
 import { createDebouncedResourceLogicFn } from './debounced-resource-logic-fn';
 
-/**
- * Creates a logic function for an async condition.
- *
- * Delegates lifecycle (per-field signal store, debouncing, rxResource +
- * withPreviousValue) to {@link createDebouncedResourceLogicFn}; this function
- * just supplies the async-condition-specific bits: the trigger payload is
- * the FieldContext snapshot the loader needs to build its evaluation
- * context, and the stream invokes the registered or inline async function.
- *
- * Must be called in injection context (same as `createLogicFunction`).
- */
+/** Creates a logic function for an async condition. */
 export function createAsyncConditionLogicFunction<TValue>(condition: AsyncCondition): LogicFn<TValue, boolean> {
   const fieldContextRegistry = inject(FieldContextRegistryService);
   const functionRegistry = inject(FunctionRegistryService);

--- a/packages/dynamic-forms/src/lib/core/expressions/async-custom-function-types.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/async-custom-function-types.ts
@@ -1,45 +1,13 @@
 import { Observable } from 'rxjs';
 import { EvaluationContext } from '../../models/expressions/evaluation-context';
 
-/**
- * Async function for derivations — returns any value.
- *
- * The function receives the evaluation context and may return a Promise or Observable.
- * Register functions in `customFnConfig.asyncDerivations`.
- *
- * @example
- * ```typescript
- * const fetchPrice: AsyncDerivationFunction = async (context) => {
- *   const response = await fetch(`/api/price?product=${context.formValue.productId}`);
- *   const data = await response.json();
- *   return data.price;
- * };
- * ```
- *
- * @public
- */
+/** Async function for derivations — returns any value. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- default `any` allows AsyncDerivationFunction to accept any TFormValue without explicit generic
 export type AsyncDerivationFunction<TFormValue extends Record<string, unknown> = any> = (
   context: EvaluationContext<unknown, TFormValue>,
 ) => Promise<unknown> | Observable<unknown>;
 
-/**
- * Async function for conditions — returns boolean.
- *
- * The function receives the evaluation context and may return a Promise or Observable.
- * Register functions in `customFnConfig.asyncConditions`.
- *
- * @example
- * ```typescript
- * const checkPermission: AsyncConditionFunction = async (context) => {
- *   const response = await fetch(`/api/permissions?user=${context.formValue.userId}`);
- *   const data = await response.json();
- *   return data.canEdit;
- * };
- * ```
- *
- * @public
- */
+/** Async function for conditions — returns boolean. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- default `any` allows AsyncConditionFunction to accept any TFormValue without explicit generic
 export type AsyncConditionFunction<TFormValue extends Record<string, unknown> = any> = (
   context: EvaluationContext<unknown, TFormValue>,

--- a/packages/dynamic-forms/src/lib/core/expressions/custom-function-types.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/custom-function-types.ts
@@ -1,82 +1,18 @@
 import { EvaluationContext } from '../../models/expressions/evaluation-context';
 
-/**
- * Scope of a custom function.
- *
- * - `'field'`: Function only uses `fieldValue` (the current field's value).
- *              These functions are evaluated at field-level for better performance.
- * - `'form'`: Function may use `formValue` (access to other fields).
- *             These functions are hoisted to form-level evaluation.
- *
- * Default: `'form'` (conservative - assumes function may access other fields)
- */
+/** Scope of a custom function. */
 export type CustomFunctionScope = 'field' | 'form';
 
-/**
- * Options for registering a custom function.
- */
+/** Options for registering a custom function. */
 export interface CustomFunctionOptions {
   /**
    * The scope of the function.
    *
-   * - `'field'`: Function only uses `fieldValue` (no cross-field dependencies).
-   *              Use this when your function only reads the current field's value.
-   * - `'form'`: Function may use `formValue` (has cross-field dependencies).
-   *             This is the default, and ensures proper reactivity when accessing
-   *             other fields in the form.
-   *
    * @default 'form'
-   *
-   * @example
-   * ```typescript
-   * // Field-only function - only uses the current field value
-   * registry.registerCustomFunction('isEmpty', (ctx) => !ctx.fieldValue, { scope: 'field' });
-   *
-   * // Form-level function - accesses other fields (default)
-   * registry.registerCustomFunction('isAdult', (ctx) => ctx.formValue.age >= 18);
-   * ```
    */
   scope?: CustomFunctionScope;
 }
 
-/**
- * Custom function signature for conditional expressions
- *
- * Custom functions are used for conditional logic in:
- * - `when` conditions (field visibility, conditional validation)
- * - `readonly` logic (dynamic readonly state)
- * - `disabled` logic (dynamic disabled state)
- * - Dynamic value calculations
- *
- * Unlike validators, custom functions:
- * - Return any value (typically boolean for conditions, but could be strings, numbers, etc.)
- * - Do NOT return ValidationError objects
- * - Receive EvaluationContext (field values) not FieldContext (field state)
- *
- * @example
- * ```typescript
- * // Boolean condition function
- * const isAdult: CustomFunction = (ctx) => {
- *   return ctx.age >= 18;
- * };
- *
- * // Used in field configuration:
- * {
- *   key: 'alcoholPreference',
- *   type: 'select',
- *   when: { function: 'isAdult' }  // Only show if isAdult returns true
- * }
- * ```
- *
- * @example
- * ```typescript
- * // Calculation function
- * const calculateDiscount: CustomFunction = (ctx) => {
- *   const price = ctx.price || 0;
- *   const isVip = ctx.isVip || false;
- *   return isVip ? price * 0.8 : price * 0.9;
- * };
- * ```
- */
+/** Custom function signature for conditional expressions */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- default `any` allows CustomFunction to accept any TFormValue without explicit generic
 export type CustomFunction<TFormValue extends Record<string, unknown> = any> = (context: EvaluationContext<unknown, TFormValue>) => unknown;

--- a/packages/dynamic-forms/src/lib/core/expressions/debounced-resource-logic-fn.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/debounced-resource-logic-fn.ts
@@ -9,12 +9,6 @@ import { safeReadPathKeys } from '../../utils/safe-read-path-keys';
 /**
  * Trigger value carried through the debounced reactive pipeline.
  *
- * `key` is the stable identity used for `distinctUntilChanged` — the helper
- * skips a re-evaluation when the new key matches the prior one. `payload` is
- * the actual data the stream-builder consumes (an HTTP request, an
- * evaluation context, etc.) — it doesn't participate in the dedup so each
- * stream invocation receives the most-recently-set payload for its key.
- *
  * @internal
  */
 export interface Trigger<TPayload> {
@@ -77,25 +71,6 @@ interface ResourceHandle<TPayload, TResult> {
 
 /**
  * Shared scaffolding for both async-function and HTTP condition LogicFns.
- *
- * Encapsulates the pattern that was duplicated across the two files:
- *
- *   1. A per-field map keyed by `safeReadPathKeys(ctx).join('.')`. Each entry
- *      owns one trigger signal + one `rxResource` instance, kept alive for the
- *      lifetime of the LogicFn so the resource's loading/error state persists
- *      across LogicFn invocations.
- *   2. Resource construction wrapped in `untracked()` to avoid NG0602
- *      (resources can't be created inside a reactive consumer; LogicFn runs
- *      inside Angular Signal Forms' `BooleanOrLogic.compute`).
- *   3. The trigger signal feeds `derivedFromDeferred` with `debounceTime` +
- *      `distinctUntilChanged` (keyed by `Trigger.key`) so rapid form changes
- *      collapse into one stream invocation.
- *   4. `withPreviousValue` wraps the `rxResource` so consumers see the
- *      previous resolved value during re-fetch — prevents UI flicker.
- *
- * Caller supplies only the per-condition specifics via `config.resolve`
- * (early-return logic + how to derive the trigger from the FieldContext) and
- * `config.buildStream` (how to fetch fresh values for a trigger payload).
  *
  * @internal
  */

--- a/packages/dynamic-forms/src/lib/core/expressions/http-condition-function-cache.service.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/http-condition-function-cache.service.ts
@@ -1,15 +1,6 @@
 import { LogicFn } from '@angular/forms/signals';
 
-/**
- * DI-scoped cache for HTTP condition logic functions.
- *
- * Replaces module-scoped WeakMaps to ensure SSR safety.
- * Scoped to the DynamicForm component via `provideDynamicFormDI()`.
- *
- * Note: Per-field signal stores are closure-scoped per LogicFn, not shared here,
- * because multiple HTTP conditions on the same field share the same FieldContext
- * reference and would collide in a shared WeakMap.
- */
+/** DI-scoped cache for HTTP condition logic functions. */
 export class HttpConditionFunctionCacheService {
   /** Cache for HTTP condition logic functions, keyed by serialized condition. */
   readonly httpConditionFunctionCache = new Map<string, LogicFn<unknown, boolean>>();

--- a/packages/dynamic-forms/src/lib/core/expressions/http-condition-logic-function.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/http-condition-logic-function.ts
@@ -42,17 +42,7 @@ function extractBoolean(response: unknown, responseExpression: string | undefine
   return !!response;
 }
 
-/**
- * Creates a logic function for an HTTP condition.
- *
- * Delegates lifecycle (per-field signal store, debouncing, rxResource +
- * withPreviousValue) to {@link createDebouncedResourceLogicFn}; this function
- * just supplies the HTTP-specific bits: the trigger payload is the resolved
- * `HttpResourceRequest`, the stream fires the request, and the resolver
- * short-circuits via the response-cache before the resource gets touched.
- *
- * Must be called in injection context (same as `createLogicFunction`).
- */
+/** Creates a logic function for an HTTP condition. */
 export function createHttpConditionLogicFunction<TValue>(condition: HttpCondition): LogicFn<TValue, boolean> {
   const httpClient = inject(HttpClient, { optional: true });
   if (!httpClient) {

--- a/packages/dynamic-forms/src/lib/core/expressions/logic-function-cache.service.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/logic-function-cache.service.ts
@@ -1,20 +1,13 @@
 import { Signal, WritableSignal } from '@angular/core';
 import { LogicFn } from '@angular/forms/signals';
 
-/**
- * Per-field debounced signal pair.
- */
+/** Per-field debounced signal pair. */
 interface DebouncedSignalPair {
   immediateValue: WritableSignal<boolean>;
   debouncedValue: Signal<boolean | undefined>;
 }
 
-/**
- * DI-scoped cache for logic functions and debounced signals.
- *
- * Replaces module-scoped WeakMaps to ensure SSR safety.
- * Scoped to the DynamicForm component via `provideDynamicFormDI()`.
- */
+/** DI-scoped cache for logic functions and debounced signals. */
 export class LogicFunctionCacheService {
   /** Cache for memoized logic functions, keyed by serialized expression. */
   readonly logicFunctionCache = new Map<string, LogicFn<unknown, boolean>>();

--- a/packages/dynamic-forms/src/lib/core/expressions/logic-function-factory.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/logic-function-factory.ts
@@ -36,15 +36,6 @@ function validateNoNestedHttpConditions(expression: ConditionalExpression): void
 /**
  * Create a logic function from a conditional expression.
  *
- * This function is used for creating logic functions for hidden, readonly, disabled, and required.
- * It uses the REACTIVE evaluation context, which allows the logic function to create
- * reactive dependencies on form values. When dependent fields change, the logic function
- * will be automatically re-evaluated.
- *
- * NOTE: For validators, use createEvaluationContext directly (with untracked) to prevent
- * infinite reactive loops. Validators with cross-field dependencies should be hoisted
- * to form-level using validateTree.
- *
  * @param expression The conditional expression to evaluate
  * @returns A LogicFn that evaluates the condition in the context of a field
  */
@@ -93,10 +84,6 @@ export function createLogicFunction<TValue>(expression: ConditionalExpression): 
 
 /**
  * Create a debounced logic function from a conditional expression.
- *
- * This function wraps the condition evaluation in a debounce mechanism,
- * so state changes only take effect after the specified delay.
- * Useful for avoiding UI flicker during rapid typing.
  *
  * @param expression The conditional expression to evaluate
  * @param debounceMs The debounce duration in milliseconds

--- a/packages/dynamic-forms/src/lib/core/expressions/parser/evaluator.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/parser/evaluator.ts
@@ -1,29 +1,11 @@
 import { ASTNode, ExpressionParserError } from './types';
 
-/**
- * Evaluation context for safe expression evaluation
- */
+/** Evaluation context for safe expression evaluation */
 export interface EvaluationScope {
   [key: string]: unknown;
 }
 
-/**
- * Security Model: Whitelist-only approach for method calls
- *
- * A method is considered SAFE if it meets ALL criteria:
- * 1. Pure data access/transformation (no side effects)
- * 2. No code execution capabilities
- * 3. No global state modification
- * 4. No prototype chain modification
- * 5. No information disclosure about system internals
- *
- * Methods NOT included (unsafe):
- * - constructor: Could enable code execution via Function constructor
- * - valueOf: Could enable type confusion attacks
- * - __proto__, __defineGetter__, etc: Direct prototype manipulation
- * - hasOwnProperty, isPrototypeOf, propertyIsEnumerable: Leak object structure
- * - toLocaleString: Could expose locale/system information
- */
+/** Security Model: Whitelist-only approach for method calls */
 
 /**
  * Type-safe method whitelists derived from TypeScript primitive types
@@ -132,9 +114,7 @@ const BLOCKED_PROPERTIES = new Set<string>([
   '__lookupSetter__',
 ]);
 
-/**
- * Safely evaluates an AST node with a given context
- */
+/** Safely evaluates an AST node with a given context */
 export class Evaluator {
   private readonly scope: EvaluationScope;
   private readonly expression: string;
@@ -144,9 +124,7 @@ export class Evaluator {
     this.expression = expression;
   }
 
-  /**
-   * Evaluate an AST node
-   */
+  /** Evaluate an AST node */
   evaluate(node: ASTNode): unknown {
     switch (node.type) {
       case 'Literal':

--- a/packages/dynamic-forms/src/lib/core/expressions/parser/expression-parser.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/parser/expression-parser.ts
@@ -2,9 +2,7 @@ import { Parser } from './parser';
 import { Evaluator, EvaluationScope } from './evaluator';
 import { ASTNode, ExpressionParserError } from './types';
 
-/**
- * Maximum cache size to prevent memory issues
- */
+/** Maximum cache size to prevent memory issues */
 const MAX_AST_CACHE_SIZE = 1000;
 
 /**
@@ -56,20 +54,10 @@ class LRUCache<K, V> {
   }
 }
 
-/**
- * Cache for parsed AST nodes to improve performance
- */
+/** Cache for parsed AST nodes to improve performance */
 const astCache = new LRUCache<string, ASTNode>(MAX_AST_CACHE_SIZE);
 
-/**
- * Secure expression parser that uses AST-based evaluation
- *
- * This parser provides:
- * - Security: No arbitrary code execution, only whitelisted operations
- * - Performance: AST caching for repeated expressions
- * - Better errors: Clear error messages with position information
- * - Type safety: Strongly typed AST and evaluation
- */
+/** Secure expression parser that uses AST-based evaluation */
 export class ExpressionParser {
   /**
    * Parse an expression string into an AST
@@ -92,9 +80,7 @@ export class ExpressionParser {
     return ast;
   }
 
-  /**
-   * Evaluate an expression with a given scope
-   */
+  /** Evaluate an expression with a given scope */
   static evaluate(expression: string, scope: EvaluationScope): unknown {
     try {
       const ast = this.parse(expression);
@@ -113,16 +99,12 @@ export class ExpressionParser {
     }
   }
 
-  /**
-   * Clear the AST cache
-   */
+  /** Clear the AST cache */
   static clearCache(): void {
     astCache.clear();
   }
 
-  /**
-   * Get cache statistics
-   */
+  /** Get cache statistics */
   static getCacheStats(): { size: number; maxSize: number } {
     return {
       size: astCache.size,

--- a/packages/dynamic-forms/src/lib/core/expressions/parser/parser.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/parser/parser.ts
@@ -14,9 +14,7 @@ export class Parser {
     this.expression = expression;
   }
 
-  /**
-   * Parse the expression into an AST
-   */
+  /** Parse the expression into an AST */
   parse(): ASTNode {
     const tokenizer = new Tokenizer(this.expression);
     this.tokens = tokenizer.tokenize();
@@ -65,14 +63,6 @@ export class Parser {
   /**
    * Attempts to parse an arrow function. Returns null and leaves position
    * unchanged if the next tokens don't form an arrow function head.
-   *
-   * Supported shapes:
-   *   x => body
-   *   () => body
-   *   (x) => body
-   *   (x, y, ...) => body
-   *
-   * Body returning an object literal must be wrapped in parens: `d => ({...})`.
    */
   private tryParseArrowFunction(): ASTNode | null {
     const savedPos = this.current;

--- a/packages/dynamic-forms/src/lib/core/expressions/parser/tokenizer.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/parser/tokenizer.ts
@@ -1,8 +1,6 @@
 import { Token, TokenType, ExpressionParserError } from './types';
 
-/**
- * Tokenizes an expression string into tokens
- */
+/** Tokenizes an expression string into tokens */
 export class Tokenizer {
   private position = 0;
   private readonly expression: string;
@@ -11,9 +9,7 @@ export class Tokenizer {
     this.expression = expression;
   }
 
-  /**
-   * Tokenize the entire expression
-   */
+  /** Tokenize the entire expression */
   tokenize(): Token[] {
     const tokens: Token[] = [];
 

--- a/packages/dynamic-forms/src/lib/core/expressions/parser/types.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/parser/types.ts
@@ -1,8 +1,6 @@
 import { DynamicFormError } from '../../../errors/dynamic-form-error';
 
-/**
- * Token types for expression parsing
- */
+/** Token types for expression parsing */
 export enum TokenType {
   // Literals
   NUMBER = 'NUMBER',
@@ -53,18 +51,14 @@ export enum TokenType {
   EOF = 'EOF',
 }
 
-/**
- * Token with type, value, and position
- */
+/** Token with type, value, and position */
 export interface Token {
   type: TokenType;
   value: string;
   position: number;
 }
 
-/**
- * AST Node types
- */
+/** AST Node types */
 export type ASTNode =
   | LiteralNode
   | IdentifierNode
@@ -149,9 +143,7 @@ export interface ArrowFunctionNode {
   body: ASTNode;
 }
 
-/**
- * Parser error with position information
- */
+/** Parser error with position information */
 export class ExpressionParserError extends DynamicFormError {
   constructor(
     message: string,

--- a/packages/dynamic-forms/src/lib/core/expressions/value-utils.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/value-utils.ts
@@ -1,34 +1,10 @@
 /**
  * Compares two values using the specified comparison operator.
  *
- * Supports various comparison types including equality, numerical comparisons,
- * string operations, and regular expression matching. Type coercion is applied
- * for numerical and string operations as needed.
- *
  * @param actual - The value to compare
  * @param expected - The value to compare against
  * @param operator - Comparison operator to use
  * @returns True if the comparison succeeds, false otherwise
- *
- * @example
- * ```typescript
- * // Equality checks
- * compareValues(10, 10, 'equals')        // true
- * compareValues('test', 'other', 'notEquals') // true
- *
- * // Numerical comparisons
- * compareValues(15, 10, 'greater')       // true
- * compareValues('5', 3, 'greaterOrEqual') // true (coerced to numbers)
- *
- * // String operations
- * compareValues('hello world', 'world', 'contains')   // true
- * compareValues('prefix-test', 'prefix', 'startsWith') // true
- * compareValues('test.jpg', '.jpg', 'endsWith')       // true
- *
- * // Regular expression matching
- * compareValues('test123', '^test\\d+$', 'matches')    // true
- * compareValues('invalid', '[invalid', 'matches')      // false (invalid regex)
- * ```
  */
 export function compareValues(actual: unknown, expected: unknown, operator: string): boolean {
   switch (operator) {
@@ -64,32 +40,9 @@ export function compareValues(actual: unknown, expected: unknown, operator: stri
 /**
  * Retrieves a nested value from an object using dot notation path.
  *
- * Safely traverses object properties using a dot-separated path string.
- * Returns undefined if any part of the path is missing or if the traversal
- * encounters a non-object value.
- *
  * @param obj - The object to traverse
  * @param path - Dot-separated path to the desired property
  * @returns The value at the specified path, or undefined if not found
- *
- * @example
- * ```typescript
- * const data = {
- *   user: {
- *     profile: {
- *       name: 'John',
- *       age: 30
- *     },
- *     settings: { theme: 'dark' }
- *   }
- * };
- *
- * getNestedValue(data, 'user.profile.name')  // 'John'
- * getNestedValue(data, 'user.settings.theme') // 'dark'
- * getNestedValue(data, 'user.profile.email')  // undefined
- * getNestedValue(data, 'nonexistent.path')    // undefined
- * getNestedValue(null, 'any.path')            // undefined
- * ```
  */
 export function getNestedValue(obj: unknown, path: string): unknown {
   return path.split('.').reduce((current: unknown, key: string) => {
@@ -99,9 +52,6 @@ export function getNestedValue(obj: unknown, path: string): unknown {
 
 /**
  * Checks whether a nested property exists in an object using dot notation path.
- *
- * Unlike `getNestedValue`, this distinguishes between a property that exists
- * with value `undefined` and a property path that doesn't exist at all.
  *
  * @param obj - The object to check
  * @param path - Dot-separated path to the property

--- a/packages/dynamic-forms/src/lib/core/field-tree-mapping-context.ts
+++ b/packages/dynamic-forms/src/lib/core/field-tree-mapping-context.ts
@@ -7,19 +7,6 @@ import { createLogicFunction } from './expressions/logic-function-factory';
 /**
  * Cascading configuration that flows from parent to child during schema mapping.
  *
- * Each property here represents a setting whose effective value is
- *
- * 1. read from the field itself if defined,
- * 2. otherwise inherited from the parent's resolved value,
- * 3. otherwise the form-level value (root parent),
- * 4. otherwise the global default (used to seed the root context).
- *
- * Once a field overrides a value, the new value becomes the inherited baseline
- * for all of its descendants unless they override in turn.
- *
- * Add new cascading options here rather than threading additional parameters
- * through `mapFieldToForm` and friends.
- *
  * @internal
  */
 export interface FieldTreeMappingContext {
@@ -67,9 +54,6 @@ export function combineAncestorHiddenLogics(logics: readonly LogicFn<unknown, bo
  * Forms already exposes that through `ctx.state.hidden()`, which the gate
  * checks separately.
  *
- * Returns the parent context unchanged when the field defines no overrides —
- * saves an allocation on every leaf in the common case.
- *
  * @internal
  */
 export function resolveFieldOwnContext(
@@ -89,13 +73,6 @@ export function resolveFieldOwnContext(
  * Builds on top of `ownContext` by folding in the field's own hidden state so
  * children can correctly skip validation when this field hides them. Used for
  * groups, arrays, and layout containers that recurse into children.
- *
- * Behavior:
- * - `hidden: true` (static) → sets `ancestorAlwaysHidden`.
- * - `logic: [{type: 'hidden', condition: true}]` → sets `ancestorAlwaysHidden`.
- * - `logic: [{type: 'hidden', condition: false}]` → no effect.
- * - `logic: [{type: 'hidden', condition: <expr>}]` → appends a reactive
- *   `LogicFn` to `ancestorHiddenLogics`.
  *
  * @internal
  */

--- a/packages/dynamic-forms/src/lib/core/field-tree-utils.ts
+++ b/packages/dynamic-forms/src/lib/core/field-tree-utils.ts
@@ -1,13 +1,7 @@
 import { InjectionToken, Signal } from '@angular/core';
 import { FieldTree } from '@angular/forms/signals';
 
-/**
- * Represents a FieldTree node for dynamic bracket-access navigation.
- *
- * TypeScript's `Subfields<T>` type on `FieldTree` only allows statically-known keys,
- * but at runtime the form tree supports arbitrary string key access (e.g., `rootForm['address']`).
- * This type makes that dynamic access explicit: each string key maps to a `FieldTree | undefined`.
- */
+/** Represents a FieldTree node for dynamic bracket-access navigation. */
 export type FieldTreeRecord = Record<string, FieldTree<unknown> | undefined>;
 
 /**
@@ -18,25 +12,13 @@ export type ArrayFieldTree<T> = FieldTree<T[]> & {
   readonly [index: number]: FieldTree<T> | undefined;
 };
 
-/**
- * Get the length of an array FieldTree.
- */
+/** Get the length of an array FieldTree. */
 export function getArrayLength<T>(arrayFieldTree: ArrayFieldTree<T>): number {
   const value = arrayFieldTree().value();
   return Array.isArray(value) ? value.length : 0;
 }
 
-/**
- * Read-only view of a single field's observable state.
- *
- * Whitelisted read signals copied from Angular Signal Forms' `FieldState` so wrappers
- * can observe a field without being able to mutate it. New write-capable members
- * added in future Angular versions are excluded by default (the `Pick` list stays
- * the source of truth).
- *
- * `value` is narrowed from `WritableSignal<TValue>` to `Signal<TValue>` so consumers
- * cannot write through it.
- */
+/** Read-only view of a single field's observable state. */
 export interface ReadonlyFieldTree<TValue = unknown> {
   readonly value: Signal<TValue>;
   readonly valid: Signal<boolean>;

--- a/packages/dynamic-forms/src/lib/core/form-mapping.ts
+++ b/packages/dynamic-forms/src/lib/core/form-mapping.ts
@@ -140,14 +140,6 @@ function getNumberValidationConfig(fieldDef: FieldWithValidation): NumberValidat
 /**
  * Maps a field definition to the Angular Signal Forms schema.
  *
- * This is the main entry point that should be called from the dynamic form component.
- * It handles all field types: leaf fields, containers (page, row, group), and arrays.
- *
- * Cross-field logic (formValue.*) is handled automatically by createLogicFunction
- * which uses RootFormRegistryService.
- *
- * Cross-field validators are skipped at field level and applied at form level via validateTree.
- *
  * @param fieldDef Field definition to map
  * @param fieldPath Schema path for this field
  * @param inheritedContext Cascading mapping context from the parent. Field-level
@@ -193,15 +185,7 @@ export function mapFieldToForm(
   mapLeafField(fieldDef, fieldPath, ownContext);
 }
 
-/**
- * Maps children of a container field (page, row, group) to the form schema.
- *
- * Layout containers (page/row/container) flatten into `parentPath` and are
- * recursed through without consuming a key — same contract as `mapFieldToForm`'s
- * top-level layout branch, so any depth of layout-container nesting reaches its
- * leaf descendants. Group/array fields consume their key and look up their own
- * child path on `parentPath`.
- */
+/** Maps children of a container field (page, row, group) to the form schema. */
 function mapContainerChildren(
   fields: readonly FieldDef<unknown>[] | undefined,
   parentPath: AnySchemaPath,
@@ -339,9 +323,7 @@ function applySimpleValidationRules(fieldDef: FieldWithValidation, path: SchemaP
   }
 }
 
-/**
- * Applies field state configuration (disabled, readonly, hidden).
- */
+/** Applies field state configuration (disabled, readonly, hidden). */
 function applyFieldState(fieldDef: FieldDef<unknown>, path: SchemaPath<unknown>): void {
   if (fieldDef.disabled) {
     disabled(path);
@@ -356,20 +338,7 @@ function applyFieldState(fieldDef: FieldDef<unknown>, path: SchemaPath<unknown>)
   }
 }
 
-/**
- * Maps an array field to the form schema using applyEach.
- *
- * Supports two item formats:
- * - Primitive items: single FieldDef (not wrapped in array) → primitive value schema
- * - Object items: FieldDef[] (array of fields) → object schema with field keys
- *
- * Supports:
- * - Empty arrays (fields: []) - no initial items, add via buttons
- * - Primitive arrays - simple value lists like ['tag1', 'tag2']
- * - Object arrays - structured items like [{ name: 'Alice', email: '...' }]
- * - Heterogeneous arrays - mixed primitives and objects
- * - Container templates (row, group, page) that wrap children
- */
+/** Maps an array field to the form schema using applyEach. */
 function mapArrayFieldToForm(arrayField: FieldDef<unknown>, fieldPath: AnySchemaPath, context: FieldTreeMappingContext): void {
   if (!isArrayField(arrayField)) {
     return;

--- a/packages/dynamic-forms/src/lib/core/form-schema-merger.ts
+++ b/packages/dynamic-forms/src/lib/core/form-schema-merger.ts
@@ -7,19 +7,14 @@ import { isStandardSchemaMarker, type FormSchema } from '@ng-forge/dynamic-forms
  * Applies a form-level schema validation to a schema path.
  * Supports both Standard Schema (Zod, Valibot, ArkType) and raw Angular schema callbacks.
  *
- * This is a helper function used internally by `createSchemaFromFields`
- * to apply form-level validation after field-level validation.
- *
  * @typeParam TModel - The form value type
  * @param path - The schema path to validate (from Angular's schema callback)
  * @param formLevelSchema - Form-level schema (Standard Schema marker or Angular callback)
- *
  * @remarks
  * Type assertions are required due to Angular's complex generic constraints:
  * - `validateStandardSchema` uses `IgnoreUnknownProperties<TSchema>` to accommodate Zod's strict types
  * - `SchemaPathTree` includes `SchemaPath` via conditional types that TypeScript can't narrow
  * These assertions are safe because the path originates from Angular's schema() function.
- *
  * @internal
  */
 export function applyFormLevelSchema<TModel>(path: SchemaPathTree<TModel>, formLevelSchema: FormSchema<TModel>): void {
@@ -39,26 +34,9 @@ export function applyFormLevelSchema<TModel>(path: SchemaPathTree<TModel>, formL
 /**
  * Creates a schema from only form-level schema (when no field-level schema exists).
  *
- * Use this when the form has fields without validation rules but still
- * needs form-level validation via a Standard Schema.
- *
  * @typeParam TModel - The form value type
  * @param formLevelSchema - Form-level Standard Schema
  * @returns Schema that applies form-level validation
- *
- * @example
- * ```typescript
- * import { z } from 'zod';
- * import { standardSchema } from '@ng-forge/dynamic-forms/schema';
- *
- * const FormSchema = z.object({
- *   email: z.string().email(),
- *   password: z.string().min(8),
- * });
- *
- * // Create schema from form-level schema only
- * const formSchema = createFormLevelSchema(standardSchema(FormSchema));
- * ```
  */
 export function createFormLevelSchema<TModel>(formLevelSchema: FormSchema<TModel>): Schema<TModel> {
   return schema<TModel>((path) => {

--- a/packages/dynamic-forms/src/lib/core/http/http-condition-cache.ts
+++ b/packages/dynamic-forms/src/lib/core/http/http-condition-cache.ts
@@ -5,16 +5,7 @@ interface CacheEntry {
   expiresAt: number;
 }
 
-/**
- * TTL cache for HTTP condition responses with max entries eviction.
- *
- * Keyed by serialized resolved request (the `HttpResourceRequest` after expression evaluation).
- * Two different form states producing the same resolved URL+body hit the same cache entry.
- *
- * When `maxEntries` is exceeded, the oldest entry (by insertion order) is evicted.
- *
- * Provided via DI (scoped to DynamicForm component) for SSR safety.
- */
+/** TTL cache for HTTP condition responses with max entries eviction. */
 export class HttpConditionCache {
   private readonly cache = new Map<string, CacheEntry>();
   private readonly maxEntries: number;

--- a/packages/dynamic-forms/src/lib/core/http/http-request-resolver.ts
+++ b/packages/dynamic-forms/src/lib/core/http/http-request-resolver.ts
@@ -6,12 +6,6 @@ import { ExpressionParser } from '../expressions/parser/expression-parser';
 /**
  * Resolves an `HttpRequestConfig` into an `HttpResourceRequest` by evaluating
  * expression-based query params and (optionally) body values.
- *
- * Returns `null` if any path parameter resolves to `undefined` or `null`,
- * signaling that the request should be suppressed (the URL would be malformed).
- *
- * `debounceMs` is intentionally ignored — it's used by HTTP derivations/conditions (PRs 3-4),
- * not by validators.
  */
 export function resolveHttpRequest(config: HttpRequestConfig, context: EvaluationContext): HttpResourceRequest | null {
   let url = config.url;

--- a/packages/dynamic-forms/src/lib/core/http/http-response-evaluator.ts
+++ b/packages/dynamic-forms/src/lib/core/http/http-response-evaluator.ts
@@ -3,15 +3,7 @@ import { HttpValidationResponseMapping } from '../../models/http/http-response-m
 import { Logger } from '../../providers/features/logger/logger.interface';
 import { ExpressionParser } from '../expressions/parser/expression-parser';
 
-/**
- * Evaluates an HTTP response against a `HttpValidationResponseMapping` to produce a validation result.
- *
- * - `validWhen` === `true` → `null` (valid, no error)
- * - `validWhen` !== `true` → `{ kind: errorKind, ...evaluatedErrorParams }`
- * - Expression error → logs warning, returns `{ kind: errorKind }` (fail-closed)
- *
- * Expressions are evaluated with scope `{ response }` only.
- */
+/** Evaluates an HTTP response against a `HttpValidationResponseMapping` to produce a validation result. */
 export function evaluateHttpValidationResponse(
   response: unknown,
   mapping: HttpValidationResponseMapping,

--- a/packages/dynamic-forms/src/lib/core/logic/logic-applicator.ts
+++ b/packages/dynamic-forms/src/lib/core/logic/logic-applicator.ts
@@ -15,9 +15,7 @@ import { DynamicFormError } from '../../errors/dynamic-form-error';
 
 type AnyLogicFn<TValue> = LogicFn<TValue, boolean> | (() => boolean);
 
-/**
- * Extracts the trigger from a StateLogicConfig, handling the discriminated union.
- */
+/** Extracts the trigger from a StateLogicConfig, handling the discriminated union. */
 function getConfigTrigger(config: LogicConfig): LogicTrigger {
   if (!isStateLogicConfig(config)) {
     return 'onChange';
@@ -25,9 +23,7 @@ function getConfigTrigger(config: LogicConfig): LogicTrigger {
   return config.trigger ?? 'onChange';
 }
 
-/**
- * Extracts debounceMs from a StateLogicConfig if trigger is 'debounced'.
- */
+/** Extracts debounceMs from a StateLogicConfig if trigger is 'debounced'. */
 function getConfigDebounceMs(config: LogicConfig): number | undefined {
   if (!isStateLogicConfig(config)) {
     return undefined;

--- a/packages/dynamic-forms/src/lib/core/logic/non-field-logic-resolver.ts
+++ b/packages/dynamic-forms/src/lib/core/logic/non-field-logic-resolver.ts
@@ -21,11 +21,7 @@ const noOpLogger: Logger = {
   error: () => {},
 };
 
-/**
- * Context for resolving button disabled state.
- *
- * @public
- */
+/** Context for resolving button disabled state. */
 export interface ButtonLogicContext {
   /** The form's FieldTree instance (supports both string and number keys for array indices) */
   form: FieldTree<unknown, string | number>;
@@ -53,31 +49,16 @@ export interface ButtonLogicContext {
  * Allowed logic types for non-form-bound elements (buttons, text fields, etc.).
  * These elements only support hidden and disabled states - not readonly or required
  * since they don't participate in form validation.
- *
- * @public
  */
 export type NonFieldLogicType = 'hidden' | 'disabled';
 
 /**
  * Logic config restricted to types valid for non-form-bound elements.
  * This is a subset of LogicConfig that only includes hidden and disabled types.
- *
- * @public
  */
 export type NonFieldLogicConfig = LogicConfig & { type: NonFieldLogicType };
 
-/**
- * Context for resolving state (hidden/disabled) for non-form-bound elements.
- *
- * This is a generalized context that can be used by any field mapper (buttons, text fields,
- * or any non-form-bound elements) to evaluate logic from a `logic` array.
- *
- * Note: While this context accepts the full `LogicConfig[]` for flexibility, the resolver
- * functions only process hidden and disabled types. Other logic types (readonly, required,
- * derivation) are ignored for non-form-bound elements.
- *
- * @public
- */
+/** Context for resolving state (hidden/disabled) for non-form-bound elements. */
 export interface NonFieldLogicContext {
   /** The form's FieldTree instance (supports both string and number keys for array indices) */
   form: FieldTree<unknown, string | number>;
@@ -98,17 +79,13 @@ export interface NonFieldLogicContext {
   logger?: Logger;
 }
 
-/**
- * Default options for submit button disabled behavior.
- */
+/** Default options for submit button disabled behavior. */
 const DEFAULT_SUBMIT_BUTTON_OPTIONS: Required<SubmitButtonOptions> = {
   disableWhenInvalid: true,
   disableWhileSubmitting: true,
 };
 
-/**
- * Default options for next button disabled behavior.
- */
+/** Default options for next button disabled behavior. */
 const DEFAULT_NEXT_BUTTON_OPTIONS: Required<NextButtonOptions> = {
   disableWhenPageInvalid: true,
   disableWhileSubmitting: true,
@@ -228,28 +205,8 @@ function evaluateLogicOfType(
 /**
  * Resolves the disabled state for a submit button.
  *
- * The disabled state is determined by (in order of precedence):
- * 1. Explicit `disabled: true` on the field definition
- * 2. Field-level `logic` array (if present, overrides form-level defaults)
- * 3. Form-level `options.submitButton` defaults
- *
  * @param ctx - The button logic context
  * @returns A computed signal that returns true when the button should be disabled
- *
- * @example
- * ```typescript
- * const disabled = resolveSubmitButtonDisabled({
- *   form: formInstance,
- *   formOptions: config.options,
- *   fieldLogic: buttonField.logic,
- *   explicitlyDisabled: buttonField.disabled,
- * });
- *
- * // Use in template
- * <button [disabled]="disabled()">Submit</button>
- * ```
- *
- * @public
  */
 export function resolveSubmitButtonDisabled(ctx: ButtonLogicContext): Signal<boolean> {
   return computed(() => {
@@ -286,26 +243,8 @@ export function resolveSubmitButtonDisabled(ctx: ButtonLogicContext): Signal<boo
 /**
  * Resolves the disabled state for a next page button.
  *
- * The disabled state is determined by (in order of precedence):
- * 1. Explicit `disabled: true` on the field definition
- * 2. Field-level `logic` array (if present, overrides form-level defaults)
- * 3. Form-level `options.nextButton` defaults
- *
  * @param ctx - The button logic context
  * @returns A computed signal that returns true when the button should be disabled
- *
- * @example
- * ```typescript
- * const disabled = resolveNextButtonDisabled({
- *   form: formInstance,
- *   formOptions: config.options,
- *   fieldLogic: buttonField.logic,
- *   explicitlyDisabled: buttonField.disabled,
- *   currentPageValid: pageOrchestrator.currentPageValid,
- * });
- * ```
- *
- * @public
  */
 export function resolveNextButtonDisabled(ctx: ButtonLogicContext): Signal<boolean> {
   return computed(() => {
@@ -342,17 +281,8 @@ export function resolveNextButtonDisabled(ctx: ButtonLogicContext): Signal<boole
 /**
  * Evaluates the hidden state for non-form-bound elements synchronously.
  *
- * This is a pure function (no signal allocation) that can be called directly inside
- * an existing `computed()` block without creating ephemeral signal allocations.
- *
- * The hidden state is determined by (in order of precedence):
- * 1. Explicit `hidden: true` on the field definition
- * 2. Field-level `logic` array with `type: 'hidden'` conditions
- *
  * @param ctx - The context containing form, logic array, and explicit hidden state
  * @returns true when the element should be hidden
- *
- * @public
  */
 export function evaluateNonFieldHidden(ctx: NonFieldLogicContext): boolean {
   // 1. Explicit hidden always wins
@@ -376,14 +306,8 @@ export function evaluateNonFieldHidden(ctx: NonFieldLogicContext): boolean {
 /**
  * Resolves the hidden state for non-form-bound elements as a reactive signal.
  *
- * Wraps {@link evaluateNonFieldHidden} in a `computed()` for use cases where a standalone
- * signal is needed. When calling from inside an existing `computed()`, prefer
- * {@link evaluateNonFieldHidden} directly to avoid ephemeral signal allocation.
- *
  * @param ctx - The context containing form, logic array, and explicit hidden state
  * @returns A computed signal that returns true when the element should be hidden
- *
- * @public
  */
 export function resolveNonFieldHidden(ctx: NonFieldLogicContext): Signal<boolean> {
   return computed(() => evaluateNonFieldHidden(ctx));
@@ -392,17 +316,8 @@ export function resolveNonFieldHidden(ctx: NonFieldLogicContext): Signal<boolean
 /**
  * Evaluates the disabled state for non-form-bound elements synchronously.
  *
- * This is a pure function (no signal allocation) that can be called directly inside
- * an existing `computed()` block without creating ephemeral signal allocations.
- *
- * The disabled state is determined by (in order of precedence):
- * 1. Explicit `disabled: true` on the field definition
- * 2. Field-level `logic` array with `type: 'disabled'` conditions
- *
  * @param ctx - The context containing form, logic array, and explicit disabled state
  * @returns true when the element should be disabled
- *
- * @public
  */
 export function evaluateNonFieldDisabled(ctx: NonFieldLogicContext): boolean {
   // 1. Explicit disabled always wins
@@ -426,14 +341,8 @@ export function evaluateNonFieldDisabled(ctx: NonFieldLogicContext): boolean {
 /**
  * Resolves the disabled state for non-form-bound elements as a reactive signal.
  *
- * Wraps {@link evaluateNonFieldDisabled} in a `computed()` for use cases where a standalone
- * signal is needed. When calling from inside an existing `computed()`, prefer
- * {@link evaluateNonFieldDisabled} directly to avoid ephemeral signal allocation.
- *
  * @param ctx - The context containing form, logic array, and explicit disabled state
  * @returns A computed signal that returns true when the element should be disabled
- *
- * @public
  */
 export function resolveNonFieldDisabled(ctx: NonFieldLogicContext): Signal<boolean> {
   return computed(() => evaluateNonFieldDisabled(ctx));

--- a/packages/dynamic-forms/src/lib/core/page-orchestrator/page-orchestrator.component.ts
+++ b/packages/dynamic-forms/src/lib/core/page-orchestrator/page-orchestrator.component.ts
@@ -22,28 +22,6 @@ import { isRowField } from '../../definitions/default/row-field';
  * PageOrchestrator manages page navigation and visibility for paged forms.
  * It acts as an intermediary between the DynamicForm component and PageField components,
  * handling page state management and navigation events without interfering with form data.
- *
- * This component uses declarative rendering with @defer blocks for optimal performance,
- * ensuring that non-visible pages are lazily loaded only when needed.
- *
- * Key responsibilities:
- * - Manage current page index state
- * - Handle navigation events (next/previous)
- * - Declaratively render pages with deferred loading
- * - Emit page change events
- * - Validate navigation boundaries
- *
- * @example
- * ```html
- * <div page-orchestrator
- *   [pageFields]="pageFields"
- *   [form]="form"
- *   [fieldSignalContext]="fieldSignalContext"
- *   [config]="orchestratorConfig"
- *   (pageChanged)="onPageChanged($event)"
- *   (navigationStateChanged)="onNavigationStateChanged($event)">
- * </div>
- * ```
  */
 @Component({
   selector: 'div[page-orchestrator]',
@@ -103,9 +81,7 @@ export class PageOrchestratorComponent {
   private readonly functionRegistry = inject(FunctionRegistryService);
   private readonly formOptions = inject(FORM_OPTIONS, { optional: true });
 
-  /**
-   * Array of page field definitions to render
-   */
+  /** Array of page field definitions to render */
   pageFields = input.required<PageField[]>();
 
   /**
@@ -114,9 +90,7 @@ export class PageOrchestratorComponent {
    */
   form = input.required<FieldTree<unknown>>();
 
-  /**
-   * Field signal context for child fields
-   */
+  /** Field signal context for child fields */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- FieldSignalContext is contravariant in TModel, using any allows accepting any form type
   fieldSignalContext = input.required<FieldSignalContext<any>>();
 
@@ -146,10 +120,6 @@ export class PageOrchestratorComponent {
   /**
    * Internal signal for current page index that tracks with page fields.
    * This tracks the actual page index, not the visible page index.
-   *
-   * Note: We only track pageFields().length to handle page additions/removals.
-   * The hidden state changes should NOT reset the current page index -
-   * that would cause unwanted navigation when form values change.
    */
   private readonly currentPageIndex = linkedSignal(() => {
     const totalPages = this.pageFields().length;
@@ -160,9 +130,7 @@ export class PageOrchestratorComponent {
     return 0;
   });
 
-  /**
-   * Computed state for the orchestrator
-   */
+  /** Computed state for the orchestrator */
   readonly state = computed<PageOrchestratorState>(() => {
     const currentIndex = this.currentPageIndex();
     const totalPages = this.pageFields().length;
@@ -184,10 +152,6 @@ export class PageOrchestratorComponent {
 
   /**
    * Signal indicating whether all fields on the current page are valid.
-   *
-   * This is used by next page buttons to determine their disabled state.
-   * Returns `true` if all fields on the current page pass validation,
-   * `false` otherwise.
    *
    * @returns `true` if current page is valid, `false` otherwise
    */
@@ -222,13 +186,7 @@ export class PageOrchestratorComponent {
     return true;
   });
 
-  /**
-   * Extended field signal context that includes currentPageValid.
-   *
-   * This extends the parent context from DynamicForm with page-specific
-   * information needed by button mappers (e.g., next button needs to know
-   * if the current page is valid).
-   */
+  /** Extended field signal context that includes currentPageValid. */
   readonly extendedFieldSignalContext = computed(() => ({
     ...this.fieldSignalContext(),
     currentPageValid: this.currentPageValid,
@@ -253,6 +211,7 @@ export class PageOrchestratorComponent {
 
   /**
    * Navigate to the next visible page, skipping hidden pages.
+   *
    * @returns Navigation result
    */
   navigateToNextPage(): NavigationResult {
@@ -302,6 +261,7 @@ export class PageOrchestratorComponent {
 
   /**
    * Navigate to the previous visible page, skipping hidden pages.
+   *
    * @returns Navigation result
    */
   navigateToPreviousPage(): NavigationResult {
@@ -340,6 +300,7 @@ export class PageOrchestratorComponent {
 
   /**
    * Navigate to a specific page index
+   *
    * @param pageIndex The target page index (0-based)
    * @returns Navigation result
    */
@@ -407,9 +368,7 @@ export class PageOrchestratorComponent {
     return nearest;
   }
 
-  /**
-   * Set up event listeners for navigation events
-   */
+  /** Set up event listeners for navigation events */
   private setupEventListeners(): void {
     // Listen for next page events
     this.eventBus
@@ -474,19 +433,7 @@ export class PageOrchestratorComponent {
   }
 }
 
-/**
- * Recursively collects form-tree keys for all value-bearing nodes on a page.
- *
- * Row fields are layout-only containers whose children are flattened to the
- * parent level in the form tree, so we recurse through them transparently.
- *
- * Group fields create a nested sub-tree in the form (form['address']['street']).
- * Their group-level FieldTree node aggregates child validity, so we use the
- * group's own key — not the individual child keys — to check validity.
- *
- * Array fields are also accessed by their own key; the ArrayFieldTree node
- * covers minLength/maxLength and any item-level validators.
- */
+/** Recursively collects form-tree keys for all value-bearing nodes on a page. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any field shape for recursive traversal
 function collectLeafFieldKeys(fields: readonly FieldDef<any>[]): string[] {
   const keys: string[] = [];

--- a/packages/dynamic-forms/src/lib/core/page-orchestrator/page-orchestrator.interfaces.ts
+++ b/packages/dynamic-forms/src/lib/core/page-orchestrator/page-orchestrator.interfaces.ts
@@ -1,9 +1,7 @@
 import { ComponentRef } from '@angular/core';
 import { FormUiControl } from '@angular/forms/signals';
 
-/**
- * State interface for the page orchestrator
- */
+/** State interface for the page orchestrator */
 export interface PageOrchestratorState {
   /** Current page index (0-based) */
   currentPageIndex: number;
@@ -17,9 +15,7 @@ export interface PageOrchestratorState {
   navigationDisabled: boolean;
 }
 
-/**
- * Configuration for page orchestrator
- */
+/** Configuration for page orchestrator */
 export interface PageOrchestratorConfig {
   /** Initial page index to show (defaults to 0) */
   initialPageIndex?: number;
@@ -27,9 +23,7 @@ export interface PageOrchestratorConfig {
   initialNavigationDisabled?: boolean;
 }
 
-/**
- * Result of a navigation attempt
- */
+/** Result of a navigation attempt */
 export interface NavigationResult {
   /** Whether the navigation was successful */
   success: boolean;
@@ -39,9 +33,7 @@ export interface NavigationResult {
   error?: string;
 }
 
-/**
- * Context for page visibility management
- */
+/** Context for page visibility management */
 export interface PageVisibilityContext {
   /** Index of the page */
   pageIndex: number;

--- a/packages/dynamic-forms/src/lib/core/property-derivation/apply-property-overrides.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/apply-property-overrides.ts
@@ -43,28 +43,9 @@ const KNOWN_FIELD_PROPERTIES = new Set<string>(KNOWN_FIELD_PROPERTY_NAMES);
 /**
  * Applies property overrides to a field's input record.
  *
- * Supports dot-notation for nested properties (max 2 levels):
- * - Simple: `overrides['minDate']` → `inputs['minDate'] = value`
- * - Nested (1 dot): `overrides['props.appearance']` → `inputs.props.appearance = value`
- * - Deeper paths (2+ dots): throws DynamicFormError
- *
- * **Important:** Only simple (e.g., `'minDate'`) and single-nested (e.g., `'props.appearance'`)
- * paths are supported. Paths with 2+ dots will throw a `DynamicFormError` at runtime.
- * This is an architectural constraint — deeper nesting would require recursive cloning
- * and complicate the override merging strategy.
- *
- * Array-valued overrides replace wholesale (no merging).
- * Returns `inputs` unchanged if overrides is empty (no clone).
- *
- * In dev mode, warns when a known standard field property override key doesn't match
- * any existing input property, which may indicate a typo in the `targetProperty`
- * configuration. Dynamic/custom property keys are silently accepted.
- *
  * @param inputs - The current field inputs record
  * @param overrides - Record of property names to override values
  * @returns Updated inputs record with overrides applied
- *
- * @public
  */
 export function applyPropertyOverrides(inputs: Record<string, unknown>, overrides: Record<string, unknown>): Record<string, unknown> {
   const keys = Object.keys(overrides);

--- a/packages/dynamic-forms/src/lib/core/property-derivation/async-property-derivation-stream.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/async-property-derivation-stream.ts
@@ -15,10 +15,6 @@ import { PropertyOverrideStore } from './property-override-store';
 /**
  * Context required for creating async-function property-derivation streams.
  *
- * Mirrors `AsyncDerivationStreamContext` from the value-derivation pipeline,
- * minus the form-accessor and dirty-state plumbing — property derivations
- * don't have a user-override concept.
- *
  * @internal
  */
 export interface AsyncPropertyDerivationStreamContext {
@@ -46,9 +42,6 @@ const DEFAULT_ASYNC_DEBOUNCE_MS = 300;
 
 /**
  * Creates an RxJS Observable stream that processes an async-function property-derivation entry.
- *
- * Mirrors `createAsyncDerivationStream` (value pipeline) but writes the result via
- * `store.setOverride(fieldKey, targetProperty, value)` instead of patching the form.
  *
  * @internal
  */

--- a/packages/dynamic-forms/src/lib/core/property-derivation/http-property-derivation-stream.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/http-property-derivation-stream.ts
@@ -17,10 +17,6 @@ import { PropertyOverrideStore } from './property-override-store';
 /**
  * Context required for creating HTTP property-derivation streams.
  *
- * Mirrors `HttpDerivationStreamContext` from the value-derivation pipeline,
- * minus the form-accessor and dirty-state plumbing — property derivations
- * don't have a user-override concept.
- *
  * @internal
  */
 export interface HttpPropertyDerivationStreamContext {
@@ -48,13 +44,6 @@ const DEFAULT_HTTP_DEBOUNCE_MS = 300;
 
 /**
  * Creates an RxJS Observable stream that processes an HTTP property-derivation entry.
- *
- * Mirrors `createHttpDerivationStream` (value pipeline) but writes the result via
- * `store.setOverride(fieldKey, targetProperty, value)` instead of patching the form.
- *
- * The stream uses `startWith(null) → pairwise()` so the first emission fires a
- * request for all `dependsOn` fields, populating the derived property on initial
- * form load. Subsequent emissions only fire when a `dependsOn` field changes.
  *
  * @internal
  */

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-applicator.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-applicator.ts
@@ -13,11 +13,7 @@ import { getParentPathInScope, resolveArrayItemScope } from '../derivation/evalu
 import { isAsyncPropertyDerivationEntry, PropertyDerivationCollection, PropertyDerivationEntry } from './property-derivation-types';
 import { PropertyOverrideStore } from './property-override-store';
 
-/**
- * Context required for applying property derivations.
- *
- * @public
- */
+/** Context required for applying property derivations. */
 export interface PropertyDerivationApplicatorContext {
   /** The current form value (signal) */
   formValue: Signal<Record<string, unknown>>;
@@ -41,11 +37,7 @@ export interface PropertyDerivationApplicatorContext {
   warningTracker?: WarningTracker;
 }
 
-/**
- * Result of property derivation processing.
- *
- * @public
- */
+/** Result of property derivation processing. */
 export interface PropertyDerivationProcessingResult {
   /** Number of property derivations successfully applied */
   appliedCount: number;
@@ -61,16 +53,10 @@ const ERROR_PREFIX = '[PropertyDerivation]';
 /**
  * Applies all property derivation entries from a collection.
  *
- * Single-pass processing — property derivations read formValue and write to the
- * property override store. No iterative refinement needed because property
- * derivations don't chain among themselves.
- *
  * @param collection - The collected property derivation entries
  * @param context - Context for applying property derivations
  * @param changedFields - Optional set of changed field keys for filtering
  * @returns Result of the processing
- *
- * @public
  */
 export function applyPropertyDerivations(
   collection: PropertyDerivationCollection,
@@ -114,8 +100,6 @@ export function applyPropertyDerivations(
  * @param context - Context for applying property derivations
  * @param changedFields - Optional set of changed field keys for filtering
  * @returns Result of the processing
- *
- * @public
  */
 export function applyPropertyDerivationsForTrigger(
   collection: PropertyDerivationCollection,
@@ -150,7 +134,6 @@ function getEntriesForChangedFields(entries: PropertyDerivationEntry[], changedF
  * Attempts to apply a single property derivation entry.
  *
  * @returns true if the override was applied, false if skipped
- *
  * @internal
  */
 function tryApplyPropertyDerivation(entry: PropertyDerivationEntry, context: PropertyDerivationApplicatorContext): boolean {
@@ -222,13 +205,6 @@ function tryApplyArrayPropertyDerivation(entry: PropertyDerivationEntry, context
 
 /**
  * Creates an evaluation context for property derivation processing.
- *
- * Note: `fieldState`/`formFieldState` are intentionally not populated here.
- * Property derivations run against the form value signal and write to a
- * separate override store; the applicator does not have access to the live
- * `FieldTree` (no `rootForm` on `PropertyDerivationApplicatorContext`), so
- * field-state snapshots cannot be read in this pipeline. Functions that need
- * field state (e.g. `dirty()`, `touched()`) must use a regular derivation.
  *
  * @internal
  */

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-collector.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-collector.ts
@@ -2,16 +2,7 @@ import { FieldDef } from '../../definitions/base/field-def';
 import { collectAllDerivations } from '../derivation/derivation-collector';
 import { PropertyDerivationCollection } from './property-derivation-types';
 
-/**
- * Collects all property derivation entries from field definitions.
- *
- * Thin wrapper around `collectAllDerivations` that returns the property
- * slice. For forms that have both kinds of derivations, prefer calling
- * `collectAllDerivations` directly — it walks the field tree once instead
- * of twice (orchestrator already does this when both pipelines are active).
- *
- * @public
- */
+/** Collects all property derivation entries from field definitions. */
 export function collectPropertyDerivations(fields: FieldDef<unknown>[]): PropertyDerivationCollection {
   return collectAllDerivations(fields).property;
 }

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-types.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-derivation-types.ts
@@ -1,28 +1,9 @@
 import { DerivationEntry } from '../derivation/derivation-types';
 
-/**
- * Entry representing a collected property derivation from field definitions.
- *
- * A narrow of {@link DerivationEntry} where `targetProperty` is required —
- * the discriminator that distinguishes property derivations (writes into the
- * PropertyOverrideStore) from value derivations (writes into the FieldTree).
- *
- * Created during form initialization when traversing field definitions
- * to collect all `type: 'derivation'` logic entries with `targetProperty`.
- *
- * @public
- */
+/** Entry representing a collected property derivation from field definitions. */
 export type PropertyDerivationEntry = DerivationEntry & { targetProperty: string };
 
-/**
- * Collection of all property derivation entries from a form's field definitions.
- *
- * No topological sort needed — property derivations don't chain among
- * themselves (they read formValue and write to the store, never reading
- * from the store).
- *
- * @public
- */
+/** Collection of all property derivation entries from a form's field definitions. */
 export interface PropertyDerivationCollection {
   entries: PropertyDerivationEntry[];
 }
@@ -31,7 +12,6 @@ export interface PropertyDerivationCollection {
  * Creates an empty property derivation collection.
  *
  * @returns Empty collection
- *
  * @internal
  */
 export function createEmptyPropertyDerivationCollection(): PropertyDerivationCollection {

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-override-key.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-override-key.ts
@@ -1,40 +1,14 @@
-/**
- * Sentinel value for the `$` placeholder index used in registration keys.
- *
- * The property derivation system uses two key formats for array fields:
- * - **Placeholder format** (`items.$.email`) — used by the collector/orchestrator to register
- *   derivations and by the fast-path `hasField()` check. The `$` acts as a wildcard
- *   representing "any index".
- * - **Concrete format** (`items.0.email`) — used at render time to look up overrides
- *   for a specific array item.
- *
- * Pass `PLACEHOLDER_INDEX` as the `index` parameter to produce the placeholder format.
- *
- * @public
- */
+/** Sentinel value for the `$` placeholder index used in registration keys. */
 export const PLACEHOLDER_INDEX = '$' as const;
 
 /**
  * Builds a property override store key for a field.
- *
- * For non-array fields, the key is the dot-joined group ancestors plus the
- * field's leaf key (e.g., `address.street` for `street` inside `address`).
- * For array item fields, the key includes the array path, either a concrete
- * index or the `$` placeholder, and any group ancestors INSIDE the array
- * item (e.g., `contacts.0.email`, `contacts.$.email`, or
- * `contacts.0.profile.email` for a group nested under each contact).
- *
- * `groupPath` matches the form-value path of nested groups (collector resets
- * it at array boundaries — see `property-derivation-collector.ts`), so the
- * resulting key always mirrors the field's location in `formValue`.
  *
  * @param arrayKey - The array field key (e.g., 'contacts'), or undefined for non-array fields
  * @param index - The array item index, `PLACEHOLDER_INDEX` for the wildcard format, or undefined for non-array fields
  * @param fieldKey - The leaf field key (e.g., 'email')
  * @param groupPath - Dot-joined group ancestors scoped to the current array item (or top-level), or undefined when not inside any group
  * @returns The store key (e.g., 'email', 'address.street', 'contacts.0.email', 'contacts.$.profile.email')
- *
- * @public
  */
 export function buildPropertyOverrideKey(
   arrayKey: string | undefined,

--- a/packages/dynamic-forms/src/lib/core/property-derivation/property-override-store.ts
+++ b/packages/dynamic-forms/src/lib/core/property-derivation/property-override-store.ts
@@ -1,22 +1,10 @@
 import { InjectionToken, signal, Signal, WritableSignal } from '@angular/core';
 import { isEqual } from '../../utils/object-utils';
 
-/**
- * Per-field signal store for property overrides.
- *
- * Each field that has property derivations gets a WritableSignal containing
- * a record of property names to their override values. Mappers read from
- * this store reactively — only the specific field's signal is read, so
- * changes to one field's overrides don't cause other fields to recompute.
- *
- * @public
- */
+/** Per-field signal store for property overrides. */
 export interface PropertyOverrideStore {
   /**
    * Gets the override signal for a field.
-   *
-   * Lazily creates a per-field signal on first access. Subsequent calls
-   * return the same signal instance.
    *
    * @param fieldKey - The store key (e.g., 'endDate' or 'contacts.0.email')
    * @returns Signal containing the current overrides record
@@ -25,9 +13,6 @@ export interface PropertyOverrideStore {
 
   /**
    * Sets a single property override for a field.
-   *
-   * Uses deep equality to skip no-op updates. Setting `undefined` as the value
-   * removes the property key from the override record.
    *
    * @param fieldKey - The store key
    * @param targetProperty - The property name (e.g., 'minDate', 'options')
@@ -38,9 +23,6 @@ export interface PropertyOverrideStore {
   /**
    * Registers a field as having property derivations.
    *
-   * Called by the orchestrator during collection. Enables the fast-path
-   * check in mappers via `hasField()`.
-   *
    * @param fieldKey - The store key to register
    */
   registerField(fieldKey: string): void;
@@ -48,20 +30,12 @@ export interface PropertyOverrideStore {
   /**
    * Non-reactive check for whether a field has been registered.
    *
-   * Uses plain Map.has() — O(1), no signal creation. Used by mappers
-   * to skip the computed() wrapper for fields without property derivations.
-   *
    * @param fieldKey - The store key (or prefix for array fields)
    * @returns true if the field has property derivation entries
    */
   hasField(fieldKey: string): boolean;
 
-  /**
-   * Clears all overrides and registered fields.
-   *
-   * Prunes the internal Map entirely, releasing all signal references.
-   * Called when the form config changes (new collection = reset).
-   */
+  /** Clears all overrides and registered fields. */
   clear(): void;
 }
 
@@ -71,8 +45,6 @@ const EMPTY_OVERRIDES: Record<string, unknown> = Object.freeze({});
  * Creates a new PropertyOverrideStore instance.
  *
  * @returns A fresh PropertyOverrideStore
- *
- * @public
  */
 export function createPropertyOverrideStore(): PropertyOverrideStore {
   const store = new Map<string, WritableSignal<Record<string, unknown>>>();
@@ -129,9 +101,5 @@ export function createPropertyOverrideStore(): PropertyOverrideStore {
   };
 }
 
-/**
- * Injection token for the PropertyOverrideStore.
- *
- * @public
- */
+/** Injection token for the PropertyOverrideStore. */
 export const PROPERTY_OVERRIDE_STORE = new InjectionToken<PropertyOverrideStore>('PROPERTY_OVERRIDE_STORE');

--- a/packages/dynamic-forms/src/lib/core/registry/array-item-registry.service.ts
+++ b/packages/dynamic-forms/src/lib/core/registry/array-item-registry.service.ts
@@ -5,13 +5,6 @@ import { FieldDef } from '../../definitions/base/field-def';
  * Per-array durable state. Survives `ArrayFieldComponent` destroy/recreate
  * cycles so a hidden array that's gated with `@if` doesn't lose its dynamically
  * added items when it becomes visible again.
- *
- * `templates` is keyed by item id and holds the field definitions used to
- * resolve each item (so we can re-create them after a destroy with the right
- * field shape). `itemOrder` records the id sequence in form-value order, so a
- * fresh `ArrayFieldComponent` can map each `fieldTree` back to its existing id
- * + template instead of generating a new id and falling through to `Priority 2`
- * static templates (which drops items that were added dynamically).
  */
 export interface ArraySlot {
   /** Templates keyed by item id. Set on resolution, deleted on item removal. */
@@ -107,10 +100,6 @@ function createSlot(): ArraySlot {
  * (e.g. 'members', 'team.members', 'orders.lineItems'). Survives
  * `ArrayFieldComponent` lifecycle, dies with the `DynamicForm`. Cleared on
  * schema swap by the `formSetup` effect in `FormStateManager`.
- *
- * `ArrayFieldComponent` injects this service and obtains its slot via
- * `slotFor(arrayPath)` on mount. Replaces the prior per-component
- * `ARRAY_TEMPLATE_REGISTRY` + `ARRAY_ITEM_ID_GENERATOR` providers.
  */
 @Injectable()
 export class ArrayItemRegistryService {

--- a/packages/dynamic-forms/src/lib/core/registry/field-context-registry.service.ts
+++ b/packages/dynamic-forms/src/lib/core/registry/field-context-registry.service.ts
@@ -14,19 +14,7 @@ function isChildFieldContext<TValue>(context: FieldContext<TValue>): context is 
   return 'key' in context && isSignal(context.key);
 }
 
-/**
- * Extracts the FieldState from a FieldContext using the public `.state` property.
- *
- * FieldContext.state is a FieldState object that has all signal properties
- * (dirty, touched, valid, etc.) needed for field state snapshots.
- *
- * IMPORTANT: Always reads with `untracked()` because accessing `.state` on a
- * FieldContext can trigger reactive reads inside Angular's internal computation
- * graph. Without `untracked()`, validators would cycle (validator → state → valid
- * → validator) and logic conditions like `hidden()` would cycle (hidden → state →
- * hidden). The FieldState object reference is stable — individual signal properties
- * within it are read reactively or untracked by the Proxy as needed.
- */
+/** Extracts the FieldState from a FieldContext using the public `.state` property. */
 function extractFieldState(fieldContext: FieldContext<unknown>): FieldState<unknown> | undefined {
   return untracked(() => {
     if (!fieldContext || !('state' in fieldContext)) return undefined;
@@ -34,17 +22,7 @@ function extractFieldState(fieldContext: FieldContext<unknown>): FieldState<unkn
   });
 }
 
-/**
- * Detects whether a field lives inside an array by examining its `pathKeys`.
- *
- * Array item fields have paths like `['addresses', '0', 'street']` where
- * a numeric segment indicates an array index. Returns the array key and
- * numeric index when detected, or `undefined` for non-array fields.
- *
- * For nested arrays (e.g., `['orders', '0', 'items', '1', 'name']`), walks backwards
- * to find the innermost array context — scoping `formValue` to that item.
- * `localKey` is always the last segment (the field's own key within its parent item).
- */
+/** Detects whether a field lives inside an array by examining its `pathKeys`. */
 function detectArrayScope(pathKeys: readonly string[]): { arrayKey: string; index: number; localKey: string } | undefined {
   // Need at least 3 segments: arrayKey, index, fieldKey
   if (pathKeys.length < 3) return undefined;
@@ -69,9 +47,6 @@ function detectArrayScope(pathKeys: readonly string[]): { arrayKey: string; inde
 /**
  * Service that provides field evaluation context by combining
  * field context with root form registry information.
- *
- * This service should be provided at the component level to ensure proper
- * isolation between different form instances.
  */
 @Injectable()
 export class FieldContextRegistryService {
@@ -129,9 +104,7 @@ export class FieldContextRegistryService {
     };
   }
 
-  /**
-   * Extracts the field path (key) for a given field context.
-   */
+  /** Extracts the field path (key) for a given field context. */
   private extractFieldPath(fieldContext: FieldContext<unknown>): string {
     if (isChildFieldContext(fieldContext)) {
       try {
@@ -145,16 +118,7 @@ export class FieldContextRegistryService {
     return '';
   }
 
-  /**
-   * Builds an evaluation context scoped to a specific array item.
-   *
-   * When a field lives inside an array (e.g., `addresses.0.street`), its logic conditions
-   * need `formValue` scoped to the array item so that `fieldValue` lookups like
-   * `hasApartment` resolve against the item rather than the root form.
-   *
-   * Falls back to root form behavior when the array data is missing or the index is
-   * out of bounds.
-   */
+  /** Builds an evaluation context scoped to a specific array item. */
   private buildArrayScopedContext<TValue>(
     rootFormValue: Record<string, unknown>,
     arrayScope: { arrayKey: string; index: number; localKey: string },
@@ -251,20 +215,7 @@ export class FieldContextRegistryService {
     return resolved;
   }
 
-  /**
-   * Creates a REACTIVE evaluation context for logic functions.
-   *
-   * Unlike createEvaluationContext, this method does NOT use untracked(),
-   * which allows logic functions (hidden, readonly, disabled, required) to
-   * create reactive dependencies on form values.
-   *
-   * When a dependent field value changes, the logic function will be re-evaluated.
-   *
-   * NOTE: This should ONLY be used for logic functions, not validators.
-   * Validators should use createEvaluationContext with untracked() to prevent
-   * infinite reactive loops. Validators with cross-field dependencies should be
-   * hoisted to form-level using validateTree.
-   */
+  /** Creates a REACTIVE evaluation context for logic functions. */
   createReactiveEvaluationContext<TValue>(
     fieldContext: FieldContext<TValue>,
     customFunctions?: Record<string, (context: EvaluationContext) => unknown>,
@@ -301,17 +252,6 @@ export class FieldContextRegistryService {
   /**
    * Creates an evaluation context for display-only components (text fields, pages)
    * that don't have their own FieldContext.
-   *
-   * This is useful for:
-   * - Text fields (display-only, not part of form schema)
-   * - Pages (containers that need to evaluate visibility logic)
-   *
-   * Uses reactive form value access to allow logic re-evaluation when form values change.
-   *
-   * NOTE: This method does NOT support array-scoped context because display-only
-   * components don't have a FieldContext (and therefore no `pathKeys` signal to
-   * detect array scope from). If display-only components are placed inside arrays,
-   * their logic conditions will evaluate against the root form value.
    *
    * @param fieldPath - The key/path of the display-only component
    * @param customFunctions - Optional custom functions for expression evaluation

--- a/packages/dynamic-forms/src/lib/core/registry/function-registry.service.ts
+++ b/packages/dynamic-forms/src/lib/core/registry/function-registry.service.ts
@@ -3,70 +3,7 @@ import { CustomFunction, CustomFunctionOptions, CustomFunctionScope } from '../e
 import type { AsyncConditionFunction, AsyncDerivationFunction } from '../expressions/async-custom-function-types';
 import { AsyncCustomValidator, CustomValidator, HttpCustomValidator } from '../validation/validator-types';
 
-/**
- * Registry service for custom functions and validators
- *
- * This service maintains six separate registries:
- *
- * 1. **Custom Functions** - For conditional expressions (when/readonly/disabled)
- *    - Used in: when conditions, readonly logic, disabled logic
- *    - Return type: any value (typically boolean)
- *    - Example: `isAdult: (ctx) => ctx.age >= 18`
- *
- * 2. **Custom Validators** - For synchronous validation using Angular's public FieldContext API
- *    - Used in: validators array on fields
- *    - Return type: ValidationError | ValidationError[] | null
- *    - Example: `noSpaces: (ctx) => ctx.value().includes(' ') ? { kind: 'noSpaces' } : null`
- *
- * 3. **Async Validators** - For asynchronous validation (debouncing, database lookups, etc.)
- *    - Used in: validators array on fields with type 'async'
- *    - Return type: Observable<ValidationError | ValidationError[] | null>
- *    - Example: `checkUsername: (ctx) => userService.checkAvailability(ctx.value())`
- *
- * 4. **HTTP Validators** - For HTTP-based validation with automatic request cancellation
- *    - Used in: validators array on fields with type 'http'
- *    - Configuration object with url, method, mapResponse, etc.
- *    - Example: `{ url: '/api/check', method: 'GET', mapResponse: ... }`
- *
- * 5. **Async Derivation Functions** - For asynchronous value derivation via Promise/Observable
- *    - Used in: derivation config with `asyncFunctionName`
- *    - Return type: Promise<unknown> | Observable<unknown>
- *    - Example: `fetchPrice: (ctx) => priceService.get(ctx.formValue.productId)`
- *
- * 6. **Async Condition Functions** - For asynchronous boolean conditions via Promise/Observable
- *    - Used in: condition config with `type: 'async'` and `asyncFunctionName`
- *    - Return type: Promise<boolean> | Observable<boolean>
- *    - Example: `checkAdmin: (ctx) => authService.hasRole(ctx.formValue.userId, 'admin')`
- *
- * @example
- * ```typescript
- * // Register a custom function for expressions
- * registry.registerCustomFunction('isAdult', (ctx) => ctx.age >= 18);
- *
- * // Use in field configuration
- * {
- *   key: 'alcoholPreference',
- *   when: { function: 'isAdult' }
- * }
- *
- * // Register a custom validator
- * registry.registerValidator('noSpaces', (ctx) => {
- *   const value = ctx.value();
- *   return typeof value === 'string' && value.includes(' ')
- *     ? { kind: 'noSpaces' }
- *     : null;
- * });
- *
- * // Use in field configuration
- * {
- *   key: 'username',
- *   validators: [{ type: 'custom', functionName: 'noSpaces' }],
- *   validationMessages: {
- *     noSpaces: 'Spaces are not allowed'
- *   }
- * }
- * ```
- */
+/** Registry service for custom functions and validators */
 @Injectable()
 export class FunctionRegistryService {
   private readonly customFunctions = new Map<string, CustomFunction>();
@@ -81,21 +18,9 @@ export class FunctionRegistryService {
   /**
    * Register a custom function for conditional expressions
    *
-   * Custom functions are used for control flow logic (when/readonly/disabled),
-   * NOT for validation. They return any value, typically boolean.
-   *
    * @param name - Unique identifier for the function
    * @param fn - Function that receives EvaluationContext and returns any value
    * @param options - Optional configuration for the function
-   *
-   * @example
-   * ```typescript
-   * // Form-level function (default) - may access other fields
-   * registry.registerCustomFunction('isAdult', (ctx) => ctx.formValue.age >= 18);
-   *
-   * // Field-level function - only uses current field value (performance optimization)
-   * registry.registerCustomFunction('isEmpty', (ctx) => !ctx.fieldValue, { scope: 'field' });
-   * ```
    */
   registerCustomFunction(name: string, fn: CustomFunction, options?: CustomFunctionOptions): void {
     this.customFunctions.set(name, fn);
@@ -123,16 +48,12 @@ export class FunctionRegistryService {
     return this.customFunctionScopes.get(name) === 'field';
   }
 
-  /**
-   * Get all custom functions as an object
-   */
+  /** Get all custom functions as an object */
   getCustomFunctions(): Record<string, CustomFunction> {
     return Object.fromEntries(this.customFunctions);
   }
 
-  /**
-   * Clear all custom functions and their scopes
-   */
+  /** Clear all custom functions and their scopes */
   clearCustomFunctions(): void {
     this.customFunctions.clear();
     this.customFunctionScopes.clear();
@@ -145,34 +66,19 @@ export class FunctionRegistryService {
   /**
    * Register a derivation function for value derivation logic.
    *
-   * Derivation functions compute derived values and are called when a
-   * `DerivationLogicConfig` references them by `functionName`.
-   *
    * @param name - Unique identifier for the function
    * @param fn - Function that receives EvaluationContext and returns the derived value
-   *
-   * @example
-   * ```typescript
-   * registry.registerDerivationFunction('getCurrencyForCountry', (ctx) => {
-   *   const countryToCurrency = { 'USA': 'USD', 'Germany': 'EUR', 'UK': 'GBP' };
-   *   return countryToCurrency[ctx.formValue.country] ?? 'USD';
-   * });
-   * ```
    */
   registerDerivationFunction(name: string, fn: CustomFunction): void {
     this.derivationFunctions.set(name, fn);
   }
 
-  /**
-   * Get a derivation function by name
-   */
+  /** Get a derivation function by name */
   getDerivationFunction(name: string): CustomFunction | undefined {
     return this.derivationFunctions.get(name);
   }
 
-  /**
-   * Get all derivation functions as an object
-   */
+  /** Get all derivation functions as an object */
   getDerivationFunctions(): Record<string, CustomFunction> {
     return Object.fromEntries(this.derivationFunctions);
   }
@@ -187,9 +93,7 @@ export class FunctionRegistryService {
     this.setRegistryIfChanged(this.derivationFunctions, derivations);
   }
 
-  /**
-   * Clear all derivation functions
-   */
+  /** Clear all derivation functions */
   clearDerivationFunctions(): void {
     this.derivationFunctions.clear();
   }
@@ -201,9 +105,6 @@ export class FunctionRegistryService {
   /**
    * Register an async derivation function.
    *
-   * Async derivation functions perform asynchronous operations (service calls,
-   * complex pipelines) and return the derived value via a Promise or Observable.
-   *
    * @param name - Unique identifier for the function
    * @param fn - Function that receives EvaluationContext and returns Promise/Observable
    */
@@ -211,16 +112,12 @@ export class FunctionRegistryService {
     this.asyncDerivationFunctions.set(name, fn);
   }
 
-  /**
-   * Get an async derivation function by name
-   */
+  /** Get an async derivation function by name */
   getAsyncDerivationFunction(name: string): AsyncDerivationFunction | undefined {
     return this.asyncDerivationFunctions.get(name);
   }
 
-  /**
-   * Get all async derivation functions as an object
-   */
+  /** Get all async derivation functions as an object */
   getAsyncDerivationFunctions(): Record<string, AsyncDerivationFunction> {
     return Object.fromEntries(this.asyncDerivationFunctions);
   }
@@ -235,9 +132,7 @@ export class FunctionRegistryService {
     this.setRegistryIfChanged(this.asyncDerivationFunctions, fns);
   }
 
-  /**
-   * Clear all async derivation functions
-   */
+  /** Clear all async derivation functions */
   clearAsyncDerivationFunctions(): void {
     this.asyncDerivationFunctions.clear();
   }
@@ -249,8 +144,6 @@ export class FunctionRegistryService {
   /**
    * Register an async condition function.
    *
-   * Async condition functions perform asynchronous operations and return a boolean.
-   *
    * @param name - Unique identifier for the function
    * @param fn - Function that receives EvaluationContext and returns Promise/Observable of boolean
    */
@@ -258,16 +151,12 @@ export class FunctionRegistryService {
     this.asyncConditionFunctions.set(name, fn);
   }
 
-  /**
-   * Get an async condition function by name
-   */
+  /** Get an async condition function by name */
   getAsyncConditionFunction(name: string): AsyncConditionFunction | undefined {
     return this.asyncConditionFunctions.get(name);
   }
 
-  /**
-   * Get all async condition functions as an object
-   */
+  /** Get all async condition functions as an object */
   getAsyncConditionFunctions(): Record<string, AsyncConditionFunction> {
     return Object.fromEntries(this.asyncConditionFunctions);
   }
@@ -282,9 +171,7 @@ export class FunctionRegistryService {
     this.setRegistryIfChanged(this.asyncConditionFunctions, fns);
   }
 
-  /**
-   * Clear all async condition functions
-   */
+  /** Clear all async condition functions */
   clearAsyncConditionFunctions(): void {
     this.asyncConditionFunctions.clear();
   }
@@ -292,74 +179,19 @@ export class FunctionRegistryService {
   /**
    * Register a custom validator using Angular's public FieldContext API
    *
-   * Validators receive the full FieldContext, allowing access to:
-   * - Current field value: `ctx.value()`
-   * - Field state: `ctx.state` (errors, touched, dirty, etc.)
-   * - Other field values: `ctx.valueOf(path)` (public API!)
-   * - Other field states: `ctx.stateOf(path)`
-   * - Parameters from JSON configuration via second argument
-   *
    * @param name - Unique identifier for the validator
    * @param fn - Validator function (ctx, params?) => ValidationError | ValidationError[] | null
-   *
-   * @example Single Field Validation
-   * ```typescript
-   * registry.registerValidator('noSpaces', (ctx) => {
-   *   const value = ctx.value();
-   *   if (typeof value === 'string' && value.includes(' ')) {
-   *     return { kind: 'noSpaces' };
-   *   }
-   *   return null;
-   * });
-   * ```
-   *
-   * @example Cross-Field Validation (Public API)
-   * ```typescript
-   * registry.registerValidator('lessThan', (ctx, params) => {
-   *   const value = ctx.value();
-   *   const compareToPath = params?.field as string;
-   *
-   *   // Use valueOf() to access other fields - public API!
-   *   const otherValue = ctx.valueOf(compareToPath as any);
-   *
-   *   if (otherValue !== undefined && value >= otherValue) {
-   *     return { kind: 'notLessThan' };
-   *   }
-   *   return null;
-   * });
-   * ```
-   *
-   * @example Multiple Errors (Cross-Field Validation)
-   * ```typescript
-   * registry.registerValidator('validateDateRange', (ctx) => {
-   *   const errors: ValidationError[] = [];
-   *   const startDate = ctx.valueOf('startDate' as any);
-   *   const endDate = ctx.valueOf('endDate' as any);
-   *
-   *   if (!startDate) errors.push({ kind: 'startDateRequired' });
-   *   if (!endDate) errors.push({ kind: 'endDateRequired' });
-   *   if (startDate && endDate && startDate > endDate) {
-   *     errors.push({ kind: 'invalidDateRange' });
-   *   }
-   *
-   *   return errors.length > 0 ? errors : null;
-   * });
-   * ```
    */
   registerValidator(name: string, fn: CustomValidator): void {
     this.validators.set(name, fn);
   }
 
-  /**
-   * Get a validator by name
-   */
+  /** Get a validator by name */
   getValidator(name: string): CustomValidator | undefined {
     return this.validators.get(name);
   }
 
-  /**
-   * Clear all validators
-   */
+  /** Clear all validators */
   clearValidators(): void {
     this.validators.clear();
   }
@@ -367,49 +199,19 @@ export class FunctionRegistryService {
   /**
    * Register an async validator using Angular's public validateAsync() API
    *
-   * Async validators return Observables for asynchronous validation logic.
-   * Use for debouncing, database lookups, or complex async business logic.
-   *
    * @param name - Unique identifier for the async validator
    * @param fn - Async validator function (ctx, params?) => Observable<ValidationError | ValidationError[] | null>
-   *
-   * @example Debounced Username Check
-   * ```typescript
-   * registry.registerAsyncValidator('checkUsernameAvailable', (ctx) => {
-   *   const username = ctx.value();
-   *   return of(username).pipe(
-   *     debounceTime(300),
-   *     switchMap(name => userService.checkAvailability(name)),
-   *     map(available => available ? null : { kind: 'usernameTaken' })
-   *   );
-   * });
-   * ```
-   *
-   * @example Async Cross-Field Validation
-   * ```typescript
-   * registry.registerAsyncValidator('validatePasswordStrength', (ctx) => {
-   *   const password = ctx.value();
-   *   const email = ctx.valueOf('email' as any);
-   *   return passwordService.checkStrength(password, email).pipe(
-   *     map(result => result.strong ? null : { kind: 'weakPassword' })
-   *   );
-   * });
-   * ```
    */
   registerAsyncValidator(name: string, fn: AsyncCustomValidator): void {
     this.asyncValidators.set(name, fn);
   }
 
-  /**
-   * Get an async validator by name
-   */
+  /** Get an async validator by name */
   getAsyncValidator(name: string): AsyncCustomValidator | undefined {
     return this.asyncValidators.get(name);
   }
 
-  /**
-   * Clear all async validators
-   */
+  /** Clear all async validators */
   clearAsyncValidators(): void {
     this.asyncValidators.clear();
   }
@@ -417,60 +219,26 @@ export class FunctionRegistryService {
   /**
    * Register an HTTP validator configuration using Angular's public validateHttp() API
    *
-   * HTTP validators provide optimized HTTP validation with automatic request cancellation,
-   * caching, and debouncing. Preferred over AsyncCustomValidator for HTTP requests.
-   *
    * @param name - Unique identifier for the HTTP validator
    * @param config - HTTP validator configuration object
-   *
-   * @example Username Availability Check
-   * ```typescript
-   * registry.registerHttpValidator('checkUsername', {
-   *   url: (ctx) => `/api/users/check-username?username=${encodeURIComponent(ctx.value())}`,
-   *   method: 'GET',
-   *   mapResponse: (response, ctx) => {
-   *     return response.available ? null : { kind: 'usernameTaken' };
-   *   }
-   * });
-   * ```
-   *
-   * @example POST Request with Body
-   * ```typescript
-   * registry.registerHttpValidator('validateAddress', {
-   *   url: '/api/validate-address',
-   *   method: 'POST',
-   *   body: (ctx) => ({
-   *     street: ctx.valueOf('street' as any),
-   *     city: ctx.valueOf('city' as any),
-   *     zipCode: ctx.value()
-   *   }),
-   *   mapResponse: (response) => {
-   *     return response.valid ? null : { kind: 'invalidAddress' };
-   *   },
-   *   debounceTime: 500
-   * });
-   * ```
    */
   registerHttpValidator(name: string, config: HttpCustomValidator): void {
     this.httpValidators.set(name, config);
   }
 
-  /**
-   * Get an HTTP validator by name
-   */
+  /** Get an HTTP validator by name */
   getHttpValidator(name: string): HttpCustomValidator | undefined {
     return this.httpValidators.get(name);
   }
 
-  /**
-   * Clear all HTTP validators
-   */
+  /** Clear all HTTP validators */
   clearHttpValidators(): void {
     this.httpValidators.clear();
   }
 
   /**
    * Generic helper to set registry values only if they have changed
+   *
    * @param registry - The Map to update
    * @param values - Object mapping keys to values
    */
@@ -515,9 +283,7 @@ export class FunctionRegistryService {
     this.setRegistryIfChanged(this.httpValidators, httpValidators);
   }
 
-  /**
-   * Clear everything (functions and all validators)
-   */
+  /** Clear everything (functions and all validators) */
   clearAll(): void {
     this.clearCustomFunctions();
     this.clearDerivationFunctions();

--- a/packages/dynamic-forms/src/lib/core/registry/root-form-registry.service.ts
+++ b/packages/dynamic-forms/src/lib/core/registry/root-form-registry.service.ts
@@ -1,12 +1,7 @@
 import { Signal } from '@angular/core';
 import { FieldTree } from '@angular/forms/signals';
 
-/**
- * Registry service that provides access to the root form and its values.
- *
- * Constructed via factory in `provideDynamicFormDI` with signals from
- * `FormStateManager` — no DI injection, no Maps, no lifecycle.
- */
+/** Registry service that provides access to the root form and its values. */
 export class RootFormRegistryService {
   constructor(
     readonly formValue: Signal<Record<string, unknown>>,

--- a/packages/dynamic-forms/src/lib/core/registry/schema-registry.service.ts
+++ b/packages/dynamic-forms/src/lib/core/registry/schema-registry.service.ts
@@ -5,37 +5,27 @@ import { SchemaDefinition } from '../../models/schemas/schema-definition';
 export class SchemaRegistryService {
   private readonly registeredSchemas = new Map<string, SchemaDefinition>();
 
-  /**
-   * Register a reusable schema
-   */
+  /** Register a reusable schema */
   registerSchema(schema: SchemaDefinition): void {
     this.registeredSchemas.set(schema.name, schema);
   }
 
-  /**
-   * Get registered schema by name
-   */
+  /** Get registered schema by name */
   getSchema(name: string): SchemaDefinition | undefined {
     return this.registeredSchemas.get(name);
   }
 
-  /**
-   * Get all registered schemas
-   */
+  /** Get all registered schemas */
   getAllSchemas(): Map<string, SchemaDefinition> {
     return new Map(this.registeredSchemas);
   }
 
-  /**
-   * Clear all registered schemas
-   */
+  /** Clear all registered schemas */
   clearSchemas(): void {
     this.registeredSchemas.clear();
   }
 
-  /**
-   * Resolve schema from string reference or direct definition
-   */
+  /** Resolve schema from string reference or direct definition */
   resolveSchema(schema: string | SchemaDefinition): SchemaDefinition | null {
     if (typeof schema === 'string') {
       return this.getSchema(schema) || null;

--- a/packages/dynamic-forms/src/lib/core/schema-application.ts
+++ b/packages/dynamic-forms/src/lib/core/schema-application.ts
@@ -12,11 +12,6 @@ import { DynamicFormLogger } from '../providers/features/logger/logger.token';
 /**
  * Apply schema configuration.
  * Accepts both SchemaPath and SchemaPathTree for flexibility.
- *
- * Note: We cast fieldPath to suppress TypeScript's union type errors. This is safe because:
- * 1. We only use signal forms (not AbstractControl), so SchemaPathTree is always the supported branch
- * 2. The Angular apply functions accept SchemaPath with any value type
- * 3. The actual schema application happens at runtime via the schema function
  */
 export function applySchema(config: SchemaApplicationConfig, fieldPath: SchemaPath<unknown> | SchemaPathTree<unknown>): void {
   const logger = inject(DynamicFormLogger);
@@ -63,13 +58,7 @@ export function applySchema(config: SchemaApplicationConfig, fieldPath: SchemaPa
   }
 }
 
-/**
- * Create a schema function from schema definition.
- *
- * Schema functions receive SchemaPathTree which includes both the base SchemaPath
- * and nested child access properties. The validator/logic/schema application functions
- * accept SchemaPath | SchemaPathTree, so we can pass the path directly.
- */
+/** Create a schema function from schema definition. */
 export function createSchemaFunction(schema: SchemaDefinition): SchemaOrSchemaFn<unknown> {
   return (path: SchemaPathTree<unknown>) => {
     // Apply validators - path is SchemaPathTree which is accepted by applyValidator

--- a/packages/dynamic-forms/src/lib/core/schema-builder.ts
+++ b/packages/dynamic-forms/src/lib/core/schema-builder.ts
@@ -23,12 +23,7 @@ import { FieldTreeMappingContext, resolveDescendantContext, resolveFieldOwnConte
 
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-/**
- * Gets a FieldTree by key, supporting nested paths with dot notation.
- *
- * @example
- * getFieldTreeByKey(ctx, 'address.street') // Returns FieldTree for nested 'street' field
- */
+/** Gets a FieldTree by key, supporting nested paths with dot notation. */
 function getFieldTreeByKey<TModel>(ctx: FieldContext<TModel>, key: string): FieldTree<unknown> | undefined {
   // Simple case - no nesting
   if (!key.includes('.')) {
@@ -51,50 +46,15 @@ function getFieldTreeByKey<TModel>(ctx: FieldContext<TModel>, key: string): Fiel
   return current as FieldTree<unknown> | undefined;
 }
 
-/**
- * Options for creating a schema from field definitions.
- */
+/** Options for creating a schema from field definitions. */
 export interface CreateSchemaOptions<TModel = unknown> {
-  /**
-   * Optional array of collected cross-field validators.
-   */
+  /** Optional array of collected cross-field validators. */
   crossFieldValidators?: CrossFieldValidatorEntry[];
 
-  /**
-   * Optional form-level Standard Schema for additional validation.
-   *
-   * Supports Zod, Valibot, ArkType, and other Standard Schema compliant libraries.
-   * Useful for cross-field validation rules.
-   *
-   * @example
-   * ```typescript
-   * import { z } from 'zod';
-   * import { standardSchema } from '@ng-forge/dynamic-forms/schema';
-   *
-   * const PasswordSchema = z.object({
-   *   password: z.string().min(8),
-   *   confirmPassword: z.string(),
-   * }).refine(
-   *   (data) => data.password === data.confirmPassword,
-   *   { message: 'Passwords must match', path: ['confirmPassword'] }
-   * );
-   *
-   * const schema = createSchemaFromFields(fields, registry, {
-   *   formLevelSchema: standardSchema(PasswordSchema),
-   * });
-   * ```
-   */
+  /** Optional form-level Standard Schema for additional validation. */
   formLevelSchema?: FormSchema<TModel>;
 
-  /**
-   * Form-level `validateWhenHidden` setting (from `FormConfig.options.validateWhenHidden`).
-   *
-   * Acts as the root inherited value for the field tree. Per-field
-   * `FieldDef.validateWhenHidden` overrides it for a subtree, and the new value is
-   * inherited by descendants unless they override in turn.
-   *
-   * When `undefined`, the global `withValidationExecutionDefaults()` value is used.
-   */
+  /** Form-level `validateWhenHidden` setting (from `FormConfig.options.validateWhenHidden`). */
   validateWhenHidden?: boolean;
 }
 
@@ -102,11 +62,6 @@ export interface CreateSchemaOptions<TModel = unknown> {
  * Creates an Angular signal forms schema from field definitions
  * This is the single entry point at dynamic form level that replaces createSchemaFromFields
  * Uses the new modular signal forms adapter structure
- *
- * Cross-field logic (formValue.*) is handled automatically by createLogicFunction
- * which uses RootFormRegistryService. No special context needed.
- *
- * Cross-field validators are passed directly and applied at form level using validateTree.
  *
  * @param fields Field definitions to create schema from
  * @param registry Field type registry
@@ -190,17 +145,6 @@ export function createSchemaFromFields<TModel = unknown>(
 /**
  * Applies cross-field validators using Angular's validateTree API.
  *
- * This is the key integration point that routes cross-field validation errors
- * to the appropriate target fields via Angular's form state system.
- *
- * The validateTree function allows returning errors with a `fieldTree` property
- * that targets specific fields, which Angular automatically routes to those
- * fields' errors() signal.
- *
- * Supports two types of hoisted validators:
- * 1. Custom validators with cross-field expressions (e.g., `formValue.password === formValue.confirmPassword`)
- * 2. Built-in validators with cross-field `when` conditions (e.g., `required` when `country === 'USA'`)
- *
  * @param rootPath The root schema path tree
  * @param validators Array of collected cross-field validators
  * @param functionRegistry Registry containing custom functions for expression evaluation
@@ -253,9 +197,7 @@ function applyCrossFieldTreeValidator<TModel>(
   });
 }
 
-/**
- * Evaluates a single cross-field validator entry and returns an error if validation fails.
- */
+/** Evaluates a single cross-field validator entry and returns an error if validation fails. */
 function evaluateCrossFieldValidator<TModel>(
   entry: CrossFieldValidatorEntry,
   formValue: Record<string, unknown>,
@@ -285,9 +227,7 @@ function evaluateCrossFieldValidator<TModel>(
   }
 }
 
-/**
- * Evaluates a custom cross-field validator with an expression.
- */
+/** Evaluates a custom cross-field validator with an expression. */
 function evaluateCustomCrossFieldValidator<TModel>(
   config: CustomValidatorConfig,
   evaluationContext: EvaluationContext,
@@ -479,9 +419,7 @@ function applyBuiltInValidationLogic(config: ValidatorConfig, fieldValue: unknow
   }
 }
 
-/**
- * Utility to convert field definitions to default values object
- */
+/** Utility to convert field definitions to default values object */
 export function fieldsToDefaultValues<TModel = unknown>(fields: FieldDef<unknown>[], registry: Map<string, FieldTypeDefinition>): TModel {
   const defaultValues: Record<string, unknown> = {};
 

--- a/packages/dynamic-forms/src/lib/core/validation/validator-factory.ts
+++ b/packages/dynamic-forms/src/lib/core/validation/validator-factory.ts
@@ -258,15 +258,7 @@ function createExpressionValidator(
   };
 }
 
-/**
- * Apply async validator to field path using Angular's public validateAsync() API
- *
- * Angular's validateAsync uses the resource API, which requires:
- * - params: Function that computes params from field context
- * - factory: Function that creates ResourceRef from params signal
- * - onSuccess: Maps resource result to validation errors
- * - onError: Optional handler for resource errors
- */
+/** Apply async validator to field path using Angular's public validateAsync() API */
 function applyAsyncValidator(config: AsyncValidatorConfig, fieldPath: SchemaPath<unknown>): void {
   if (config.fn && config.functionName) {
     const logger = inject(DynamicFormLogger);
@@ -325,14 +317,7 @@ function applyUnifiedHttpValidator(
   applyDeclarativeHttpValidator(config, fieldPath);
 }
 
-/**
- * Apply function-based HTTP validator to field path using Angular's public validateHttp() API.
- *
- * Angular's validateHttp requires:
- * - request: Function that returns URL string or HttpResourceRequest
- * - onSuccess: Maps HTTP response to validation errors (inverted logic!)
- * - onError: Optional handler for HTTP errors
- */
+/** Apply function-based HTTP validator to field path using Angular's public validateHttp() API. */
 function applyFunctionHttpValidator(config: FunctionHttpValidatorConfig, fieldPath: SchemaPath<unknown>): void {
   if (config.fn && config.functionName) {
     const logger = inject(DynamicFormLogger);
@@ -366,12 +351,7 @@ function applyFunctionHttpValidator(config: FunctionHttpValidatorConfig, fieldPa
   validateHttp(fieldPath, httpOptions as Parameters<typeof validateHttp>[1]);
 }
 
-/**
- * Apply declarative HTTP validator — fully JSON-serializable, no function registration needed.
- *
- * Uses `resolveHttpRequest` to build the request from expressions and `evaluateHttpValidationResponse`
- * to map the HTTP response to a validation result.
- */
+/** Apply declarative HTTP validator — fully JSON-serializable, no function registration needed. */
 function applyDeclarativeHttpValidator(config: DeclarativeHttpValidatorConfig, fieldPath: SchemaPath<unknown>): void {
   const fieldContextRegistry = inject(FieldContextRegistryService);
   const functionRegistry = inject(FunctionRegistryService);

--- a/packages/dynamic-forms/src/lib/core/validation/validator-types.ts
+++ b/packages/dynamic-forms/src/lib/core/validation/validator-types.ts
@@ -4,88 +4,6 @@ import { Signal, ResourceRef } from '@angular/core';
 /**
  * Custom validator function signature using Angular's public FieldContext API
  *
- * Takes FieldContext (full Angular context) and optional params, returns validation error(s) or null.
- * Provides access to field state, form hierarchy, and other fields for validation logic.
- *
- * **Use FieldContext public APIs to access:**
- * - Current field value: `ctx.value()`
- * - Field state: `ctx.state` (errors, touched, dirty, etc.)
- * - Other field values: `ctx.valueOf(path)` where path is a FieldPath
- * - Other field states: `ctx.stateOf(path)`
- * - Other fields: `ctx.fieldTreeOf(path)`
- * - Current field tree: `ctx.fieldTree`
- *
- * **Return Types:**
- * - Single error: `{ kind: 'errorKind' }` for field-level validation
- * - Multiple errors: `[{ kind: 'error1' }, { kind: 'error2' }]` for cross-field validation
- * - No error: `null` when validation passes
- *
- * **Best Practice - Return Only Error Kind:**
- * Validators should focus on validation logic, not presentation.
- * Return just the error `kind` and configure messages at field level for i18n support.
- *
- * @example Single Field Validation
- * ```typescript
- * const noSpaces: CustomValidator<string> = (ctx) => {
- *   const value = ctx.value();
- *   if (typeof value === 'string' && value.includes(' ')) {
- *     return { kind: 'noSpaces' };
- *   }
- *   return null;
- * };
- *
- * // Field configuration
- * {
- *   key: 'username',
- *   validators: [{ type: 'custom', functionName: 'noSpaces' }],
- *   validationMessages: {
- *     noSpaces: 'Spaces are not allowed'
- *   }
- * }
- * ```
- *
- * @example Cross-Field Validation with valueOf()
- * ```typescript
- * // Compare two fields using public API
- * const lessThan: CustomValidator<number> = (ctx, params) => {
- *   const value = ctx.value();
- *   const compareToPath = params?.field as string;
- *
- *   // Use valueOf() to access other field - public API!
- *   const otherValue = ctx.valueOf(compareToPath as any);
- *
- *   if (otherValue !== undefined && value >= otherValue) {
- *     return { kind: 'notLessThan' };
- *   }
- *   return null;
- * };
- * ```
- *
- * @example Multiple Errors (Cross-Field Validation)
- * ```typescript
- * const validateDateRange: CustomValidator = (ctx) => {
- *   const errors: ValidationError[] = [];
- *
- *   const startDate = ctx.valueOf('startDate' as any);
- *   const endDate = ctx.valueOf('endDate' as any);
- *
- *   if (!startDate) errors.push({ kind: 'startDateRequired' });
- *   if (!endDate) errors.push({ kind: 'endDateRequired' });
- *   if (startDate && endDate && startDate > endDate) {
- *     errors.push({ kind: 'invalidDateRange' });
- *   }
- *
- *   return errors.length > 0 ? errors : null;
- * };
- * ```
- *
- * **Message Resolution Priority:**
- * 1. Field-level `validationMessages[kind]` (highest priority - per-field customization)
- * 2. Form-level `defaultValidationMessages[kind]` (fallback for common messages)
- * 3. **No message configured = Warning logged + error NOT displayed**
- *
- * **Important:** Validator-returned messages are NOT used. All messages MUST be explicitly configured.
- *
  * @template TValue The type of value stored in the field being validated
  */
 export type CustomValidator<TValue = unknown> = (
@@ -95,49 +13,6 @@ export type CustomValidator<TValue = unknown> = (
 
 /**
  * Async custom validator configuration using Angular's resource-based API
- *
- * Angular's validateAsync uses the resource API for async validation,
- * which provides better integration with Signal Forms lifecycle management.
- *
- * **Structure:**
- * - `params`: Function that computes params from field context
- * - `factory`: Function that creates a ResourceRef from params signal
- * - `onSuccess`: Maps successful resource result to validation errors
- * - `onError`: Optional handler for resource errors (network failures, etc.)
- *
- * **Use Cases:**
- * - Database lookups via services with resource API
- * - Complex async business logic with Angular resources
- * - Any async operation using Angular's resource pattern
- *
- * **Note:** For HTTP validation, prefer `HttpCustomValidator` which provides
- * a simpler API specifically designed for HTTP requests.
- *
- * @example Database Lookup with Resource
- * ```typescript
- * const checkUsernameAvailable: AsyncCustomValidator<string> = {
- *   params: (ctx) => ({ username: ctx.value() }),
- *   factory: (params) => {
- *     const injector = inject(Injector);
- *     return resource({
- *       request: () => params(),
- *       loader: ({ request }) => {
- *         if (!request?.username) return null;
- *         const service = injector.get(UserService);
- *         return firstValueFrom(service.checkAvailability(request.username));
- *       }
- *     });
- *   },
- *   onSuccess: (result, ctx) => {
- *     if (!result) return null;
- *     return result.available ? null : { kind: 'usernameTaken' };
- *   },
- *   onError: (error, ctx) => {
- *     console.error('Availability check failed:', error);
- *     return null; // Don't block form on network errors
- *   }
- * };
- * ```
  *
  * @template TValue The type of value stored in the field being validated
  * @template TParams The type of params passed to the resource
@@ -169,9 +44,7 @@ export interface AsyncCustomValidator<TValue = unknown, TParams = unknown, TResu
   readonly onError?: (error: unknown, ctx: FieldContext<TValue>) => ValidationError | ValidationError[] | null;
 }
 
-/**
- * HTTP request configuration for validateHttp API
- */
+/** HTTP request configuration for validateHttp API */
 export interface HttpResourceRequest {
   url: string;
   method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
@@ -181,66 +54,6 @@ export interface HttpResourceRequest {
 
 /**
  * HTTP-based validator configuration for Angular's validateHttp API
- *
- * Angular's validateHttp provides optimized HTTP validation with automatic
- * request cancellation and integration with the resource API.
- *
- * **Benefits:**
- * - Automatic request cancellation when field value changes
- * - Built-in integration with Angular's resource management
- * - Simpler than AsyncCustomValidator for HTTP use cases
- *
- * **Structure:**
- * - `request`: Function that returns URL string or HttpResourceRequest
- * - `onSuccess`: REQUIRED - Maps HTTP response to validation errors (inverted logic!)
- * - `onError`: Optional handler for HTTP errors (network failures, 4xx/5xx)
- *
- * **Important:** `onSuccess` uses inverted logic - it maps SUCCESSFUL HTTP responses
- * to validation errors. For example, if the API returns `{ available: false }`,
- * your `onSuccess` should return `{ kind: 'usernameTaken' }`.
- *
- * @example Username Availability Check (GET)
- * ```typescript
- * const checkUsername: HttpCustomValidator<string> = {
- *   request: (ctx) => {
- *     const username = ctx.value();
- *     if (!username) return undefined; // Skip validation if empty
- *     return `/api/users/check-username?username=${encodeURIComponent(username)}`;
- *   },
- *   onSuccess: (response, ctx) => {
- *     // Inverted logic: successful response may indicate validation failure
- *     return response.available ? null : { kind: 'usernameTaken' };
- *   },
- *   onError: (error, ctx) => {
- *     console.error('Availability check failed:', error);
- *     return null; // Don't block form on network errors
- *   }
- * };
- * ```
- *
- * @example Address Validation (POST with Body)
- * ```typescript
- * const validateAddress: HttpCustomValidator = {
- *   request: (ctx) => {
- *     const zipCode = ctx.value();
- *     if (!zipCode) return undefined;
- *
- *     return {
- *       url: '/api/validate-address',
- *       method: 'POST',
- *       body: {
- *         street: ctx.valueOf('street' as any),
- *         city: ctx.valueOf('city' as any),
- *         zipCode: zipCode
- *       },
- *       headers: { 'Content-Type': 'application/json' }
- *     };
- *   },
- *   onSuccess: (response) => {
- *     return response.valid ? null : { kind: 'invalidAddress' };
- *   }
- * };
- * ```
  *
  * @template TValue The type of value stored in the field being validated
  * @template TResult The type of HTTP response
@@ -255,22 +68,12 @@ export interface HttpCustomValidator<TValue = unknown, TResult = unknown> {
    */
   readonly request: (ctx: FieldContext<TValue>, config?: Record<string, unknown>) => string | HttpResourceRequest | undefined;
 
-  /**
-   * REQUIRED function to map successful HTTP response to validation errors.
-   *
-   * **Inverted Logic:** This is called on successful HTTP responses.
-   * Return null if validation passes, or ValidationError/ValidationError[] if validation fails.
-   *
-   * Example: API returns `{ available: false }` → return `{ kind: 'usernameTaken' }`
-   */
+  /** REQUIRED function to map successful HTTP response to validation errors. */
   readonly onSuccess: (result: TResult, ctx: FieldContext<TValue>) => TreeValidationResult;
 
   /**
    * Optional error handler for HTTP errors (network failures, 4xx/5xx status codes).
    * Return null to ignore the error, or ValidationError to display it to the user.
-   *
-   * Common pattern: Log the error and return null to avoid blocking form submission
-   * on network issues.
    */
   readonly onError?: (error: unknown, ctx: FieldContext<TValue>) => ValidationError | ValidationError[] | null;
 }

--- a/packages/dynamic-forms/src/lib/core/values/dynamic-value-function-cache.service.ts
+++ b/packages/dynamic-forms/src/lib/core/values/dynamic-value-function-cache.service.ts
@@ -1,11 +1,6 @@
 import { LogicFn } from '@angular/forms/signals';
 
-/**
- * DI-scoped cache for dynamic value functions.
- *
- * Replaces module-scoped WeakMap to ensure SSR safety.
- * Scoped to the DynamicForm component via `provideDynamicFormDI()`.
- */
+/** DI-scoped cache for dynamic value functions. */
 export class DynamicValueFunctionCacheService {
   /** Cache for memoized dynamic value functions, keyed by expression string. */
   readonly dynamicValueFunctionCache = new Map<string, LogicFn<unknown, unknown>>();

--- a/packages/dynamic-forms/src/lib/core/values/type-predicate-factory.ts
+++ b/packages/dynamic-forms/src/lib/core/values/type-predicate-factory.ts
@@ -4,21 +4,9 @@ import { ExpressionParser } from '../expressions/parser/expression-parser';
 /**
  * Create a type predicate function from a predicate string.
  *
- * Uses the secure ExpressionParser with whitelist-based evaluation instead of
- * dynamic code execution. This provides security through:
- * - AST-based parsing (no code execution)
- * - Whitelisted operators only
- * - Whitelisted methods only (Array.isArray, typeof, instanceof, etc.)
- * - No access to global scope beyond whitelisted constructors
- *
  * @param predicate - A JavaScript expression that evaluates to boolean. The value to check is available as `value`.
  * @param logger - Logger for error reporting
  * @returns A type predicate function
- *
- * @example
- * createTypePredicateFunction('typeof value === "string"')
- * createTypePredicateFunction('Array.isArray(value)')
- * createTypePredicateFunction('value instanceof Date')
  */
 export function createTypePredicateFunction<T = unknown>(predicate: string, logger: Logger): (value: unknown) => value is T {
   return (value: unknown): value is T => {

--- a/packages/dynamic-forms/src/lib/definitions/base/base-checked-field.ts
+++ b/packages/dynamic-forms/src/lib/definitions/base/base-checked-field.ts
@@ -20,14 +20,6 @@ export interface BaseCheckedField<TProps, TMeta extends FieldMeta = FieldMeta, T
   /**
    * Whether the field accepts `null` as a valid value.
    *
-   * When `true`, `value` may be `null` and an omitted `value` resolves to `null`
-   * (rather than the type-specific empty default of `false`). Orthogonal to `required`.
-   *
-   * The data model is decoupled from the UI: a null value is a legitimate
-   * "undecided" state at the storage / OpenAPI layer. Whether the rendered
-   * checkbox shows an indeterminate visual is controlled separately via
-   * `props.indeterminate` and is not driven by this flag.
-   *
    * @default false
    */
   nullable?: TNullable;

--- a/packages/dynamic-forms/src/lib/definitions/base/base-value-field.ts
+++ b/packages/dynamic-forms/src/lib/definitions/base/base-value-field.ts
@@ -18,11 +18,6 @@ export interface BaseValueField<TProps, TValue, TMeta extends FieldMeta = FieldM
   /**
    * Placeholder text displayed when the field is empty.
    * Supports static strings, Observables, and Signals for dynamic content.
-   *
-   * Note: placeholder lives at the field level, NOT inside `props`. The integration-layer
-   * `props` interfaces (InputProps, TextareaProps, SelectProps, DatepickerProps) intentionally
-   * omit `placeholder` — TypeScript's excess property check rejects `props: { placeholder: ... }`
-   * for any `props` literal typed against those interfaces.
    */
   placeholder?: DynamicText;
 
@@ -30,13 +25,6 @@ export interface BaseValueField<TProps, TValue, TMeta extends FieldMeta = FieldM
 
   /**
    * Whether the field accepts `null` as a valid value.
-   *
-   * When `true`, `value` may be `null` and an omitted `value` resolves to `null`
-   * (rather than the type-specific empty default). Orthogonal to `required`.
-   *
-   * Read-side caveat: a user clearing a text input reads back as `""`, not `null`
-   * — this matches classic Reactive Forms and is enforced by the Web IDL contract.
-   * `nullable` is a contract for accepted values, not a guarantee of emitted ones.
    *
    * @default false
    */

--- a/packages/dynamic-forms/src/lib/definitions/base/field-def.ts
+++ b/packages/dynamic-forms/src/lib/definitions/base/field-def.ts
@@ -9,181 +9,30 @@ import { FieldMeta } from './field-meta';
 /**
  * Base interface for all dynamic form field definitions.
  *
- * This interface defines the common properties that all field types must implement.
- * Field-specific properties are defined through the generic TProps parameter,
- * providing type safety for field-specific configuration.
- *
- * @example
- * ```typescript
- * // Basic text input field
- * const textField: FieldDef<{ type?: string }> = {
- *   key: 'email',
- *   type: 'input',
- *   label: 'Email Address',
- *   props: { type: 'email' },
- *   col: 12
- * };
- * ```
- *
- * @example
- * ```typescript
- * // Complex field with conditional logic
- * const conditionalField: FieldDef<SelectProps> = {
- *   key: 'country',
- *   type: 'select',
- *   label: 'Country',
- *   props: {
- *     options: [
- *       { label: 'United States', value: 'us' },
- *       { label: 'Canada', value: 'ca' }
- *     ]
- *   },
- *   hidden: false,
- *   disabled: false,
- *   col: 6
- * };
- * ```
- *
  * @typeParam TProps - Field-specific properties interface
  * @typeParam TMeta - Native HTML attributes interface (extends FieldMeta)
- *
- * @public
  */
 export interface FieldDef<TProps, TMeta extends FieldMeta = FieldMeta> {
-  /**
-   * Unique field identifier used for form binding and value tracking.
-   *
-   * This key is used to associate the field with form values and must be
-   * unique within the form. It follows object property naming conventions.
-   *
-   * @example
-   * ```typescript
-   * // Simple field key
-   * key: 'email'
-   *
-   * // Nested object notation
-   * key: 'address.street'
-   *
-   * // Array notation
-   * key: 'hobbies[0]'
-   * ```
-   */
+  /** Unique field identifier used for form binding and value tracking. */
   key: string;
 
-  /**
-   * Field type identifier for component selection.
-   *
-   * Determines which component will be rendered for this field. Names
-   * registered through module augmentation of `DynamicFormFieldRegistry`
-   * are surfaced as IDE autocomplete suggestions via `RegisteredFieldTypes`;
-   * the `(string & {})` branch keeps arbitrary custom identifiers accepted
-   * as an escape hatch for fields that haven't been augmented into the
-   * registry.
-   *
-   * @example
-   * ```typescript
-   * type: 'input'     // Text input field (registered)
-   * type: 'select'    // Dropdown selection (registered)
-   * type: 'checkbox'  // Boolean checkbox  (registered)
-   * type: 'group'     // Field group container (registered)
-   * type: 'my-custom' // Unregistered — still accepted, no autocomplete
-   * ```
-   *
-   * Wrapper types are intentionally excluded — wrappers are configured through
-   * `wrappers` / `withFormWrappers()` rather than via the field-type discriminant.
-   */
+  /** Field type identifier for component selection. */
   type: RegisteredFieldTypes['type'] | (string & {});
 
-  /**
-   * Human-readable field label displayed to users.
-   *
-   * Provides accessible labeling for form fields and is typically
-   * displayed above or beside the field input. Supports static strings,
-   * translation keys, Observables, and Signals for dynamic content.
-   *
-   * @example
-   * ```typescript
-   * // Static string
-   * label: 'Email Address'
-   *
-   * // Translation key (auto-detected)
-   * label: 'form.email.label'
-   *
-   * // Observable from translation service
-   * label: this.transloco.selectTranslate('form.email.label')
-   *
-   * // Signal-based
-   * label: computed(() => this.translations().email.label)
-   * ```
-   */
+  /** Human-readable field label displayed to users. */
   label?: DynamicText;
 
-  /**
-   * Field-specific properties and configuration options.
-   *
-   * Contains type-specific configuration that varies based on the field type.
-   * The shape is defined by the TProps generic parameter.
-   *
-   * @example
-   * ```typescript
-   * // Input field props (placeholder is at field level, not inside props)
-   * props: { type: 'email' }
-   *
-   * // Select field props
-   * props: { options: [{ label: 'Yes', value: true }], multiple: false }
-   *
-   * // Button field props
-   * props: { buttonType: 'submit', variant: 'primary' }
-   * ```
-   */
+  /** Field-specific properties and configuration options. */
   props?: TProps;
 
-  /**
-   * Native HTML attributes to pass through to the underlying element.
-   *
-   * Contains attributes that are applied directly to the native input/element.
-   * Useful for accessibility, autocomplete hints, and custom attributes.
-   * The shape is defined by the TMeta generic parameter, which extends FieldMeta.
-   *
-   * @example
-   * ```typescript
-   * // Input field meta
-   * meta: {
-   *   autocomplete: 'email',
-   *   inputmode: 'email',
-   *   'aria-describedby': 'email-help',
-   *   'data-testid': 'email-input'
-   * }
-   *
-   * // Textarea meta
-   * meta: {
-   *   wrap: 'soft',
-   *   spellcheck: true,
-   *   'aria-label': 'Description field'
-   * }
-   * ```
-   */
+  /** Native HTML attributes to pass through to the underlying element. */
   meta?: TMeta;
 
-  /**
-   * Additional CSS classes for custom styling.
-   *
-   * Space-separated string of CSS class names that will be applied
-   * to the field container for custom styling.
-   *
-   * @example
-   * ```typescript
-   * className: 'highlight required-field'
-   * className: 'mt-4 text-center'
-   * ```
-   */
+  /** Additional CSS classes for custom styling. */
   className?: string;
 
   /**
    * Whether the field is disabled and cannot be interacted with.
-   *
-   * When true, the field is rendered in a disabled state and cannot
-   * receive user input. The value can still be modified programmatically.
    *
    * @value false
    */
@@ -192,9 +41,6 @@ export interface FieldDef<TProps, TMeta extends FieldMeta = FieldMeta> {
   /**
    * Whether the field is read-only.
    *
-   * When true, the field displays its value but cannot be modified
-   * by user interaction. Differs from disabled in styling and accessibility.
-   *
    * @value false
    */
   readonly?: boolean;
@@ -202,34 +48,15 @@ export interface FieldDef<TProps, TMeta extends FieldMeta = FieldMeta> {
   /**
    * Whether the field is hidden from view.
    *
-   * When true, the field is not rendered in the UI. By default, validators on
-   * a hidden field are skipped — set {@link validateWhenHidden} to `true` (on
-   * the field, an ancestor, the form, or globally) to keep validation running
-   * while hidden. State logic and value derivations continue to apply.
-   *
    * @value false
    */
   hidden?: boolean;
 
-  /**
-   * Tab index for keyboard navigation.
-   *
-   * Controls the order in which fields receive focus when navigating
-   * with the Tab key. Follows standard HTML tabindex behavior.
-   *
-   * @example
-   * ```typescript
-   * tabIndex: 1    // First field in tab order
-   * tabIndex: -1   // Excluded from tab navigation
-   * tabIndex: 0    // Natural tab order
-   * ```
-   */
+  /** Tab index for keyboard navigation. */
   tabIndex?: number | undefined;
 
   /**
    * Whether to exclude this field's value from submission output when hidden.
-   *
-   * Overrides both the global `withValueExclusionDefaults()` and form-level `FormOptions` settings.
    *
    * @default undefined (uses form-level or global setting)
    */
@@ -238,16 +65,12 @@ export interface FieldDef<TProps, TMeta extends FieldMeta = FieldMeta> {
   /**
    * Whether to exclude this field's value from submission output when disabled.
    *
-   * Overrides both the global `withValueExclusionDefaults()` and form-level `FormOptions` settings.
-   *
    * @default undefined (uses form-level or global setting)
    */
   excludeValueIfDisabled?: boolean;
 
   /**
    * Whether to exclude this field's value from submission output when readonly.
-   *
-   * Overrides both the global `withValueExclusionDefaults()` and form-level `FormOptions` settings.
    *
    * @default undefined (uses form-level or global setting)
    */
@@ -257,16 +80,6 @@ export interface FieldDef<TProps, TMeta extends FieldMeta = FieldMeta> {
    * Whether to run validation when this field is hidden — statically (`hidden: true`),
    * via a `hidden` logic rule, or via any hidden ancestor.
    *
-   * When `false`, all validators on this field (built-in like `required`/`email`/`min`,
-   * custom `validate()`/expression validators, and `required` state logic) are skipped
-   * while the field is hidden. The hidden state, disabled state, readonly state, and
-   * value derivations continue to apply.
-   *
-   * Inherited from the parent field — once a field overrides this value, all of its
-   * descendants inherit the new value unless they override in turn. Form-level
-   * `FormOptions.validateWhenHidden` is the root inherited value, falling back to the
-   * global default.
-   *
    * @default undefined — inherits from parent / form / global default (which is `false`)
    */
   validateWhenHidden?: boolean;
@@ -274,29 +87,11 @@ export interface FieldDef<TProps, TMeta extends FieldMeta = FieldMeta> {
   /**
    * Column sizing configuration for responsive grid layout.
    *
-   * Specifies how many columns this field should span in a 12-column
-   * grid system. Supports responsive behavior and field arrangement.
-   *
-   * @example
-   * ```typescript
-   * col: 12  // Full width
-   * col: 6   // Half width
-   * col: 4   // One third width
-   * col: 3   // Quarter width
-   * ```
-   *
    * @value 12
    */
   col?: number;
 
-  /**
-   * Wrapper components to chain around this field.
-   *
-   * - `undefined` — inherit auto-associations + form defaults.
-   * - `null` — render bare (see `skipAuto`/`skipDefaults` for partial opt-out).
-   * - `readonly WrapperConfig[]` — merged innermost with auto + defaults.
-   * - `[]` is **not** an opt-out; inherits like `undefined`.
-   */
+  /** Wrapper components to chain around this field. */
   wrappers?: readonly WrapperConfig[] | null;
 
   /**
@@ -312,23 +107,7 @@ export interface FieldDef<TProps, TMeta extends FieldMeta = FieldMeta> {
    */
   skipDefaultWrappers?: boolean;
 
-  /**
-   * Addons rendered inside this field's slots (typically `prefix` / `suffix`).
-   *
-   * Each addon declares its kind, slot, and kind-specific configuration.
-   * Whether a field type accepts addons — and which slots / kinds — is
-   * declared at registration via `FieldTypeDefinition.addons`. Field types
-   * without that registration ("Tier 3", e.g., toggle, radio) drop any
-   * `addons` value with a lenient warning at config init.
-   *
-   * @example
-   * ```typescript
-   * addons: [
-   *   { slot: 'prefix', kind: 'prime-icon', icon: 'search' },
-   *   { slot: 'suffix', kind: 'prime-button', preset: 'clear', ariaLabel: 'Clear' },
-   * ]
-   * ```
-   */
+  /** Addons rendered inside this field's slots (typically `prefix` / `suffix`). */
   addons?: ReadonlyArray<AnyAddon>;
 }
 
@@ -337,17 +116,6 @@ type IncludedKeys = 'label' | 'className' | 'hidden' | 'tabIndex';
 /**
  * Type utility for extracting component input properties from field definitions.
  *
- * Transforms field definition properties into Angular component input signals,
- * enabling type-safe component binding with automatic signal creation.
- *
- * @example
- * ```typescript
- * // Field definition
- * interface MyFieldDef extends FieldDef<MyProps> {
- *   customProp: string;
- * }
- *
- * // Component using FieldComponent type
  * @Component({...})
  * export class MyFieldComponent implements FieldComponent<MyFieldDef> {
  *   label = input<string>();
@@ -356,9 +124,6 @@ type IncludedKeys = 'label' | 'className' | 'hidden' | 'tabIndex';
  *   tabIndex = input<number>();
  * }
  * ```
- *
  * @typeParam T - Field definition type to extract properties from
- *
- * @public
  */
 export type FieldComponent<T extends FieldDef<unknown, FieldMeta>> = Prettify<WithInputSignals<Pick<T, IncludedKeys>>>;

--- a/packages/dynamic-forms/src/lib/definitions/base/field-meta.ts
+++ b/packages/dynamic-forms/src/lib/definitions/base/field-meta.ts
@@ -1,34 +1,11 @@
-/**
- * Base interface for native HTML attributes that can be passed to form field elements.
- *
- * This interface serves as the base type for all meta attributes. Specific field types
- * (like input, textarea) extend this with their own specialized meta types.
- *
- * @example
- * ```typescript
- * // Using FieldMeta for custom attributes
- * meta: {
- *   'data-testid': 'email-input',
- *   'aria-describedby': 'email-help',
- *   'x-custom': 'value'
- * }
- * ```
- *
- * @public
- */
+/** Base interface for native HTML attributes that can be passed to form field elements. */
 export interface FieldMeta {
-  /**
-   * Allows any data-* attribute
-   */
+  /** Allows any data-* attribute */
   [key: `data-${string}`]: string | undefined;
 
-  /**
-   * Allows any aria-* attribute
-   */
+  /** Allows any aria-* attribute */
   [key: `aria-${string}`]: string | boolean | undefined;
 
-  /**
-   * Allows additional custom attributes as escape hatch
-   */
+  /** Allows additional custom attributes as escape hatch */
   [key: string]: string | number | boolean | undefined;
 }

--- a/packages/dynamic-forms/src/lib/definitions/base/field-with-validation.ts
+++ b/packages/dynamic-forms/src/lib/definitions/base/field-with-validation.ts
@@ -22,42 +22,7 @@ export interface FieldWithValidation {
   // Logic rules (hidden, readonly, disabled, required, derivation)
   readonly logic?: LogicConfig[];
 
-  /**
-   * Shorthand for simple computed/derived fields.
-   *
-   * The expression is evaluated whenever its dependencies change,
-   * and the result is set as this field's value.
-   *
-   * Has access to `formValue` object containing all form values.
-   * Uses the same secure AST-based parser as other expressions.
-   *
-   * For conditional derivations or derivations targeting other fields,
-   * use the full `logic` array with `{ type: 'derivation', ... }`.
-   *
-   * @example
-   * ```typescript
-   * // Compute total from quantity and price
-   * {
-   *   key: 'total',
-   *   type: 'number',
-   *   derivation: 'formValue.quantity * formValue.unitPrice'
-   * }
-   *
-   * // Concatenate names
-   * {
-   *   key: 'fullName',
-   *   type: 'input',
-   *   derivation: 'formValue.firstName + " " + formValue.lastName'
-   * }
-   *
-   * // Calculate discounted price
-   * {
-   *   key: 'discountedPrice',
-   *   type: 'number',
-   *   derivation: 'formValue.price * (1 - formValue.discountPercent / 100)'
-   * }
-   * ```
-   */
+  /** Shorthand for simple computed/derived fields. */
   readonly derivation?: string;
 
   // Schema applications for complex configurations

--- a/packages/dynamic-forms/src/lib/definitions/default/array-field.ts
+++ b/packages/dynamic-forms/src/lib/definitions/default/array-field.ts
@@ -12,74 +12,10 @@ export type ArrayItemTemplate = readonly ArrayAllowedChildren[];
  * An array item definition can be either:
  * - A single field (ArrayAllowedChildren) for PRIMITIVE array items - extracts field value directly
  * - An array of fields (ArrayItemTemplate) for OBJECT array items - merges fields into object
- *
- * This allows support for:
- * - Primitive arrays: `['tag1', 'tag2']`
- * - Object arrays: `[{ name: 'Alice', email: '...' }]`
- * - Heterogeneous arrays: `[{ value: 'x' }, 'y']` (mixed primitives and objects)
  */
 export type ArrayItemDefinition = ArrayAllowedChildren | ArrayItemTemplate;
 
-/**
- * Array field interface for creating dynamic field collections that map to array values.
- *
- * Key concepts:
- * - The outer `fields` array defines INITIAL ITEMS (each element is one array item to render)
- * - Each element can be either:
- *   - A single FieldDef (primitive item) - the field's value is extracted directly
- *   - An array of FieldDefs (object item) - fields are merged into an object
- * - Items can have different field configurations (heterogeneous arrays supported)
- * - Empty `fields: []` means no initial items - user adds via buttons with explicit templates
- * - Initial values are declared via `value` property on each field definition
- *
- * @example
- * // Primitive array: ['angular', 'typescript']
- * {
- *   key: 'tags',
- *   type: 'array',
- *   fields: [
- *     { key: 'tag', type: 'input', value: 'angular' },      // Single field = primitive
- *     { key: 'tag', type: 'input', value: 'typescript' },
- *   ]
- * }
- *
- * @example
- * // Object array: [{ name: 'Alice', email: '...' }]
- * {
- *   key: 'contacts',
- *   type: 'array',
- *   fields: [
- *     [                                                      // Array = object
- *       { key: 'name', type: 'input', value: 'Alice' },
- *       { key: 'email', type: 'input', value: 'alice@example.com' }
- *     ],
- *   ]
- * }
- *
- * @example
- * // Heterogeneous array: [{ label: 'Structured' }, 'Simple']
- * {
- *   key: 'items',
- *   type: 'array',
- *   fields: [
- *     [{ key: 'label', type: 'input', value: 'Structured' }],  // Object item
- *     { key: 'value', type: 'input', value: 'Simple' },        // Primitive item
- *   ]
- * }
- *
- * @example
- * // Empty array (add items via buttons)
- * {
- *   key: 'tags',
- *   type: 'array',
- *   fields: []  // No initial items - user adds via button with template
- * }
- *
- * Nesting constraints: Arrays can contain rows, leaf fields, or groups (for object arrays),
- * but NOT pages or other arrays. Runtime validation enforces these rules.
- *
- * Note: Arrays are container fields and do not support `meta` since they have no native form element.
- */
+/** Array field interface for creating dynamic field collections that map to array values. */
 export interface ArrayField<TFields extends readonly ArrayItemDefinition[] = readonly ArrayItemDefinition[]> extends FieldDef<never> {
   type: 'array';
 
@@ -93,10 +29,10 @@ export interface ArrayField<TFields extends readonly ArrayItemDefinition[] = rea
    */
   readonly fields: TFields;
 
-  /** Array fields do not have a label property **/
+  /** Array fields do not have a label property * */
   readonly label?: never;
 
-  /** Arrays do not support meta - they have no native form element **/
+  /** Arrays do not support meta - they have no native form element * */
   readonly meta?: never;
 
   /**
@@ -130,9 +66,7 @@ export function isArrayField(field: FieldDef<any>): field is ArrayField {
 
 export type ArrayComponent<T extends ArrayItemTemplate[]> = FieldComponent<ArrayField<T>>;
 
-/**
- * Configuration for auto-generated add/remove buttons in simplified array fields.
- */
+/** Configuration for auto-generated add/remove buttons in simplified array fields. */
 export interface ArrayButtonConfig {
   /** Custom label for the button */
   readonly label?: string;
@@ -140,46 +74,7 @@ export interface ArrayButtonConfig {
   readonly props?: Record<string, unknown>;
 }
 
-/**
- * Simplified array field interface for common use cases.
- *
- * Instead of manually specifying each item in `fields`, provide a `template` that defines
- * the structure of a single item, and a `value` array with initial data.
- * The library auto-generates add/remove buttons.
- *
- * Discriminant: `template` presence → simplified API; `Array.isArray(template)` → object vs primitive.
- *
- * @example
- * // Primitive array: ['angular', 'typescript']
- * {
- *   key: 'tags',
- *   type: 'array',
- *   template: { key: 'value', type: 'input', label: 'Tag', required: true },
- *   value: ['angular', 'typescript']
- * }
- *
- * @example
- * // Object array: [{ name: 'Jane', phone: '555' }]
- * {
- *   key: 'contacts',
- *   type: 'array',
- *   template: [
- *     { key: 'name', type: 'input', label: 'Contact Name', required: true },
- *     { key: 'phone', type: 'input', label: 'Phone Number' },
- *   ],
- *   value: [{ name: 'Jane', phone: '555' }]
- * }
- *
- * @example
- * // Button customization / opt-out
- * {
- *   key: 'tags',
- *   type: 'array',
- *   template: { key: 'value', type: 'input', label: 'Tag' },
- *   addButton: { label: 'Add Tag', props: { color: 'primary' } },
- *   removeButton: false
- * }
- */
+/** Simplified array field interface for common use cases. */
 export interface SimplifiedArrayField extends FieldDef<never> {
   type: 'array';
 

--- a/packages/dynamic-forms/src/lib/definitions/default/container-field.ts
+++ b/packages/dynamic-forms/src/lib/definitions/default/container-field.ts
@@ -3,56 +3,7 @@ import { ContainerAllowedChildren } from '../../models/types/nesting-constraints
 import { ContainerLogicConfig } from '../base/container-logic-config';
 import { WrapperConfig } from '../../models/wrapper-type';
 
-/**
- * Container field interface for wrapping child fields with UI chrome.
- *
- * A container field is a container that renders its children inside a chain
- * of wrapper components. Each wrapper provides visual decoration (sections,
- * headers, expand/collapse, styling) without affecting the form data structure.
- *
- * Like a row field, the container field:
- * - Does not create a new form context
- * - Flattens child values into the parent form
- * - Is purely a visual/layout container
- *
- * Unlike a row field, the container field:
- * - Supports a `wrappers` array that chains wrapper components around the children
- * - Uses imperative `ViewContainerRef.createComponent()` for the wrapper chain
- *
- * Containers are pure layout primitives that flatten their children into the
- * parent form, so any registered field type may appear inside — including
- * pages, hidden fields, rows, and other containers (see
- * {@link ContainerAllowedChildren}).
- *
- * @example
- * ```typescript
- * const field: ContainerField = {
- *   type: 'container',
- *   key: 'contactSection',
- *   fields: [
- *     { key: 'email', type: 'input', value: '' },
- *     { key: 'phone', type: 'input', value: '' },
- *   ],
- *   wrappers: [
- *     { type: 'section', header: 'Contact Info' },
- *   ]
- * };
- * ```
- *
- * @example
- * ```typescript
- * // Multiple wrappers chain from outermost to innermost
- * const field: ContainerField = {
- *   type: 'container',
- *   key: 'styledSection',
- *   fields: [{ key: 'name', type: 'input', value: '' }],
- *   wrappers: [
- *     { type: 'section', header: 'Details' },  // outermost
- *     { type: 'style', class: 'highlight' },    // innermost
- *   ]
- * };
- * ```
- */
+/** Container field interface for wrapping child fields with UI chrome. */
 export interface ContainerField<
   TFields extends readonly ContainerAllowedChildren[] = readonly ContainerAllowedChildren[],
   TWrapperConfigs extends readonly WrapperConfig[] = readonly WrapperConfig[],
@@ -83,14 +34,7 @@ export interface ContainerField<
   readonly logic?: ContainerLogicConfig[];
 }
 
-/**
- * Type guard for ContainerField with proper type narrowing.
- *
- * `wrappers` is part of the type but optional in practice — many configs use
- * containers purely as flex/layout wrappers without any wrapper components.
- * Match on `type === 'container'` and the `fields` shape only, mirroring
- * `isPageField` / `isRowField`.
- */
+/** Type guard for ContainerField with proper type narrowing. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Type guard must accept any field type
 export function isContainerTypedField(field: FieldDef<any>): field is ContainerField {
   return (

--- a/packages/dynamic-forms/src/lib/definitions/default/group-field.ts
+++ b/packages/dynamic-forms/src/lib/definitions/default/group-field.ts
@@ -6,22 +6,16 @@ import { ContainerLogicConfig } from '../base/container-logic-config';
  * Group field interface for creating logical field groupings that map to object values
  * Groups create nested form structures where child field values are collected into an object
  * This is a programmatic grouping only - users cannot customize this field type
- *
- * TypeScript cannot enforce field nesting rules due to circular dependency limitations.
- * For documentation: Groups should contain rows and leaf fields, but NOT pages or other groups.
- * Runtime validation enforces these rules.
- *
- * Note: Groups are container fields and do not support `meta` since they have no native form element.
  */
 export interface GroupField<TFields extends readonly GroupAllowedChildren[] = readonly GroupAllowedChildren[]> extends FieldDef<never> {
   type: 'group';
 
   readonly fields: TFields;
 
-  /** Groups do not have a label property - they are logical containers only **/
+  /** Groups do not have a label property - they are logical containers only * */
   readonly label?: never;
 
-  /** Groups do not support meta - they have no native form element **/
+  /** Groups do not support meta - they have no native form element * */
   readonly meta?: never;
 
   /**
@@ -31,9 +25,7 @@ export interface GroupField<TFields extends readonly GroupAllowedChildren[] = re
   readonly logic?: ContainerLogicConfig[];
 }
 
-/**
- * Type guard for GroupField with proper type narrowing
- */
+/** Type guard for GroupField with proper type narrowing */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Type guard must accept any field type
 export function isGroupField(field: FieldDef<any>): field is GroupField {
   return field.type === 'group' && 'fields' in field;

--- a/packages/dynamic-forms/src/lib/definitions/default/hidden-field.ts
+++ b/packages/dynamic-forms/src/lib/definitions/default/hidden-field.ts
@@ -16,32 +16,6 @@ export type HiddenValue = HiddenScalar | HiddenScalar[];
 /**
  * Hidden field definition for storing values without rendering UI.
  *
- * Hidden fields participate in the form schema and contribute to form values,
- * but do not render any visible component. They are useful for:
- * - Storing IDs when updating existing records
- * - Persisting metadata that shouldn't be user-editable
- * - Tracking computed values that need to be submitted
- *
- * Unlike the `hidden` property on other fields (which hides a rendered field),
- * this field type renders nothing at all - it's a componentless field.
- *
- * @example
- * ```typescript
- * // Store a record ID for updates
- * const idField: HiddenField<string> = {
- *   type: 'hidden',
- *   key: 'id',
- *   value: '550e8400-e29b-41d4-a716-446655440000',
- * };
- *
- * // Store multiple tag IDs
- * const tagIdsField: HiddenField<number[]> = {
- *   type: 'hidden',
- *   key: 'tagIds',
- *   value: [1, 2, 3],
- * };
- * ```
- *
  * @typeParam TValue - The type of value stored (must be HiddenValue compatible)
  */
 export interface HiddenField<TValue extends HiddenValue = HiddenValue> extends FieldDef<never> {

--- a/packages/dynamic-forms/src/lib/definitions/default/page-field.ts
+++ b/packages/dynamic-forms/src/lib/definitions/default/page-field.ts
@@ -11,12 +11,6 @@ import { ContainerLogicConfig } from '../base/container-logic-config';
  * The page itself doesn't have a value - it's a layout container like row
  * Pages can only be used at the top level and cannot be nested
  * This is a programmatic field type only - users cannot customize this field type
- *
- * TypeScript cannot enforce field nesting rules due to circular dependency limitations.
- * For documentation: Pages should contain rows, groups, and leaf fields, but NOT other pages.
- * Runtime validation enforces these rules.
- *
- * Note: Pages are container fields and do not support `meta` since they have no native form element.
  */
 export interface PageField<TFields extends readonly PageAllowedChildren[] = PageAllowedChildren[]> extends FieldDef<never> {
   type: 'page';
@@ -24,46 +18,27 @@ export interface PageField<TFields extends readonly PageAllowedChildren[] = Page
   /** Child field definitions to render within this page */
   readonly fields: TFields;
 
-  /** Page fields do not have a label property **/
+  /** Page fields do not have a label property * */
   readonly label?: never;
 
-  /** Pages do not support meta - they have no native form element **/
+  /** Pages do not support meta - they have no native form element * */
   readonly meta?: never;
 
   /**
    * Logic configurations for conditional page visibility.
    * Only 'hidden' type logic is supported for pages.
-   *
-   * @example
-   * ```typescript
-   * {
-   *   key: 'businessPage',
-   *   type: 'page',
-   *   logic: [{
-   *     type: 'hidden',
-   *     condition: {
-   *       type: 'fieldValue',
-   *       fieldPath: 'accountType',
-   *       operator: 'notEquals',
-   *       value: 'business',
-   *     },
-   *   }],
-   *   fields: [...]
-   * }
-   * ```
    */
   readonly logic?: ContainerLogicConfig[];
 }
 
-/**
- * Type guard for PageField with proper type narrowing
- */
+/** Type guard for PageField with proper type narrowing */
 export function isPageField(field: FieldDef<unknown>): field is PageField {
   return field.type === 'page' && 'fields' in field && Array.isArray((field as PageField).fields);
 }
 
 /**
  * Validates that a page field doesn't contain nested page fields
+ *
  * @param pageField The page field to validate
  * @returns true if valid (no nested pages), false otherwise
  */
@@ -71,9 +46,7 @@ export function validatePageNesting(pageField: PageField): boolean {
   return !hasNestedPages(pageField.fields);
 }
 
-/**
- * Type guard to check if a field is a container with fields property
- */
+/** Type guard to check if a field is a container with fields property */
 function isContainerWithFields(field: FieldDef<unknown>): field is FieldDef<unknown> & { readonly fields: readonly FieldDef<unknown>[] } {
   return (
     (isRowField(field) || isGroupField(field) || isContainerTypedField(field)) &&
@@ -84,6 +57,7 @@ function isContainerWithFields(field: FieldDef<unknown>): field is FieldDef<unkn
 
 /**
  * Recursively checks if fields contain any nested page fields
+ *
  * @param fields Array of field definitions to check
  * @returns true if nested pages found, false otherwise
  */

--- a/packages/dynamic-forms/src/lib/definitions/default/row-field.ts
+++ b/packages/dynamic-forms/src/lib/definitions/default/row-field.ts
@@ -7,8 +7,6 @@ import { ContainerLogicConfig } from '../base/container-logic-config';
  * A row is a synthetic field type that resolves to a Container at runtime,
  * with a synthesized `{ type: 'row' }` wrapper applied for layout. The row
  * itself does not hold a value — its children flatten into the parent form.
- *
- * Note: Rows do not support `meta` since they have no native form element.
  */
 export interface RowField<TFields extends readonly RowAllowedChildren[] = readonly RowAllowedChildren[]> extends FieldDef<never> {
   type: 'row';
@@ -16,10 +14,10 @@ export interface RowField<TFields extends readonly RowAllowedChildren[] = readon
   /** Child definitions to render within this row */
   readonly fields: TFields;
 
-  /** Row fields do not have a label property **/
+  /** Row fields do not have a label property * */
   readonly label?: never;
 
-  /** Rows do not support meta - they have no native form element **/
+  /** Rows do not support meta - they have no native form element * */
   readonly meta?: never;
 
   /**
@@ -29,9 +27,7 @@ export interface RowField<TFields extends readonly RowAllowedChildren[] = readon
   readonly logic?: ContainerLogicConfig[];
 }
 
-/**
- * Type guard for RowField with proper type narrowing
- */
+/** Type guard for RowField with proper type narrowing */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Type guard must accept any field type
 export function isRowField(field: FieldDef<any>): field is RowField {
   return field.type === 'row' && 'fields' in field && Array.isArray((field as RowField).fields);

--- a/packages/dynamic-forms/src/lib/definitions/default/text-field.ts
+++ b/packages/dynamic-forms/src/lib/definitions/default/text-field.ts
@@ -1,22 +1,16 @@
 import { FieldDef } from '../base/field-def';
 import { NonFieldLogicConfig } from '../../core/logic/non-field-logic-resolver';
 
-/**
- * Text element type for rendering different HTML text elements
- */
+/** Text element type for rendering different HTML text elements */
 export type TextElementType = 'p' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'span';
 
-/**
- * Properties for text field configuration
- */
+/** Properties for text field configuration */
 export type TextProps = {
   /** The HTML element type to render */
   elementType: TextElementType;
 };
 
-/**
- * Text field definition for displaying translatable text content
- */
+/** Text field definition for displaying translatable text content */
 export interface TextField extends FieldDef<TextProps> {
   type: 'text';
 

--- a/packages/dynamic-forms/src/lib/directives/df-field-outlet/df-field-outlet.directive.ts
+++ b/packages/dynamic-forms/src/lib/directives/df-field-outlet/df-field-outlet.directive.ts
@@ -13,40 +13,6 @@ import { FieldComponentSlot } from './field-component-slot';
 /**
  * Structural directive that renders a `ResolvedField` with its effective
  * wrapper chain.
- *
- * Replaces `*ngComponentOutlet` in field-rendering templates. When the field
- * has no wrappers, the component is created directly at the outlet position
- * (no extra DOM nesting). When wrappers apply, they chain outermost-first and
- * the field renders in the innermost slot.
- *
- * Effective wrappers are merged from (outermost → innermost):
- * 1. `WrapperTypeDefinition.types` auto-associations for the field's `type`
- * 2. `FormConfig.defaultWrappers`
- * 3. Field-level `FieldDef.wrappers` (`null` = explicit opt-out; `[]` does not
- *    opt out — auto + defaults still apply)
- *
- * Wrapper config keys (minus `type`) are pushed as individual Angular inputs;
- * every wrapper also receives `fieldInputs` — a `WrapperFieldInputs` bag that
- * includes the field's mapper outputs and a `ReadonlyFieldTree` view of its
- * form state.
- *
- * Rendering is gated by `field.renderReady() && !field.hidden()` — the
- * directive waits until the mapper produces the required inputs AND the
- * field isn't hidden before instantiating the component. Once rendered, a
- * transient `renderReady → false` does *not* tear the chain down; the
- * controller keeps the mounted components alive and ignores the flicker.
- * Only a structural change (wrappers or component class) triggers a rebuild.
- *
- * Imperative `ComponentRef` / `ViewContainerRef` lifecycle is encapsulated
- * in `FieldComponentSlot` — the directive itself is signal definitions
- * plus three method calls (`mountOrReuse`, `detach`, `destroyOnTeardown`).
- *
- * @example
- * ```html
- * \@for (field of resolvedFields(); track field.key) {
- *   <ng-container *dfFieldOutlet="field; environmentInjector: envInjector" />
- * }
- * ```
  */
 @Directive({
   selector: '[dfFieldOutlet]',

--- a/packages/dynamic-forms/src/lib/directives/df-field-outlet/field-component-slot.ts
+++ b/packages/dynamic-forms/src/lib/directives/df-field-outlet/field-component-slot.ts
@@ -18,15 +18,6 @@ interface FocusSnapshot {
  * exactly the data each phase needs, so nothing in the slot is "optional state
  * that might be undefined" — the type forces every code path to handle the
  * empty/mounted/detached cases distinctly.
- *
- * - `empty`     — no `ComponentRef` exists. Either initial state or post-teardown.
- * - `mounted`   — the ref is inserted into `slot`. Inputs are being pushed.
- * - `detached`  — the ref's host view has been pulled from its slot; held briefly
- *                 between `detach()` and the next `mountOrReuse()` so a same-class
- *                 reuse can re-insert it and replay focus.
- *
- * State objects are frozen at construction so any accidental mutation throws in
- * strict mode rather than silently producing torn state.
  */
 export type FieldSlotState =
   | { readonly phase: 'empty' }
@@ -49,20 +40,6 @@ const EMPTY_STATE: FieldSlotState = Object.freeze({ phase: 'empty' });
  * directive itself stays declarative — signals + constructor wiring — while
  * the unavoidable mutable bookkeeping (Angular's view container API is
  * imperative) lives in one place behind a small, focused surface.
- *
- * State is held in a single `signal<FieldSlotState>` discriminated union;
- * every mutation is an explicit `state.set(...)` transition. No nullable
- * instance fields, no `undefined`-initialized refs — each phase carries
- * exactly the data it owns.
- *
- * Responsibilities:
- * - Create the component (or reuse the same-class instance across a rebuild,
- *   preserving its DOM state, focus, and caret).
- * - Push mapper inputs via `setInput`, dedup'd per-key so dev-mode NG0303
- *   warnings for undeclared mapper keys don't replay on every emission.
- * - Detach cleanly before the outer VCR clears, so same-class reuse can
- *   re-insert the preserved `hostView`.
- * - Destroy on directive teardown when the host view is still detached.
  */
 export class FieldComponentSlot {
   private readonly state = signal<FieldSlotState>(EMPTY_STATE);
@@ -126,15 +103,6 @@ export class FieldComponentSlot {
    * `setInput` on unknown keys logs NG0303 per call (Angular 21 is lenient
    * at runtime but warns); without the cache, every emission would re-warn
    * for every undeclared mapper key.
-   *
-   * Updates the `lastInputs` cache (a plain field, not part of `state`) so the
-   * `state` signal doesn't churn its reference on every keystroke.
-   *
-   * `reflectComponentType` does NOT include hostDirective-forwarded inputs
-   * (angular/angular#49734), so a declared-input filter here would skip every
-   * value flowing through `NgForgeFieldShell` / `NgForgeField` /
-   * `NgForgeAction`. Mapper-as-contract is enforced by the `*_INPUTS`
-   * lockstep type assertions, not at runtime here.
    */
   pushInputs(rawInputs: Record<string, unknown>, fieldInputs?: WrapperFieldInputs): void {
     const current = this.state();

--- a/packages/dynamic-forms/src/lib/directives/df-template.directive.ts
+++ b/packages/dynamic-forms/src/lib/directives/df-template.directive.ts
@@ -3,24 +3,6 @@ import { Directive, Injectable, inject, input, Signal, signal, TemplateRef } fro
 /**
  * Marks an `<ng-template>` projected into `<df-dynamic-form>` content as
  * available to template addons by name.
- *
- * The host form collects all `DfTemplate` instances via `contentChildren`
- * and exposes them through {@link DF_FIELD_TEMPLATES}, where the template
- * addon kind looks them up by `templateKey` at render time.
- *
- * @example
- * ```html
- * <df-dynamic-form [config]="config">
- *   <ng-template dfTemplate="searchIcon" let-field>
- *     <my-icon [field]="field" />
- *   </ng-template>
- * </df-dynamic-form>
- * ```
- *
- * In the field config:
- * ```ts
- * { slot: 'prefix', kind: 'template', templateKey: 'searchIcon' }
- * ```
  */
 @Directive({
   selector: 'ng-template[dfTemplate]',

--- a/packages/dynamic-forms/src/lib/dynamic-form.component.ts
+++ b/packages/dynamic-forms/src/lib/dynamic-form.component.ts
@@ -44,11 +44,6 @@ import { DF_FIELD_TEMPLATES } from './models/addon/df-field-templates.token';
 /**
  * Dynamic form component — renders a form based on configuration.
  * Delegates state management to `FormStateManager`.
- *
- * @example
- *```html
- * <form [dynamic-form]="formConfig" [(value)]="formData" (submitted)="handleSubmit($event)"></form>
- * ```
  */
 @Component({
   selector: 'form[dynamic-form]',
@@ -137,8 +132,6 @@ export class DynamicForm<
   /** All `<ng-template dfTemplate="...">` instances projected into this form. */
   private readonly _projectedTemplates = contentChildren(DfTemplate);
 
-  /** State manager that owns all form state. Initialized via connectDeps() to guarantee
-   * FORM_STATE_DEPS is populated before FormStateManager is injected. */
   private readonly stateManager = this.connectDeps();
 
   // ─────────────────────────────────────────────────────────────────────────────
@@ -215,9 +208,6 @@ export class DynamicForm<
   /**
    * Recursively counts container components that will emit ComponentInitializedEvent.
    * Includes the dynamic-form component itself (+1).
-   *
-   * Recurses into all container children, including those nested inside array
-   * item templates, to avoid a premature (initialized) emission.
    */
   private totalComponentsCount = computed(() => {
     const fields = this.stateManager.formSetup()?.fields ?? [];
@@ -245,15 +235,7 @@ export class DynamicForm<
   /** Emits when form dirty state changes. */
   dirtyChange = outputFromObservable(toObservable(this.dirty));
 
-  /**
-   * Emits form values when submitted (via SubmitEvent) and form is valid.
-   *
-   * **Important:** This output only emits when the form is valid. If you need to
-   * handle submit events regardless of validity, use the `(events)` output and
-   * filter for `'submit'` events.
-   *
-   * Note: Does not emit when `submission.action` is configured - use one or the other.
-   */
+  /** Emits form values when submitted (via SubmitEvent) and form is valid. */
   submitted = outputFromObservable(this.stateManager.submitted$);
 
   /** Emits when form is reset to default values. */
@@ -302,9 +284,6 @@ export class DynamicForm<
    * - Pressing Enter in an input field
    * - Clicking a button with type="submit"
    * - Programmatic form.submit() calls
-   *
-   * This method prevents the default form submission behavior (page reload)
-   * and dispatches a SubmitEvent through the EventBus for processing.
    *
    * @param event - The native submit event from the form element
    */

--- a/packages/dynamic-forms/src/lib/errors/dynamic-form-error.ts
+++ b/packages/dynamic-forms/src/lib/errors/dynamic-form-error.ts
@@ -1,10 +1,4 @@
-/**
- * Base error class for all Dynamic Forms errors.
- *
- * This class centralizes the `[Dynamic Forms]` prefix, ensuring consistent
- * error messaging across the library without requiring each error site to
- * manually include the prefix.
- */
+/** Base error class for all Dynamic Forms errors. */
 export class DynamicFormError extends Error {
   private static readonly PREFIX = '[Dynamic Forms]';
 

--- a/packages/dynamic-forms/src/lib/events/array-event.ts
+++ b/packages/dynamic-forms/src/lib/events/array-event.ts
@@ -9,39 +9,6 @@ import { RemoveAtIndexEvent } from './constants/remove-at-index.event';
 /**
  * Builder for array manipulation events.
  *
- * Provides a fluent, discoverable API for array operations.
- * Type `arrayEvent('key').` in your IDE to see all available operations.
- *
- * **BREAKING CHANGE**: Template is now required for add operations.
- *
- * Supports both primitive and object array items:
- * - Primitive: Pass a single field definition → extracts field value directly
- * - Object: Pass an array of field definitions → merges fields into object
- *
- * @example
- * ```typescript
- * import { arrayEvent } from '@ng-forge/dynamic-forms';
- *
- * // Object item: append { name, email } object
- * eventBus.dispatch(arrayEvent('contacts').append([
- *   { key: 'name', type: 'input', label: 'Name' },
- *   { key: 'email', type: 'input', label: 'Email' }
- * ]));
- *
- * // Primitive item: append single value
- * eventBus.dispatch(arrayEvent('tags').append(
- *   { key: 'tag', type: 'input', label: 'Tag' }
- * ));
- *
- * // Removing items (no template needed)
- * eventBus.dispatch(arrayEvent('contacts').pop());      // Remove last
- * eventBus.dispatch(arrayEvent('contacts').shift());    // Remove first
- * eventBus.dispatch(arrayEvent('contacts').removeAt(2)); // Remove at index
- *
- * // Reordering items (no template needed, preserves item identity)
- * eventBus.dispatch(arrayEvent('contacts').move(0, 2)); // Move first to third
- * ```
- *
  * @param arrayKey - The key of the array field to operate on
  * @returns An object with methods for all 7 array operations
  */
@@ -55,19 +22,6 @@ export function arrayEvent(arrayKey: string) {
      *   - Single field: Creates a primitive item (field's value is extracted directly)
      *   - Array of fields: Creates an object item (fields merged into object)
      * @returns An AppendArrayItemEvent to dispatch
-     *
-     * @example
-     * ```typescript
-     * // Object item
-     * eventBus.dispatch(arrayEvent('contacts').append([
-     *   { key: 'name', type: 'input', label: 'Name' }
-     * ]));
-     *
-     * // Primitive item
-     * eventBus.dispatch(arrayEvent('tags').append(
-     *   { key: 'tag', type: 'input', label: 'Tag' }
-     * ));
-     * ```
      */
     append: <T extends ArrayItemDefinitionTemplate>(template: T) => new AppendArrayItemEvent(arrayKey, template),
 
@@ -79,19 +33,6 @@ export function arrayEvent(arrayKey: string) {
      *   - Single field: Creates a primitive item (field's value is extracted directly)
      *   - Array of fields: Creates an object item (fields merged into object)
      * @returns A PrependArrayItemEvent to dispatch
-     *
-     * @example
-     * ```typescript
-     * // Object item
-     * eventBus.dispatch(arrayEvent('contacts').prepend([
-     *   { key: 'name', type: 'input', label: 'Name' }
-     * ]));
-     *
-     * // Primitive item
-     * eventBus.dispatch(arrayEvent('tags').prepend(
-     *   { key: 'tag', type: 'input', label: 'Tag' }
-     * ));
-     * ```
      */
     prepend: <T extends ArrayItemDefinitionTemplate>(template: T) => new PrependArrayItemEvent(arrayKey, template),
 
@@ -104,19 +45,6 @@ export function arrayEvent(arrayKey: string) {
      *   - Single field: Creates a primitive item (field's value is extracted directly)
      *   - Array of fields: Creates an object item (fields merged into object)
      * @returns An InsertArrayItemEvent to dispatch
-     *
-     * @example
-     * ```typescript
-     * // Object item at index 2
-     * eventBus.dispatch(arrayEvent('contacts').insertAt(2, [
-     *   { key: 'name', type: 'input', label: 'Name' }
-     * ]));
-     *
-     * // Primitive item at index 2
-     * eventBus.dispatch(arrayEvent('tags').insertAt(2,
-     *   { key: 'tag', type: 'input', label: 'Tag' }
-     * ));
-     * ```
      */
     insertAt: <T extends ArrayItemDefinitionTemplate>(index: number, template: T) => new InsertArrayItemEvent(arrayKey, index, template),
 
@@ -125,11 +53,6 @@ export function arrayEvent(arrayKey: string) {
      * Equivalent to JavaScript's `Array.pop()`.
      *
      * @returns A PopArrayItemEvent to dispatch
-     *
-     * @example
-     * ```typescript
-     * eventBus.dispatch(arrayEvent('contacts').pop());
-     * ```
      */
     pop: () => new PopArrayItemEvent(arrayKey),
 
@@ -138,11 +61,6 @@ export function arrayEvent(arrayKey: string) {
      * Equivalent to JavaScript's `Array.shift()`.
      *
      * @returns A ShiftArrayItemEvent to dispatch
-     *
-     * @example
-     * ```typescript
-     * eventBus.dispatch(arrayEvent('contacts').shift());
-     * ```
      */
     shift: () => new ShiftArrayItemEvent(arrayKey),
 
@@ -152,11 +70,6 @@ export function arrayEvent(arrayKey: string) {
      *
      * @param index - The position of the item to remove
      * @returns A RemoveAtIndexEvent to dispatch
-     *
-     * @example
-     * ```typescript
-     * eventBus.dispatch(arrayEvent('contacts').removeAt(2));
-     * ```
      */
     removeAt: (index: number) => new RemoveAtIndexEvent(arrayKey, index),
 
@@ -168,12 +81,6 @@ export function arrayEvent(arrayKey: string) {
      * @param from - The current index of the item to move
      * @param to - The target index to move the item to
      * @returns A MoveArrayItemEvent to dispatch
-     *
-     * @example
-     * ```typescript
-     * // Move item from index 0 to index 2
-     * eventBus.dispatch(arrayEvent('contacts').move(0, 2));
-     * ```
      */
     move: (from: number, to: number) => new MoveArrayItemEvent(arrayKey, from, to),
   };

--- a/packages/dynamic-forms/src/lib/events/constants/append-array-item.event.ts
+++ b/packages/dynamic-forms/src/lib/events/constants/append-array-item.event.ts
@@ -14,23 +14,6 @@ export type { ArrayItemTemplate };
 /**
  * Event dispatched to append a new item at the END of an array field.
  *
- * This is the most common array operation - adding items to the end.
- * For other positions, use {@link PrependArrayItemEvent} or {@link InsertArrayItemEvent}.
- *
- * @example
- * ```typescript
- * // Object item: append { name, email } object
- * eventBus.dispatch(arrayEvent('contacts').append([
- *   { key: 'name', type: 'input', label: 'Name' },
- *   { key: 'email', type: 'input', label: 'Email' }
- * ]));
- *
- * // Primitive item: append single value
- * eventBus.dispatch(arrayEvent('tags').append(
- *   { key: 'tag', type: 'input', label: 'Tag' }
- * ));
- * ```
- *
  * @typeParam TTemplate - The type of the template (single field or array of fields)
  */
 export class AppendArrayItemEvent<TTemplate extends ArrayItemDefinitionTemplate = ArrayItemDefinitionTemplate> implements FormEvent {

--- a/packages/dynamic-forms/src/lib/events/constants/form-clear.event.ts
+++ b/packages/dynamic-forms/src/lib/events/constants/form-clear.event.ts
@@ -1,25 +1,6 @@
 import { FormEvent } from '../interfaces/form-event';
 
-/**
- * Event dispatched when the form should be cleared.
- *
- * This event instructs the dynamic form component to clear all field values,
- * resetting them to empty/undefined state regardless of their default values.
- *
- * @example
- * ```typescript
- * // Dispatch from a button component
- * eventBus.dispatch(FormClearEvent);
- * ```
- *
- * @example
- * ```typescript
- * // Listen for clear events
- * eventBus.on<FormClearEvent>('form-clear').subscribe(() => {
- *   console.log('Form was cleared');
- * });
- * ```
- */
+/** Event dispatched when the form should be cleared. */
 export class FormClearEvent implements FormEvent {
   readonly type = 'form-clear' as const;
 }

--- a/packages/dynamic-forms/src/lib/events/constants/form-reset.event.ts
+++ b/packages/dynamic-forms/src/lib/events/constants/form-reset.event.ts
@@ -1,25 +1,6 @@
 import { FormEvent } from '../interfaces/form-event';
 
-/**
- * Event dispatched when the form should be reset to its default values.
- *
- * This event instructs the dynamic form component to restore all field values
- * to their initial default values as defined in the form configuration.
- *
- * @example
- * ```typescript
- * // Dispatch from a button component
- * eventBus.dispatch(FormResetEvent);
- * ```
- *
- * @example
- * ```typescript
- * // Listen for reset events
- * eventBus.on<FormResetEvent>('form-reset').subscribe(() => {
- *   console.log('Form was reset to defaults');
- * });
- * ```
- */
+/** Event dispatched when the form should be reset to its default values. */
 export class FormResetEvent implements FormEvent {
   readonly type = 'form-reset' as const;
 }

--- a/packages/dynamic-forms/src/lib/events/constants/insert-array-item.event.ts
+++ b/packages/dynamic-forms/src/lib/events/constants/insert-array-item.event.ts
@@ -4,22 +4,6 @@ import { ArrayItemDefinitionTemplate } from './append-array-item.event';
 /**
  * Event dispatched to insert a new item at a SPECIFIC INDEX in an array field.
  *
- * Use this when you need precise control over where the new item appears.
- * For simpler operations, use {@link AppendArrayItemEvent} or {@link PrependArrayItemEvent}.
- *
- * @example
- * ```typescript
- * // Object item: insert { name } object at index 2
- * eventBus.dispatch(arrayEvent('contacts').insertAt(2, [
- *   { key: 'name', type: 'input', label: 'Name' }
- * ]));
- *
- * // Primitive item: insert single value at index 2
- * eventBus.dispatch(arrayEvent('tags').insertAt(2,
- *   { key: 'tag', type: 'input', label: 'Tag' }
- * ));
- * ```
- *
  * @typeParam TTemplate - The type of the template (single field or array of fields)
  */
 export class InsertArrayItemEvent<TTemplate extends ArrayItemDefinitionTemplate = ArrayItemDefinitionTemplate> implements FormEvent {

--- a/packages/dynamic-forms/src/lib/events/constants/move-array-item.event.ts
+++ b/packages/dynamic-forms/src/lib/events/constants/move-array-item.event.ts
@@ -1,21 +1,6 @@
 import { FormEvent } from '../interfaces/form-event';
 
-/**
- * Event dispatched to move an existing item from one index to another within an array field.
- *
- * This is an atomic reorder operation — the item at `fromIndex` is removed and
- * reinserted at `toIndex`. No template is required because the existing item
- * (resolved component, form value, and stored template) is preserved.
- *
- * @example
- * ```typescript
- * // Use the builder API (recommended)
- * eventBus.dispatch(arrayEvent('contacts').move(0, 2));
- *
- * // Or instantiate directly
- * eventBus.dispatch(new MoveArrayItemEvent('contacts', 0, 2));
- * ```
- */
+/** Event dispatched to move an existing item from one index to another within an array field. */
 export class MoveArrayItemEvent implements FormEvent {
   readonly type = 'move-array-item' as const;
 

--- a/packages/dynamic-forms/src/lib/events/constants/pop-array-item.event.ts
+++ b/packages/dynamic-forms/src/lib/events/constants/pop-array-item.event.ts
@@ -1,21 +1,6 @@
 import { FormEvent } from '../interfaces/form-event';
 
-/**
- * Event dispatched to remove the LAST item from an array field.
- *
- * Equivalent to JavaScript's `Array.pop()` - removes from the end.
- * For removing from the beginning, use {@link ShiftArrayItemEvent}.
- * For removing at a specific index, use {@link RemoveAtIndexEvent}.
- *
- * @example
- * ```typescript
- * // Use the builder API (recommended)
- * eventBus.dispatch(arrayEvent('contacts').pop());
- *
- * // Or instantiate directly
- * eventBus.dispatch(new PopArrayItemEvent('contacts'));
- * ```
- */
+/** Event dispatched to remove the LAST item from an array field. */
 export class PopArrayItemEvent implements FormEvent {
   readonly type = 'pop-array-item' as const;
 

--- a/packages/dynamic-forms/src/lib/events/constants/prepend-array-item.event.ts
+++ b/packages/dynamic-forms/src/lib/events/constants/prepend-array-item.event.ts
@@ -4,22 +4,6 @@ import { ArrayItemDefinitionTemplate } from './append-array-item.event';
 /**
  * Event dispatched to prepend a new item at the BEGINNING of an array field.
  *
- * Use this when new items should appear at the start of the list.
- * For appending to the end, use {@link AppendArrayItemEvent}.
- *
- * @example
- * ```typescript
- * // Object item: prepend { name } object
- * eventBus.dispatch(arrayEvent('contacts').prepend([
- *   { key: 'name', type: 'input', label: 'Name' }
- * ]));
- *
- * // Primitive item: prepend single value
- * eventBus.dispatch(arrayEvent('tags').prepend(
- *   { key: 'tag', type: 'input', label: 'Tag' }
- * ));
- * ```
- *
  * @typeParam TTemplate - The type of the template (single field or array of fields)
  */
 export class PrependArrayItemEvent<TTemplate extends ArrayItemDefinitionTemplate = ArrayItemDefinitionTemplate> implements FormEvent {

--- a/packages/dynamic-forms/src/lib/events/constants/remove-at-index.event.ts
+++ b/packages/dynamic-forms/src/lib/events/constants/remove-at-index.event.ts
@@ -1,20 +1,6 @@
 import { FormEvent } from '../interfaces/form-event';
 
-/**
- * Event dispatched to remove an item at a SPECIFIC INDEX from an array field.
- *
- * Use this when you need precise control over which item to remove.
- * For simpler operations, use {@link PopArrayItemEvent} or {@link ShiftArrayItemEvent}.
- *
- * @example
- * ```typescript
- * // Use the builder API (recommended)
- * eventBus.dispatch(arrayEvent('contacts').removeAt(2));
- *
- * // Or instantiate directly
- * eventBus.dispatch(new RemoveAtIndexEvent('contacts', 2));
- * ```
- */
+/** Event dispatched to remove an item at a SPECIFIC INDEX from an array field. */
 export class RemoveAtIndexEvent implements FormEvent {
   readonly type = 'remove-at-index' as const;
 

--- a/packages/dynamic-forms/src/lib/events/constants/shift-array-item.event.ts
+++ b/packages/dynamic-forms/src/lib/events/constants/shift-array-item.event.ts
@@ -1,21 +1,6 @@
 import { FormEvent } from '../interfaces/form-event';
 
-/**
- * Event dispatched to remove the FIRST item from an array field.
- *
- * Equivalent to JavaScript's `Array.shift()` - removes from the beginning.
- * For removing from the end, use {@link PopArrayItemEvent}.
- * For removing at a specific index, use {@link RemoveAtIndexEvent}.
- *
- * @example
- * ```typescript
- * // Use the builder API (recommended)
- * eventBus.dispatch(arrayEvent('contacts').shift());
- *
- * // Or instantiate directly
- * eventBus.dispatch(new ShiftArrayItemEvent('contacts'));
- * ```
- */
+/** Event dispatched to remove the FIRST item from an array field. */
 export class ShiftArrayItemEvent implements FormEvent {
   readonly type = 'shift-array-item' as const;
 

--- a/packages/dynamic-forms/src/lib/events/event-dispatcher.ts
+++ b/packages/dynamic-forms/src/lib/events/event-dispatcher.ts
@@ -5,20 +5,6 @@ import { FormEvent } from '../events/interfaces/form-event';
 /**
  * Injectable service for dispatching events into a DynamicForm from outside the form.
  *
- * ## When to use
- *
- * Use `EventDispatcher` when you need to drive form behaviour **from the host component** —
- * for example, appending array items in response to a field value change, triggering a form
- * reset from a toolbar button, or reacting to external application state.
- *
- * This is the recommended alternative to accessing the form's internals via `viewChild`.
- *
- * ## Setup
- *
- * Provide `EventDispatcher` at the **host component** level (not root). DynamicForm
- * automatically detects it and connects its internal event bus to the dispatcher.
- *
- * ```typescript
  * @Component({
  *   providers: [EventDispatcher],
  *   template: `<form [dynamic-form]="config" [(value)]="formValue"></form>`

--- a/packages/dynamic-forms/src/lib/events/event.bus.ts
+++ b/packages/dynamic-forms/src/lib/events/event.bus.ts
@@ -45,28 +45,6 @@ function attachFormValue<T extends FormEvent>(event: T, formValue: Record<string
 /**
  * Event bus for form-wide event communication between field components.
  *
- * **Intended for use inside DynamicForm** — i.e. within custom field components,
- * field mappers, or other services that live inside the form's component injector.
- * Inject it directly to dispatch or observe events from within a field:
- *
- * ```typescript
- * // Inside a custom field component
- * export class MyFieldComponent {
- *   private readonly eventBus = inject(EventBus);
- *
- *   onAction() {
- *     this.eventBus.dispatch(arrayEvent('items').append(template));
- *   }
- * }
- * ```
- *
- * **If you are outside DynamicForm** (e.g. in a host component or a service that wraps
- * the form), use {@link EventDispatcher} instead. Injecting `EventBus` in a parent
- * component gives you a *different instance* that the form knows nothing about.
- *
- * `EventBus` is scoped to each `DynamicForm` instance via `provideDynamicFormDI()`.
- * It provides type-safe dispatching and RxJS-based subscription for all form events.
- *
  * @see EventDispatcher — for dispatching events from outside the form
  */
 
@@ -85,38 +63,14 @@ export class EventBus {
   /**
    * Dispatches a pre-created event instance directly.
    *
-   * Use this overload with the `arrayEvent()` factory or any other code that
-   * produces a `FormEvent` instance rather than a constructor:
-   *
-   * ```typescript
-   * eventBus.dispatch(arrayEvent('contacts').append(template));
-   * eventBus.dispatch(arrayEvent('contacts').pop());
-   * ```
-   *
    * @param event - A FormEvent instance to dispatch
    */
   dispatch(event: FormEvent): void;
   /**
    * Dispatches an event to all subscribers by instantiating the provided constructor.
    *
-   * Creates an instance of the provided event constructor and broadcasts it
-   * through the event pipeline to all active subscribers.
-   *
-   * If `withEventFormValue()` is enabled globally or `options.emitFormValueOnEvents`
-   * is set to `true` in the form config, the current form value will be attached
-   * to the event's `formValue` property.
-   *
    * @param eventConstructor - Constructor function for the event to dispatch
    * @param args - Arguments to pass to the event constructor
-   *
-   * @example
-   * ```typescript
-   * // Dispatch a submit event
-   * eventBus.dispatch(SubmitEvent);
-   *
-   * // Dispatch a custom event with args
-   * eventBus.dispatch(CustomFormEvent, 'arg1', 42);
-   * ```
    */
   // TypeScript limitation: Must use ConstructorParameters which relies on `any` in FormEventConstructor
   dispatch<T extends FormEventConstructor>(eventConstructor: T, ...args: ConstructorParameters<T>): void;
@@ -131,6 +85,7 @@ export class EventBus {
   /**
    * Dispatches a pre-created event instance directly.
    * Used internally by EventDispatcher to forward events into the bus.
+   *
    * @internal
    */
   emitInstance(event: FormEvent): void {
@@ -167,13 +122,7 @@ export class EventBus {
     }
   }
 
-  /**
-   * Determines whether form value should be attached to events.
-   *
-   * Precedence rules:
-   * 1. Per-form setting (if defined) takes precedence
-   * 2. Falls back to global setting
-   */
+  /** Determines whether form value should be attached to events. */
   private shouldEmitFormValue(): boolean {
     const formLevelSetting = this.formOptions?.()?.emitFormValueOnEvents;
     return formLevelSetting ?? this.globalEmitFormValue;
@@ -196,34 +145,8 @@ export class EventBus {
   /**
    * Subscribes to form events with type-safe filtering.
    *
-   * Provides a reactive stream of events filtered by type. Supports both single
-   * event type subscriptions and multi-type subscriptions for flexible event handling.
-   *
    * @param eventType - Event type string or array of event type strings to filter by
    * @returns Observable stream of filtered events
-   *
-   * @example
-   * ```typescript
-   * // Subscribe to a single event type
-   * eventBus.on<SubmitEvent>('submit').subscribe(event => {
-   *   console.log('Submit event received');
-   * });
-   *
-   * // Subscribe to multiple event types
-   * eventBus.on<SubmitEvent | FormResetEvent | ValidationErrorEvent>(['submit', 'form-reset', 'validation-error']).subscribe(event => {
-   *   switch (event.type) {
-   *     case 'submit':
-   *       handleSubmit();
-   *       break;
-   *     case 'form-reset':
-   *       handleReset();
-   *       break;
-   *     case 'validation-error':
-   *       handleValidationError();
-   *       break;
-   *   }
-   * });
-   * ```
    */
   on<T extends FormEvent>(eventType: T['type'] | Array<T['type']>): Observable<T> {
     if (Array.isArray(eventType)) {

--- a/packages/dynamic-forms/src/lib/events/interfaces/form-event.ts
+++ b/packages/dynamic-forms/src/lib/events/interfaces/form-event.ts
@@ -1,30 +1,10 @@
-/**
- * Base interface for all form events in the dynamic form system.
- *
- * All form events must implement this interface to be compatible with
- * the event bus system. The type property is used for event filtering
- * and type-safe subscriptions.
- *
- * @example
- * ```typescript
- * export class SubmitEvent implements FormEvent {
- *   readonly type = 'submit';
- * }
- *
- * export class ValidationErrorEvent implements FormEvent {
- *   readonly type = 'validation-error';
- *   constructor(public errors: ValidationErrors) {}
- * }
- * ```
- */
+/** Base interface for all form events in the dynamic form system. */
 export interface FormEvent {
   /** Unique identifier for the event type used for filtering and subscriptions */
   readonly type: string;
   /**
    * Optional form value attached to the event when `withEventFormValue()` is enabled
    * or `options.emitFormValueOnEvents` is set to `true` in the form config.
-   *
-   * Use the `hasFormValue()` type guard to check if this property is present.
    */
   readonly formValue?: unknown;
 }
@@ -32,23 +12,8 @@ export interface FormEvent {
 /**
  * Type guard to check if a form event has a form value attached.
  *
- * Use this to safely access the `formValue` property on events when
- * `withEventFormValue()` is enabled globally or `options.emitFormValueOnEvents`
- * is set to `true` in the form config.
- *
- * @example
- * ```typescript
- * eventBus.on<SubmitEvent>('submit').subscribe(event => {
- *   if (hasFormValue(event)) {
- *     console.log('Form value:', event.formValue);
- *   }
- * });
- * ```
- *
  * @param event - The form event to check
  * @returns `true` if the event has a form value attached, narrowing the type
- *
- * @public
  */
 export function hasFormValue<T extends FormEvent>(event: T): event is T & { formValue: unknown } {
   return 'formValue' in event && event.formValue !== undefined;
@@ -57,21 +22,7 @@ export function hasFormValue<T extends FormEvent>(event: T): event is T & { form
 /**
  * Constructor type for form event classes.
  *
- * Defines the shape of event class constructors that can be used with
- * the event bus dispatch system. Supports both parameterless and
- * parameterized event constructors.
- *
  * @typeParam T - The form event type being constructed
- *
- * @example
- * ```typescript
- * // Parameterless event constructor
- * const SubmitEventCtor: FormEventConstructor<SubmitEvent> = SubmitEvent;
- *
- * // Parameterized event constructor
- * const ErrorEventCtor: FormEventConstructor<ErrorEvent> = ErrorEvent;
- * eventBus.dispatch(ErrorEventCtor);
- * ```
  */
 // TypeScript limitation: Constructor types with varying parameter signatures require `any[]`
 // because `unknown[]` cannot be assigned from more specific parameter types (contravariance).

--- a/packages/dynamic-forms/src/lib/events/utils/token-resolver.ts
+++ b/packages/dynamic-forms/src/lib/events/utils/token-resolver.ts
@@ -1,6 +1,4 @@
-/**
- * Context for token resolution in event args
- */
+/** Context for token resolution in event args */
 export interface TokenContext {
   /** Current field key */
   key?: string;
@@ -17,28 +15,9 @@ export interface TokenContext {
 /**
  * Resolves special tokens in event arguments to their actual values
  *
- * Supported tokens:
- * - $key: The current field key
- * - $index: The array index (if inside an array field)
- * - $arrayKey: The parent array field key (if inside an array field)
- * - $template: The template for array item creation
- * - formValue: Reference to the current form value for indexing
- *
  * @param args - Array of arguments that may contain tokens
  * @param context - Context object containing token values
  * @returns Array with resolved values
- *
- * @example
- * resolveTokens(['$arrayKey', '$index'], { arrayKey: 'contacts', index: 2 })
- * // Returns: ['contacts', 2]
- *
- * @example
- * resolveTokens(['$key', 'static'], { key: 'myField' })
- * // Returns: ['myField', 'static']
- *
- * @example
- * resolveTokens(['$arrayKey', '$template'], { arrayKey: 'contacts', template: [{ key: 'name', type: 'input' }] })
- * // Returns: ['contacts', [{ key: 'name', type: 'input' }]]
  */
 export function resolveTokens(
   args: readonly (string | number | boolean | null | undefined)[],

--- a/packages/dynamic-forms/src/lib/fields/array/array-field-state-machine.ts
+++ b/packages/dynamic-forms/src/lib/fields/array/array-field-state-machine.ts
@@ -6,17 +6,6 @@ import { signal, Signal } from '@angular/core';
  * `settledInitializationCycle`) plus scattered `currentVersion !== updateVersion`
  * cancellation guards with one machine.
  *
- * States
- * - `idle`     — no resolution in flight; previous work (if any) is complete.
- * - `pending`  — resolution started; awaiting `resolve()` on the active `RunHandle`.
- * - `settled`  — resolution complete; emit-effect will fire `componentInitialized`
- *                once `allResolvedFieldsRenderReady()` is true, then auto-return to `idle`.
- *
- * Cancellation
- * Every `dispatch()` bumps `runId` and returns a `RunHandle`. Async callers capture
- * the handle, run their work, and check `handle.isStale()` before applying side-effects —
- * any newer dispatch invalidates the in-flight run.
- *
  * @internal
  */
 export type ArrayMachineKind = 'idle' | 'pending' | 'settled';

--- a/packages/dynamic-forms/src/lib/fields/array/array-field.component.ts
+++ b/packages/dynamic-forms/src/lib/fields/array/array-field.component.ts
@@ -35,14 +35,7 @@ import { DynamicFormLogger } from '../../providers/features/logger/logger.token'
 import { ArrayFieldTree } from '../../core/field-tree-utils';
 import { getNormalizedArrayMetadata } from '../../utils/array-field/normalized-array-metadata';
 
-/**
- * Container component for rendering dynamic arrays of fields.
- *
- * Supports add/remove/move operations via the arrayEvent() builder API.
- * Uses differential updates to optimize rendering - only recreates items when necessary.
- * Each item gets a scoped injector with ARRAY_CONTEXT for position-aware operations.
- * Supports multiple sibling fields per array item (e.g., name + email without a wrapper).
- */
+/** Container component for rendering dynamic arrays of fields. */
 @Component({
   selector: 'array-field',
   imports: [DfFieldOutlet],
@@ -132,14 +125,6 @@ export default class ArrayFieldComponent<TModel extends Record<string, unknown> 
    * For primitive array items, the key of the value field template (e.g., 'value').
    * Used to wrap the FormControl in the item context so getFieldTree(key) works.
    * Returns undefined for object arrays (FormGroup items have natural child navigation).
-   *
-   * Detection order:
-   * 1. Normalization metadata (for simplified arrays — always available at normalization time)
-   * 2. Existing item definitions (non-empty full-API arrays)
-   * 3. Dynamically discovered key from handleAddFromEvent (empty full-API arrays)
-   *
-   * Uses linkedSignal: recomputes when field() changes, supports manual set()
-   * for the dynamic discovery case.
    */
   private readonly primitiveFieldKey = linkedSignal<string | undefined>(() => {
     // Priority 1: Normalization metadata (simplified arrays always have this)
@@ -160,10 +145,6 @@ export default class ArrayFieldComponent<TModel extends Record<string, unknown> 
   /**
    * Normalized item templates WITHOUT auto-remove button appended.
    * Each element is normalized to an array: single FieldDef → [FieldDef], array stays as-is.
-   *
-   * Used by moveItem() to stash raw templates into the templateRegistry, preserving
-   * the invariant that registry entries are pre-synthesis (withAutoRemove() adds the
-   * button during resolution).
    */
   private readonly rawItemTemplates = computed<ArrayItemTemplate[]>(() => {
     const arrayField = this.field();
@@ -178,12 +159,6 @@ export default class ArrayFieldComponent<TModel extends Record<string, unknown> 
    * Resolves the effective fallback template for this array — used when the form
    * value contains an item with no registered template (i.e., items that were
    * neither added via event handlers nor covered by a positional entry in `fields`).
-   *
-   * Populated from `SimplifiedArrayField.template` via normalization metadata, so every
-   * simplified array gets an automatic default. Returns undefined for full-API arrays;
-   * `createResolveItemObservable` then falls back to warn-and-drop.
-   *
-   * Homogeneous arrays only — all fallback items receive the same template.
    */
   private readonly fallbackTemplate = computed<FieldDef<unknown>[] | undefined>(() => {
     const raw = getNormalizedArrayMetadata(this.field())?.template;
@@ -196,12 +171,6 @@ export default class ArrayFieldComponent<TModel extends Record<string, unknown> 
    * Each element can be either:
    * - A single FieldDef (primitive item) - normalized to [FieldDef]
    * - An array of FieldDefs (object item) - used as-is
-   *
-   * When auto-remove is configured, the remove button is appended to each item's
-   * template list for rendering. This is purely visual — the form schema uses the
-   * original primitive item definition (single FieldDef → FormControl → flat value).
-   *
-   * Returns normalized templates where all items are arrays for consistent handling.
    */
   private readonly itemTemplates = computed<ArrayItemTemplate[]>(() => {
     const raw = this.rawItemTemplates();
@@ -340,8 +309,6 @@ export default class ArrayFieldComponent<TModel extends Record<string, unknown> 
    * Creates resolved items FIRST, then updates form value.
    * This ensures prepend/insert work correctly - differential update sees "none"
    * because resolved items count already matches the new array length.
-   *
-   * Supports both primitive (single FieldDef) and object (FieldDef[]) templates.
    */
   private async handleAddFromEvent(template: FieldDef<unknown> | readonly FieldDef<unknown>[], index?: number): Promise<void> {
     // Normalize template to mutable array for consistent handling.
@@ -607,19 +574,7 @@ export default class ArrayFieldComponent<TModel extends Record<string, unknown> 
     }
   }
 
-  /**
-   * Creates an observable that resolves a single array item.
-   *
-   * Template resolution order:
-   * 1. Use overrideTemplate if provided (from recreate with stored templates)
-   * 2. Use itemTemplates[index] if within defined templates range
-   * 3. Use the simplified-array fallback template (from normalization metadata) for
-   *    untracked items present in the form value (e.g., external `value.set`, parent
-   *    two-way binding, initial values beyond what was declared via simplified `value`).
-   *    Registers the resolved item in templateRegistry so subsequent recreates use
-   *    Priority 1.
-   * 4. Return undefined (item cannot be resolved without a template)
-   */
+  /** Creates an observable that resolves a single array item. */
   private createResolveItemObservable(
     index: number,
     overrideTemplate?: FieldDef<unknown>[],
@@ -707,11 +662,6 @@ export default class ArrayFieldComponent<TModel extends Record<string, unknown> 
    * The button is added for visual rendering only — it doesn't affect the form schema.
    * Original templates are stored in templateRegistry WITHOUT the remove button,
    * so this method is called during resolution to add it dynamically.
-   *
-   * Uses a WeakMap cache keyed by template array reference. Cache hits occur
-   * during recreate/resolution paths where stored templates are reused.
-   * Add operations always pass a fresh `[...template]` copy, so they miss
-   * the cache intentionally (the copy is needed for mutable item construction).
    */
   private withAutoRemove(templates: FieldDef<unknown>[]): FieldDef<unknown>[] {
     const removeButton = this.autoRemoveButton();

--- a/packages/dynamic-forms/src/lib/fields/container/container-field.component.ts
+++ b/packages/dynamic-forms/src/lib/fields/container/container-field.component.ts
@@ -25,17 +25,7 @@ import { DEFAULT_WRAPPERS } from '../../models/field-signal-context.token';
 import { isSameWrapperChain, resolveWrappers } from '../../utils/resolve-wrappers/resolve-wrappers';
 import { createWrapperChainController } from '../../utils/wrapper-chain/wrapper-chain-controller';
 
-/**
- * Layout container that wraps child fields with UI chrome.
- *
- * Resolves children like a row, then chains wrapper components around them
- * using imperative `ViewContainerRef.createComponent()` — each wrapper's
- * `#fieldComponent` slot hosts the next wrapper or the children template.
- *
- * Does not create a new form context - fields share the parent's context.
- * Field values are flattened into the parent form (no nesting under container key).
- * Purely a visual/layout container with no impact on form structure.
- */
+/** Layout container that wraps child fields with UI chrome. */
 @Component({
   selector: 'div[container-field]',
   imports: [DfFieldOutlet],

--- a/packages/dynamic-forms/src/lib/fields/group/group-field.component.ts
+++ b/packages/dynamic-forms/src/lib/fields/group/group-field.component.ts
@@ -30,13 +30,7 @@ import { createSchemaFromFields } from '../../core/schema-builder';
 import { EventBus } from '../../events/event.bus';
 import { SubmitEvent } from '../../events/constants/submit.event';
 
-/**
- * Container component for rendering nested form groups.
- *
- * Creates a scoped form context with its own validation state.
- * Child fields receive a FIELD_SIGNAL_CONTEXT scoped to this group's form instance.
- * Group values are nested under the group's key in the parent form.
- */
+/** Container component for rendering nested form groups. */
 @Component({
   selector: 'fieldset[group-field]',
   imports: [DfFieldOutlet],

--- a/packages/dynamic-forms/src/lib/fields/page/page-field.component.ts
+++ b/packages/dynamic-forms/src/lib/fields/page/page-field.component.ts
@@ -12,13 +12,7 @@ import { NextPageEvent, PageChangeEvent, PreviousPageEvent } from '../../events/
 import { FieldDef } from '../../definitions/base/field-def';
 import { DynamicFormLogger } from '../../providers/features/logger/logger.token';
 
-/**
- * Renders a single page in multi-page (wizard) forms.
- *
- * Visibility is controlled by the PageOrchestrator via the isVisible input.
- * Pages cannot be nested within other pages - validation prevents this.
- * Field values are flattened into the parent form (no nesting under page key).
- */
+/** Renders a single page in multi-page (wizard) forms. */
 @Component({
   selector: 'section[page-field]',
   imports: [DfFieldOutlet],

--- a/packages/dynamic-forms/src/lib/helpers/create-field.ts
+++ b/packages/dynamic-forms/src/lib/helpers/create-field.ts
@@ -1,72 +1,23 @@
 import { DynamicFormError } from '../errors/dynamic-form-error';
 import { AvailableFieldTypes, ExtractField } from '../models';
 
-/**
- * Container field types that do NOT support labels
- */
+/** Container field types that do NOT support labels */
 const CONTAINER_TYPES = ['group', 'row', 'array', 'container'] as const;
 
-/**
- * Container and page field types that only support 'hidden' logic
- */
+/** Container and page field types that only support 'hidden' logic */
 const HIDDEN_ONLY_LOGIC_TYPES = ['group', 'row', 'array', 'container', 'page'] as const;
 
-/**
- * Field types that support options at the field level
- */
+/** Field types that support options at the field level */
 const OPTION_FIELD_TYPES = ['select', 'radio', 'multi-checkbox'] as const;
 
-/**
- * Field type that uses minValue/maxValue instead of min/max in props
- */
+/** Field type that uses minValue/maxValue instead of min/max in props */
 const SLIDER_TYPE = 'slider' as const;
 
-/**
- * Hidden field type - no logic, no validators, no label
- */
+/** Hidden field type - no logic, no validators, no label */
 const HIDDEN_TYPE = 'hidden' as const;
 
 /**
  * Creates a typed field configuration with helpful error messages for common mistakes.
- *
- * This helper function provides early validation and clear error messages
- * for common configuration pitfalls that would otherwise cause runtime errors.
- *
- * @example
- * ```typescript
- * // Basic usage
- * const nameField = createField('input', {
- *   key: 'name',
- *   label: 'Name',
- *   value: ''
- * });
- *
- * // With validation
- * const emailField = createField('input', {
- *   key: 'email',
- *   label: 'Email',
- *   required: true,
- *   email: true,
- *   props: { type: 'email' }
- * });
- *
- * // Select with options (at field level)
- * const countryField = createField('select', {
- *   key: 'country',
- *   label: 'Country',
- *   options: [{ label: 'USA', value: 'us' }]
- * });
- *
- * // Slider with minValue/maxValue (at field level)
- * const ratingField = createField('slider', {
- *   key: 'rating',
- *   label: 'Rating',
- *   minValue: 1,
- *   maxValue: 10,
- *   step: 1,
- *   value: 5
- * });
- * ```
  *
  * @param type - The field type (e.g., 'input', 'select', 'group')
  * @param config - The field configuration (excluding the 'type' property)
@@ -189,12 +140,5 @@ export function createField<T extends AvailableFieldTypes>(type: T, config: Omit
   return { type, ...config } as ExtractField<T>;
 }
 
-/**
- * Shorthand alias for createField
- *
- * @example
- * ```typescript
- * const nameField = field('input', { key: 'name', label: 'Name', value: '' });
- * ```
- */
+/** Shorthand alias for createField */
 export const field = createField;

--- a/packages/dynamic-forms/src/lib/helpers/form-config.ts
+++ b/packages/dynamic-forms/src/lib/helpers/form-config.ts
@@ -6,54 +6,10 @@ import type { FormSchema } from '@ng-forge/dynamic-forms/schema';
 /**
  * Type-safe form config builder that ensures schema matches field structure.
  *
- * This helper function provides type safety when using form-level schemas by
- * automatically inferring the form value type from fields and constraining
- * the schema type parameter accordingly.
- *
- * **When to use:**
- * - When you have a form-level `schema` and want type safety between fields and schema
- * - When you prefer function syntax over `as const satisfies FormConfig`
- *
- * **Note:** This is optional. Users who don't need schema type safety can
- * continue using `as const satisfies FormConfig` directly.
- *
  * @typeParam TFields - The field definitions array (narrowed via `as const`)
  * @typeParam TProps - Optional form-level default props type
- *
  * @param config - The form configuration object
  * @returns The same configuration with proper type inference
- *
- * @example Basic usage with Zod schema
- * ```typescript
- * import { z } from 'zod';
- * import { formConfig } from '@ng-forge/dynamic-forms';
- * import { standardSchema } from '@ng-forge/dynamic-forms/schema';
- *
- * const passwordSchema = z.object({
- *   password: z.string().min(8),
- *   confirmPassword: z.string(),
- * }).refine(
- *   (data) => data.password === data.confirmPassword,
- *   { message: 'Passwords must match', path: ['confirmPassword'] }
- * );
- *
- * const config = formConfig({
- *   schema: standardSchema(passwordSchema),
- *   fields: [
- *     { key: 'password', type: 'input', label: 'Password', required: true, props: { type: 'password' } },
- *     { key: 'confirmPassword', type: 'input', label: 'Confirm', required: true, props: { type: 'password' } },
- *     { key: 'submit', type: 'submit', label: 'Register' },
- *   ] as const,
- * });
- * ```
- *
- * @example Equivalent without helper
- * ```typescript
- * const config = {
- *   schema: standardSchema(passwordSchema),
- *   fields: [...],
- * } as const satisfies FormConfig;
- * ```
  */
 export function formConfig<const TFields extends NarrowFields, TProps extends object = Record<string, unknown>>(
   config: Omit<FormConfig<TFields, InferFormValue<TFields>, TProps>, 'schema'> & {

--- a/packages/dynamic-forms/src/lib/index.ts
+++ b/packages/dynamic-forms/src/lib/index.ts
@@ -14,7 +14,6 @@
  * - Specific field types (InputField, SelectField, etc.)
  * - Field mappers (valueFieldMapper, checkboxFieldMapper, etc.)
  * - Error utilities (createResolvedErrorsSignal, shouldShowErrors)
- *
  */
 
 // ============================================================

--- a/packages/dynamic-forms/src/lib/mappers/apply-hidden-logic.ts
+++ b/packages/dynamic-forms/src/lib/mappers/apply-hidden-logic.ts
@@ -11,10 +11,6 @@ interface FieldWithHiddenLogic {
 /**
  * Applies hidden logic to a mapper's input record.
  *
- * Evaluates the field's `hidden` property and `logic` array to determine
- * if the component should be hidden. Only runs evaluation when there's
- * actually something to evaluate (explicit `hidden: true` or logic with type 'hidden').
- *
  * @param inputs The mutable input record to potentially add `hidden` to
  * @param fieldDef The field definition containing `hidden` and `logic`
  * @param rootFormRegistry The root form registry for accessing form state

--- a/packages/dynamic-forms/src/lib/mappers/array/array-field-mapper.ts
+++ b/packages/dynamic-forms/src/lib/mappers/array/array-field-mapper.ts
@@ -7,12 +7,6 @@ import { applyHiddenLogic } from '../apply-hidden-logic';
 /**
  * Maps an array field definition to component inputs.
  *
- * Array components create nested form structures under the array's key.
- * The array component will inject the parent FIELD_SIGNAL_CONTEXT and create
- * a scoped child injector for its array item fields.
- *
- * Supports hidden state resolution via `logic` array or static `hidden` property.
- *
  * @param fieldDef The array field definition
  * @returns Signal containing Record of input names to values for ngComponentOutlet
  */

--- a/packages/dynamic-forms/src/lib/mappers/base/base-field-mapper.ts
+++ b/packages/dynamic-forms/src/lib/mappers/base/base-field-mapper.ts
@@ -5,9 +5,6 @@ import { getGridClassString } from '../../utils/grid-classes/grid-classes';
 /**
  * Builds base input properties from a field definition.
  *
- * This is a helper function that extracts common field properties.
- * Used by mappers to build the inputs record.
- *
  * @param fieldDef The field definition to extract properties from
  * @param defaultProps Optional form-level default props to merge with field props
  * @returns Record of input names to values
@@ -74,9 +71,6 @@ export function buildBaseInputs(fieldDef: FieldDef<unknown>, defaultProps?: Reco
 
 /**
  * Base field mapper that extracts common field properties into component inputs.
- *
- * Returns a Signal containing the Record of input names to values that will be
- * passed to ngComponentOutlet. The signal enables reactive updates.
  *
  * @param fieldDef The field definition to map
  * @returns Signal containing Record of input names to values

--- a/packages/dynamic-forms/src/lib/mappers/container/container-field-mapper.ts
+++ b/packages/dynamic-forms/src/lib/mappers/container/container-field-mapper.ts
@@ -7,11 +7,6 @@ import { applyHiddenLogic } from '../apply-hidden-logic';
 /**
  * Maps a container field definition to component inputs.
  *
- * Container components are layout containers that don't change the form shape.
- * The container component will inject FIELD_SIGNAL_CONTEXT directly.
- *
- * Supports hidden state resolution via `logic` array or static `hidden` property.
- *
  * @param fieldDef The container field definition
  * @returns Signal containing Record of input names to values for ngComponentOutlet
  */

--- a/packages/dynamic-forms/src/lib/mappers/group/group-field-mapper.ts
+++ b/packages/dynamic-forms/src/lib/mappers/group/group-field-mapper.ts
@@ -7,12 +7,6 @@ import { applyHiddenLogic } from '../apply-hidden-logic';
 /**
  * Maps a group field definition to component inputs.
  *
- * Group components create nested form structures under the group's key.
- * The group component will inject the parent FIELD_SIGNAL_CONTEXT and create
- * a scoped child injector for its nested fields.
- *
- * Supports hidden state resolution via `logic` array or static `hidden` property.
- *
  * @param fieldDef The group field definition
  * @returns Signal containing Record of input names to values for ngComponentOutlet
  */

--- a/packages/dynamic-forms/src/lib/mappers/page/page-field-mapper.ts
+++ b/packages/dynamic-forms/src/lib/mappers/page/page-field-mapper.ts
@@ -5,13 +5,6 @@ import { buildClassName } from '../../utils/grid-classes/grid-classes';
 /**
  * Maps a page field definition to component inputs.
  *
- * Page fields are layout containers that don't modify the form context.
- * The page component will inject FIELD_SIGNAL_CONTEXT directly.
- *
- * Note: Unlike other container mappers (group, row, array), the page mapper does NOT
- * resolve hidden logic here. Page visibility is managed by the {@link PageOrchestratorComponent}
- * which evaluates `ContainerLogicConfig` conditions and controls the `isVisible` input.
- *
  * @param fieldDef The page field definition
  * @returns Signal containing Record of input names to values for ngComponentOutlet
  */

--- a/packages/dynamic-forms/src/lib/mappers/row/row-field-mapper.ts
+++ b/packages/dynamic-forms/src/lib/mappers/row/row-field-mapper.ts
@@ -6,16 +6,7 @@ import { applyHiddenLogic } from '../apply-hidden-logic';
 
 const ROW_WRAPPERS = [{ type: 'row' }] as const;
 
-/**
- * Maps a row field definition to container component inputs.
- *
- * `row` is a virtual field type: it resolves to `ContainerFieldComponent` with a
- * synthesized `{ type: 'row' }` wrapper, so the user-facing config stays
- * `{ type: 'row', fields: [...] }` while the runtime uses the container +
- * wrapper pipeline.
- *
- * Supports hidden state resolution via `logic` array or static `hidden` property.
- */
+/** Maps a row field definition to container component inputs. */
 export function rowFieldMapper(fieldDef: RowField): Signal<Record<string, unknown>> {
   const rootFormRegistry = inject(RootFormRegistryService);
   const className = buildClassName(fieldDef);

--- a/packages/dynamic-forms/src/lib/mappers/text/text-field-mapper.ts
+++ b/packages/dynamic-forms/src/lib/mappers/text/text-field-mapper.ts
@@ -8,16 +8,6 @@ import { applyHiddenLogic } from '../apply-hidden-logic';
 /**
  * Maps a text field definition to component inputs.
  *
- * Text fields are display-only fields that don't participate in the form schema.
- * This mapper handles the `logic` configuration by using the non-field-hidden resolver
- * to evaluate conditions against the form value from RootFormRegistryService.
- *
- * Hidden state is resolved using the non-field-hidden resolver which considers:
- * 1. Explicit `hidden: true` on the field definition
- * 2. Field-level `logic` array with `type: 'hidden'` conditions
- *
- * Note: Text fields don't support disabled logic since they are display-only.
- *
  * @param fieldDef The text field definition
  * @returns Signal containing Record of input names to values for ngComponentOutlet
  */

--- a/packages/dynamic-forms/src/lib/mappers/types.ts
+++ b/packages/dynamic-forms/src/lib/mappers/types.ts
@@ -5,16 +5,6 @@ import { FieldTree } from '@angular/forms/signals';
 /**
  * Field signal context - the "nervous system" of the dynamic form.
  * Provided via FIELD_SIGNAL_CONTEXT injection token.
- *
- * Gives mappers and components access to form state, values, and configuration.
- * Container fields (Group, Array) create scoped contexts with nested forms.
- *
- * The `form` property uses Angular's FieldTree which includes Subfields<TModel>
- * for type-safe child field access via bracket notation when TModel is a Record.
- *
- * Note: Form-level configuration (defaultValidationMessages, formOptions, defaultProps)
- * is provided via dedicated injection tokens (DEFAULT_VALIDATION_MESSAGES, FORM_OPTIONS,
- * DEFAULT_PROPS) at the DynamicForm level and inherited by all children.
  */
 export interface FieldSignalContext<TModel extends Record<string, unknown> = Record<string, unknown>> {
   injector: Injector;
@@ -44,26 +34,11 @@ export interface ArrayContext {
   field: FieldDef<unknown>;
 }
 
-/**
- * Group context for fields rendered inside `group` containers.
- *
- * Carries a reactive dot-separated chain of group ancestors (including the
- * current group). Used by `mapFieldToInputs` to scope DOM IDs of group
- * children, so the same leaf key can appear inside different groups without
- * producing duplicate `id` attributes (issue #401).
- *
- * Re-provided by every group's child injector — a nested group reads its
- * parent's context signal and composes its own path through `computed()`.
- */
+/** Group context for fields rendered inside `group` containers. */
 export interface GroupContext {
   /** Dot-separated path of group ancestors, including the current group's key (e.g. `'address'` or `'user.address'`). */
   groupPath: Signal<string>;
 }
 
-/**
- * Mapper function that converts a field definition to component inputs.
- *
- * Mappers run within an injection context and can inject FIELD_SIGNAL_CONTEXT.
- * Returns a Signal to enable reactive updates when dependencies change.
- */
+/** Mapper function that converts a field definition to component inputs. */
 export type MapperFn<T extends FieldDef<unknown>> = (input: T) => Signal<Record<string, unknown>>;

--- a/packages/dynamic-forms/src/lib/models/addon/addon-action.ts
+++ b/packages/dynamic-forms/src/lib/models/addon/addon-action.ts
@@ -24,9 +24,6 @@ interface AddonActionContextBase<TValue> {
  * Field-bound variant — the addon is attached to a real field and has a
  * working value-writer. The common case for `pi-button` / `mat-button` /
  * `bs-button` / `ion-button` inside an adapter input field.
- *
- * `setValue` is non-optional here; the optional chain (`ctx.setValue?.()`)
- * is unnecessary noise once you've narrowed via {@link isFieldBoundContext}.
  */
 export interface FieldBoundAddonActionContext<TValue = unknown> extends AddonActionContextBase<TValue> {
   /** Read-only view of the host field's tree — same view wrappers receive. */
@@ -46,24 +43,7 @@ export interface OrphanAddonActionContext<TValue = unknown> extends AddonActionC
   readonly setValue?: undefined;
 }
 
-/**
- * Context handed to inline addon actions and registered handler functions.
- *
- * Discriminated by `form`: field-bound contexts have a non-null `form` and a
- * required `setValue`; orphan contexts have `form: null` and no `setValue`.
- * Use {@link isFieldBoundContext} when the handler needs to write back.
- *
- * @example
- * ```typescript
- * provideAddonActions({
- *   submit: (ctx) => {
- *     if (!isFieldBoundContext(ctx)) return;
- *     // ctx.setValue is now `(next: TValue) => void` — no optional chain.
- *     myService.send(ctx.field.key, ctx.value, ctx.setValue);
- *   },
- * });
- * ```
- */
+/** Context handed to inline addon actions and registered handler functions. */
 export type AddonActionContext<TValue = unknown> = FieldBoundAddonActionContext<TValue> | OrphanAddonActionContext<TValue>;
 
 /** Type guard narrowing {@link AddonActionContext} to its field-bound variant. */
@@ -71,74 +51,20 @@ export function isFieldBoundContext<TValue>(ctx: AddonActionContext<TValue>): ct
   return ctx.form !== null;
 }
 
-/**
- * Built-in preset actions shared across adapters.
- *
- * Adapter kinds that accept a `preset` field render the corresponding
- * behaviour:
- *
- * - `'clear'`: empties the field value.
- * - `'reset'`: restores the field's configured default value (resolved
- *   from the form's `defaultValues` map at click time); falls back to
- *   empty when no default is reachable.
- * - `'paste'`: reads from the system clipboard and writes the result.
- * - `'copy'`: writes the field's current value to the system clipboard.
- * - `'toggle-password-visibility'`: flips a host input's `type` between
- *   `password` and `text` (requires the host field to provide a type
- *   override token, e.g., `PRIME_INPUT_TYPE_OVERRIDE`).
- *
- * Form submission is intentionally NOT exposed as a button-addon preset —
- * use the dedicated `'submit'` field type instead.
- */
+/** Built-in preset actions shared across adapters. */
 export type CommonAddonActionPreset = 'clear' | 'reset' | 'paste' | 'copy' | 'toggle-password-visibility';
 
-/**
- * Module-augmentable registry of adapter-specific preset names.
- *
- * Adapters add their canonical actions (e.g., Material's
- * `'mat-datepicker-open'`) without forking the `AddonActionPreset` union.
- *
- * @example
- * ```typescript
- * declare module '@ng-forge/dynamic-forms' {
- *   interface DynamicFormAddonActionPresetRegistry {
- *     'mat-datepicker-open': true;
- *   }
- * }
- * ```
- */
+/** Module-augmentable registry of adapter-specific preset names. */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type -- Intentionally empty: module-augmentation seam
 export interface DynamicFormAddonActionPresetRegistry {}
 
 /**
  * Union of every preset name an addon may reference — universal presets
  * plus any contributed via {@link DynamicFormAddonActionPresetRegistry}.
- *
- * The `(string & {})` escape hatch keeps autocomplete on the known +
- * augmented presets while accepting arbitrary strings for one-off adapter
- * presets that don't warrant a module-augmentation. The runtime preset
- * runner already handles unknown names gracefully via its `default:` arm
- * (logs a warning, no throw). Mirrors `FieldDef.type`'s
- * `RegisteredFieldTypes['type'] | (string & {})` shape.
  */
 export type AddonActionPreset = CommonAddonActionPreset | keyof DynamicFormAddonActionPresetRegistry | (string & {});
 
-/**
- * Module-augmentable registry of user-defined named action handlers.
- *
- * Users register handlers once at bootstrap with `provideAddonActions({...})`
- * and reference them from JSON-driven configs via `actionRef: 'handlerName'`.
- *
- * @example
- * ```typescript
- * declare module '@ng-forge/dynamic-forms' {
- *   interface DynamicFormActionRegistry {
- *     openProfile: true;
- *     runWorkflow: true;
- *   }
- * }
- * ```
- */
+/** Module-augmentable registry of user-defined named action handlers. */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type -- Intentionally empty: module-augmentation seam
 export interface DynamicFormActionRegistry {}
 

--- a/packages/dynamic-forms/src/lib/models/addon/addon-def.ts
+++ b/packages/dynamic-forms/src/lib/models/addon/addon-def.ts
@@ -3,19 +3,7 @@ import { DynamicText } from '../types/dynamic-text';
 import { DynamicValue } from '../types/dynamic-value';
 import { AddonSlot } from './addon-slot';
 
-/**
- * Base shape every addon kind extends.
- *
- * Public contract:
- * - `slot` chooses where the addon renders (prefix / suffix / adapter-specific).
- * - `hidden` / `disabled` are reactive — re-evaluated when their underlying
- *   signals or observables emit.
- * - Multiple addons in the same slot render in array order, left-to-right
- *   within the slot (LTR; mirrored in RTL).
- *
- * Note: `meta` is intentionally absent — adapters declare addon-specific
- * fields via module augmentation rather than an untyped escape hatch.
- */
+/** Base shape every addon kind extends. */
 export interface BaseAddon<TSlot extends AddonSlot = AddonSlot> {
   /** Slot to render this addon in. */
   readonly slot: TSlot;
@@ -27,54 +15,25 @@ export interface BaseAddon<TSlot extends AddonSlot = AddonSlot> {
   readonly disabled?: DynamicValue<boolean>;
 }
 
-/**
- * Module-augmentable registry of addon kinds.
- *
- * Each key is the kind discriminant; each value is the addon's full shape
- * (extending {@link BaseAddon}). Core ships `text`, `template`, and
- * `component`; adapters add their own (e.g., `prime-icon`, `prime-button`).
- *
- * @example
- * ```typescript
- * declare module '@ng-forge/dynamic-forms' {
- *   interface DynamicFormAddonRegistry {
- *     'prime-icon': PrimeIconAddon;
- *     'prime-button': PrimeButtonAddon;
- *   }
- * }
- * ```
- */
+/** Module-augmentable registry of addon kinds. */
 export interface DynamicFormAddonRegistry {
   text: TextAddon;
   template: TemplateAddon;
   component: ComponentAddon;
 }
 
-/**
- * Union of every registered addon shape.
- */
+/** Union of every registered addon shape. */
 export type AnyAddon = DynamicFormAddonRegistry[keyof DynamicFormAddonRegistry];
 
 /* -- Core-shipped universal kinds -------------------------------------- */
 
-/**
- * Renders text content inline.
- *
- * `text` is `DynamicText`, supporting plain strings, observables, and
- * signals — so values like `'$'`, `'.com'`, or interpolated counters
- * (`'42/100'`) all work uniformly.
- */
+/** Renders text content inline. */
 export interface TextAddon extends BaseAddon {
   readonly kind: 'text';
   readonly text: DynamicText;
 }
 
-/**
- * Renders a named `<ng-template>` projected into the host `<df-dynamic-form>`.
- *
- * JSON-safe — backends ship the key, FE supplies the template definition.
- * Use the `templateAddon(ref)` helper for rename-safe authoring in code.
- */
+/** Renders a named `<ng-template>` projected into the host `<df-dynamic-form>`. */
 export interface TemplateAddon extends BaseAddon {
   readonly kind: 'template';
   readonly templateKey: string;
@@ -82,13 +41,6 @@ export interface TemplateAddon extends BaseAddon {
 
 /**
  * Renders an arbitrary Angular component as the addon body.
- *
- * The loader returns either a component class directly or a module with a
- * `default` export. For non-default exports, unwrap with `.then(m => m.X)`:
- *
- * ```ts
- * { kind: 'component', component: () => import('./my').then(m => m.MyComponent) }
- * ```
  *
  * @codeOnly The `component` loader is a function and cannot survive
  * `JSON.stringify`/`parse`. The lenient validator drops this kind when the

--- a/packages/dynamic-forms/src/lib/models/addon/addon-kind.ts
+++ b/packages/dynamic-forms/src/lib/models/addon/addon-kind.ts
@@ -9,12 +9,6 @@ import { AddonSlot } from './addon-slot';
  * (`type`/`properties`/`required`/`enum`/etc.) without pulling in a full JSON
  * Schema dependency. Extra keys are allowed via the `[key: string]` index so
  * vendor-specific annotations (`x-foo`, `markdownDescription`) still typecheck.
- *
- * Tooling-only: the runtime addon validator does NOT consult `schema` — it
- * relies on each kind's `validate?(addon, fieldKey)` callback for shape
- * enforcement. `schema` exists exclusively so the MCP server (and any other
- * AI-driven form authoring tool) can describe the kind to a model without
- * hand-maintaining a parallel registry.
  */
 export interface AddonKindSchema {
   readonly $ref?: string;
@@ -59,13 +53,7 @@ export interface AddonKindSchema {
  */
 export type AddonShapeValidator<T extends BaseAddon = BaseAddon> = (addon: T, fieldKey: string) => void;
 
-/**
- * Per-kind registration metadata.
- *
- * Registered via `withCustomAddon(...)` features (or adapter feature
- * helpers like `withPrimeNGAddons()`); resolved at render time by
- * `<df-addon-slot>`.
- */
+/** Per-kind registration metadata. */
 export interface AddonKindDefinition<T extends BaseAddon = BaseAddon> {
   /** Discriminant matching `addon.kind`. */
   readonly kind: string;
@@ -86,16 +74,7 @@ export interface AddonKindDefinition<T extends BaseAddon = BaseAddon> {
   readonly jsonSafe?: boolean;
 }
 
-/**
- * Per-field-type addon-support metadata declared at field registration.
- *
- * Source of truth for the runtime validator: which slots are valid for a
- * field type, which kinds are accepted (optional whitelist).
- *
- * Field types that do not declare `addons` on their `FieldTypeDefinition`
- * are treated as Tier 3 — addons configured on such fields are dropped
- * with a warning at config init.
- */
+/** Per-field-type addon-support metadata declared at field registration. */
 export interface FieldAddonSupport {
   /** Slots a field of this type accepts. */
   readonly slots: readonly AddonSlot[];
@@ -103,13 +82,7 @@ export interface FieldAddonSupport {
   readonly allowedKinds?: readonly string[];
 }
 
-/**
- * Global registry of addon kinds.
- *
- * Populated by `withCustomAddon(...)` features and adapter feature helpers
- * (e.g., `withPrimeNGAddons()`). Read by `<df-addon-slot>` to resolve a
- * kind discriminant to its renderer component.
- */
+/** Global registry of addon kinds. */
 export const ADDON_KIND_REGISTRY = new InjectionToken<Map<string, AddonKindDefinition>>('ADDON_KIND_REGISTRY', {
   providedIn: 'root',
   factory: () => new Map<string, AddonKindDefinition>(),

--- a/packages/dynamic-forms/src/lib/models/addon/addon-slot.ts
+++ b/packages/dynamic-forms/src/lib/models/addon/addon-slot.ts
@@ -1,27 +1,7 @@
-/**
- * Universal addon slot names supported by every adapter.
- *
- * Adapters render `prefix` to the leading edge of a field and `suffix` to
- * the trailing edge (mirrored in RTL). Additional slots may be contributed
- * via {@link DynamicFormAddonSlotRegistry} module augmentation.
- */
+/** Universal addon slot names supported by every adapter. */
 export type CommonAddonSlot = 'prefix' | 'suffix';
 
-/**
- * Module-augmentable registry of adapter-specific addon slot names.
- *
- * Adapters that expose slots beyond the universal `prefix` / `suffix` (e.g.,
- * an "error overlay" slot specific to one design system) declare them here.
- *
- * @example
- * ```typescript
- * declare module '@ng-forge/dynamic-forms' {
- *   interface DynamicFormAddonSlotRegistry {
- *     'mat-error-overlay': true;
- *   }
- * }
- * ```
- */
+/** Module-augmentable registry of adapter-specific addon slot names. */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type -- Intentionally empty: module-augmentation seam
 export interface DynamicFormAddonSlotRegistry {}
 

--- a/packages/dynamic-forms/src/lib/models/addon/df-field-templates.token.ts
+++ b/packages/dynamic-forms/src/lib/models/addon/df-field-templates.token.ts
@@ -5,13 +5,5 @@ import { InjectionToken, Signal, TemplateRef } from '@angular/core';
  * `<ng-template dfTemplate="...">` children projected into its content.
  * The directive selector is `dfTemplate` (see `DfTemplate`); the input
  * value is the name addons reference via `templateKey`.
- *
- * The `template` addon kind looks up its `templateKey` in this map at
- * render time. Exposed as a `Signal` so projections can be added or
- * removed reactively (e.g., when the host conditionally projects).
- *
- * Provided at the form-component level (not root) so multiple
- * `<df-dynamic-form>` instances on the same page have independent
- * template scopes.
  */
 export const DF_FIELD_TEMPLATES = new InjectionToken<Signal<ReadonlyMap<string, TemplateRef<unknown>>>>('DF_FIELD_TEMPLATES');

--- a/packages/dynamic-forms/src/lib/models/expressions/conditional-expression.ts
+++ b/packages/dynamic-forms/src/lib/models/expressions/conditional-expression.ts
@@ -2,11 +2,7 @@ import type { CustomFunction } from '../../core/expressions/custom-function-type
 import type { AsyncConditionFunction } from '../../core/expressions/async-custom-function-types';
 import type { HttpRequestConfig } from '../http/http-request-config';
 
-/**
- * Comparison operators for field value and form value conditions.
- *
- * @public
- */
+/** Comparison operators for field value and form value conditions. */
 export type ComparisonOperator =
   | 'equals'
   | 'notEquals'
@@ -19,11 +15,7 @@ export type ComparisonOperator =
   | 'endsWith'
   | 'matches';
 
-/**
- * Condition that compares a specific field's value against an expected value.
- *
- * @public
- */
+/** Condition that compares a specific field's value against an expected value. */
 export interface FieldValueCondition {
   type: 'fieldValue';
   /** Path to the field whose value to compare */
@@ -34,23 +26,7 @@ export interface FieldValueCondition {
   value?: unknown;
 }
 
-/**
- * Condition that invokes a custom function.
- *
- * Two mutually exclusive forms:
- * - `functionName`: name of a function registered in `customFnConfig.customFunctions`.
- *   JSON-serializable; suitable for configs loaded from APIs, databases, or OpenAPI.
- * - `fn`: inline function. NOT JSON-serializable; for code-only configs.
- *
- * Exactly one of `functionName` or `fn` must be set.
- *
- * Encoded as a strict discriminated union (XOR via `?: never`). `CustomValidatorConfig`
- * intentionally uses a permissive interface for the same `fn`/`functionName` split
- * because validators have a third source (`expression`) and the historical interface
- * was already runtime-checked — the asymmetry is by design, not an oversight.
- *
- * @public
- */
+/** Condition that invokes a custom function. */
 export type CustomCondition =
   | {
       type: 'custom';
@@ -61,43 +37,20 @@ export type CustomCondition =
     }
   | {
       type: 'custom';
-      /**
-       * Inline custom function. Mutually exclusive with `functionName`.
-       *
-       * NOT JSON-serializable — for code-only configs. For configs loaded
-       * from JSON / OpenAPI / databases, use `functionName` to reference
-       * a function registered in `customFnConfig.customFunctions`.
-       */
+      /** Inline custom function. Mutually exclusive with `functionName`. */
       fn: CustomFunction;
       /** Registered form is forbidden when `fn` is set */
       functionName?: never;
     };
 
-/**
- * Condition that evaluates a JavaScript expression using the secure AST-based parser.
- *
- * The expression has access to `formValue`, `fieldValue`, `externalData`, etc.
- *
- * @public
- */
+/** Condition that evaluates a JavaScript expression using the secure AST-based parser. */
 export interface JavascriptCondition {
   type: 'javascript';
   /** JavaScript expression string to evaluate */
   expression: string;
 }
 
-/**
- * Condition that evaluates based on an HTTP response from a remote server.
- *
- * The HTTP request is resolved reactively — when dependent form values change,
- * the request is re-evaluated (with debouncing). The result is cached per
- * resolved request to avoid redundant network calls.
- *
- * Since `LogicFn` must return `boolean` synchronously, this condition uses
- * a signal-based async resolution pattern internally.
- *
- * @public
- */
+/** Condition that evaluates based on an HTTP response from a remote server. */
 export interface HttpCondition {
   type: 'http';
   /** HTTP request configuration */
@@ -111,11 +64,6 @@ export interface HttpCondition {
   /**
    * Value to return while the HTTP request is in-flight.
    *
-   * Choose based on the logic type and desired UX:
-   * - For `hidden`: `false` = visible while loading, `true` = hidden while loading
-   * - For `disabled`: `false` = enabled while loading, `true` = disabled while loading
-   * - For `required`: `false` = optional while loading, `true` = required while loading
-   *
    * @default false
    */
   pendingValue?: boolean;
@@ -123,6 +71,7 @@ export interface HttpCondition {
   cacheDurationMs?: number;
   /**
    * Debounce time in milliseconds for re-evaluation when dependent form values change.
+   *
    * @default 300
    */
   debounceMs?: number;
@@ -138,40 +87,18 @@ interface AsyncConditionBase {
   /**
    * Value to return while async resolution is pending.
    *
-   * Choose based on the logic type and desired UX:
-   * - For `hidden`: `false` = visible while loading, `true` = hidden while loading
-   * - For `disabled`: `false` = enabled while loading, `true` = disabled while loading
-   * - For `required`: `false` = optional while loading, `true` = required while loading
-   *
    * @default false
    */
   pendingValue?: boolean;
   /**
    * Debounce ms for re-evaluation.
+   *
    * @default 300
    */
   debounceMs?: number;
 }
 
-/**
- * Condition that resolves asynchronously via a custom function.
- *
- * Two mutually exclusive forms:
- * - `asyncFunctionName`: name of a function registered in `customFnConfig.asyncConditions`.
- *   JSON-serializable; suitable for configs loaded from APIs, databases, or OpenAPI.
- * - `asyncFn`: inline async function. NOT JSON-serializable; for code-only configs.
- *
- * Exactly one of `asyncFunctionName` or `asyncFn` must be set.
- *
- * The function is resolved reactively — when dependent form values change,
- * the function is re-evaluated (with debouncing). The result is cached per
- * evaluation to avoid redundant calls.
- *
- * Since `LogicFn` must return `boolean` synchronously, this condition uses
- * a signal-based async resolution pattern internally.
- *
- * @public
- */
+/** Condition that resolves asynchronously via a custom function. */
 export type AsyncCondition =
   | (AsyncConditionBase & {
       /** Name of the registered async condition function */
@@ -180,48 +107,27 @@ export type AsyncCondition =
       asyncFn?: never;
     })
   | (AsyncConditionBase & {
-      /**
-       * Inline async condition function. Mutually exclusive with `asyncFunctionName`.
-       *
-       * NOT JSON-serializable — for code-only configs. For configs loaded
-       * from JSON / OpenAPI / databases, use `asyncFunctionName` to reference
-       * a function registered in `customFnConfig.asyncConditions`.
-       */
+      /** Inline async condition function. Mutually exclusive with `asyncFunctionName`. */
       asyncFn: AsyncConditionFunction;
       /** Registered form is forbidden when `asyncFn` is set */
       asyncFunctionName?: never;
     });
 
-/**
- * Logical AND — all sub-conditions must be true.
- *
- * @public
- */
+/** Logical AND — all sub-conditions must be true. */
 export interface AndCondition {
   type: 'and';
   /** Sub-conditions that must all evaluate to true */
   conditions: ConditionalExpression[];
 }
 
-/**
- * Logical OR — at least one sub-condition must be true.
- *
- * @public
- */
+/** Logical OR — at least one sub-condition must be true. */
 export interface OrCondition {
   type: 'or';
   /** Sub-conditions where at least one must evaluate to true */
   conditions: ConditionalExpression[];
 }
 
-/**
- * Discriminated union of all conditional expression types.
- *
- * Each variant only allows the properties relevant to its type,
- * providing compile-time safety against invalid property combinations.
- *
- * @public
- */
+/** Discriminated union of all conditional expression types. */
 export type ConditionalExpression =
   | FieldValueCondition
   | CustomCondition

--- a/packages/dynamic-forms/src/lib/models/expressions/evaluation-context.ts
+++ b/packages/dynamic-forms/src/lib/models/expressions/evaluation-context.ts
@@ -7,13 +7,7 @@ export interface EvaluationContext<TValue = unknown, TFormValue extends Record<s
   /** Current field value */
   fieldValue: TValue;
 
-  /**
-   * Form value for the current evaluation scope.
-   *
-   * For regular (non-array) derivations, this contains the complete form value.
-   * For array item derivations, this is scoped to the current array item.
-   * Use `rootFormValue` to access the complete form when inside an array context.
-   */
+  /** Form value for the current evaluation scope. */
   formValue: TFormValue;
 
   /** Field path for relative references */
@@ -28,89 +22,19 @@ export interface EvaluationContext<TValue = unknown, TFormValue extends Record<s
   /**
    * Value of the field's nearest parent **group** (or array item, when the
    * field has no inner group above the array boundary).
-   *
-   * Complements `formValue` and `fieldValue` for derivations on fields nested
-   * inside groups built by factory helpers, where the parent group's key
-   * isn't known at config-authoring time. Mirrors the runtime semantics of
-   * the `'$group'` token used in `dependsOn`.
-   *
-   * Resolution at evaluation time:
-   * - Inside a group at form root: the parent group's value object (e.g.,
-   *   for `address.state`, `groupValue === formValue.address`).
-   * - Inside nested groups: the innermost parent group's value object.
-   * - Directly inside an array item (no inner group): the array item itself
-   *   (same shape as `formValue` in array context).
-   * - Inside a group inside an array item: the inner group's value object
-   *   within the current item.
-   * - Field at form root with no parent container: `undefined`.
-   *
-   * @example
-   * ```typescript
-   * // Field 'state' inside group 'address':
-   * deriveStateFromCountry: (ctx) => {
-   *   const country = ctx.groupValue?.country;  // no need to know parent key
-   *   return country === 'usa' ? 'NY' : '';
-   * }
-   * ```
    */
   groupValue?: unknown;
 
-  /**
-   * Root form value when inside an array context.
-   *
-   * This provides access to values outside the current array item.
-   * When a derivation targets an array item field (e.g., `items.$.lineTotal`),
-   * `formValue` is scoped to the current array item, while `rootFormValue`
-   * provides access to the entire form value including fields outside the array.
-   *
-   * @example
-   * ```typescript
-   * // In an array item derivation (on the lineTotal field inside lineItems array):
-   * {
-   *   key: 'lineTotal',
-   *   type: 'input',
-   *   // formValue = current array item { quantity: 2, unitPrice: 50 }
-   *   // rootFormValue = entire form { globalDiscount: 0.1, lineItems: [...] }
-   *   derivation: 'formValue.quantity * formValue.unitPrice * (1 - rootFormValue.globalDiscount)'
-   * }
-   * ```
-   *
-   * For non-array derivations, `rootFormValue` is not set and `formValue`
-   * contains the entire form value.
-   */
+  /** Root form value when inside an array context. */
   rootFormValue?: Record<string, unknown>;
 
-  /**
-   * Current array index when inside an array derivation.
-   */
+  /** Current array index when inside an array derivation. */
   arrayIndex?: number;
 
-  /**
-   * Path to the array field when inside an array derivation.
-   */
+  /** Path to the array field when inside an array derivation. */
   arrayPath?: string;
 
-  /**
-   * External data signals resolved to their current values.
-   *
-   * This allows forms to reference data from outside the form context
-   * in conditional logic, derivations, and other expressions.
-   *
-   * @example
-   * ```typescript
-   * // In form config:
-   * externalData: {
-   *   userRole: computed(() => this.userService.currentRole()),
-   *   permissions: computed(() => this.authService.permissions()),
-   * }
-   *
-   * // In JavaScript expression:
-   * condition: {
-   *   type: 'javascript',
-   *   expression: "externalData.userRole === 'admin'"
-   * }
-   * ```
-   */
+  /** External data signals resolved to their current values. */
   externalData?: Record<string, unknown>;
 
   /**
@@ -119,38 +43,10 @@ export interface EvaluationContext<TValue = unknown, TFormValue extends Record<s
    */
   deprecationTracker?: WarningTracker;
 
-  /**
-   * State of the current field being evaluated.
-   *
-   * Provides access to field state properties like `touched`, `dirty`, `valid`, etc.
-   * Uses a Proxy for lazy evaluation — properties are only read when accessed.
-   *
-   * @example
-   * ```typescript
-   * // In a JavaScript expression:
-   * condition: {
-   *   type: 'javascript',
-   *   expression: "fieldState.touched && fieldState.dirty"
-   * }
-   * ```
-   */
+  /** State of the current field being evaluated. */
   fieldState?: FieldStateContext;
 
-  /**
-   * State of all fields in the form, keyed by field key.
-   *
-   * Provides access to any field's state properties by key.
-   * Uses a Proxy for lazy evaluation — field state is only read when accessed.
-   *
-   * @example
-   * ```typescript
-   * // In a JavaScript expression:
-   * condition: {
-   *   type: 'javascript',
-   *   expression: "formFieldState.email.dirty && formFieldState.email.valid"
-   * }
-   * ```
-   */
+  /** State of all fields in the form, keyed by field key. */
   formFieldState?: FormFieldStateMap;
 
   /** Allow additional properties for flexible expression evaluation */

--- a/packages/dynamic-forms/src/lib/models/expressions/field-state-context.ts
+++ b/packages/dynamic-forms/src/lib/models/expressions/field-state-context.ts
@@ -1,11 +1,4 @@
-/**
- * Represents the state information of a single form field.
- *
- * Used in evaluation contexts to allow expressions and conditions
- * to reference field state (e.g., `fieldState.touched`, `formFieldState.email.dirty`).
- *
- * @public
- */
+/** Represents the state information of a single form field. */
 export interface FieldStateInfo {
   readonly touched: boolean;
   readonly dirty: boolean;
@@ -14,44 +7,16 @@ export interface FieldStateInfo {
   readonly valid: boolean;
   readonly invalid: boolean;
   readonly pending: boolean;
-  /**
-   * Whether the field is currently hidden.
-   *
-   * Note: This is a library-managed property, not a native Angular Signal Forms
-   * property. Returns `false` if the field instance does not expose a `hidden` signal.
-   */
+  /** Whether the field is currently hidden. */
   readonly hidden: boolean;
-  /**
-   * Whether the field is currently readonly.
-   *
-   * Note: This is a library-managed property, not a native Angular Signal Forms
-   * property. Returns `false` if the field instance does not expose a `readonly` signal.
-   */
+  /** Whether the field is currently readonly. */
   readonly readonly: boolean;
-  /**
-   * Whether the field is currently disabled.
-   *
-   * Note: This is a library-managed property, not a native Angular Signal Forms
-   * property. Returns `false` if the field instance does not expose a `disabled` signal.
-   */
+  /** Whether the field is currently disabled. */
   readonly disabled: boolean;
 }
 
-/**
- * Map of field keys to their state information.
- *
- * Used as `formFieldState` in evaluation contexts to access
- * state of any field in the form by key.
- *
- * @public
- */
+/** Map of field keys to their state information. */
 export type FormFieldStateMap = Record<string, FieldStateInfo | undefined>;
 
-/**
- * Field state context for the current field being evaluated.
- *
- * Used as `fieldState` in evaluation contexts.
- *
- * @public
- */
+/** Field state context for the current field being evaluated. */
 export type FieldStateContext = FieldStateInfo;

--- a/packages/dynamic-forms/src/lib/models/field-signal-context.token.ts
+++ b/packages/dynamic-forms/src/lib/models/field-signal-context.token.ts
@@ -5,62 +5,13 @@ import type { WrapperConfig } from './wrapper-type';
 import type { ValidationMessages } from './validation-types';
 import type { FormOptions } from './form-config';
 
-/**
- * Injection token for form-level default wrappers.
- *
- * Provides a Signal of the `defaultWrappers` array from FormConfig. Consumed by
- * `DfFieldOutlet` / `ContainerFieldComponent` to merge into each field's
- * effective wrapper chain (lowest priority after auto-associations, higher
- * than field-level `wrappers`).
- *
- * Provided once at the DynamicForm level and inherited via Angular's
- * hierarchical injector.
- */
+/** Injection token for form-level default wrappers. */
 export const DEFAULT_WRAPPERS = new InjectionToken<Signal<readonly WrapperConfig[] | undefined>>('DEFAULT_WRAPPERS');
 
-/**
- * Injection token for providing field signal context to mappers and components.
- *
- * The field signal context is the "nervous system" of the dynamic form library,
- * providing access to:
- * - The form instance and structure
- * - Current form values (as signals)
- * - Default values
- * - Validation messages
- * - The injector for creating components
- *
- * This token is provided by the DynamicForm component and can be scoped
- * for nested forms (Groups, Arrays) via child injectors.
- *
- * @example
- * ```typescript
- * // In a mapper function — prefer the helper for required access (descriptive error).
- * export function mapValueField(fieldDef: BaseValueField<any, any>): Binding[] {
- *   const context = injectFieldSignalContext();
- *   const form = context.form();
- *   // ... use context
- * }
- *
- * // Optional access — token directly, returns null if not provided.
- * const ctx = inject(FIELD_SIGNAL_CONTEXT, { optional: true });
- * if (ctx) {
- *   // ...
- * }
- * ```
- */
+/** Injection token for providing field signal context to mappers and components. */
 export const FIELD_SIGNAL_CONTEXT = new InjectionToken<FieldSignalContext>('FIELD_SIGNAL_CONTEXT');
 
-/**
- * Throwing accessor for {@link FIELD_SIGNAL_CONTEXT}.
- *
- * Use when the consumer requires the context — group/array containers and
- * mappers that depend on form structure. Throws a descriptive
- * `DynamicFormError` instead of Angular's generic `NullInjectorError` when
- * the token isn't provided.
- *
- * Consumers that may legitimately run outside a `DynamicForm` should keep
- * using `inject(FIELD_SIGNAL_CONTEXT, { optional: true })`.
- */
+/** Throwing accessor for {@link FIELD_SIGNAL_CONTEXT}. */
 export function injectFieldSignalContext<TModel extends Record<string, unknown> = Record<string, unknown>>(): FieldSignalContext<TModel> {
   const ctx = inject(FIELD_SIGNAL_CONTEXT, { optional: true });
   if (!ctx) {
@@ -69,46 +20,10 @@ export function injectFieldSignalContext<TModel extends Record<string, unknown> 
   return ctx as FieldSignalContext<TModel>;
 }
 
-/**
- * Injection token for providing array context metadata to mappers and components.
- *
- * This token is optionally provided by ArrayFieldComponent when creating injectors
- * for array items. It contains metadata about the array item's position and parent.
- *
- * Mappers can inject this token with {optional: true} to access array context:
- *
- * @example
- * ```typescript
- * // In a mapper function
- * export function buttonMapper(fieldDef: FieldDef<any>): Binding[] {
- *   const arrayContext = inject(ARRAY_CONTEXT, { optional: true });
- *   if (arrayContext) {
- *     // Use arrayContext.index, arrayContext.arrayKey, etc.
- *   }
- * }
- * ```
- */
+/** Injection token for providing array context metadata to mappers and components. */
 export const ARRAY_CONTEXT = new InjectionToken<ArrayContext>('ARRAY_CONTEXT');
 
-/**
- * Injection token for providing group ancestry to mappers and components.
- *
- * Re-provided in two places:
- * 1. `GroupFieldComponent` provides a context whose `groupPath()` is the
- *    parent path extended by its own key (e.g. `'address'` or `'user.address'`).
- * 2. `createArrayItemInjector` provides a sentinel with an empty `groupPath`,
- *    resetting the chain at array boundaries — descendants of an array item
- *    that re-enter a group compose paths INSIDE the array item, matching the
- *    property-derivation collector's keying.
- *
- * `mapFieldToInputs` reads this to scope DOM IDs and override-store keys so
- * the same leaf key can appear in different groups without colliding (#401).
- *
- * Inject with `{ optional: true }` because top-level fields with no group
- * ancestor (and no enclosing array) won't have the token provided. The token
- * IS present for fields inside an array even when no inner group exists — the
- * array-boundary sentinel makes injection succeed with an empty `groupPath`.
- */
+/** Injection token for providing group ancestry to mappers and components. */
 // No factory: GROUP_CONTEXT is optional-by-design — `GroupFieldComponent` and
 // `createArrayItemInjector` re-provide it where it makes sense, and consumers
 // inject with `{ optional: true }` to handle the top-level case. Mirrors the
@@ -117,93 +32,14 @@ export const ARRAY_CONTEXT = new InjectionToken<ArrayContext>('ARRAY_CONTEXT');
 // before honoring `optional`), so non-group fields would crash on every render.
 export const GROUP_CONTEXT = new InjectionToken<GroupContext>('GROUP_CONTEXT');
 
-/**
- * Injection token for form-level default props.
- *
- * Default props are form-wide property defaults that are merged with field-level props.
- * Field props take precedence over default props.
- *
- * Unlike FIELD_SIGNAL_CONTEXT which is re-provided by container components (Group, Array),
- * DEFAULT_PROPS is provided ONCE at the DynamicForm level and inherited by all children
- * via Angular's hierarchical injector.
- *
- * The token provides a Signal to enable reactivity - when config changes, mappers
- * that read the signal inside their computed() will automatically update.
- *
- * @example
- * ```typescript
- * // In a mapper function
- * const defaultPropsSignal = inject(DEFAULT_PROPS);
- *
- * return computed(() => {
- *   const defaultProps = defaultPropsSignal?.();  // Read inside computed for reactivity
- *   const baseInputs = buildBaseInputs(fieldDef, defaultProps);
- *   // ...
- * });
- * ```
- */
+/** Injection token for form-level default props. */
 export const DEFAULT_PROPS = new InjectionToken<Signal<Record<string, unknown> | undefined>>('DEFAULT_PROPS');
 
-/**
- * Injection token for form-level default validation messages.
- *
- * Default validation messages act as fallbacks when fields have validation
- * errors but no field-level `validationMessages` defined.
- *
- * Like DEFAULT_PROPS, this token is provided ONCE at the DynamicForm level
- * and inherited by all children via Angular's hierarchical injector.
- *
- * The token provides a Signal to enable reactivity - when config changes, mappers
- * that read the signal inside their computed() will automatically update.
- *
- * @example
- * ```typescript
- * // In a mapper or component
- * const defaultMessagesSignal = inject(DEFAULT_VALIDATION_MESSAGES);
- *
- * return computed(() => {
- *   const defaultMessages = defaultMessagesSignal?.();  // Read inside computed for reactivity
- *   const message = defaultMessages?.required ?? 'Field is required';
- *   // ...
- * });
- * ```
- */
+/** Injection token for form-level default validation messages. */
 export const DEFAULT_VALIDATION_MESSAGES = new InjectionToken<Signal<ValidationMessages | undefined>>('DEFAULT_VALIDATION_MESSAGES');
 
-/**
- * Injection token for form-level options.
- *
- * Form options control form-wide behavior including button disabled states.
- * Used by button mappers to determine default disabled behavior.
- *
- * Like DEFAULT_PROPS, this token is provided ONCE at the DynamicForm level
- * and inherited by all children via Angular's hierarchical injector.
- *
- * The token provides a Signal to enable reactivity - when config changes, mappers
- * that read the signal inside their computed() will automatically update.
- *
- * @example
- * ```typescript
- * // In a button mapper
- * const formOptionsSignal = inject(FORM_OPTIONS);
- *
- * return computed(() => {
- *   const formOptions = formOptionsSignal?.();  // Read inside computed for reactivity
- *   const disableWhenInvalid = formOptions?.submitButton?.disableWhenInvalid ?? true;
- *   // ...
- * });
- * ```
- */
+/** Injection token for form-level options. */
 export const FORM_OPTIONS = new InjectionToken<Signal<FormOptions | undefined>>('FORM_OPTIONS');
 
-/**
- * Injection token for form-level external data.
- *
- * Provides a Signal of the external data record from the form config.
- * Used by `FieldContextRegistryService` to resolve external data for expression evaluation
- * without coupling to `FormStateManager` directly.
- *
- * Like DEFAULT_PROPS, this token is provided ONCE at the DynamicForm level
- * and inherited by all children via Angular's hierarchical injector.
- */
+/** Injection token for form-level external data. */
 export const EXTERNAL_DATA = new InjectionToken<Signal<Record<string, Signal<unknown>> | undefined>>('EXTERNAL_DATA');

--- a/packages/dynamic-forms/src/lib/models/field-type.ts
+++ b/packages/dynamic-forms/src/lib/models/field-type.ts
@@ -4,53 +4,19 @@ import { MapperFn } from '../mappers/types';
 import { FieldAddonSupport } from './addon/addon-kind';
 import { LazyComponentLoader } from './wrapper-type';
 
-/**
- * Defines how a field type handles form values and data collection.
- *
- * - 'include': Field contributes to form values (default for input fields)
- * - 'exclude': Field is excluded from form values (for display/layout fields)
- * - 'flatten': Field's children are flattened to parent level (for container fields)
- */
+/** Defines how a field type handles form values and data collection. */
 export type ValueHandlingMode = 'include' | 'exclude' | 'flatten';
 
-/**
- * Semantic grouping of interchangeable field UI alternatives.
- *
- * Used by tooling (e.g., openapi-generator) to discover which field types
- * can substitute for each other. A field with scope 'boolean' means it's
- * one of several ways to render a boolean value (checkbox, toggle, etc.).
- */
+/** Semantic grouping of interchangeable field UI alternatives. */
 export type FieldScope = 'boolean' | 'single-select' | 'multi-select' | 'text-input' | 'numeric' | 'date';
 
-/**
- * Mapped component inputs that must be available before a field component is instantiated.
- *
- * This protects components that declare required Angular inputs and eagerly read them in
- * host bindings or computed signals. Renderers should defer component creation until all
- * listed mapped inputs are present.
- */
+/** Mapped component inputs that must be available before a field component is instantiated. */
 export type RenderReadyInput = 'field' | (string & {});
 
 /**
  * Configuration interface for registering custom field types.
  *
- * Defines how a field type should be handled by the dynamic form system,
- * including its component loading strategy and field-to-component mapping logic.
- * Supports both eager-loaded and lazy-loaded components.
- *
  * @typeParam T - The field definition type this field type handles
- *
- * @example
- * ```typescript
- * const CustomInputType: FieldTypeDefinition<InputFieldDef> = {
- *   name: 'custom-input',
- *   loadComponent: () => import('./custom-input.component').then(m => m.CustomInputComponent),
- *   mapper: customInputMapper
- * };
- *
- * // Register with providers
- * provideDynamicForm(CustomInputType)
- * ```
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Intentionally using `any` for maximum flexibility in field type registration
 export interface FieldTypeDefinition<T extends FieldDef<any> = any> {
@@ -61,41 +27,13 @@ export interface FieldTypeDefinition<T extends FieldDef<any> = any> {
   /**
    * Function to load the component (supports lazy loading).
    * Returns a Promise that resolves to the component class or module with default export.
-   *
-   * Optional - omit for componentless fields (e.g., hidden fields) that only
-   * contribute to form values without rendering any UI.
    */
   loadComponent?: LazyComponentLoader;
-  /**
-   * Mapper function that converts field definition to component bindings.
-   *
-   * Optional - omit for componentless fields (like hidden fields) that don't need
-   * input mapping. When omitted for componentless fields (no loadComponent), an empty
-   * signal is returned. When omitted for regular fields with a component, falls back
-   * to baseFieldMapper.
-   */
+  /** Mapper function that converts field definition to component bindings. */
   mapper?: MapperFn<T>;
   /** How this field type handles form values and data collection (defaults to 'include') */
   valueHandling?: ValueHandlingMode;
-  /**
-   * List of prop keys to forward to the meta object.
-   *
-   * Some props (like `type` for inputs, `rows`/`cols` for textareas) are actually
-   * native HTML attributes. Specifying them here causes them to be merged into
-   * the meta object before being passed to the component, ensuring they're applied
-   * via the meta tracking mechanism.
-   *
-   * Note: Meta values always take precedence over forwarded props.
-   *
-   * @example
-   * ```typescript
-   * {
-   *   name: 'input',
-   *   propsToMeta: ['type'],
-   *   // ...
-   * }
-   * ```
-   */
+  /** List of prop keys to forward to the meta object. */
   propsToMeta?: string[];
   /** Semantic scope for tooling to discover interchangeable field alternatives */
   scope?: FieldScope | FieldScope[];
@@ -105,36 +43,11 @@ export interface FieldTypeDefinition<T extends FieldDef<any> = any> {
   /**
    * Declares which addon slots this field accepts and (optionally) the
    * subset of kinds allowed.
-   *
-   * Source of truth for the runtime addon validator. Field types that
-   * omit this property are treated as Tier 3 — any `addons` configured
-   * on such a field are dropped with a warning at config init.
-   *
-   * @example
-   * ```typescript
-   * {
-   *   name: 'prime-input',
-   *   addons: { slots: ['prefix', 'suffix'] },
-   * }
-   * ```
    */
   addons?: FieldAddonSupport;
 }
 
-/**
- * Injection token for the global field type registry.
- *
- * Provides access to the map of registered field types throughout the application.
- * The registry is populated by the provideDynamicForm function and used by
- * field rendering components to resolve field types to their implementations.
- *
- * @example
- * ```typescript
- * constructor(@Inject(FIELD_REGISTRY) private registry: Map<string, FieldTypeDefinition>) {
- *   const inputType = registry.get('input');
- * }
- * ```
- */
+/** Injection token for the global field type registry. */
 export const FIELD_REGISTRY = new InjectionToken<Map<string, FieldTypeDefinition>>('FIELD_REGISTRY', {
   providedIn: 'root',
   factory: () => new Map(),

--- a/packages/dynamic-forms/src/lib/models/form-config.ts
+++ b/packages/dynamic-forms/src/lib/models/form-config.ts
@@ -13,31 +13,9 @@ import type { FormSchema } from '@ng-forge/dynamic-forms/schema';
 /**
  * Configuration interface for defining dynamic form structure and behavior.
  *
- * This interface defines the complete form schema including field definitions,
- * validation rules, conditional logic, and submission handling using Angular's
- * signal-based reactive forms.
- *
- * @example
- * ```typescript
- * const formConfig = {
- *   fields: [
- *     { type: 'input', key: 'email', value: '', label: 'Email', required: true },
- *     { type: 'group', key: 'address', label: 'Address', fields: [
- *       { type: 'input', key: 'street', value: '', label: 'Street' },
- *       { type: 'input', key: 'city', value: '', label: 'City' }
- *     ]},
- *   ],
- * } as const satisfies FormConfig;
- *
- * // Infer form value type from config
- * type FormValue = InferFormValue<typeof formConfig>;
- * ```
- *
  * @typeParam TFields - Array of registered field types available for this form
  * @typeParam TValue - The strongly-typed interface for form values
  * @typeParam TProps - The type for form-level default props (library-specific)
- *
- * @public
  */
 export interface FormConfig<
   TFields extends NarrowFields | RegisteredFieldTypes[] = RegisteredFieldTypes[],
@@ -45,586 +23,69 @@ export interface FormConfig<
   TProps extends object = Record<string, unknown>,
   TSchemaValue = unknown,
 > {
-  /**
-   * Array of field definitions that define the form structure.
-   *
-   * Fields are rendered in the order they appear in this array.
-   * Supports nested groups and conditional field visibility.
-   *
-   * @example
-   * ```typescript
-   * fields: [
-   *   { type: 'input', key: 'firstName', label: 'First Name' },
-   *   { type: 'group', key: 'address', label: 'Address', fields: [
-   *     { type: 'input', key: 'street', label: 'Street' }
-   *   ]}
-   * ]
-   * ```
-   */
+  /** Array of field definitions that define the form structure. */
   fields: TFields;
 
-  /**
-   * Optional form-level validation schema using Standard Schema spec.
-   *
-   * Provides additional validation beyond field-level validation.
-   * Supports Zod, Valibot, ArkType, and other Standard Schema compliant libraries.
-   * Useful for cross-field validation rules.
-   *
-   * @example
-   * ```typescript
-   * import { z } from 'zod';
-   * import { standardSchema } from '@ng-forge/dynamic-forms/schema';
-   *
-   * const PasswordSchema = z.object({
-   *   password: z.string().min(8),
-   *   confirmPassword: z.string(),
-   * }).refine(
-   *   (data) => data.password === data.confirmPassword,
-   *   { message: 'Passwords must match', path: ['confirmPassword'] }
-   * );
-   *
-   * const formConfig = {
-   *   fields: [...],
-   *   schema: standardSchema(PasswordSchema),
-   * } as const satisfies FormConfig;
-   * ```
-   */
+  /** Optional form-level validation schema using Standard Schema spec. */
   schema?: FormSchema<TSchemaValue>;
 
   /**
    * Global form configuration options.
    *
-   * Controls form-wide behavior like validation timing and disabled state.
-   *
    * @value {}
    */
   options?: FormOptions;
 
-  /**
-   * Global schemas available to all fields.
-   *
-   * Reusable validation schemas that can be referenced by field definitions.
-   * Promotes consistency and reduces duplication.
-   *
-   * @example
-   * ```typescript
-   * schemas: [
-   *   { name: 'addressSchema', schema: {
-   *     street: validators.required,
-   *     zipCode: validators.pattern(/^\d{5}$/)
-   *   }}
-   * ]
-   * ```
-   */
+  /** Global schemas available to all fields. */
   schemas?: SchemaDefinition[];
 
-  /**
-   * Form-level validation messages that act as fallback for field-level messages.
-   *
-   * These messages are used when a field has validation errors but no
-   * field-level `validationMessages` are defined for that specific error.
-   * This allows you to define common validation messages once at the form level
-   * instead of repeating them for each field.
-   *
-   * @example
-   * ```typescript
-   * defaultValidationMessages: {
-   *   required: 'This field is required',
-   *   email: 'Please enter a valid email address',
-   *   minLength: 'Must be at least {{requiredLength}} characters'
-   * }
-   * ```
-   */
+  /** Form-level validation messages that act as fallback for field-level messages. */
   defaultValidationMessages?: ValidationMessages;
 
-  /**
-   * Signal forms adapter configuration.
-   */
+  /** Signal forms adapter configuration. */
   customFnConfig?: CustomFnConfig<TValue extends Record<string, unknown> ? TValue : Record<string, unknown>>;
 
-  /**
-   * Form submission configuration.
-   *
-   * When provided, enables integration with Angular Signal Forms' native `submit()` function.
-   * The submission mechanism is **optional** - you can still handle submission manually
-   * via the `(submitted)` output if you prefer.
-   *
-   * While the submission action is executing, `form().submitting()` will be `true`,
-   * which automatically disables submit buttons (unless configured otherwise).
-   *
-   * Server errors returned from the action will be automatically applied to the
-   * corresponding form fields.
-   *
-   * @example
-   * ```typescript
-   * const config: FormConfig = {
-   *   fields: [...],
-   *   submission: {
-   *     action: async (form) => {
-   *       const value = form().value();
-   *       try {
-   *         await this.api.submit(value);
-   *         return undefined;
-   *       } catch (error) {
-   *         return [{ field: form.email, error: { kind: 'server', message: 'Email exists' }}];
-   *       }
-   *     }
-   *   }
-   * };
-   * ```
-   */
+  /** Form submission configuration. */
   submission?: SubmissionConfig<TValue>;
 
-  /**
-   * Default props applied to all fields in the form.
-   *
-   * These props serve as defaults that can be overridden at the field level.
-   * Useful for setting consistent styling across the entire form (e.g., appearance,
-   * size, or other UI library-specific props).
-   *
-   * The cascade order is: Library config → Form defaultProps → Field props
-   * Each level can override the previous one.
-   *
-   * @example
-   * ```typescript
-   * // Material example
-   * const config: MatFormConfig = {
-   *   defaultProps: {
-   *     appearance: 'outline',
-   *     subscriptSizing: 'dynamic',
-   *   },
-   *   fields: [
-   *     { type: 'input', key: 'name', label: 'Name' },  // Uses defaultProps
-   *     { type: 'input', key: 'email', props: { appearance: 'fill' } },  // Override
-   *   ],
-   * };
-   * ```
-   */
+  /** Default props applied to all fields in the form. */
   defaultProps?: TProps;
 
-  /**
-   * External data signals available to conditional logic and derivations.
-   *
-   * Provides a way to inject external application state into form expressions.
-   * Each property is a Signal that will be unwrapped and made available in the
-   * `EvaluationContext` under `externalData`.
-   *
-   * The signals are read reactively in logic functions (when/readonly/disabled)
-   * so changes to the external data will trigger re-evaluation of conditions.
-   *
-   * @example
-   * ```typescript
-   * const config: FormConfig = {
-   *   externalData: {
-   *     userRole: computed(() => this.authService.currentRole()),
-   *     permissions: computed(() => this.authService.permissions()),
-   *     featureFlags: computed(() => this.featureFlagService.flags()),
-   *   },
-   *   fields: [
-   *     {
-   *       type: 'input',
-   *       key: 'adminField',
-   *       label: 'Admin Only Field',
-   *       logic: [{
-   *         effect: 'show',
-   *         condition: {
-   *           type: 'javascript',
-   *           expression: "externalData.userRole === 'admin'"
-   *         }
-   *       }]
-   *     },
-   *     {
-   *       type: 'select',
-   *       key: 'advancedOption',
-   *       label: 'Advanced Option',
-   *       logic: [{
-   *         effect: 'show',
-   *         condition: {
-   *           type: 'javascript',
-   *           expression: "externalData.featureFlags.advancedMode === true"
-   *         }
-   *       }]
-   *     }
-   *   ]
-   * };
-   * ```
-   */
+  /** External data signals available to conditional logic and derivations. */
   externalData?: Record<string, Signal<unknown>>;
 
-  /**
-   * Form-wide default wrappers applied to every field that does not explicitly opt out.
-   *
-   * Merged into a field's effective wrapper chain between auto-associated wrappers
-   * (outermost) and field-level `wrappers` (innermost). Fields with `wrappers: null`
-   * opt out entirely — no defaults, no auto-associations.
-   *
-   * @example
-   * ```typescript
-   * const config: FormConfig = {
-   *   defaultWrappers: [{ type: 'css', cssClasses: 'mb-2' }],
-   *   fields: [
-   *     { type: 'input', key: 'name' },                           // gets default wrappers
-   *     { type: 'input', key: 'email', wrappers: null },           // opts out
-   *     { type: 'input', key: 'age', wrappers: [{ type: 'css', cssClasses: 'highlight' }] }, // defaults + field-level
-   *   ],
-   * };
-   * ```
-   */
+  /** Form-wide default wrappers applied to every field that does not explicitly opt out. */
   defaultWrappers?: readonly WrapperConfig[];
 }
 
-/**
- * Signal forms adapter configuration for advanced form behavior.
- *
- * Provides configuration options for signal forms integration including
- * legacy migration, custom functions, and custom validators.
- *
- * @example
- * ```typescript
- * customFnConfig: {
- *   customFunctions: {
- *     isAdult: (context) => context.age >= 18,
- *     formatCurrency: (context) => new Intl.NumberFormat('en-US', {
- *       style: 'currency',
- *       currency: 'USD'
- *     }).format(context.value)
- *   },
- *   derivations: {
- *     getCurrencyForCountry: (context) => {
- *       const countryToCurrency: Record<string, string> = {
- *         'USA': 'USD', 'Germany': 'EUR', 'UK': 'GBP'
- *       };
- *       return countryToCurrency[context.formValue.country as string] ?? 'USD';
- *     }
- *   },
- *   simpleValidators: {
- *     noSpaces: (value) => {
- *       return typeof value === 'string' && value.includes(' ')
- *         ? { kind: 'noSpaces', message: 'Spaces not allowed' }
- *         : null;
- *     }
- *   },
- *   contextValidators: {
- *     lessThanField: (ctx, params) => {
- *       const value = ctx.value();
- *       const otherField = params?.field as string;
- *       const otherValue = ctx.root()[otherField]?.value();
- *       if (otherValue !== undefined && value >= otherValue) {
- *         return { kind: 'notLessThan', message: `Must be less than ${otherField}` };
- *       }
- *       return null;
- *     }
- *   }
- * }
- * ```
- *
- * @public
- */
+/** Signal forms adapter configuration for advanced form behavior. */
 export interface CustomFnConfig<TFormValue extends Record<string, unknown> = Record<string, unknown>> {
-  /**
-   * Custom evaluation functions for conditional expressions.
-   *
-   * Used for: when/readonly/disabled logic
-   * Return type: any value (typically boolean)
-   *
-   * @example
-   * ```typescript
-   * customFunctions: {
-   *   isAdult: (context) => context.age >= 18,
-   *   calculateAge: (context) => {
-   *     const birthDate = new Date(context.birthDate);
-   *     return new Date().getFullYear() - birthDate.getFullYear();
-   *   }
-   * }
-   * ```
-   */
+  /** Custom evaluation functions for conditional expressions. */
   customFunctions?: Record<string, CustomFunction<TFormValue>>;
 
-  /**
-   * Custom derivation functions for value derivation logic.
-   *
-   * These functions compute derived values and are called when a
-   * `DerivationLogicConfig` references them by `functionName`.
-   *
-   * Derivation functions:
-   * - Receive an `EvaluationContext` with access to `formValue`
-   * - Return the value to set on the target field
-   * - Are called reactively when dependencies change
-   *
-   * Use derivation functions for complex mappings or logic that
-   * can't be easily expressed as a JavaScript expression.
-   *
-   * @example
-   * ```typescript
-   * derivations: {
-   *   // Country to currency mapping
-   *   getCurrencyForCountry: (context) => {
-   *     const countryToCurrency: Record<string, string> = {
-   *       'USA': 'USD',
-   *       'Germany': 'EUR',
-   *       'France': 'EUR',
-   *       'UK': 'GBP',
-   *       'Japan': 'JPY'
-   *     };
-   *     return countryToCurrency[context.formValue.country as string] ?? 'USD';
-   *   },
-   *
-   *   // Complex tax calculation
-   *   calculateTax: (context) => {
-   *     const subtotal = context.formValue.subtotal as number ?? 0;
-   *     const state = context.formValue.state as string;
-   *     const taxRates: Record<string, number> = {
-   *       'CA': 0.0725, 'NY': 0.08, 'TX': 0.0625
-   *     };
-   *     return subtotal * (taxRates[state] ?? 0);
-   *   },
-   *
-   *   // Format phone number
-   *   formatPhoneNumber: (context) => {
-   *     const phone = context.fieldValue as string ?? '';
-   *     const digits = phone.replace(/\D/g, '');
-   *     if (digits.length === 10) {
-   *       return `(${digits.slice(0,3)}) ${digits.slice(3,6)}-${digits.slice(6)}`;
-   *     }
-   *     return phone;
-   *   }
-   * }
-   * ```
-   *
-   * Field configuration using a derivation function:
-   * ```typescript
-   * // Derivation is defined on the target field (currency), not the source field (country)
-   * {
-   *   key: 'currency',
-   *   type: 'select',
-   *   logic: [
-   *     {
-   *       type: 'derivation',
-   *       functionName: 'getCurrencyForCountry',
-   *       dependsOn: ['country']
-   *     }
-   *   ]
-   * }
-   * ```
-   */
+  /** Custom derivation functions for value derivation logic. */
   derivations?: Record<string, CustomFunction<TFormValue>>;
 
-  /**
-   * Async derivation functions for asynchronous value derivation logic.
-   *
-   * These functions perform asynchronous operations (service calls, complex pipelines)
-   * and return the derived value via a Promise or Observable. They are called when a
-   * `DerivationLogicConfig` references them by `asyncFunctionName`.
-   *
-   * Async derivation functions:
-   * - Receive an `EvaluationContext` with access to `formValue`
-   * - Return a Promise or Observable of the value to set on the target field
-   * - Handle their own I/O (no HttpClient provided — use injected services)
-   * - Require explicit `dependsOn` to avoid triggering on every form change
-   *
-   * @example
-   * ```typescript
-   * asyncDerivations: {
-   *   fetchSuggestedPrice: async (context) => {
-   *     const response = await fetch(`/api/price?product=${context.formValue.productId}`);
-   *     const data = await response.json();
-   *     return data.suggestedPrice;
-   *   },
-   *   lookupAddress: (context) => {
-   *     return addressService.lookup(context.formValue.zipCode).pipe(
-   *       map(result => result.formattedAddress)
-   *     );
-   *   },
-   * }
-   * ```
-   */
+  /** Async derivation functions for asynchronous value derivation logic. */
   asyncDerivations?: Record<string, AsyncDerivationFunction<TFormValue>>;
 
-  /**
-   * Async condition functions for asynchronous field state logic.
-   *
-   * These functions perform asynchronous operations and return a boolean
-   * indicating whether the condition is met. They are referenced by
-   * `asyncFunctionName` in `AsyncCondition` expressions.
-   *
-   * Async condition functions:
-   * - Receive an `EvaluationContext` with access to `formValue`
-   * - Return a Promise or Observable of boolean
-   * - Handle their own I/O (use injected services)
-   *
-   * @example
-   * ```typescript
-   * asyncConditions: {
-   *   checkPermission: async (context) => {
-   *     const response = await fetch(`/api/permissions?role=${context.formValue.role}`);
-   *     const data = await response.json();
-   *     return data.canEdit;
-   *   },
-   * }
-   * ```
-   */
+  /** Async condition functions for asynchronous field state logic. */
   asyncConditions?: Record<string, AsyncConditionFunction<TFormValue>>;
 
-  /**
-   * Custom validators using Angular's public FieldContext API
-   *
-   * (ctx, params?) => ValidationError | ValidationError[] | null
-   *
-   * Validators receive FieldContext which provides access to:
-   * - Current field value: `ctx.value()`
-   * - Field state: `ctx.state` (errors, touched, dirty, etc.)
-   * - Other field values: `ctx.valueOf(path)` - public API!
-   * - Other field states: `ctx.stateOf(path)`
-   * - Parameters from JSON configuration
-   *
-   * **Return Types:**
-   * - Single error: `{ kind: 'errorKind' }` for field-level validation
-   * - Multiple errors: `[{ kind: 'error1' }, { kind: 'error2' }]` for cross-field validation
-   * - No error: `null` when validation passes
-   *
-   * @example Single Field Validation
-   * ```typescript
-   * validators: {
-   *   noSpaces: (ctx) => {
-   *     const value = ctx.value();
-   *     if (typeof value === 'string' && value.includes(' ')) {
-   *       return { kind: 'noSpaces' };
-   *     }
-   *     return null;
-   *   }
-   * }
-   * ```
-   *
-   * @example Cross-Field Validation (Public API)
-   * ```typescript
-   * validators: {
-   *   lessThan: (ctx, params) => {
-   *     const value = ctx.value();
-   *     const compareToPath = params?.field as string;
-   *
-   *     // Use valueOf() to access other field - public API!
-   *     const otherValue = ctx.valueOf(compareToPath as any);
-   *
-   *     if (otherValue !== undefined && value >= otherValue) {
-   *       return { kind: 'notLessThan' };
-   *     }
-   *     return null;
-   *   }
-   * }
-   * ```
-   *
-   * @example Multiple Errors
-   * ```typescript
-   * validators: {
-   *   validateDateRange: (ctx) => {
-   *     const errors: ValidationError[] = [];
-   *     const startDate = ctx.valueOf('startDate' as any);
-   *     const endDate = ctx.valueOf('endDate' as any);
-   *
-   *     if (!startDate) errors.push({ kind: 'startDateRequired' });
-   *     if (!endDate) errors.push({ kind: 'endDateRequired' });
-   *     if (startDate && endDate && startDate > endDate) {
-   *       errors.push({ kind: 'invalidDateRange' });
-   *     }
-   *
-   *     return errors.length > 0 ? errors : null;
-   *   }
-   * }
-   * ```
-   */
+  /** Custom validators using Angular's public FieldContext API */
   validators?: Record<string, CustomValidator>;
 
-  /**
-   * Async custom validators using Angular's resource-based validateAsync() API
-   *
-   * Angular's validateAsync uses the resource API for async validation.
-   * Validators must provide params, factory, onSuccess, and optional onError callbacks.
-   *
-   * **Structure:**
-   * - `params`: Function that computes params from field context
-   * - `factory`: Function that creates ResourceRef from params signal
-   * - `onSuccess`: Maps resource result to validation errors
-   * - `onError`: Optional handler for resource errors
-   *
-   * **Use Cases:**
-   * - Database lookups via services with resource API
-   * - Complex async business logic with Angular resources
-   *
-   * **Note:** For HTTP validation, prefer `httpValidators` which provides
-   * a simpler API specifically designed for HTTP requests.
-   *
-   * @example Database Lookup with Resource
-   * ```typescript
-   * asyncValidators: {
-   *   checkUsernameAvailable: {
-   *     params: (ctx) => ({ username: ctx.value() }),
-   *     factory: (params) => {
-   *       const injector = inject(Injector);
-   *       return resource({
-   *         request: () => params(),
-   *         loader: ({ request }) => {
-   *           if (!request?.username) return null;
-   *           const service = injector.get(UserService);
-   *           return firstValueFrom(service.checkAvailability(request.username));
-   *         }
-   *       });
-   *     },
-   *     onSuccess: (result, ctx) => {
-   *       if (!result) return null;
-   *       return result.available ? null : { kind: 'usernameTaken' };
-   *     },
-   *     onError: (error, ctx) => {
-   *       console.error('Availability check failed:', error);
-   *       return null; // Don't block form on network errors
-   *     }
-   *   }
-   * }
-   * ```
-   */
+  /** Async custom validators using Angular's resource-based validateAsync() API */
   asyncValidators?: Record<string, AsyncCustomValidator>;
 
-  /**
-   * HTTP validators using Angular's validateHttp() API.
-   *
-   * For function-based HTTP validation with automatic request cancellation.
-   * Prefer declarative HTTP validators (`type: 'http'` with `http` + `responseMapping`)
-   * for fully JSON-serializable validation when possible.
-   *
-   * @example
-   * ```typescript
-   * httpValidators: {
-   *   checkUsername: {
-   *     request: (ctx) => `/api/users/check?username=${encodeURIComponent(ctx.value())}`,
-   *     onSuccess: (response) => response.available ? null : { kind: 'usernameTaken' },
-   *   }
-   * }
-   * ```
-   */
+  /** HTTP validators using Angular's validateHttp() API. */
   httpValidators?: Record<string, HttpCustomValidator>;
 }
 
-/**
- * Global form configuration options.
- *
- * Controls form-wide behavior including disabled state
- * and button behavior configuration.
- *
- * @example
- * ```typescript
- * options: {
- *   disabled: false,
- *   submitButton: { disableWhenInvalid: true }
- * }
- * ```
- *
- * @public
- */
+/** Global form configuration options. */
 export interface FormOptions {
   /**
    * Disable the entire form.
-   *
-   * When enabled, all form fields become read-only and cannot
-   * be modified by user interaction.
    *
    * @value false
    */
@@ -633,58 +94,18 @@ export interface FormOptions {
   /**
    * Maximum number of iterations for derivation chain processing.
    *
-   * Derivations can trigger other derivations (e.g., A → B → C).
-   * This limit prevents infinite loops in case of circular dependencies
-   * that weren't caught at build time.
-   *
-   * Increase this value if you have legitimate deep derivation chains
-   * (more than 10 levels deep).
-   *
    * @default 10
    */
   maxDerivationIterations?: number;
 
-  /**
-   * Default disabled behavior for submit buttons.
-   *
-   * Controls when submit buttons are automatically disabled.
-   * Can be overridden per-button via the `logic` array on individual button fields.
-   *
-   * @example
-   * ```typescript
-   * options: {
-   *   submitButton: {
-   *     disableWhenInvalid: true,      // Disable when form is invalid
-   *     disableWhileSubmitting: true,  // Disable during submission
-   *   }
-   * }
-   * ```
-   */
+  /** Default disabled behavior for submit buttons. */
   submitButton?: SubmitButtonOptions;
 
-  /**
-   * Default disabled behavior for next page buttons.
-   *
-   * Controls when next page buttons are automatically disabled in paged forms.
-   * Can be overridden per-button via the `logic` array on individual button fields.
-   *
-   * @example
-   * ```typescript
-   * options: {
-   *   nextButton: {
-   *     disableWhenPageInvalid: true,  // Disable when current page is invalid
-   *     disableWhileSubmitting: true,  // Disable during submission
-   *   }
-   * }
-   * ```
-   */
+  /** Default disabled behavior for next page buttons. */
   nextButton?: NextButtonOptions;
 
   /**
    * Whether to exclude values of hidden fields from submission output.
-   *
-   * Overrides the global `withValueExclusionDefaults()` setting for this form.
-   * Can be further overridden per-field on individual `FieldDef` entries.
    *
    * @default undefined (uses global setting)
    */
@@ -693,18 +114,12 @@ export interface FormOptions {
   /**
    * Whether to exclude values of disabled fields from submission output.
    *
-   * Overrides the global `withValueExclusionDefaults()` setting for this form.
-   * Can be further overridden per-field on individual `FieldDef` entries.
-   *
    * @default undefined (uses global setting)
    */
   excludeValueIfDisabled?: boolean;
 
   /**
    * Whether to exclude values of readonly fields from submission output.
-   *
-   * Overrides the global `withValueExclusionDefaults()` setting for this form.
-   * Can be further overridden per-field on individual `FieldDef` entries.
    *
    * @default undefined (uses global setting)
    */
@@ -713,13 +128,6 @@ export interface FormOptions {
   /**
    * Whether to run validation when a field is hidden.
    *
-   * Acts as the root inherited value for the entire form — per-field
-   * `FieldDef.validateWhenHidden` overrides it for a subtree, and once
-   * overridden the new value is itself inherited by descendants unless
-   * they override in turn.
-   *
-   * Overrides the global `withValidationExecutionDefaults()` setting for this form.
-   *
    * @default undefined (uses global setting, which defaults to `false`)
    */
   validateWhenHidden?: boolean;
@@ -727,39 +135,12 @@ export interface FormOptions {
   /**
    * Whether to attach the current form value to all events dispatched through the EventBus.
    *
-   * This per-form setting overrides the global `withEventFormValue()` feature:
-   * - `true` - Enable form value emission for this form (even if globally disabled)
-   * - `false` - Disable form value emission for this form (even if globally enabled)
-   * - `undefined` - Use global setting (default)
-   *
-   * When enabled, events will include a `formValue` property with the current form state.
-   * Use the `hasFormValue()` type guard to safely access this property.
-   *
-   * @example
-   * ```typescript
-   * // Enable for this form only (no global withEventFormValue() needed)
-   * const config: FormConfig = {
-   *   fields: [...],
-   *   options: { emitFormValueOnEvents: true }
-   * };
-   *
-   * // Disable for this form (when globally enabled)
-   * const config: FormConfig = {
-   *   fields: [...],
-   *   options: { emitFormValueOnEvents: false }
-   * };
-   * ```
-   *
    * @default undefined (uses global setting)
    */
   emitFormValueOnEvents?: boolean;
 }
 
-/**
- * Options for controlling submit button disabled behavior.
- *
- * @public
- */
+/** Options for controlling submit button disabled behavior. */
 export interface SubmitButtonOptions {
   /**
    * Disable submit button when the form is invalid.
@@ -771,18 +152,12 @@ export interface SubmitButtonOptions {
   /**
    * Disable submit button while the form is submitting.
    *
-   * Requires `submission.action` to be configured for automatic detection.
-   *
    * @default true
    */
   disableWhileSubmitting?: boolean;
 }
 
-/**
- * Options for controlling next page button disabled behavior.
- *
- * @public
- */
+/** Options for controlling next page button disabled behavior. */
 export interface NextButtonOptions {
   /**
    * Disable next button when the current page has invalid fields.

--- a/packages/dynamic-forms/src/lib/models/http/http-request-config.ts
+++ b/packages/dynamic-forms/src/lib/models/http/http-request-config.ts
@@ -1,9 +1,4 @@
-/**
- * Configuration for an HTTP request used by declarative HTTP validators, derivations, and conditions.
- *
- * All string values in `queryParams` are treated as expressions evaluated by ExpressionParser.
- * When `evaluateBodyExpressions` is true, top-level string values in `body` are also evaluated as expressions (shallow only).
- */
+/** Configuration for an HTTP request used by declarative HTTP validators, derivations, and conditions. */
 export interface HttpRequestConfig {
   /** URL to send the request to */
   url: string;
@@ -14,15 +9,6 @@ export interface HttpRequestConfig {
   /**
    * URL path parameters. Keys correspond to `:key` placeholders in the URL.
    * Values are expressions evaluated by ExpressionParser against the current EvaluationContext.
-   *
-   * @example
-   * ```typescript
-   * {
-   *   url: '/api/users/:userId/orders/:orderId',
-   *   params: { userId: 'formValue.userId', orderId: 'fieldValue' }
-   * }
-   * // With userId=42 and fieldValue='abc' → '/api/users/42/orders/abc'
-   * ```
    */
   params?: Record<string, string>;
 

--- a/packages/dynamic-forms/src/lib/models/http/http-response-mapping.ts
+++ b/packages/dynamic-forms/src/lib/models/http/http-response-mapping.ts
@@ -1,18 +1,6 @@
-/**
- * Mapping configuration for interpreting HTTP responses as validation results.
- *
- * Expressions in `validWhen` and `errorParams` are evaluated with scope `{ response }` only —
- * they do NOT have access to `formValue`, `fieldValue`, or the full `EvaluationContext`.
- * This is intentional for v1: response mapping is purely about interpreting the HTTP response.
- */
+/** Mapping configuration for interpreting HTTP responses as validation results. */
 export interface HttpValidationResponseMapping {
-  /**
-   * Expression evaluated with scope `{ response }`. Must evaluate to `true` (strict boolean) to be valid.
-   *
-   * NOTE: This is the OPPOSITE of the function-based HttpCustomValidator.onSuccess
-   * convention, which maps successful HTTP responses to validation errors.
-   * Here, `=== true` means "validation passed". Non-boolean results are treated as invalid and trigger a warning.
-   */
+  /** Expression evaluated with scope `{ response }`. Must evaluate to `true` (strict boolean) to be valid. */
   validWhen: string;
 
   /** Error kind returned when validation fails — maps to field-level `validationMessages` */

--- a/packages/dynamic-forms/src/lib/models/logic/logic-config.ts
+++ b/packages/dynamic-forms/src/lib/models/logic/logic-config.ts
@@ -3,37 +3,7 @@ import type { CustomFunction } from '../../core/expressions/custom-function-type
 import { ConditionalExpression } from '../expressions/conditional-expression';
 import { HttpRequestConfig } from '../http/http-request-config';
 
-/**
- * Special form-state conditions for button disabled logic.
- *
- * These conditions evaluate form or page-level state rather than field values,
- * and are primarily used for controlling button disabled states.
- *
- * @example
- * ```typescript
- * // Disable submit button when form is invalid or submitting
- * {
- *   key: 'submit',
- *   type: 'submit',
- *   label: 'Submit',
- *   logic: [
- *     { type: 'disabled', condition: 'formInvalid' },
- *     { type: 'disabled', condition: 'formSubmitting' },
- *   ]
- * }
- *
- * // Disable next button when current page is invalid
- * nextButton({
- *   key: 'next',
- *   label: 'Next',
- *   logic: [
- *     { type: 'disabled', condition: 'pageInvalid' },
- *   ]
- * })
- * ```
- *
- * @public
- */
+/** Special form-state conditions for button disabled logic. */
 export type FormStateCondition =
   /** True when form.valid() === false */
   | 'formInvalid'
@@ -42,11 +12,7 @@ export type FormStateCondition =
   /** True when fields on the current page are invalid (for paged forms) */
   | 'pageInvalid';
 
-/**
- * Logic type for controlling field state (hidden, readonly, disabled, required).
- *
- * @public
- */
+/** Logic type for controlling field state (hidden, readonly, disabled, required). */
 export type StateLogicType = 'hidden' | 'readonly' | 'disabled' | 'required';
 
 /**
@@ -55,41 +21,10 @@ export type StateLogicType = 'hidden' | 'readonly' | 'disabled' | 'required';
  * @internal
  */
 interface BaseStateLogicConfig {
-  /**
-   * Logic type identifier for field state.
-   *
-   * - `hidden`: Hide the field from view (still participates in form state)
-   * - `readonly`: Make the field read-only
-   * - `disabled`: Disable user interaction
-   * - `required`: Make the field required
-   */
+  /** Logic type identifier for field state. */
   type: StateLogicType;
 
-  /**
-   * Condition that determines when this logic applies.
-   *
-   * Can be:
-   * - `boolean`: Static value (always applies or never applies)
-   * - `ConditionalExpression`: Expression evaluated against field/form values
-   * - `FormStateCondition`: Special form/page state check (for buttons)
-   *
-   * @example
-   * ```typescript
-   * // Static condition
-   * condition: true
-   *
-   * // Field value condition
-   * condition: {
-   *   type: 'fieldValue',
-   *   fieldPath: 'status',
-   *   operator: 'equals',
-   *   value: 'locked'
-   * }
-   *
-   * // Form state condition (for buttons)
-   * condition: 'formSubmitting'
-   * ```
-   */
+  /** Condition that determines when this logic applies. */
   condition: ConditionalExpression | boolean | FormStateCondition;
 }
 
@@ -101,6 +36,7 @@ interface BaseStateLogicConfig {
 interface ImmediateStateLogicConfig extends BaseStateLogicConfig {
   /**
    * Trigger for immediate evaluation.
+   *
    * @default 'onChange'
    */
   trigger?: 'onChange';
@@ -121,65 +57,16 @@ interface DebouncedStateLogicConfig extends BaseStateLogicConfig {
   trigger: 'debounced';
   /**
    * Debounce duration in milliseconds.
+   *
    * @default 500
    */
   debounceMs?: number;
 }
 
-/**
- * Configuration for conditional field state logic.
- *
- * Defines how field behavior changes based on conditions.
- * Supports hiding, disabling, making readonly, or requiring fields
- * based on form state or field values.
- *
- * @example
- * ```typescript
- * // Hide email field when contact method is not email
- * {
- *   type: 'hidden',
- *   condition: {
- *     type: 'fieldValue',
- *     fieldPath: 'contactMethod',
- *     operator: 'notEquals',
- *     value: 'email'
- *   }
- * }
- *
- * // Disable button when form is submitting
- * {
- *   type: 'disabled',
- *   condition: 'formSubmitting'
- * }
- *
- * // Debounced visibility (avoids flicker during rapid typing)
- * {
- *   type: 'hidden',
- *   trigger: 'debounced',
- *   debounceMs: 300,
- *   condition: {
- *     type: 'fieldValue',
- *     fieldPath: 'search',
- *     operator: 'isEmpty'
- *   }
- * }
- * ```
- *
- * @public
- */
+/** Configuration for conditional field state logic. */
 export type StateLogicConfig = ImmediateStateLogicConfig | DebouncedStateLogicConfig;
 
-/**
- * Trigger timing for when logic is evaluated.
- *
- * - `onChange`: Evaluate immediately when any dependency changes (default)
- * - `debounced`: Evaluate after the value has stabilized for a duration
- *
- * Use `debounced` for self-transforms (lowercase, trim) or to avoid
- * UI flicker during rapid typing.
- *
- * @public
- */
+/** Trigger timing for when logic is evaluated. */
 export type LogicTrigger = 'onChange' | 'debounced';
 
 /**
@@ -188,120 +75,21 @@ export type LogicTrigger = 'onChange' | 'debounced';
  * @internal
  */
 interface SharedDerivationFields {
-  /**
-   * Logic type identifier for value derivation.
-   */
+  /** Logic type identifier for value derivation. */
   type: 'derivation';
 
-  /**
-   * Target property name for property derivation.
-   *
-   * When set, this derivation targets a field property (like `minDate`, `options`,
-   * `label`, `placeholder`) instead of the field's value. The derivation is routed
-   * to the property derivation pipeline.
-   *
-   * When absent, the derivation targets the field's value (default behavior).
-   *
-   * **Depth limit (max 2 levels):** Only simple and single-dot-nested paths are
-   * supported. Paths with 2+ dots (e.g., `'a.b.c'`) will throw at runtime.
-   *
-   * @example
-   * ```typescript
-   * // Property derivation (new unified API)
-   * {
-   *   key: 'endDate',
-   *   type: 'datepicker',
-   *   logic: [{
-   *     type: 'derivation',
-   *     targetProperty: 'minDate',
-   *     expression: 'formValue.startDate'
-   *   }]
-   * }
-   *
-   * // Value derivation (no targetProperty — existing behavior)
-   * {
-   *   key: 'total',
-   *   type: 'input',
-   *   logic: [{
-   *     type: 'derivation',
-   *     expression: 'formValue.quantity * formValue.unitPrice'
-   *   }]
-   * }
-   * ```
-   */
+  /** Target property name for property derivation. */
   targetProperty?: string;
 
-  /**
-   * Optional name for this derivation for debugging purposes.
-   *
-   * When provided, this name appears in derivation debug logs,
-   * making it easier to identify specific derivations in complex forms.
-   *
-   * @example
-   * ```typescript
-   * {
-   *   key: 'lineTotal',
-   *   type: 'input',
-   *   logic: [{
-   *     type: 'derivation',
-   *     debugName: 'Calculate line total',
-   *     expression: 'formValue.quantity * formValue.unitPrice'
-   *   }]
-   * }
-   * ```
-   */
+  /** Optional name for this derivation for debugging purposes. */
   debugName?: string;
 
-  /**
-   * Condition that determines when this derivation applies.
-   *
-   * Can be:
-   * - `boolean`: Static value (always applies or never applies)
-   * - `ConditionalExpression`: Expression evaluated against field/form values
-   *
-   * Defaults to `true` (always apply).
-   *
-   * Note: FormStateCondition is not supported for derivations.
-   *
-   * @example
-   * ```typescript
-   * // Always compute (default)
-   * condition: true
-   *
-   * // Conditional derivation
-   * condition: {
-   *   type: 'fieldValue',
-   *   fieldPath: 'country',
-   *   operator: 'equals',
-   *   value: 'USA'
-   * }
-   * ```
-   */
+  /** Condition that determines when this derivation applies. */
   condition?: ConditionalExpression | boolean;
 
   /**
    * When true, the derivation stops running after the user manually
    * edits the target field.
-   *
-   * This is useful for "smart defaults" — values that should be
-   * auto-filled initially but respected once the user explicitly changes them.
-   *
-   * Uses the field's `dirty()` signal to detect user modification.
-   * Derivations write directly to `value.set()` which does not trigger
-   * `markAsDirty()`, so `dirty === true` reliably indicates a user edit.
-   *
-   * @example
-   * ```typescript
-   * // Auto-fill display name from first + last name, but stop if user edits it
-   * {
-   *   key: 'displayName',
-   *   logic: [{
-   *     type: 'derivation',
-   *     expression: 'formValue.firstName + " " + formValue.lastName',
-   *     stopOnUserOverride: true
-   *   }]
-   * }
-   * ```
    */
   stopOnUserOverride?: boolean;
 
@@ -309,31 +97,13 @@ interface SharedDerivationFields {
    * When true (and `stopOnUserOverride` is also true), clears the
    * user-override flag when any dependency of this derivation changes,
    * allowing the derivation to run again.
-   *
-   * This is useful when a user override should only persist until the
-   * underlying data changes — e.g., when switching countries, the
-   * phone prefix should re-derive even if the user previously edited it.
-   *
-   * @example
-   * ```typescript
-   * {
-   *   key: 'phonePrefix',
-   *   logic: [{
-   *     type: 'derivation',
-   *     value: '+1',
-   *     condition: { type: 'fieldValue', fieldPath: 'country', operator: 'equals', value: 'USA' },
-   *     stopOnUserOverride: true,
-   *     reEngageOnDependencyChange: true,
-   *     dependsOn: ['country']
-   *   }]
-   * }
-   * ```
    */
   reEngageOnDependencyChange?: boolean;
 }
 
 /**
  * Trigger variants for derivation timing.
+ *
  * @internal
  */
 type ImmediateDerivationTrigger = { trigger?: 'onChange'; debounceMs?: never };
@@ -356,57 +126,14 @@ interface HttpDerivationBase extends SharedDerivationFields {
   fn?: never;
   /** Forbidden on HTTP source */
   asyncFn?: never;
-  /**
-   * HTTP request configuration for server-driven derivations.
-   *
-   * The request is sent when dependencies change, with automatic
-   * debouncing and cancellation of in-flight requests.
-   *
-   * Configure debounce via the `trigger: 'debounced'` + `debounceMs` mechanism.
-   *
-   * @example
-   * ```typescript
-   * {
-   *   key: 'exchangeRate',
-   *   logic: [{
-   *     type: 'derivation',
-   *     source: 'http',
-   *     http: {
-   *       url: '/api/exchange-rate',
-   *       method: 'GET',
-   *       queryParams: {
-   *         from: 'formValue.sourceCurrency',
-   *         to: 'formValue.targetCurrency',
-   *       },
-   *     },
-   *     responseExpression: 'response.rate',
-   *     dependsOn: ['sourceCurrency', 'targetCurrency'],
-   *   }]
-   * }
-   * ```
-   */
+  /** HTTP request configuration for server-driven derivations. */
   http: HttpRequestConfig;
   /**
    * Explicit field dependencies. Required for HTTP derivations to prevent
    * wildcard triggering on every keystroke.
-   *
-   * The wildcard token `'*'` is rejected. The structural token `'$group'`
-   * (and `'$group.X'`) is allowed and resolves to the field's parent container
-   * path — be aware this fires whenever any sibling under that group changes,
-   * so the caller owns the request frequency (consider `trigger: 'debounced'`).
    */
   dependsOn: string[];
-  /**
-   * Expression to extract the derived value from the HTTP response.
-   *
-   * Evaluated via `ExpressionParser` with `{ response }` as the evaluation scope.
-   *
-   * @example
-   * ```typescript
-   * responseExpression: 'response.rate'
-   * responseExpression: 'response.data.suggestedPrice'
-   * ```
-   */
+  /** Expression to extract the derived value from the HTTP response. */
   responseExpression: string;
   // Mutual exclusivity: other sources are not allowed
   value?: never;
@@ -432,12 +159,6 @@ interface AsyncFunctionDerivationShared extends SharedDerivationFields {
   /**
    * Explicit field dependencies. Required for async derivations to prevent
    * wildcard triggering on every form change.
-   *
-   * The wildcard token `'*'` is rejected. The structural token `'$group'`
-   * (and `'$group.X'`) is allowed and resolves to the field's parent container
-   * path — be aware this fires whenever any sibling under that group changes,
-   * so the caller owns the invocation frequency (handle this via
-   * `trigger: 'debounced'` or via debouncing inside the async function).
    */
   dependsOn: string[];
   // Mutual exclusivity: other sources are not allowed
@@ -457,37 +178,13 @@ interface AsyncFunctionDerivationShared extends SharedDerivationFields {
  */
 type AsyncFunctionDerivationBase =
   | (AsyncFunctionDerivationShared & {
-      /**
-       * Name of a registered async derivation function.
-       *
-       * The function receives the evaluation context and returns a Promise or Observable
-       * of the derived value. Register functions in `customFnConfig.asyncDerivations`.
-       *
-       * @example
-       * ```typescript
-       * {
-       *   key: 'suggestedPrice',
-       *   logic: [{
-       *     type: 'derivation',
-       *     source: 'asyncFunction',
-       *     asyncFunctionName: 'fetchSuggestedPrice',
-       *     dependsOn: ['productId', 'quantity'],
-       *   }]
-       * }
-       * ```
-       */
+      /** Name of a registered async derivation function. */
       asyncFunctionName: string;
       /** Inline form is forbidden when `asyncFunctionName` is set */
       asyncFn?: never;
     })
   | (AsyncFunctionDerivationShared & {
-      /**
-       * Inline async derivation function. Mutually exclusive with `asyncFunctionName`.
-       *
-       * NOT JSON-serializable — for code-only configs. For configs loaded
-       * from JSON / OpenAPI / databases, use `asyncFunctionName` to reference
-       * a function registered in `customFnConfig.asyncDerivations`.
-       */
+      /** Inline async derivation function. Mutually exclusive with `asyncFunctionName`. */
       asyncFn: AsyncDerivationFunction;
       /** Registered form is forbidden when `asyncFn` is set */
       asyncFunctionName?: never;
@@ -508,40 +205,9 @@ interface ExpressionDerivationBase extends SharedDerivationFields {
   fn?: never;
   /** Forbidden on expression mode */
   asyncFn?: never;
-  /**
-   * JavaScript expression to evaluate for the derived value.
-   *
-   * Has access to `formValue` object containing all form values.
-   * For array fields, `formValue` is scoped to the current array item.
-   * Uses the same secure AST-based parser as other expressions.
-   *
-   * @example
-   * ```typescript
-   * expression: 'formValue.quantity * formValue.unitPrice'
-   * expression: 'formValue.firstName + " " + formValue.lastName'
-   * expression: 'formValue.price * (1 - formValue.discount / 100)'
-   * ```
-   */
+  /** JavaScript expression to evaluate for the derived value. */
   expression: string;
-  /**
-   * Explicit field dependencies for expressions.
-   *
-   * For `expression`, dependencies are automatically extracted from the expression.
-   * Provide `dependsOn` to override automatic detection for complex expressions.
-   *
-   * @example
-   * ```typescript
-   * // Override automatic detection for complex expressions
-   * {
-   *   key: 'total',
-   *   logic: [{
-   *     type: 'derivation',
-   *     expression: 'calculateTotal(formValue)',
-   *     dependsOn: ['quantity', 'unitPrice', 'discount']
-   *   }]
-   * }
-   * ```
-   */
+  /** Explicit field dependencies for expressions. */
   dependsOn?: string[];
   // Mutual exclusivity: other mode payload fields are not allowed
   value?: never;
@@ -562,26 +228,9 @@ interface ValueDerivationBase extends SharedDerivationFields {
   fn?: never;
   /** Forbidden on value mode */
   asyncFn?: never;
-  /**
-   * Static value to set on this field.
-   *
-   * Use when the derived value is a constant.
-   *
-   * @example
-   * ```typescript
-   * value: '+1'           // String
-   * value: 100            // Number
-   * value: true           // Boolean
-   * value: { code: 'US' } // Object
-   * ```
-   */
+  /** Static value to set on this field. */
   value: unknown;
-  /**
-   * Explicit field dependencies for value derivations.
-   *
-   * For `value` (static), no dependencies are needed.
-   * Provide `dependsOn` to conditionally re-evaluate when specific fields change.
-   */
+  /** Explicit field dependencies for value derivations. */
   dependsOn?: string[];
   // Mutual exclusivity: other mode payload fields are not allowed
   expression?: never;
@@ -600,26 +249,7 @@ interface FunctionDerivationShared extends SharedDerivationFields {
   source?: never;
   /** Forbidden on function-derivation mode */
   asyncFn?: never;
-  /**
-   * Explicit field dependencies for function derivations.
-   *
-   * If not provided, defaults to all fields ('*').
-   * Specify `dependsOn` for better performance when the function only
-   * depends on a subset of fields.
-   *
-   * @example
-   * ```typescript
-   * // Only re-evaluate when country changes
-   * {
-   *   key: 'currency',
-   *   logic: [{
-   *     type: 'derivation',
-   *     functionName: 'getCurrencyForCountry',
-   *     dependsOn: ['country']
-   *   }]
-   * }
-   * ```
-   */
+  /** Explicit field dependencies for function derivations. */
   dependsOn?: string[];
   // Mutual exclusivity: other mode payload fields are not allowed
   value?: never;
@@ -637,31 +267,13 @@ interface FunctionDerivationShared extends SharedDerivationFields {
  */
 type FunctionDerivationBase =
   | (FunctionDerivationShared & {
-      /**
-       * Name of a registered custom derivation function.
-       *
-       * The function receives the evaluation context and returns the derived value.
-       * Register functions in `customFnConfig.derivations`.
-       *
-       * @example
-       * ```typescript
-       * functionName: 'getCurrencyForCountry'
-       * functionName: 'calculateTax'
-       * functionName: 'formatPhoneNumber'
-       * ```
-       */
+      /** Name of a registered custom derivation function. */
       functionName: string;
       /** Inline form is forbidden when `functionName` is set */
       fn?: never;
     })
   | (FunctionDerivationShared & {
-      /**
-       * Inline custom derivation function. Mutually exclusive with `functionName`.
-       *
-       * NOT JSON-serializable — for code-only configs. For configs loaded
-       * from JSON / OpenAPI / databases, use `functionName` to reference
-       * a function registered in `customFnConfig.derivations`.
-       */
+      /** Inline custom derivation function. Mutually exclusive with `functionName`. */
       fn: CustomFunction;
       /** Registered form is forbidden when `fn` is set */
       functionName?: never;
@@ -669,124 +281,75 @@ type FunctionDerivationBase =
 
 /**
  * HTTP derivation that evaluates immediately on change (default).
+ *
  * @internal
  */
 type OnChangeHttpDerivationLogicConfig = HttpDerivationBase & ImmediateDerivationTrigger;
 
 /**
  * HTTP derivation that evaluates after a debounce period.
+ *
  * @internal
  */
 type DebouncedHttpDerivationLogicConfig = HttpDerivationBase & DebouncedDerivationTrigger;
 
 /**
  * Async function derivation that evaluates immediately on change (default).
+ *
  * @internal
  */
 type OnChangeAsyncFunctionDerivationLogicConfig = AsyncFunctionDerivationBase & ImmediateDerivationTrigger;
 
 /**
  * Async function derivation that evaluates after a debounce period.
+ *
  * @internal
  */
 type DebouncedAsyncFunctionDerivationLogicConfig = AsyncFunctionDerivationBase & DebouncedDerivationTrigger;
 
 /**
  * Expression derivation that evaluates immediately on change (default).
+ *
  * @internal
  */
 type OnChangeExpressionDerivationLogicConfig = ExpressionDerivationBase & ImmediateDerivationTrigger;
 
 /**
  * Expression derivation that evaluates after a debounce period.
+ *
  * @internal
  */
 type DebouncedExpressionDerivationLogicConfig = ExpressionDerivationBase & DebouncedDerivationTrigger;
 
 /**
  * Value derivation that evaluates immediately on change (default).
+ *
  * @internal
  */
 type OnChangeValueDerivationLogicConfig = ValueDerivationBase & ImmediateDerivationTrigger;
 
 /**
  * Value derivation that evaluates after a debounce period.
+ *
  * @internal
  */
 type DebouncedValueDerivationLogicConfig = ValueDerivationBase & DebouncedDerivationTrigger;
 
 /**
  * Function derivation that evaluates immediately on change (default).
+ *
  * @internal
  */
 type OnChangeFunctionDerivationLogicConfig = FunctionDerivationBase & ImmediateDerivationTrigger;
 
 /**
  * Function derivation that evaluates after a debounce period.
+ *
  * @internal
  */
 type DebouncedFunctionDerivationLogicConfig = FunctionDerivationBase & DebouncedDerivationTrigger;
 
-/**
- * Configuration for value derivation logic.
- *
- * Enables programmatic value derivation based on conditions.
- * Derivations are self-targeting: the logic is placed on the field
- * that should receive the computed value.
- *
- * @example
- * ```typescript
- * // Set phone prefix based on country selection
- * {
- *   key: 'phonePrefix',
- *   logic: [{
- *     type: 'derivation',
- *     value: '+1',
- *     condition: {
- *       type: 'fieldValue',
- *       fieldPath: 'country',
- *       operator: 'equals',
- *       value: 'USA'
- *     }
- *   }]
- * }
- *
- * // Compute total from quantity and price
- * {
- *   key: 'total',
- *   derivation: 'formValue.quantity * formValue.unitPrice'
- * }
- *
- * // Use custom function for complex logic
- * {
- *   key: 'currency',
- *   logic: [{
- *     type: 'derivation',
- *     functionName: 'getCurrencyForCountry'
- *   }]
- * }
- *
- * // Self-transform with debounced trigger
- * // (applies after user stops typing)
- * {
- *   key: 'email',
- *   logic: [{
- *     type: 'derivation',
- *     expression: 'formValue.email.toLowerCase()',
- *     trigger: 'debounced',
- *     debounceMs: 500
- *   }]
- * }
- *
- * // Array item derivation (formValue is scoped to current item)
- * {
- *   key: 'lineTotal',  // Inside array field
- *   derivation: 'formValue.quantity * formValue.unitPrice'
- * }
- * ```
- *
- * @public
- */
+/** Configuration for value derivation logic. */
 export type DerivationLogicConfig =
   | OnChangeHttpDerivationLogicConfig
   | DebouncedHttpDerivationLogicConfig
@@ -799,32 +362,13 @@ export type DerivationLogicConfig =
   | OnChangeFunctionDerivationLogicConfig
   | DebouncedFunctionDerivationLogicConfig;
 
-/**
- * Union type for all logic configurations.
- *
- * - `StateLogicConfig`: For field state changes (hidden, readonly, disabled, required)
- * - `DerivationLogicConfig`: For value derivation (including property derivation via `targetProperty`)
- *
- * @public
- */
+/** Union type for all logic configurations. */
 export type LogicConfig = StateLogicConfig | DerivationLogicConfig;
 
-/**
- * Log level for derivation debug output.
- *
- * - 'none': No debug logging
- * - 'summary': Log cycle completion with counts (default in dev mode)
- * - 'verbose': Log individual derivation evaluations with details
- *
- * @public
- */
+/** Log level for derivation debug output. */
 export type DerivationLogLevel = 'none' | 'summary' | 'verbose';
 
-/**
- * Configuration for derivation debug logging.
- *
- * @public
- */
+/** Configuration for derivation debug logging. */
 export interface DerivationLogConfig {
   /** Log level for derivation debugging. Defaults to 'none'. */
   level: DerivationLogLevel;
@@ -833,11 +377,7 @@ export interface DerivationLogConfig {
 /**
  * Creates the default derivation log configuration.
  *
- * Defaults to 'none' (silent). Users can enable logging via `withLoggerConfig`.
- *
  * @returns Default DerivationLogConfig
- *
- * @public
  */
 export function createDefaultDerivationLogConfig(): DerivationLogConfig {
   return {
@@ -851,8 +391,6 @@ export function createDefaultDerivationLogConfig(): DerivationLogConfig {
  * @param config - Current log configuration
  * @param minLevel - Minimum level required for logging
  * @returns True if logging should occur
- *
- * @public
  */
 export function shouldLog(config: DerivationLogConfig, minLevel: 'summary' | 'verbose'): boolean {
   if (config.level === 'none') return false;
@@ -865,8 +403,6 @@ export function shouldLog(config: DerivationLogConfig, minLevel: 'summary' | 've
  *
  * @param condition - The condition to check
  * @returns true if the condition is a FormStateCondition
- *
- * @public
  */
 export function isFormStateCondition(
   condition: StateLogicConfig['condition'] | DerivationLogicConfig['condition'],
@@ -879,8 +415,6 @@ export function isFormStateCondition(
  *
  * @param config - The logic config to check
  * @returns true if the config is for field state logic
- *
- * @public
  */
 export function isStateLogicConfig(config: LogicConfig): config is StateLogicConfig {
   return config.type === 'hidden' || config.type === 'readonly' || config.type === 'disabled' || config.type === 'required';
@@ -891,8 +425,6 @@ export function isStateLogicConfig(config: LogicConfig): config is StateLogicCon
  *
  * @param config - The logic config to check
  * @returns true if the config is for value derivation
- *
- * @public
  */
 export function isDerivationLogicConfig(config: LogicConfig): config is DerivationLogicConfig {
   return config.type === 'derivation';
@@ -901,13 +433,8 @@ export function isDerivationLogicConfig(config: LogicConfig): config is Derivati
 /**
  * Type guard to check if a derivation config targets a property rather than the field value.
  *
- * When `targetProperty` is present on a `type: 'derivation'` config, it is routed
- * to the property derivation pipeline instead of the value derivation pipeline.
- *
  * @param config - The derivation logic config to check
  * @returns true if the config has a targetProperty (property derivation)
- *
- * @public
  */
 export function hasTargetProperty(config: DerivationLogicConfig): config is DerivationLogicConfig & { targetProperty: string } {
   return 'targetProperty' in config && typeof config.targetProperty === 'string' && config.targetProperty.length > 0;

--- a/packages/dynamic-forms/src/lib/models/registry/field-registry.ts
+++ b/packages/dynamic-forms/src/lib/models/registry/field-registry.ts
@@ -8,18 +8,7 @@ import { CssWrapper } from '../../wrappers/css/css-wrapper.type';
 import { RowWrapper } from '../../wrappers/row/row-wrapper.type';
 import { ContainerField } from '../../definitions/default/container-field';
 
-/**
- * Container fields registry - augment this interface to add custom container fields
- *
- * @example
- * ```typescript
- * declare module '@ng-forge/dynamic-forms' {
- *   interface FieldRegistryContainers {
- *     'my-container': MyContainerFieldDef;
- *   }
- * }
- * ```
- */
+/** Container fields registry - augment this interface to add custom container fields */
 export interface FieldRegistryContainers {
   page: PageField;
   row: RowField;
@@ -28,37 +17,13 @@ export interface FieldRegistryContainers {
   container: ContainerField;
 }
 
-/**
- * Leaf fields registry - augment this interface to add custom leaf fields
- *
- * @example
- * ```typescript
- * declare module '@ng-forge/dynamic-forms' {
- *   interface FieldRegistryLeaves {
- *     'my-input': MyInputFieldDef;
- *   }
- * }
- * ```
- */
+/** Leaf fields registry - augment this interface to add custom leaf fields */
 export interface FieldRegistryLeaves {
   text: TextField;
   hidden: HiddenField;
 }
 
-/**
- * Wrapper type registry for module augmentation.
- *
- * Augment this interface to add type-safe wrapper type definitions.
- *
- * @example
- * ```typescript
- * declare module '@ng-forge/dynamic-forms' {
- *   interface FieldRegistryWrappers {
- *     'section': MySectionFieldDef
- *   }
- * }
- * ```
- */
+/** Wrapper type registry for module augmentation. */
 export interface FieldRegistryWrappers {
   css: CssWrapper;
   row: RowWrapper;
@@ -67,52 +32,31 @@ export interface FieldRegistryWrappers {
 /**
  * Global interface for dynamic form field definitions with categorization
  * This interface combines containers and leaves from their respective registries
- *
- * Container fields: Layout fields that contain other fields (page, row, group, array)
- * Leaf fields: Fields that can hold values or display content (input, text, etc.)
- *
- * To add custom fields, augment FieldRegistryContainers or FieldRegistryLeaves
  */
 export interface DynamicFormFieldRegistry {
-  /**
-   * Container fields that hold other fields (no value, have children)
-   */
+  /** Container fields that hold other fields (no value, have children) */
   containers: FieldRegistryContainers;
 
-  /**
-   * Leaf fields that have values or display content
-   */
+  /** Leaf fields that have values or display content */
   leaves: FieldRegistryLeaves;
 
-  /**
-   * Field wrappers types
-   */
+  /** Field wrappers types */
   wrappers: FieldRegistryWrappers;
 }
 
-/**
- * Union type of all registered container field definitions
- */
+/** Union type of all registered container field definitions */
 export type ContainerFieldTypes = DynamicFormFieldRegistry['containers'][keyof DynamicFormFieldRegistry['containers']];
 
-/**
- * Union type of all registered leaf field definitions
- */
+/** Union type of all registered leaf field definitions */
 export type LeafFieldTypes = DynamicFormFieldRegistry['leaves'][keyof DynamicFormFieldRegistry['leaves']];
 
-/**
- * Union type of all registered field definitions
- */
+/** Union type of all registered field definitions */
 export type RegisteredFieldTypes = ContainerFieldTypes | LeafFieldTypes;
 
-/**
- * Extract field types that are available in the registry
- */
+/** Extract field types that are available in the registry */
 export type AvailableFieldTypes = keyof DynamicFormFieldRegistry['containers'] | keyof DynamicFormFieldRegistry['leaves'];
 
-/**
- * Extract wrapper types that are available in the registry
- */
+/** Extract wrapper types that are available in the registry */
 export type RegisteredWrapperTypes = keyof DynamicFormFieldRegistry['wrappers'];
 
 /**
@@ -124,46 +68,17 @@ type FieldTypeMap = DynamicFormFieldRegistry['containers'] & DynamicFormFieldReg
 /**
  * Extract a specific field type from RegisteredFieldTypes based on the `type` discriminant.
  * This enables proper type narrowing when defining fields.
- *
- * @example
- * ```typescript
- * // Extract a specific field type
- * type MyInputField = ExtractField<'input'>;
- *
- * // Use in field definitions for proper props inference
- * const field: ExtractField<'input'> = {
- *   type: 'input',
- *   key: 'email',
- *   value: '',
- *   props: { type: 'email' } // Only input props allowed here
- * };
- * ```
  */
 export type ExtractField<T extends AvailableFieldTypes> = T extends keyof FieldTypeMap ? FieldTypeMap[T] : never;
 
 /**
  * Narrow a field definition based on its `type` property.
  * Use this to get proper type inference when working with field unions.
- *
- * @example
- * ```typescript
- * function processField<T extends RegisteredFieldTypes>(field: T): NarrowField<T> {
- *   return field as NarrowField<T>;
- * }
- * ```
  */
 export type NarrowField<T> = T extends { type: infer TType } ? (TType extends AvailableFieldTypes ? ExtractField<TType> : T) : T;
 
 /**
  * Narrow each field in an array based on its `type` property.
  * Use with `satisfies` to get proper type inference for field arrays.
- *
- * @example
- * ```typescript
- * const fields = [
- *   { type: 'input', key: 'name', value: '', props: { type: 'text' } },
- *   { type: 'select', key: 'country', value: 'us', options: [...] },
- * ] as const satisfies NarrowFields;
- * ```
  */
 export type NarrowFields = readonly NarrowField<RegisteredFieldTypes>[];

--- a/packages/dynamic-forms/src/lib/models/schemas/schema-definition.ts
+++ b/packages/dynamic-forms/src/lib/models/schemas/schema-definition.ts
@@ -2,9 +2,7 @@ import { ValidatorConfig } from '../validation/validator-config';
 import { LogicConfig } from '../logic/logic-config';
 import { ConditionalExpression } from '../expressions/conditional-expression';
 
-/**
- * Configuration for applying predefined schemas
- */
+/** Configuration for applying predefined schemas */
 export interface SchemaApplicationConfig {
   /** Schema application type */
   type: 'apply' | 'applyWhen' | 'applyWhenValue' | 'applyEach';
@@ -19,9 +17,7 @@ export interface SchemaApplicationConfig {
   typePredicate?: string;
 }
 
-/**
- * Reusable schema definition that can be referenced by name
- */
+/** Reusable schema definition that can be referenced by name */
 export interface SchemaDefinition {
   /** Unique schema identifier */
   name: string;

--- a/packages/dynamic-forms/src/lib/models/submission-config.ts
+++ b/packages/dynamic-forms/src/lib/models/submission-config.ts
@@ -4,126 +4,20 @@ import { Observable } from 'rxjs';
 /**
  * The result type for submission actions.
  * Can be either a Promise or an Observable.
- *
- * For success: return `undefined`, `null`, `void`, or any non-TreeValidationResult value.
- * For server errors: return `TreeValidationResult` (array of field errors).
  */
 export type SubmissionActionResult = Promise<TreeValidationResult> | Observable<TreeValidationResult | unknown>;
 
 /**
  * Configuration for form submission handling.
  *
- * When provided, enables integration with Angular Signal Forms' native `submit()` function.
- * The submission mechanism is **optional** - you can still handle submission manually
- * via the `(submitted)` output if you prefer.
- *
- * Supports both Promise-based and Observable-based submission actions. When an Observable
- * is returned, it will be automatically converted using `firstValueFrom`.
- *
- * @example
- * ```typescript
- * // Using Observable (recommended for HTTP calls)
- * // Simply return the HTTP observable - no need to map the result
- * const config: FormConfig = {
- *   fields: [...],
- *   submission: {
- *     action: (form) => this.http.post('/api/submit', form().value())
- *   }
- * };
- *
- * // With error handling for server validation errors
- * const config: FormConfig = {
- *   fields: [...],
- *   submission: {
- *     action: (form) => {
- *       return this.http.post('/api/submit', form().value()).pipe(
- *         catchError((error) => {
- *           if (error.error?.code === 'EMAIL_EXISTS') {
- *             return of([{ field: form.email, error: { kind: 'server', message: 'Email already exists' }}]);
- *           }
- *           throw error;
- *         })
- *       );
- *     }
- *   }
- * };
- *
- * // Using Promise (also supported)
- * const config: FormConfig = {
- *   fields: [...],
- *   submission: {
- *     action: async (form) => {
- *       const value = form().value();
- *       try {
- *         await this.api.submit(value);
- *         return undefined;
- *       } catch (error) {
- *         if (error.code === 'EMAIL_EXISTS') {
- *           return [{ field: form.email, error: { kind: 'server', message: 'Email already exists' }}];
- *         }
- *         throw error;
- *       }
- *     }
- *   }
- * };
- * ```
- *
  * @typeParam TValue - The form value type
- *
- * @public
  */
 export interface SubmissionConfig<TValue = unknown> {
   /**
    * Action called when the form is submitted.
    *
-   * This function receives the form's `FieldTree` and should return either a Promise or
-   * an Observable. For Observable returns, it will be automatically converted using `firstValueFrom`.
-   *
-   * **Return values:**
-   * - For success: return `undefined`, `null`, or simply let the Observable complete (the emitted value is ignored unless it's a TreeValidationResult)
-   * - For server errors: return `TreeValidationResult` (array of field/error pairs)
-   *
-   * **Observable support:** You can return an HttpClient observable directly without mapping the result.
-   * The form will treat Observable completion as success. Only return `TreeValidationResult` if you need
-   * to report server-side validation errors.
-   *
-   * Server errors returned will be automatically applied to the corresponding form fields.
-   *
-   * While this action is executing, `form().submitting()` will be `true`, enabling
-   * automatic button disabling and loading states.
-   *
    * @param form - The form's FieldTree instance
    * @returns Promise or Observable - for errors, return TreeValidationResult
-   *
-   * @example
-   * ```typescript
-   * // Simple - just return the HTTP observable
-   * action: (form) => this.http.post('/api/register', form().value())
-   *
-   * // With server error handling
-   * action: (form) => {
-   *   return this.http.post('/api/register', form().value()).pipe(
-   *     catchError((error) => {
-   *       if (error.status === 409) {
-   *         return of([{
-   *           field: form.email,
-   *           error: { kind: 'server', message: 'Email already exists' }
-   *         }]);
-   *       }
-   *       throw error;
-   *     })
-   *   );
-   * }
-   *
-   * // Promise-based alternative
-   * action: async (form) => {
-   *   await fetch('/api/register', {
-   *     method: 'POST',
-   *     body: JSON.stringify(form().value())
-   *   });
-   *   // Return undefined for success, or TreeValidationResult for errors
-   * }
-   * ```
    */
   action: (form: FieldTree<TValue>) => SubmissionActionResult;
 }

--- a/packages/dynamic-forms/src/lib/models/types/dynamic-value.ts
+++ b/packages/dynamic-forms/src/lib/models/types/dynamic-value.ts
@@ -1,19 +1,5 @@
 import { Signal } from '@angular/core';
 import { Observable } from 'rxjs';
 
-/**
- * Generic reactive value — a static value, an Angular Signal, or an RxJS Observable.
- *
- * Generalises {@link DynamicText} for arbitrary value types. Used by
- * cross-cutting properties that need to react to form state without forcing
- * every consumer to deal with reactivity (e.g., `hidden` / `disabled` on
- * addons).
- *
- * @example
- * ```typescript
- * const a: DynamicValue<boolean> = true;
- * const b: DynamicValue<boolean> = signal(false);
- * const c: DynamicValue<boolean> = isValid$;
- * ```
- */
+/** Generic reactive value — a static value, an Angular Signal, or an RxJS Observable. */
 export type DynamicValue<T> = T | Signal<T> | Observable<T>;

--- a/packages/dynamic-forms/src/lib/models/types/field-helpers.ts
+++ b/packages/dynamic-forms/src/lib/models/types/field-helpers.ts
@@ -1,6 +1,4 @@
-/**
- * Helper types for creating type-safe field configurations with proper nesting constraints
- */
+/** Helper types for creating type-safe field configurations with proper nesting constraints */
 
 import type { SchemaPath, SchemaPathTree } from '@angular/forms/signals';
 

--- a/packages/dynamic-forms/src/lib/models/types/form-mode.ts
+++ b/packages/dynamic-forms/src/lib/models/types/form-mode.ts
@@ -5,16 +5,12 @@ import { RegisteredFieldTypes } from '../registry/field-registry';
 // Re-export isPageField for external usage
 export { isPageField };
 
-/**
- * Interface for fields that contain child fields
- */
+/** Interface for fields that contain child fields */
 interface ContainerField<T> extends FieldDef<T> {
   fields: FieldDef<unknown>[];
 }
 
-/**
- * Type guard to check if a field is a container with fields
- */
+/** Type guard to check if a field is a container with fields */
 function isContainerWithFields<T>(field: FieldDef<T>): field is FieldDef<T> & ContainerField<T> {
   return (
     (field.type === 'row' || field.type === 'group' || field.type === 'page' || field.type === 'container') &&
@@ -23,14 +19,10 @@ function isContainerWithFields<T>(field: FieldDef<T>): field is FieldDef<T> & Co
   );
 }
 
-/**
- * Form mode enumeration distinguishing between paged and non-paged forms
- */
+/** Form mode enumeration distinguishing between paged and non-paged forms */
 export type FormMode = 'paged' | 'non-paged';
 
-/**
- * Result of form mode detection with validation details
- */
+/** Result of form mode detection with validation details */
 export interface FormModeDetectionResult {
   /** The detected form mode */
   mode: FormMode;
@@ -66,6 +58,7 @@ export function isNonPagedForm<TFields extends RegisteredFieldTypes[]>(fields: T
 
 /**
  * Detects the form mode and validates the configuration
+ *
  * @param fields The form field definitions
  * @returns Detection result with mode and validation status
  */
@@ -120,6 +113,7 @@ export function detectFormMode<TFields extends RegisteredFieldTypes[]>(fields: T
 
 /**
  * Recursively checks if any field definition is a page field
+ *
  * @param fields Array of field definitions to check
  * @returns true if any page field is found at any level
  */
@@ -142,6 +136,7 @@ function hasAnyPageFields(fields: FieldDef<unknown>[]): boolean {
 /**
  * Checks if fields contain nested page fields within their children
  * (This is different from hasAnyPageFields as it checks NESTED pages, not root pages)
+ *
  * @param fields Array of field definitions to check
  * @returns true if nested page fields found
  */
@@ -164,17 +159,13 @@ function hasNestedPageFields(fields: FieldDef<unknown>[]): boolean {
   return false;
 }
 
-/**
- * Type predicate for valid paged form configurations
- */
+/** Type predicate for valid paged form configurations */
 export function isValidPagedForm<TFields extends RegisteredFieldTypes[]>(fields: TFields): boolean {
   const result = detectFormMode(fields);
   return result.mode === 'paged' && result.isValid;
 }
 
-/**
- * Type predicate for valid non-paged form configurations
- */
+/** Type predicate for valid non-paged form configurations */
 export function isValidNonPagedForm<TFields extends RegisteredFieldTypes[]>(fields: TFields): boolean {
   const result = detectFormMode(fields);
   return result.mode === 'non-paged' && result.isValid;

--- a/packages/dynamic-forms/src/lib/models/types/form-value-inference.ts
+++ b/packages/dynamic-forms/src/lib/models/types/form-value-inference.ts
@@ -6,30 +6,12 @@ import { RegisteredFieldTypes } from '../registry/field-registry';
  */
 type UnionToIntersection<U> = (U extends U ? (k: U) => void : never) extends (k: infer I) => void ? I : never;
 
-/**
- * Depth counter for recursion limiting (prevents infinite type instantiation)
- */
+/** Depth counter for recursion limiting (prevents infinite type instantiation) */
 type Depth = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
 /**
  * Widens literal types to their primitive equivalents, recursively for objects and arrays.
  * This prevents `as const` from over-narrowing types like `''` to literal `''` instead of `string`.
- *
- * Depth-limited to prevent slow type checking on deeply nested `as const` objects.
- * Falls back to `T` (unwidened) when depth is exhausted.
- *
- * Note: For object types, `readonly` modifiers are intentionally stripped (`-readonly`)
- * so that inferred form value types have mutable properties. This is by design since
- * `as const` adds `readonly` to all properties, but form values should be mutable.
- *
- * @example
- * ```typescript
- * type A = Widen<''>; // string
- * type B = Widen<false>; // boolean
- * type C = Widen<42>; // number
- * type D = Widen<string[]>; // string[]
- * type E = Widen<{ name: 'Jane' }>; // { name: string }
- * ```
  */
 type Widen<T, D extends number = 5> = [D] extends [never]
   ? T
@@ -119,9 +101,7 @@ type InferArrayValue<T, D extends number> = T extends { template: unknown; value
         : unknown[]
       : unknown[];
 
-/**
- * Process a single field and determine its contribution to the form value type
- */
+/** Process a single field and determine its contribution to the form value type */
 type ProcessField<T, D extends number = 5> = [D] extends [never]
   ? Record<string, unknown>
   : // Container: page/row - flatten children
@@ -163,14 +143,10 @@ type ProcessField<T, D extends number = 5> = [D] extends [never]
                   : never
                 : never;
 
-/**
- * Internal helper with depth tracking
- */
+/** Internal helper with depth tracking */
 type InferFormValueWithDepth<T extends RegisteredFieldTypes[], D extends number = 5> = UnionToIntersection<ProcessField<T[number], D>>;
 
-/**
- * Helper to extract fields from either fields array or FormConfig
- */
+/** Helper to extract fields from either fields array or FormConfig */
 type ExtractFields<T> = T extends { fields: infer TFields }
   ? TFields extends readonly RegisteredFieldTypes[]
     ? TFields
@@ -183,27 +159,6 @@ type ExtractFields<T> = T extends { fields: infer TFields }
  * Infer form value type from fields array or FormConfig.
  * Recursively processes nested structures and merges the results.
  * Limited to 5 levels of nesting to prevent infinite type instantiation.
- *
- * @example
- * ```typescript
- * // From fields array
- * const fields = [
- *   { type: 'input', key: 'email', value: '', required: true },
- *   { type: 'input', key: 'name', value: '' }
- * ] as const;
- * type FieldsValue = InferFormValue<typeof fields>;
- *
- * // From FormConfig
- * const config = {
- *   fields: [
- *     { type: 'input', key: 'email', value: '', required: true },
- *     { type: 'input', key: 'name', value: '' }
- *   ]
- * } as const satisfies FormConfig;
- * type ConfigValue = InferFormValue<typeof config>;
- *
- * // Result: { email: string; name?: string }
- * ```
  */
 export type InferFormValue<T> =
   ExtractFields<T> extends readonly RegisteredFieldTypes[]

--- a/packages/dynamic-forms/src/lib/models/types/nesting-constraints.ts
+++ b/packages/dynamic-forms/src/lib/models/types/nesting-constraints.ts
@@ -7,8 +7,6 @@ import type { ContainerField } from '../../definitions/default/container-field';
 /**
  * Type constraints for field nesting rules
  * These ensure that container fields can only contain valid child field types
- *
- * Note: We explicitly list types instead of using Exclude to avoid circular dependencies
  */
 
 /**

--- a/packages/dynamic-forms/src/lib/models/validation-execution-config.ts
+++ b/packages/dynamic-forms/src/lib/models/validation-execution-config.ts
@@ -1,28 +1,11 @@
-/**
- * Configuration for when validation runs based on a field's reactive state.
- *
- * Currently controls whether hidden fields are validated. Resolved through a
- * tree-aware hierarchy: per-field overrides inherit down to descendants, with
- * per-form `FormOptions` and global `withValidationExecutionDefaults()` providing
- * the root inherited value.
- *
- * @public
- */
+/** Configuration for when validation runs based on a field's reactive state. */
 export interface ValidationExecutionConfig {
   /**
    * Whether validators run while a field is hidden (statically, via `hidden`
    * logic, or because any ancestor is hidden).
-   *
-   * When `false`, all validators on a hidden field are skipped — the field is
-   * effectively inert until shown. State logic (hidden/disabled/readonly) and
-   * value derivations continue to apply.
    */
   readonly validateWhenHidden?: boolean;
 }
 
-/**
- * Fully resolved validation execution config — every property defined.
- *
- * @public
- */
+/** Fully resolved validation execution config — every property defined. */
 export type ResolvedValidationExecutionConfig = Required<ValidationExecutionConfig>;

--- a/packages/dynamic-forms/src/lib/models/validation/validator-config.ts
+++ b/packages/dynamic-forms/src/lib/models/validation/validator-config.ts
@@ -3,17 +3,13 @@ import { ConditionalExpression } from '../expressions/conditional-expression';
 import { HttpRequestConfig } from '../http/http-request-config';
 import { HttpValidationResponseMapping } from '../http/http-response-mapping';
 
-/**
- * Base configuration shared by all validators
- */
+/** Base configuration shared by all validators */
 export interface BaseValidatorConfig {
   /** Conditional logic for when validator applies */
   when?: ConditionalExpression;
 }
 
-/**
- * Built-in validator configuration (required, email, min, max, etc.)
- */
+/** Built-in validator configuration (required, email, min, max, etc.) */
 export interface BuiltInValidatorConfig extends BaseValidatorConfig {
   /** Validator type identifier */
   type: 'required' | 'email' | 'min' | 'max' | 'minLength' | 'maxLength' | 'pattern';
@@ -28,22 +24,6 @@ export interface BuiltInValidatorConfig extends BaseValidatorConfig {
 /**
  * Custom validator configuration using Angular's public FieldContext API.
  * Returns ValidationError | ValidationError[] | null synchronously.
- *
- * Three authoring forms (mutually exclusive at runtime, not enforced by TypeScript):
- * 1. Registered function: `{ type: 'custom', functionName: 'myValidator' }`
- * 2. Inline function (code-only): `{ type: 'custom', fn: (ctx) => ... }`
- * 3. Expression-based: `{ type: 'custom', expression: 'fieldValue === formValue.password', kind: 'passwordMismatch' }`
- *
- * Unlike `AsyncValidatorConfig` and `FunctionHttpValidatorConfig` (strict `fn` ↔
- * `functionName` XOR via discriminated unions), this surface keeps a permissive
- * interface — the historical expression-vs-functionName split was already
- * runtime-checked, so adding `fn` follows the same precedent. The runtime
- * resolver picks one source and warns if `fn` and `functionName` are both set;
- * inline `fn` wins.
- *
- * `fn` is NOT JSON-serializable — for code-only configs. For configs loaded from
- * JSON / OpenAPI / databases, prefer `functionName` to reference a function
- * registered in `customFnConfig.validators`.
  */
 export interface CustomValidatorConfig extends BaseValidatorConfig {
   /** Validator type identifier */
@@ -70,13 +50,6 @@ export interface CustomValidatorConfig extends BaseValidatorConfig {
   /**
    * Parameters to include in error object for message interpolation (expression-based pattern)
    * Map of parameter names to expressions that will be evaluated in the same context as the validation expression
-   *
-   * @example
-   * errorParams: {
-   *   minValue: 'formValue.minValue',
-   *   maxValue: 'formValue.maxValue'
-   * }
-   * // Allows message template: "Value must be between {{minValue}} and {{maxValue}}"
    */
   errorParams?: Record<string, string>;
 }
@@ -96,13 +69,6 @@ interface AsyncValidatorConfigShared extends BaseValidatorConfig {
 /**
  * Async custom validator configuration using Angular's `validateAsync` API.
  * Returns Observable<ValidationError | ValidationError[] | null>.
- *
- * Two mutually exclusive authoring forms:
- * - `functionName`: name of a function registered in `customFnConfig.asyncValidators`.
- *   JSON-serializable; suitable for configs loaded from APIs, databases, or OpenAPI.
- * - `fn`: inline async validator. NOT JSON-serializable; for code-only configs.
- *
- * Exactly one of `functionName` or `fn` must be set.
  */
 export type AsyncValidatorConfig =
   | (AsyncValidatorConfigShared & {
@@ -112,13 +78,7 @@ export type AsyncValidatorConfig =
       fn?: never;
     })
   | (AsyncValidatorConfigShared & {
-      /**
-       * Inline async validator. Mutually exclusive with `functionName`.
-       *
-       * NOT JSON-serializable — for code-only configs. For configs loaded
-       * from JSON / OpenAPI / databases, use `functionName` to reference
-       * a validator registered in `customFnConfig.asyncValidators`.
-       */
+      /** Inline async validator. Mutually exclusive with `functionName`. */
       fn: AsyncCustomValidator;
       /** Registered form is forbidden when `fn` is set */
       functionName?: never;
@@ -136,19 +96,7 @@ interface FunctionHttpValidatorConfigShared extends BaseValidatorConfig {
   params?: Record<string, unknown>;
 }
 
-/**
- * Function-based HTTP validator configuration. Uses Angular's `validateHttp` API.
- *
- * Two mutually exclusive authoring forms:
- * - `functionName`: name of an HTTP validator registered in `customFnConfig.httpValidators`.
- *   JSON-serializable.
- * - `fn`: inline HTTP validator. NOT JSON-serializable; for code-only configs.
- *
- * Exactly one of `functionName` or `fn` must be set.
- *
- * Discriminated from `DeclarativeHttpValidatorConfig` by the presence of `functionName`
- * or `fn` (and absence of `http` + `responseMapping`).
- */
+/** Function-based HTTP validator configuration. Uses Angular's `validateHttp` API. */
 export type FunctionHttpValidatorConfig =
   | (FunctionHttpValidatorConfigShared & {
       /** Name of registered HTTP validator configuration */
@@ -157,27 +105,13 @@ export type FunctionHttpValidatorConfig =
       fn?: never;
     })
   | (FunctionHttpValidatorConfigShared & {
-      /**
-       * Inline HTTP validator. Mutually exclusive with `functionName`.
-       *
-       * NOT JSON-serializable — for code-only configs. For configs loaded
-       * from JSON / OpenAPI / databases, use `functionName` to reference
-       * an HTTP validator registered in `customFnConfig.httpValidators`.
-       */
+      /** Inline HTTP validator. Mutually exclusive with `functionName`. */
       fn: HttpCustomValidator;
       /** Registered form is forbidden when `fn` is set */
       functionName?: never;
     });
 
-/**
- * Declarative HTTP validator configuration — fully JSON-serializable, no function registration required.
- *
- * Uses `HttpRequestConfig` to define the HTTP request and `HttpValidationResponseMapping`
- * to interpret the response as a validation result. Powered by Angular's `validateHttp` API.
- *
- * Discriminated from `FunctionHttpValidatorConfig` by the presence of `http` + `responseMapping`
- * (and absence of `functionName`).
- */
+/** Declarative HTTP validator configuration — fully JSON-serializable, no function registration required. */
 export interface DeclarativeHttpValidatorConfig extends BaseValidatorConfig {
   /** Validator type identifier */
   type: 'http';
@@ -192,10 +126,6 @@ export interface DeclarativeHttpValidatorConfig extends BaseValidatorConfig {
 /**
  * Configuration for signal forms validator functions that can be serialized from API.
  * Discriminated union type for type-safe validator configuration.
- *
- * Note: `FunctionHttpValidatorConfig` and `DeclarativeHttpValidatorConfig` both use `type: 'http'`.
- * They are discriminated by property presence: `functionName` → function-based, `http` → declarative.
- * Use `isFunctionHttpValidator()` for type-safe narrowing when `type` alone is insufficient.
  */
 export type ValidatorConfig =
   | BuiltInValidatorConfig
@@ -204,12 +134,7 @@ export type ValidatorConfig =
   | FunctionHttpValidatorConfig
   | DeclarativeHttpValidatorConfig;
 
-/**
- * Type guard to distinguish function-based HTTP validators from declarative ones.
- *
- * Both use `type: 'http'`, so `switch (config.type)` cannot narrow between them.
- * Use this guard when you need type-safe access to `FunctionHttpValidatorConfig` properties.
- */
+/** Type guard to distinguish function-based HTTP validators from declarative ones. */
 export function isFunctionHttpValidator(
   config: FunctionHttpValidatorConfig | DeclarativeHttpValidatorConfig,
 ): config is FunctionHttpValidatorConfig {

--- a/packages/dynamic-forms/src/lib/models/value-exclusion-config.ts
+++ b/packages/dynamic-forms/src/lib/models/value-exclusion-config.ts
@@ -1,18 +1,10 @@
 /**
  * Configuration for excluding field values from form submission output
  * based on their reactive state (hidden, disabled, readonly).
- *
- * Supports a 3-tier configuration hierarchy: Field > Form > Global.
- * The most specific level wins for each property.
- *
- * @public
  */
 export interface ValueExclusionConfig {
   /**
    * Whether to exclude the value of hidden fields from submission output.
-   *
-   * When `true`, fields whose `hidden()` state is `true` will have their
-   * values omitted from the submitted form value.
    *
    * @remarks
    * This does NOT affect HiddenField (`type: 'hidden'`) — those fields
@@ -20,27 +12,15 @@ export interface ValueExclusionConfig {
    */
   readonly excludeValueIfHidden?: boolean;
 
-  /**
-   * Whether to exclude the value of disabled fields from submission output.
-   *
-   * When `true`, fields whose `disabled()` state is `true` will have their
-   * values omitted from the submitted form value.
-   */
+  /** Whether to exclude the value of disabled fields from submission output. */
   readonly excludeValueIfDisabled?: boolean;
 
-  /**
-   * Whether to exclude the value of readonly fields from submission output.
-   *
-   * When `true`, fields whose `readonly()` state is `true` will have their
-   * values omitted from the submitted form value.
-   */
+  /** Whether to exclude the value of readonly fields from submission output. */
   readonly excludeValueIfReadonly?: boolean;
 }
 
 /**
  * Fully resolved exclusion config with all properties required.
  * Produced by the 3-tier resolution: `field ?? form ?? global`.
- *
- * @public
  */
 export type ResolvedValueExclusionConfig = Required<ValueExclusionConfig>;

--- a/packages/dynamic-forms/src/lib/models/wrapper-type.ts
+++ b/packages/dynamic-forms/src/lib/models/wrapper-type.ts
@@ -1,25 +1,7 @@
 import { InjectionToken, Signal, Type, ViewContainerRef } from '@angular/core';
 import { FieldRegistryWrappers, RegisteredWrapperTypes } from './registry/field-registry';
 
-/**
- * Resolves a wrapper type name to its registered config interface.
- *
- * When `TWrappers` is a specific registered key (e.g., `'css'`), resolves to
- * the full config type from `FieldRegistryWrappers` (e.g., `CssWrapper`),
- * providing type-safe access to wrapper-specific properties like `cssClasses`.
- *
- * When `TWrappers` is the full `RegisteredWrapperTypes` union, distributes
- * to produce a discriminated union of all registered wrapper configs.
- *
- * @example
- * ```typescript
- * // Resolves to CssWrapper — cssClasses is typed
- * type CssConfig = WrapperConfig<'css'>;
- *
- * // Union of all registered wrapper configs
- * type AnyConfig = WrapperConfig;
- * ```
- */
+/** Resolves a wrapper type name to its registered config interface. */
 
 export type WrapperConfig<TWrappers extends RegisteredWrapperTypes = RegisteredWrapperTypes> = TWrappers extends keyof FieldRegistryWrappers
   ? FieldRegistryWrappers[TWrappers]
@@ -40,21 +22,7 @@ export type LazyComponentLoader<T = unknown> = () => Promise<Type<T> | { default
  */
 export type WrapperAutoAssociations = ReadonlyMap<string, readonly WrapperConfig[]>;
 
-/**
- * Configuration interface for registering wrapper types.
- *
- * Defines how a wrapper component is loaded and identified. Wrapper components
- * provide visual decoration around field content (sections, headers, styling)
- * without affecting the form data structure.
- *
- * @example
- * ```typescript
- * const SectionWrapper: WrapperTypeDefinition = {
- *   name: 'section',
- *   loadComponent: () => import('./section-wrapper.component').then(m => m.SectionWrapperComponent),
- * };
- * ```
- */
+/** Configuration interface for registering wrapper types. */
 export interface WrapperTypeDefinition<T extends WrapperConfig = WrapperConfig> {
   /** Unique identifier for the wrapper type (also serves as discriminant from FieldTypeDefinition) */
   wrapperName: string;
@@ -65,22 +33,11 @@ export interface WrapperTypeDefinition<T extends WrapperConfig = WrapperConfig> 
    * Returns a Promise that resolves to the component class or module with default export.
    */
   loadComponent: LazyComponentLoader;
-  /**
-   * Field types this wrapper should auto-apply to.
-   *
-   * When a field's `type` matches any entry, the wrapper is injected into that
-   * field's effective wrapper chain at the lowest priority (can be overridden
-   * by `FormConfig.defaultWrappers` or the field-level `wrappers` array, and
-   * fully cleared with `wrappers: null`).
-   */
+  /** Field types this wrapper should auto-apply to. */
   types?: readonly string[];
 }
 
-/**
- * Type guard for WrapperTypeDefinition.
- *
- * Discriminates via `wrapperName` — field types use `name`, wrapper types use `wrapperName`.
- */
+/** Type guard for WrapperTypeDefinition. */
 export function isWrapperTypeDefinition(value: unknown): value is WrapperTypeDefinition {
   return typeof value === 'object' && value !== null && 'wrapperName' in value;
 }
@@ -88,16 +45,6 @@ export function isWrapperTypeDefinition(value: unknown): value is WrapperTypeDef
 /**
  * Contract that wrapper components must satisfy.
  *
- * Each wrapper exposes a `#fieldComponent` ViewContainerRef where the inner
- * content (next wrapper, or the field) is rendered imperatively. Config
- * properties (minus `type`) are set on the component via `setInput`; a
- * wrapper opts into a key by declaring a matching `input()`, and unknown
- * keys are silently dropped. Wrappers may additionally declare a
- * `fieldInputs` input for the wrapped field's mapper outputs (see
- * `WrapperFieldInputs` for when that's undefined).
- *
- * @example
- * ```typescript
  * @Component({
  *   template: `
  *     <dbx-section [header]="header() ?? ''">
@@ -117,28 +64,13 @@ export interface FieldWrapper {
   readonly fieldComponent: Signal<ViewContainerRef>;
 }
 
-/**
- * Injection token for the wrapper type registry.
- *
- * Provides access to the map of registered wrapper types. The registry is
- * populated via `provideDynamicForm()` and used by `ContainerFieldComponent` to
- * resolve wrapper types to their component implementations.
- */
+/** Injection token for the wrapper type registry. */
 export const WRAPPER_REGISTRY = new InjectionToken<Map<string, WrapperTypeDefinition>>('WRAPPER_REGISTRY', {
   providedIn: 'root',
   factory: () => new Map(),
 });
 
-/**
- * Component cache for loaded wrapper components.
- *
- * Caches resolved wrapper component classes for instant re-resolution.
- * SSR-safe because it's DI-scoped, not module-scoped.
- *
- * NOTE: The cache grows across the application lifetime. It's bounded by the
- * number of wrapper types registered (typically small), so this is not a leak;
- * the COMPONENT_CACHE for field types has the same shape.
- */
+/** Component cache for loaded wrapper components. */
 export const WRAPPER_COMPONENT_CACHE = new InjectionToken<Map<string, Type<unknown>>>('WRAPPER_COMPONENT_CACHE', {
   providedIn: 'root',
   factory: () => new Map(),

--- a/packages/dynamic-forms/src/lib/pipes/dynamic-text/dynamic-text.pipe.ts
+++ b/packages/dynamic-forms/src/lib/pipes/dynamic-text/dynamic-text.pipe.ts
@@ -6,25 +6,6 @@ import { DynamicText } from '../../models/types/dynamic-text';
 /**
  * Pipe that handles dynamic text resolution with support for static strings,
  * Observables, and Signals.
- *
- * Supports:
- * - Static strings (pass-through)
- * - Observables (subscribed internally)
- * - Signals (converted to Observable using toObservable for reactivity)
- *
- * @example
- * ```html
- * <!-- Static string -->
- * {{ 'Hello World' | dynamicText | async }}
- *
- * <!-- Observable -->
- * {{ transloco.selectTranslate('key') | dynamicText | async }}
- *
- * <!-- Signal -->
- * {{ myTextSignal | dynamicText | async }}
- * ```
- *
- * @public
  */
 @Pipe({
   name: 'dynamicText',

--- a/packages/dynamic-forms/src/lib/providers/built-in-addons.ts
+++ b/packages/dynamic-forms/src/lib/providers/built-in-addons.ts
@@ -1,13 +1,7 @@
 import { DynamicFormError } from '../errors/dynamic-form-error';
 import { AddonKindDefinition } from '../models/addon/addon-kind';
 
-/**
- * Built-in addon kinds shipped by core.
- *
- * Universally adapter-independent: `text`, `template`, `component`. Adapters
- * register their own kinds (e.g., `prime-icon`, `prime-button`) via
- * `withCustomAddon(...)` features.
- */
+/** Built-in addon kinds shipped by core. */
 export const BUILT_IN_ADDON_KINDS: readonly AddonKindDefinition[] = [
   {
     kind: 'text',

--- a/packages/dynamic-forms/src/lib/providers/built-in-fields.ts
+++ b/packages/dynamic-forms/src/lib/providers/built-in-fields.ts
@@ -15,37 +15,7 @@ import { ContainerField } from '../definitions/default/container-field';
 import { WrapperTypeDefinition } from '../models';
 import { CssWrapper, RowWrapper } from '../definitions/default';
 
-/**
- * Built-in field types provided by the dynamic form library.
- *
- * These core field types handle form structure and layout. They are automatically
- * registered when using provideDynamicForm() and form the foundation for building
- * complex form layouts with nested fields and multi-step flows.
- *
- * @example
- * ```typescript
- * // Row field for horizontal layout
- * { type: 'row', fields: [
- *   { type: 'input', key: 'firstName' },
- *   { type: 'input', key: 'lastName' }
- * ]}
- *
- * // Group field for nested form sections
- * { type: 'group', key: 'address', fields: [
- *   { type: 'input', key: 'street' },
- *   { type: 'input', key: 'city' }
- * ]}
- *
- * // Array field for array-based form sections
- * { type: 'array', key: 'items', fields: [
- *   { type: 'input', key: 'name' },
- *   { type: 'input', key: 'quantity' }
- * ]}
- *
- * // Page field for multi-step forms
- * { type: 'page', key: 'step1', fields: [...] }
- * ```
- */
+/** Built-in field types provided by the dynamic form library. */
 /**
  * Base for container field types that consume the mapper-emitted `field` input
  * (row, group, array, page, container).
@@ -62,13 +32,7 @@ const DISPLAY_FIELD_TYPES_BASE = {
   renderReadyWhen: [],
 } as const;
 
-/**
- * Built-in field types provided by the dynamic form library.
- *
- * Each field type is validated at compile time using satisfies, ensuring
- * type safety of the mapper function while allowing the array to be typed
- * as FieldTypeDefinition[] for consumer flexibility.
- */
+/** Built-in field types provided by the dynamic form library. */
 export const BUILT_IN_FIELDS: FieldTypeDefinition[] = [
   {
     name: 'row',

--- a/packages/dynamic-forms/src/lib/providers/dynamic-form-di.ts
+++ b/packages/dynamic-forms/src/lib/providers/dynamic-form-di.ts
@@ -152,11 +152,6 @@ function derivationProviders(): Provider[] {
  * Providers for the property-derivation pipeline: the override store consumed
  * by the unified `DerivationOrchestrator` plus the back-compat alias token.
  *
- * Kept separate from {@link derivationProviders} so a future
- * `withPropertyDerivations()` feature factory can drop this group when callers
- * don't use property derivations — at which point the orchestrator's property
- * branch stays dormant (no `propertyStore` in its config).
- *
  * @internal
  */
 function propertyDerivationProviders(): Provider[] {

--- a/packages/dynamic-forms/src/lib/providers/dynamic-form-providers.ts
+++ b/packages/dynamic-forms/src/lib/providers/dynamic-form-providers.ts
@@ -23,37 +23,25 @@ import { isWrappersBundle, WrappersBundle } from '../wrappers/create-wrappers';
 export type { DynamicFormFieldRegistry, AvailableFieldTypes } from '../models/registry';
 export type { RegisteredFieldTypes } from '../models/types';
 
-/**
- * Extract FieldDef type from FieldTypeDefinition
- */
+/** Extract FieldDef type from FieldTypeDefinition */
 type ExtractFieldDef<T> = T extends FieldTypeDefinition<infer F> ? F : never;
 
-/**
- * Union of all FieldDef types from provided field types
- */
+/** Union of all FieldDef types from provided field types */
 type FieldDefUnion<T extends FieldTypeDefinition[]> = ExtractFieldDef<T[number]>;
 
-/**
- * Infer form value type from field definitions using the real inference type.
- */
+/** Infer form value type from field definitions using the real inference type. */
 type InferFormValue<TFieldDefs extends FieldDef<unknown>[]> = RealInferFormValue<TFieldDefs>;
 
-/**
- * Provider result with type inference
- */
+/** Provider result with type inference */
 type ProvideDynamicFormResult<T extends FieldTypeDefinition[]> = EnvironmentProviders & {
   __fieldDefs?: FieldDefUnion<T>;
   __formValue?: InferFormValue<FieldDefUnion<T>[]>;
 };
 
-/**
- * Union type for items that can be passed to provideDynamicForm
- */
+/** Union type for items that can be passed to provideDynamicForm */
 type FieldTypeOrFeature = FieldTypeDefinition | WrapperTypeDefinition | WrappersBundle | DynamicFormFeature;
 
-/**
- * Extract only FieldTypeDefinition items from a tuple type
- */
+/** Extract only FieldTypeDefinition items from a tuple type */
 type ExtractFieldTypes<T extends FieldTypeOrFeature[]> = {
   [K in keyof T]: T[K] extends FieldTypeDefinition ? T[K] : never;
 }[number] extends infer U
@@ -65,50 +53,9 @@ type ExtractFieldTypes<T extends FieldTypeOrFeature[]> = {
 /**
  * Provider function to configure the dynamic form system with field types and options.
  *
- * This function creates environment providers that can be used at application or route level
- * to register field types. It provides type-safe field registration with automatic type inference.
- *
  * @param items - Field type definitions and/or features (like withLoggerConfig)
  * @returns Environment providers for dependency injection with type inference
- *
- * @example
- * ```typescript
- * // Application-level setup
- * bootstrapApplication(AppComponent, {
- *   providers: [
- *     provideDynamicForm(...withMaterialFields())
- *   ]
- * });
- * ```
- *
- * @example
- * ```typescript
- * // Disable logging
- * bootstrapApplication(AppComponent, {
- *   providers: [
- *     provideDynamicForm(
- *       ...withMaterialFields(),
- *       withLoggerConfig(false)
- *     )
- *   ]
- * });
- * ```
- *
- * @example
- * ```typescript
- * // Custom field types with type inference
- * import { CustomFieldType, AnotherFieldType } from './custom-fields';
- *
- * export const appConfig: ApplicationConfig = {
- *   providers: [
- *     provideDynamicForm(CustomFieldType, AnotherFieldType)
- *   ]
- * };
- * ```
- *
  * @typeParam T - Array of field type definitions for type inference
- *
- * @public
  */
 export function provideDynamicForm<const T extends FieldTypeOrFeature[]>(
   ...items: T
@@ -214,12 +161,8 @@ export function provideDynamicForm<const T extends FieldTypeOrFeature[]>(
   ]) as ProvideDynamicFormResult<ExtractFieldTypes<T> extends FieldTypeDefinition[] ? ExtractFieldTypes<T> : FieldTypeDefinition[]>;
 }
 
-/**
- * Extract FieldDef types from provider result
- */
+/** Extract FieldDef types from provider result */
 export type ExtractFieldDefs<T> = T extends { __fieldDefs?: infer F } ? F : never;
 
-/**
- * Extract form value type from provider result
- */
+/** Extract form value type from provider result */
 export type ExtractFormValue<T> = T extends { __formValue?: infer V } ? V : never;

--- a/packages/dynamic-forms/src/lib/providers/features/addons/addon-action-registry.token.ts
+++ b/packages/dynamic-forms/src/lib/providers/features/addons/addon-action-registry.token.ts
@@ -1,13 +1,7 @@
 import { inject, InjectionToken } from '@angular/core';
 import { AddonActionContext } from '../../../models/addon/addon-action';
 
-/**
- * Handler signature for user-registered addon actions.
- *
- * Backends reference handlers by name via `actionRef: 'name'` on button-style
- * addons; the dispatcher invokes the registered function with the addon's
- * action context.
- */
+/** Handler signature for user-registered addon actions. */
 export type AddonActionHandler<TValue = unknown> = (ctx: AddonActionContext<TValue>) => void;
 
 /**

--- a/packages/dynamic-forms/src/lib/providers/features/addons/provide-addon-actions.ts
+++ b/packages/dynamic-forms/src/lib/providers/features/addons/provide-addon-actions.ts
@@ -6,42 +6,13 @@ import { AddonActionHandler, ADDON_ACTION_HANDLERS } from './addon-action-regist
  * registered handler keys as a phantom type so consumers can derive the
  * `DynamicFormActionRegistry` augmentation in one line instead of hand-typing
  * every key.
- *
- * Phantom field is `__handlerKeys` (the leading underscores signal "internal,
- * type-only — not for runtime access").
  */
 export type AddonActionsFeature<K extends string = string> = DynamicFormFeature<'addon-actions'> & {
   /** @internal Phantom field carrying the registered keys; never read at runtime. */
   readonly __handlerKeys?: K;
 };
 
-/**
- * Register named action handlers reachable via JSON-driven addon configs.
- *
- * Once registered, a backend can ship
- * `{ kind: 'prime-button', actionRef: 'openProfile' }` and the FE will invoke
- * the corresponding handler at click time.
- *
- * Define handlers once and augment the registry from the same object:
- *
- * ```typescript
- * export const appActions = provideAddonActions({
- *   openProfile: (ctx) => modalService.open(ProfileModal, { data: ctx.value }),
- *   runWorkflow: (ctx) => workflowService.run(ctx.field.key, ctx.value),
- * });
- *
- * declare module '@ng-forge/dynamic-forms' {
- *   // Pulls the keys straight off `appActions` — no manual list to keep in sync.
- *   interface DynamicFormActionRegistry extends Record<NonNullable<typeof appActions['__handlerKeys']>, true> {}
- * }
- *
- * // Then in your bootstrap:
- * provideDynamicForm(...withPrimeNGFields(), appActions);
- * ```
- *
- * Multiple `provideAddonActions(...)` calls are merged; later names override
- * earlier ones for the same key.
- */
+/** Register named action handlers reachable via JSON-driven addon configs. */
 export function provideAddonActions<const H extends Record<string, AddonActionHandler>>(
   handlers: H,
 ): AddonActionsFeature<keyof H & string> {

--- a/packages/dynamic-forms/src/lib/providers/features/addons/with-custom-addon.ts
+++ b/packages/dynamic-forms/src/lib/providers/features/addons/with-custom-addon.ts
@@ -3,35 +3,7 @@ import { BaseAddon } from '../../../models/addon/addon-def';
 import { createFeature, DynamicFormFeature } from '../dynamic-form-feature';
 import { ADDON_KIND_DEFINITIONS } from './addon-kind-definitions.token';
 
-/**
- * Register a custom addon kind with the form.
- *
- * The provided definition is added to `ADDON_KIND_REGISTRY` at form
- * initialisation, alongside the built-in `text` / `template` / `component`
- * kinds and any kinds contributed by adapter feature helpers
- * (`withPrimeNGAddons()` etc.).
- *
- * @example
- * ```typescript
- * provideDynamicForm(
- *   ...withMaterialFields(),
- *   withCustomAddon({
- *     kind: 'lucide-icon',
- *     // Match how field types register: a default-exported component lets
- *     // `loadComponent` return the import promise directly.
- *     loadComponent: () => import('./lucide-icon-addon.component'),
- *     validate: (addon) => {
- *       if (typeof addon.icon !== 'string') {
- *         throw new Error('lucide-icon: icon string is required');
- *       }
- *     },
- *   }),
- * );
- * ```
- *
- * Multiple `withCustomAddon(...)` calls are supported; later registrations
- * for the same kind override earlier ones (with a warning logged).
- */
+/** Register a custom addon kind with the form. */
 export function withCustomAddon<T extends BaseAddon>(definition: AddonKindDefinition<T>): DynamicFormFeature<'addons'> {
   return createFeature('addons', [
     {

--- a/packages/dynamic-forms/src/lib/providers/features/dynamic-form-feature.ts
+++ b/packages/dynamic-forms/src/lib/providers/features/dynamic-form-feature.ts
@@ -4,8 +4,6 @@ import { Provider } from '@angular/core';
  * Base interface for dynamic form features.
  * Features are configuration options that can be passed to provideDynamicForm
  * alongside field type definitions.
- *
- * Uses Angular-style internal marker (ɵkind) to distinguish from field types.
  */
 export interface DynamicFormFeature<TKind extends string = string> {
   /** Internal marker to identify this as a feature, not a field type */
@@ -27,9 +25,7 @@ export type DynamicFormFeatureKind =
   | 'addons'
   | 'addon-actions';
 
-/**
- * Type guard to check if a value is a DynamicFormFeature
- */
+/** Type guard to check if a value is a DynamicFormFeature */
 export function isDynamicFormFeature(value: unknown): value is DynamicFormFeature {
   return (
     typeof value === 'object' &&
@@ -41,13 +37,7 @@ export function isDynamicFormFeature(value: unknown): value is DynamicFormFeatur
   );
 }
 
-/**
- * Helper to create a feature with proper typing.
- *
- * `kind` is the discriminant compared by string equality at the
- * provider-resolution site (and in feature-specific type guards). Each
- * feature module owns its own kind literal — no central registry.
- */
+/** Helper to create a feature with proper typing. */
 export function createFeature<TKind extends string>(kind: TKind, providers: Provider[]): DynamicFormFeature<TKind> {
   return {
     ɵkind: kind,

--- a/packages/dynamic-forms/src/lib/providers/features/event-form-value/emit-form-value.token.ts
+++ b/packages/dynamic-forms/src/lib/providers/features/event-form-value/emit-form-value.token.ts
@@ -3,12 +3,6 @@ import { InjectionToken } from '@angular/core';
 /**
  * Injection token for globally enabling form value emission on events.
  *
- * When set to `true`, all events dispatched through the EventBus will include
- * the current form value in the `formValue` property.
- *
- * This token is configured via `withEventFormValue()` feature function.
- * Per-form overrides can be set via `options.emitFormValueOnEvents` in the form config.
- *
  * @internal
  */
 export const EMIT_FORM_VALUE_ON_EVENTS = new InjectionToken<boolean>('EMIT_FORM_VALUE_ON_EVENTS', {

--- a/packages/dynamic-forms/src/lib/providers/features/event-form-value/with-event-form-value.ts
+++ b/packages/dynamic-forms/src/lib/providers/features/event-form-value/with-event-form-value.ts
@@ -4,35 +4,6 @@ import { EMIT_FORM_VALUE_ON_EVENTS } from './emit-form-value.token';
 /**
  * Enables automatic form value attachment to all events dispatched through the EventBus.
  *
- * When this feature is enabled, events dispatched via `eventBus.dispatch()` will include
- * the current form value in the `formValue` property. This is useful for event handlers
- * that need access to the complete form state at the time of the event.
- *
- * @example Global opt-in
- * ```typescript
- * provideDynamicForm(
- *   ...withMaterialFields(),
- *   withEventFormValue()
- * )
- * ```
- *
- * @example Consumer usage
- * ```typescript
- * eventBus.on<SubmitEvent>('submit').subscribe(event => {
- *   if (hasFormValue(event)) {
- *     console.log('Form value:', event.formValue);
- *   }
- * });
- * ```
- *
- * @example Per-form disable (when globally enabled)
- * ```typescript
- * const config: FormConfig = {
- *   fields: [...],
- *   options: { emitFormValueOnEvents: false }
- * };
- * ```
- *
  * @remarks
  * **Precedence rules:**
  * 1. Per-form `false` - Disables for this form, regardless of global setting
@@ -40,10 +11,7 @@ import { EMIT_FORM_VALUE_ON_EVENTS } from './emit-form-value.token';
  * 3. Per-form `undefined` - Uses global setting
  * 4. Global `withEventFormValue()` - Enables globally
  * 5. No global feature - Disabled globally (default)
- *
  * @returns A DynamicFormFeature that enables form value attachment to events
- *
- * @public
  */
 export function withEventFormValue(): DynamicFormFeature<'event-form-value'> {
   return createFeature('event-form-value', [{ provide: EMIT_FORM_VALUE_ON_EVENTS, useValue: true }]);

--- a/packages/dynamic-forms/src/lib/providers/features/legacy-status-classes/with-legacy-status-classes.ts
+++ b/packages/dynamic-forms/src/lib/providers/features/legacy-status-classes/with-legacy-status-classes.ts
@@ -7,25 +7,7 @@ import { createFeature, DynamicFormFeature } from '../dynamic-form-feature';
  * `.ng-dirty` / `.ng-pristine` / `.ng-untouched` / `.ng-pending` /
  * `.ng-valid` CSS classes on form-bound elements.
  *
- * Wires Angular's `@angular/forms/signals/compat` `NG_STATUS_CLASSES` strategy
- * via `provideSignalFormsConfig`. Without this feature the modern Signal Forms
- * class strategy is active, which omits the legacy `ng-*` classes.
- *
- * @example Opt in once at the application root
- * ```typescript
- * bootstrapApplication(AppComponent, {
- *   providers: [
- *     provideDynamicForm(
- *       ...withMaterialFields(),
- *       withLegacyStatusClasses()
- *     )
- *   ]
- * });
- * ```
- *
  * @returns A DynamicFormFeature that enables the legacy `ng-*` class strategy
- *
- * @public
  */
 export function withLegacyStatusClasses(): DynamicFormFeature<'legacy-status-classes'> {
   return createFeature('legacy-status-classes', [...provideSignalFormsConfig({ classes: NG_STATUS_CLASSES })]);

--- a/packages/dynamic-forms/src/lib/providers/features/logger/console-logger.ts
+++ b/packages/dynamic-forms/src/lib/providers/features/logger/console-logger.ts
@@ -1,8 +1,6 @@
 import type { Logger } from './logger.interface';
 
-/**
- * Console-based logger implementation.
- */
+/** Console-based logger implementation. */
 export class ConsoleLogger implements Logger {
   private readonly prefix = '[Dynamic Forms]';
 

--- a/packages/dynamic-forms/src/lib/providers/features/logger/logger.token.ts
+++ b/packages/dynamic-forms/src/lib/providers/features/logger/logger.token.ts
@@ -1,10 +1,5 @@
 import { InjectionToken } from '@angular/core';
 import type { Logger } from './logger.interface';
 
-/**
- * Injection token for the dynamic forms logger.
- *
- * Provided by provideDynamicForm() with ConsoleLogger as default.
- * Override with withLoggerConfig(false) to disable logging.
- */
+/** Injection token for the dynamic forms logger. */
 export const DynamicFormLogger = new InjectionToken<Logger>('DynamicFormLogger');

--- a/packages/dynamic-forms/src/lib/providers/features/logger/with-logger-config.ts
+++ b/packages/dynamic-forms/src/lib/providers/features/logger/with-logger-config.ts
@@ -15,11 +15,7 @@ export const DERIVATION_LOG_CONFIG = new InjectionToken<DerivationLogConfig>('DE
   factory: createDefaultDerivationLogConfig,
 });
 
-/**
- * Configuration options for the logger feature.
- *
- * @public
- */
+/** Configuration options for the logger feature. */
 export interface LoggerConfigOptions {
   /**
    * Whether general logging is enabled.
@@ -31,10 +27,6 @@ export interface LoggerConfigOptions {
   /**
    * Derivation logging level.
    *
-   * - `'none'`: No derivation debug logging (default)
-   * - `'summary'`: Log cycle completion with counts
-   * - `'verbose'`: Log individual derivation evaluations with details
-   *
    * @default 'none'
    */
   derivations?: DerivationLogLevel;
@@ -43,40 +35,8 @@ export interface LoggerConfigOptions {
 /**
  * Configure logging for dynamic forms.
  *
- * By default, general logging is enabled (ConsoleLogger) and derivation
- * logging is disabled ('none'). Use this feature to enable derivation debugging.
- *
- * @example
- * ```typescript
- * // Disable all logging
- * provideDynamicForm(
- *   ...withMaterialFields(),
- *   withLoggerConfig(false)
- * )
- *
- * // Enable verbose derivation logging
- * provideDynamicForm(
- *   ...withMaterialFields(),
- *   withLoggerConfig({ derivations: 'verbose' })
- * )
- *
- * // Disable derivation logging but keep general logging
- * provideDynamicForm(
- *   ...withMaterialFields(),
- *   withLoggerConfig({ derivations: 'none' })
- * )
- *
- * // Conditional logging (e.g., only in dev mode)
- * provideDynamicForm(
- *   ...withMaterialFields(),
- *   withLoggerConfig(() => isDevMode())
- * )
- * ```
- *
  * @param config - Boolean to enable/disable logging, a function returning boolean, or a config object
  * @returns A DynamicFormFeature that configures logging
- *
- * @public
  */
 export function withLoggerConfig(config: boolean | (() => boolean) | LoggerConfigOptions = true): DynamicFormFeature<'logger'> {
   // Handle boolean or function

--- a/packages/dynamic-forms/src/lib/providers/features/validation-execution/validation-execution.token.ts
+++ b/packages/dynamic-forms/src/lib/providers/features/validation-execution/validation-execution.token.ts
@@ -4,15 +4,6 @@ import { ResolvedValidationExecutionConfig } from '../../../models/validation-ex
 /**
  * Injection token for global validation execution defaults.
  *
- * Controls whether validators run on hidden fields. By default, validation is
- * skipped when a field is hidden (`validateWhenHidden: false`).
- *
- * Configured via `withValidationExecutionDefaults()`. Per-form overrides via
- * `FormOptions.validateWhenHidden`. Per-field overrides via `FieldDef.validateWhenHidden`,
- * which inherits down the field tree.
- *
- * **Resolution order:** Field (with parent inheritance) > Form > Global.
- *
  * @internal
  */
 export const VALIDATION_EXECUTION_DEFAULTS = new InjectionToken<ResolvedValidationExecutionConfig>('VALIDATION_EXECUTION_DEFAULTS', {

--- a/packages/dynamic-forms/src/lib/providers/features/validation-execution/with-validation-execution-defaults.ts
+++ b/packages/dynamic-forms/src/lib/providers/features/validation-execution/with-validation-execution-defaults.ts
@@ -6,24 +6,6 @@ import { VALIDATION_EXECUTION_DEFAULTS } from './validation-execution.token';
  * Configures global validation execution defaults — when validators should run
  * relative to a field's reactive state.
  *
- * By default, validators are **skipped** for hidden fields (`validateWhenHidden: false`),
- * matching what most users expect: a hidden field is inert. Use this feature to
- * restore the legacy behavior where hidden fields still validate.
- *
- * @example Default behavior — no feature needed
- * ```typescript
- * provideDynamicForm(...withMaterialFields())
- * // hidden fields skip validation
- * ```
- *
- * @example Restore legacy validation-on-hidden behavior
- * ```typescript
- * provideDynamicForm(
- *   ...withMaterialFields(),
- *   withValidationExecutionDefaults({ validateWhenHidden: true })
- * )
- * ```
- *
  * @remarks
  * **Precedence rules:**
  * 1. Per-field `FieldDef.validateWhenHidden` — wins for that field; inherits down to descendants
@@ -31,11 +13,8 @@ import { VALIDATION_EXECUTION_DEFAULTS } from './validation-execution.token';
  * 2. Per-form `FormOptions.validateWhenHidden` — root inherited value for the form.
  * 3. Global `withValidationExecutionDefaults()` — fallback when no form/field setting.
  * 4. No feature configured — uses token default (`validateWhenHidden: false`).
- *
  * @param config - Partial override. Unspecified properties keep their defaults.
  * @returns A `DynamicFormFeature` that configures validation execution defaults.
- *
- * @public
  */
 export function withValidationExecutionDefaults(config?: Partial<ValidationExecutionConfig>): DynamicFormFeature<'validation-execution'> {
   const resolved: ResolvedValidationExecutionConfig = {

--- a/packages/dynamic-forms/src/lib/providers/features/value-exclusion/value-exclusion.token.ts
+++ b/packages/dynamic-forms/src/lib/providers/features/value-exclusion/value-exclusion.token.ts
@@ -4,20 +4,6 @@ import { ResolvedValueExclusionConfig } from '../../../models/value-exclusion-co
 /**
  * Injection token for global value exclusion defaults.
  *
- * Controls which field values are excluded from form submission output
- * based on their reactive state (hidden, disabled, readonly).
- *
- * By default, all three exclusion rules are enabled:
- * - Hidden fields are excluded from submission
- * - Disabled fields are excluded from submission
- * - Readonly fields are excluded from submission
- *
- * This token is configured via `withValueExclusionDefaults()` feature function.
- * Per-form overrides can be set via `FormOptions`.
- * Per-field overrides can be set on individual `FieldDef` entries.
- *
- * **Resolution order:** Field > Form > Global (most specific wins).
- *
  * @internal
  */
 export const VALUE_EXCLUSION_DEFAULTS = new InjectionToken<ResolvedValueExclusionConfig>('VALUE_EXCLUSION_DEFAULTS', {

--- a/packages/dynamic-forms/src/lib/providers/features/value-exclusion/with-value-exclusion-defaults.ts
+++ b/packages/dynamic-forms/src/lib/providers/features/value-exclusion/with-value-exclusion-defaults.ts
@@ -5,50 +5,14 @@ import { VALUE_EXCLUSION_DEFAULTS } from './value-exclusion.token';
 /**
  * Configures global value exclusion defaults for form submission output.
  *
- * Value exclusion is **enabled by default** — field values are excluded from the
- * `(submitted)` output based on their reactive state. Use this feature to
- * override those defaults. This does NOT affect two-way binding (`value` model /
- * `entity`) — fields retain their values internally.
- *
- * @example Default behavior (all exclusions enabled)
- * ```typescript
- * provideDynamicForm(
- *   ...withMaterialFields(),
- *   withValueExclusionDefaults()
- * )
- * ```
- *
- * @example Disable specific exclusions
- * ```typescript
- * provideDynamicForm(
- *   ...withMaterialFields(),
- *   withValueExclusionDefaults({ excludeValueIfReadonly: false })
- * )
- * ```
- *
- * @example Disable all exclusions (restore pre-v1 behavior)
- * ```typescript
- * provideDynamicForm(
- *   ...withMaterialFields(),
- *   withValueExclusionDefaults({
- *     excludeValueIfHidden: false,
- *     excludeValueIfDisabled: false,
- *     excludeValueIfReadonly: false,
- *   })
- * )
- * ```
- *
  * @remarks
  * **Precedence rules:**
  * 1. Per-field `excludeValueIf*` on `FieldDef` — wins for that field
  * 2. Per-form `excludeValueIf*` on `FormOptions` — wins for all fields in that form
  * 3. Global `withValueExclusionDefaults()` — baseline default
  * 4. No global feature — uses token default (all enabled)
- *
  * @param config - Partial override of exclusion rules. Unspecified properties default to `true`.
  * @returns A DynamicFormFeature that configures value exclusion defaults
- *
- * @public
  */
 export function withValueExclusionDefaults(config?: Partial<ValueExclusionConfig>): DynamicFormFeature<'value-exclusion'> {
   const resolved = {

--- a/packages/dynamic-forms/src/lib/providers/form-initializer.token.ts
+++ b/packages/dynamic-forms/src/lib/providers/form-initializer.token.ts
@@ -5,11 +5,6 @@ import { InjectionToken } from '@angular/core';
  * construction side effect — useful for orchestrators that need to wire reactive
  * streams before first render but don't need to be referenced at use-sites.
  *
- * Feature providers register their orchestrators here via `useExisting`, so the
- * DynamicForm component never has to know which orchestrators exist. Without a
- * feature provider, FORM_INITIALIZER is empty (no static reference to that
- * feature's orchestrator class).
- *
  * @internal
  */
 export const FORM_INITIALIZER = new InjectionToken<readonly unknown[]>('FORM_INITIALIZER');

--- a/packages/dynamic-forms/src/lib/state/form-state-machine.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-machine.ts
@@ -62,8 +62,6 @@ export interface FormStateMachineConfig<TFields extends RegisteredFieldTypes[] =
  * RxJS-based state machine for form lifecycle management.
  * Uses `concatMap` for sequential action processing.
  *
- * Flow: uninitialized → initializing → ready ⇄ transitioning (teardown → applying → restoring)
- *
  * @internal
  */
 export class FormStateMachine<TFields extends RegisteredFieldTypes[] = RegisteredFieldTypes[]> {

--- a/packages/dynamic-forms/src/lib/state/form-state-manager.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-manager.ts
@@ -66,11 +66,6 @@ import { createFormStateMachine, FormStateMachine } from './form-state-machine';
  * field initializer (runs before FormStateManager is injected in declaration order);
  * FormStateManager reads them.
  *
- * `any` is required for config/value because Angular DI is non-generic and
- * Signal/WritableSignal are invariant in TypeScript — Signal<FormConfig<TFields>>
- * is not assignable to Signal<FormConfig>. Safe because the same component
- * instance populates and consumes these properties.
- *
  * @internal
  */
 export interface FormStateDeps {
@@ -88,14 +83,7 @@ export interface FormStateDeps {
 /** @internal */
 export const FORM_STATE_DEPS = new InjectionToken<FormStateDeps>('FORM_STATE_DEPS');
 
-/**
- * Casts a FieldTree to a record of per-key sub-trees.
- *
- * FieldTree<TModel> is structurally a callable that exposes per-key child trees
- * via bracket access (e.g., `tree['fieldKey']`), but TypeScript's FieldTree type
- * doesn't surface this as an index signature. This helper makes the cast explicit
- * and centralizes it to a single location.
- */
+/** Casts a FieldTree to a record of per-key sub-trees. */
 function asFieldTreeRecord(tree: FieldTree<unknown>): Record<string, FieldTree<unknown>> {
   return tree as unknown as Record<string, FieldTree<unknown>>;
 }
@@ -246,11 +234,6 @@ export class FormStateManager<
    * Used to skip re-logging warnings that already fired for the previous
    * config — avoids spam when the form swaps config repeatedly but the
    * addon issues haven't changed.
-   *
-   * Scoping: per-FormStateManager (i.e., per `<df-dynamic-form>` component
-   * instance). Replaced wholesale on every config setup — bounded by the
-   * current config's warning count, never grows unbounded across swaps.
-   * A warning that disappears and later returns re-logs as expected.
    */
   private lastAddonWarningKeys: Set<string> = new Set();
 
@@ -271,9 +254,7 @@ export class FormStateManager<
   // Internal State Signals
   // ─────────────────────────────────────────────────────────────────────────────
 
-  /**
-   * Field loading errors accumulated during resolution.
-   */
+  /** Field loading errors accumulated during resolution. */
   readonly fieldLoadingErrors = signal<FieldLoadingError[]>([]);
 
   /**
@@ -309,9 +290,7 @@ export class FormStateManager<
     return undefined;
   });
 
-  /**
-   * Current render phase: 'render' = showing form, 'teardown' = hiding old components.
-   */
+  /** Current render phase: 'render' = showing form, 'teardown' = hiding old components. */
   readonly renderPhase = computed(() => {
     const state = this.machine.state();
     if (isTransitioningState(state) && state.phase === Phase.Teardown) return Phase.Teardown;
@@ -321,9 +300,7 @@ export class FormStateManager<
   /** Whether to render the form template. */
   readonly shouldRender = computed(() => this.activeConfig() !== undefined);
 
-  /**
-   * Computed form mode detection with validation.
-   */
+  /** Computed form mode detection with validation. */
   readonly formModeDetection = computed(() => {
     const config = this.activeConfig();
     if (!config) {
@@ -340,9 +317,7 @@ export class FormStateManager<
     return FormModeValidator.validateFormConfiguration(config.fields || []);
   });
 
-  /**
-   * Effective form options (merged from config and input).
-   */
+  /** Effective form options (merged from config and input). */
   readonly effectiveFormOptions = computed(() => {
     const config = this.activeConfig();
     const configOptions = config?.options || {};
@@ -350,9 +325,7 @@ export class FormStateManager<
     return { ...configOptions, ...inputOptions };
   });
 
-  /**
-   * Page field definitions (for paged forms).
-   */
+  /** Page field definitions (for paged forms). */
   readonly pageFieldDefinitions = computed(() => {
     const config = this.activeConfig();
     const mode = this.formModeDetection().mode;
@@ -407,9 +380,7 @@ export class FormStateManager<
     return this.createEmptyFormSetup(registry);
   });
 
-  /**
-   * Default values computed from field definitions.
-   */
+  /** Default values computed from field definitions. */
   readonly defaultValues = linkedSignal(() => this.formSetup().defaultValues as TModel);
 
   /** Valid field keys — memoized separately so the Set isn't rebuilt on every keystroke. */
@@ -449,22 +420,7 @@ export class FormStateManager<
   // Computed Signals - Entity & Form
   // ─────────────────────────────────────────────────────────────────────────────
 
-  /**
-   * Entity (form value merged with defaults).
-   *
-   * Bidirectional sync with `deps.value`:
-   *
-   * 1. **Inward** (deps.value → entity): When the host component sets `value` externally
-   *    (e.g. two-way binding), this `linkedSignal` source recomputes, merging the new
-   *    input with field defaults and filtering to valid keys.
-   *
-   * 2. **Outward** (entity → deps.value): An `explicitEffect` in `setupEffects()` watches
-   *    `entity` and writes changes back to `deps.value`, keeping the host's model signal
-   *    in sync with internal form state (e.g. after derivations or reset).
-   *
-   * The `isEqual` guard on the effect prevents infinite ping-pong: if entity already
-   * matches deps.value, the write-back is skipped.
-   */
+  /** Entity (form value merged with defaults). */
   readonly entity = linkedSignal<TModel>(
     () => {
       const inputValue = this.deps.value();
@@ -526,9 +482,7 @@ export class FormStateManager<
     }),
   );
 
-  /**
-   * The Angular Signal Form instance.
-   */
+  /** The Angular Signal Form instance. */
   readonly form = computed(() => {
     const schema = this.formSchema();
     const injector = this.injector;
@@ -577,14 +531,7 @@ export class FormStateManager<
   /** Current form values (reactive). */
   readonly formValue = computed(() => this.formInstance().value());
 
-  /**
-   * Form values filtered by value exclusion rules.
-   *
-   * Excludes field values from the output based on their reactive state
-   * (hidden, disabled, readonly) and the 3-tier exclusion config
-   * (Field > Form > Global). Only affects submission output — internal
-   * form state and two-way binding are unaffected.
-   */
+  /** Form values filtered by value exclusion rules. */
   readonly filteredFormValue = computed(() => {
     const rawValue = this.formValue();
     const setup = this.formSetup();
@@ -620,19 +567,7 @@ export class FormStateManager<
     );
   });
 
-  /**
-   * Form value used for the outward two-way binding sync.
-   *
-   * Only honors *explicit* form-level and field-level `excludeValueIf*` settings — global
-   * defaults (`VALUE_EXCLUSION_DEFAULTS`) are intentionally ignored here. Rationale:
-   * - Original V1 behavior: the bound model carries all values regardless of visibility.
-   * - Bug fix: when a user explicitly sets `excludeValueIfHidden: true` on a field/form,
-   *   they expect that value to disappear from the bound model when hidden (e.g. NaN for
-   *   number inputs, see issue #394).
-   * - Without explicit opt-in, the bound model keeps the V1 contract.
-   * `filteredFormValue` (above) still applies the full Field > Form > Global hierarchy
-   * for the submission output.
-   */
+  /** Form value used for the outward two-way binding sync. */
   private readonly boundFormValue = computed(() => {
     const rawValue = this.formValue();
     const setup = this.formSetup();
@@ -692,12 +627,6 @@ export class FormStateManager<
   /**
    * Phase-aware field source that coordinates component lifecycle with form updates.
    * Teardown/Applying → intersection of old/new fields; Restoring → all new fields.
-   *
-   * Uses per-field reference equality to suppress spurious emissions when the same
-   * field definitions are returned (e.g. memoized intersections during transitions)
-   * while still triggering re-resolution when the underlying field definition
-   * references change (e.g. a config swap that updates options/props for a
-   * same-keyed field).
    */
   private readonly fieldsSource = computed(
     () => {
@@ -728,15 +657,7 @@ export class FormStateManager<
     },
   );
 
-  /**
-   * Injector for field components with FIELD_SIGNAL_CONTEXT.
-   *
-   * Recreates the Injector on every `fieldSignalContext` change. This is intentional:
-   * `reconcileFields()` compares the injector reference to detect context changes
-   * (e.g. after a config transition). A new injector reference signals that
-   * `NgComponentOutlet` should pick up the updated context, while an unchanged
-   * reference preserves object identity to avoid unnecessary re-renders.
-   */
+  /** Injector for field components with FIELD_SIGNAL_CONTEXT. */
   private readonly fieldInjector = computed(() =>
     Injector.create({
       parent: this.injector,
@@ -943,16 +864,12 @@ export class FormStateManager<
   // Public Methods
   // ─────────────────────────────────────────────────────────────────────────────
 
-  /**
-   * Updates the form value model.
-   */
+  /** Updates the form value model. */
   updateValue(value: Partial<TModel>): void {
     this.deps.value.set(value);
   }
 
-  /**
-   * Resets the form to default values.
-   */
+  /** Resets the form to default values. */
   reset(): void {
     this.excludedValueStore.set({});
     const defaults = this.defaultValues();
@@ -960,9 +877,7 @@ export class FormStateManager<
     this.deps.value.set(defaults as Partial<TModel>);
   }
 
-  /**
-   * Clears the form to empty state.
-   */
+  /** Clears the form to empty state. */
   clear(): void {
     this.excludedValueStore.set({});
     const emptyValue = {} as TModel;
@@ -970,9 +885,7 @@ export class FormStateManager<
     this.deps.value.set(emptyValue);
   }
 
-  /**
-   * Triggers form submission.
-   */
+  /** Triggers form submission. */
   submit(): void {
     this.eventBus.dispatch(SubmitEvent);
   }

--- a/packages/dynamic-forms/src/lib/state/index.ts
+++ b/packages/dynamic-forms/src/lib/state/index.ts
@@ -1,6 +1,7 @@
 /**
  * State management module barrel — organizational reference only.
  * Internal code must import directly from specific files, not this barrel.
+ *
  * @internal
  */
 

--- a/packages/dynamic-forms/src/lib/state/side-effect-scheduler.ts
+++ b/packages/dynamic-forms/src/lib/state/side-effect-scheduler.ts
@@ -57,10 +57,6 @@ export class SideEffectScheduler {
   /**
    * Defers effect to next rAF (~16ms), giving CD and the async field resolution
    * pipeline time to settle before the state machine continues.
-   *
-   * When `options.skipIf` returns `true`, the effect executes synchronously
-   * (like `executeBlocking`), eliminating ~16ms of unnecessary delay when
-   * the field pipeline has already settled (e.g. all components cached).
    */
   executeAtFrameBoundary<T>(effect: () => T, options?: { skipIf?: () => boolean }): Observable<T> {
     if (options?.skipIf?.()) {

--- a/packages/dynamic-forms/src/lib/state/state-types.ts
+++ b/packages/dynamic-forms/src/lib/state/state-types.ts
@@ -10,6 +10,7 @@ import { FormMode } from '../models/types/form-mode';
 
 /**
  * Lifecycle state discriminants.
+ *
  * @internal
  */
 export const LifecycleState = {
@@ -25,6 +26,7 @@ export type LifecycleStateType = (typeof LifecycleState)[keyof typeof LifecycleS
 
 /**
  * Transition phase discriminants.
+ *
  * @internal
  */
 export const Phase = {
@@ -38,6 +40,7 @@ export type PhaseType = (typeof Phase)[keyof typeof Phase];
 
 /**
  * Action type discriminants.
+ *
  * @internal
  */
 export const Action = {
@@ -56,6 +59,7 @@ export type ActionType = (typeof Action)[keyof typeof Action];
 
 /**
  * Side effect type discriminants.
+ *
  * @internal
  */
 export const Effect = {
@@ -210,11 +214,7 @@ export type SideEffect =
   | { readonly type: (typeof Effect)['CreateForm'] }
   | { readonly type: (typeof Effect)['RestoreValues']; readonly values: Record<string, unknown> };
 
-/**
- * Error from async field component loading.
- *
- * @public
- */
+/** Error from async field component loading. */
 export interface FieldLoadingError {
   readonly fieldType: string;
   readonly fieldKey: string;

--- a/packages/dynamic-forms/src/lib/utils/apply-meta.ts
+++ b/packages/dynamic-forms/src/lib/utils/apply-meta.ts
@@ -3,27 +3,10 @@ import { FieldMeta } from '../definitions/base/field-meta';
 /**
  * Applies meta attributes to a DOM element and tracks which attributes were applied.
  *
- * This utility handles:
- * - Removing previously applied attributes that are no longer in meta
- * - Setting new attributes from meta
- * - Converting all values to strings via String()
- *
  * @param element - The DOM element to apply attributes to
  * @param meta - The meta object containing attributes to apply
  * @param previouslyApplied - Set of attribute names that were previously applied
  * @returns A new Set containing the attribute names that were applied
- *
- * @example
- * ```typescript
- * private appliedAttrs = new Set<string>();
- *
- * explicitEffect([this.meta], ([meta]) => {
- *   const input = this.el.nativeElement.querySelector('input');
- *   if (input) {
- *     this.appliedAttrs = applyMetaToElement(input, meta, this.appliedAttrs);
- *   }
- * });
- * ```
  */
 export function applyMetaToElement(element: Element, meta: FieldMeta | undefined, previouslyApplied: Set<string>): Set<string> {
   const newApplied = new Set<string>();

--- a/packages/dynamic-forms/src/lib/utils/array-field/array-event-handler.ts
+++ b/packages/dynamic-forms/src/lib/utils/array-field/array-event-handler.ts
@@ -9,9 +9,7 @@ import { RemoveAtIndexEvent } from '../../events/constants/remove-at-index.event
 import { EventBus } from '../../events/event.bus';
 import { FieldDef } from '../../definitions/base/field-def';
 
-/**
- * Union type of all array manipulation events.
- */
+/** Union type of all array manipulation events. */
 export type ArrayEvent =
   | AppendArrayItemEvent
   | PrependArrayItemEvent
@@ -21,9 +19,7 @@ export type ArrayEvent =
   | ShiftArrayItemEvent
   | RemoveAtIndexEvent;
 
-/**
- * All array event type discriminants.
- */
+/** All array event type discriminants. */
 const ARRAY_EVENT_TYPES: ArrayEvent['type'][] = [
   'append-array-item',
   'prepend-array-item',
@@ -74,19 +70,6 @@ function toArrayAction(event: ArrayEvent): ArrayAction {
  * @param eventBus - The event bus to subscribe to
  * @param arrayKey - Function returning the array key to filter events for
  * @returns Observable of normalized ArrayAction objects
- *
- * @example
- * ```typescript
- * observeArrayActions(this.eventBus, () => this.key())
- *   .pipe(takeUntilDestroyed())
- *   .subscribe(action => {
- *     if (action.action === 'add') {
- *       this.addItem(action.template, action.index);
- *     } else {
- *       this.removeItem(action.index);
- *     }
- *   });
- * ```
  */
 export function observeArrayActions(eventBus: EventBus, arrayKey: () => string): Observable<ArrayAction> {
   return eventBus.on<ArrayEvent>(ARRAY_EVENT_TYPES).pipe(

--- a/packages/dynamic-forms/src/lib/utils/array-field/array-field.types.ts
+++ b/packages/dynamic-forms/src/lib/utils/array-field/array-field.types.ts
@@ -1,12 +1,7 @@
 import { Injector, Signal, type Type } from '@angular/core';
 import type { FieldDef } from '../../definitions/base/field-def';
 
-/**
- * A single field within a resolved array item.
- *
- * Structurally compatible with `ResolvedField` so the same DfFieldOutlet
- * directive can render both top-level and array-item fields.
- */
+/** A single field within a resolved array item. */
 export interface ResolvedArrayItemField {
   /** Field key (used for tracking and test IDs). */
   key: string;
@@ -61,21 +56,7 @@ export type DifferentialUpdateOperation =
   | { type: 'recreate' }
   | { type: 'none' };
 
-/**
- * Determines the optimal differential update operation based on current and new state.
- *
- * Operations:
- * - Clear all (empty array)
- * - Initial render (no existing items)
- * - Append only (items added at end)
- * - Recreate (items removed - we can't know which items, so recreate all)
- * - None (same length - items update via linkedSignal)
- *
- * Note: We always use 'recreate' for removals because we can't determine which
- * specific items were removed. Operations like shift, removeAtIndex remove from
- * the middle, not just the end. Each array item has its own local form that
- * doesn't reactively track parent changes, so we must recreate to get correct values.
- */
+/** Determines the optimal differential update operation based on current and new state. */
 export function determineDifferentialOperation(currentItems: ResolvedArrayItem[], newLength: number): DifferentialUpdateOperation {
   const currentLength = currentItems.length;
 

--- a/packages/dynamic-forms/src/lib/utils/array-field/create-array-item-injector.ts
+++ b/packages/dynamic-forms/src/lib/utils/array-field/create-array-item-injector.ts
@@ -9,9 +9,7 @@ import { mapFieldToInputs } from '../field-mapper/field-mapper';
 import { RootFormRegistryService } from '../../core/registry/root-form-registry.service';
 import { isEqual } from '../object-utils';
 
-/**
- * Options for creating an array item injector.
- */
+/** Options for creating an array item injector. */
 export interface CreateArrayItemInjectorOptions<TModel extends Record<string, unknown>> {
   /** The field template defining the array item structure. */
   template: FieldDef<unknown>;
@@ -29,18 +27,11 @@ export interface CreateArrayItemInjectorOptions<TModel extends Record<string, un
    * For primitive array items, the key of the value field in the template (e.g., 'value').
    * When set, the form getter wraps the raw FormControl in `{ [primitiveFieldKey]: FormControl }`
    * so that `getFieldTree(key)` can navigate to the control by key.
-   *
-   * Primitive items store flat values (e.g., `['angular']` not `[{value: 'angular'}]`),
-   * so the FieldTree at `rootForm['arrayKey'][index]` is a FormControl, not a FormGroup.
-   * Without wrapping, `getFieldTree('value')` would access the FormControl's `.value`
-   * property (a WritableSignal) instead of a child FieldTree.
    */
   primitiveFieldKey?: string;
 }
 
-/**
- * Result of creating an array item injector.
- */
+/** Result of creating an array item injector. */
 export interface ArrayItemInjectorResult {
   /** Scoped injector providing ARRAY_CONTEXT and FIELD_SIGNAL_CONTEXT. */
   injector: Injector;
@@ -48,20 +39,7 @@ export interface ArrayItemInjectorResult {
   inputs: Signal<Record<string, unknown>> | undefined;
 }
 
-/**
- * Creates an injector and inputs for an array item.
- *
- * Uses direct root form binding - components bind directly to the root form's
- * FieldTree for array items (rootForm['arrayKey'][index]). This architecture:
- *
- * - Eliminates the need for local forms and bidirectional sync
- * - Allows Zod/StandardSchema validation errors to flow naturally to components
- * - Reduces complexity by having a single source of truth (the root form)
- *
- * The FieldSignalContext.form property uses a getter that evaluates a computed
- * signal, making form access reactive to index changes (when items reorder,
- * the component points to the correct array position).
- */
+/** Creates an injector and inputs for an array item. */
 export function createArrayItemInjectorAndInputs<TModel extends Record<string, unknown>>(
   options: CreateArrayItemInjectorOptions<TModel>,
 ): ArrayItemInjectorResult {
@@ -122,14 +100,6 @@ interface CreateItemInjectorOptions<TModel extends Record<string, unknown>> {
 /**
  * Creates a scoped injector for an array item.
  * Provides both FIELD_SIGNAL_CONTEXT (for form access) and ARRAY_CONTEXT (for position awareness).
- *
- * The FIELD_SIGNAL_CONTEXT.form uses a getter that evaluates itemFormAccessor() on access.
- * This makes form access reactive - when mappers access context.form['fieldKey'], the getter runs,
- * evaluating the computed which tracks indexSignal as a dependency. This ensures components
- * automatically update when array items reorder.
- *
- * Uses `useFactory` with `deps: [Injector]` to provide FIELD_SIGNAL_CONTEXT. Angular resolves
- * the `Injector` dep as the child injector being created, eliminating any temporal gap.
  */
 function createItemInjector<TModel extends Record<string, unknown>>(options: CreateItemInjectorOptions<TModel>): Injector {
   const { itemFormAccessor, indexSignal, parentFieldSignalContext, parentInjector, arrayField, primitiveFieldKey } = options;

--- a/packages/dynamic-forms/src/lib/utils/array-field/normalize-simplified-arrays.ts
+++ b/packages/dynamic-forms/src/lib/utils/array-field/normalize-simplified-arrays.ts
@@ -12,15 +12,7 @@ import { ArrayItemDefinition } from '../../definitions/default/array-field';
 import { setNormalizedArrayMetadata } from './normalized-array-metadata';
 import { DynamicFormError } from '../../errors/dynamic-form-error';
 
-/**
- * Normalizes simplified array fields into full array field definitions.
- *
- * Walks the field tree and expands any `SimplifiedArrayField` (those with a `template` property)
- * into a standard `ArrayField` with proper item definitions and add/remove button fields.
- *
- * This is a pure function with no DI dependencies. It is idempotent — calling it on
- * already-normalized output produces the same result.
- */
+/** Normalizes simplified array fields into full array field definitions. */
 export function normalizeSimplifiedArrays(fields: FieldDef<unknown>[]): FieldDef<unknown>[] {
   return fields.flatMap((field): FieldDef<unknown>[] => {
     // Recurse into non-array containers (page, group, row) that have child fields
@@ -90,9 +82,7 @@ function validateSimplifiedTemplate(field: SimplifiedArrayField): void {
   }
 }
 
-/**
- * Expands a simplified array field into a full ArrayField + optional add button.
- */
+/** Expands a simplified array field into a full ArrayField + optional add button. */
 function expandSimplifiedArray(field: SimplifiedArrayField): ExpandedArray {
   const {
     template,
@@ -202,23 +192,12 @@ function expandSimplifiedArray(field: SimplifiedArrayField): ExpandedArray {
   return { arrayField, addButton: addButtonField };
 }
 
-/**
- * Builds a primitive array item as a single FieldDef (not wrapped in array).
- *
- * This ensures the form schema creates FormControls (not FormGroups) for each item,
- * producing flat primitive values like `['angular', 'typescript']` instead of
- * `[{ value: 'angular' }, { value: 'typescript' }]`.
- *
- * Remove buttons are handled separately via Symbol metadata on the array field,
- * which the array component renders alongside each item without affecting form values.
- */
+/** Builds a primitive array item as a single FieldDef (not wrapped in array). */
 function buildPrimitiveItem(template: ArrayAllowedChildren, value: unknown): ArrayItemDefinition {
   return { ...template, value } as ArrayAllowedChildren;
 }
 
-/**
- * Builds an object array item: template fields with values merged + optional remove button.
- */
+/** Builds an object array item: template fields with values merged + optional remove button. */
 function buildObjectItem(
   template: readonly ArrayAllowedChildren[],
   valueObj: Record<string, unknown>,
@@ -239,9 +218,7 @@ function buildObjectItem(
   return [...fieldsWithValues, buildRemoveButton(removeButton)];
 }
 
-/**
- * Builds the add button template for object items (template fields without values + remove button).
- */
+/** Builds the add button template for object items (template fields without values + remove button). */
 function buildObjectItemTemplate(
   template: readonly ArrayAllowedChildren[],
   removeButton: ArrayButtonConfig | false | undefined,
@@ -253,9 +230,7 @@ function buildObjectItemTemplate(
   return [...template, buildRemoveButton(removeButton)];
 }
 
-/**
- * Builds a remove button field definition.
- */
+/** Builds a remove button field definition. */
 function buildRemoveButton(config: ArrayButtonConfig | undefined): ArrayAllowedChildren {
   const buttonConfig = (typeof config === 'object' ? config : {}) as ArrayButtonConfig;
   // Safe cast: removeArrayItem fields are valid ArrayAllowedChildren but not in the static union

--- a/packages/dynamic-forms/src/lib/utils/array-field/normalized-array-metadata.ts
+++ b/packages/dynamic-forms/src/lib/utils/array-field/normalized-array-metadata.ts
@@ -1,14 +1,7 @@
 import { FieldDef } from '../../definitions/base/field-def';
 import { ArrayAllowedChildren } from '../../models/types/nesting-constraints';
 
-/**
- * Metadata attached to normalized array fields during simplified array expansion.
- *
- * Stored via a well-known Symbol property on the field object. This survives
- * object spreading (`{ ...field }`) since Symbol-keyed properties are copied
- * by the spread operator, while remaining invisible to `JSON.stringify`,
- * `Object.keys`, and `for...in` loops.
- */
+/** Metadata attached to normalized array fields during simplified array expansion. */
 export interface NormalizedArrayMetadata {
   /**
    * Remove button FieldDef for primitive simplified arrays.

--- a/packages/dynamic-forms/src/lib/utils/array-field/resolve-array-item.ts
+++ b/packages/dynamic-forms/src/lib/utils/array-field/resolve-array-item.ts
@@ -9,9 +9,7 @@ import { ResolvedArrayItem, ResolvedArrayItemField } from './array-field.types';
 import { createArrayItemInjectorAndInputs } from './create-array-item-injector';
 import { createHiddenSignal, createRenderReadySignal } from '../resolve-field/resolve-field';
 
-/**
- * Options for resolving an array item.
- */
+/** Options for resolving an array item. */
 export interface ResolveArrayItemOptions<TModel extends Record<string, unknown>> {
   /** The initial index of this item in the array. */
   index: number;
@@ -52,13 +50,7 @@ export interface ResolveArrayItemOptions<TModel extends Record<string, unknown>>
   primitiveFieldKey?: string;
 }
 
-/**
- * Resolves a single array item with all its fields for declarative rendering.
- *
- * Uses linkedSignal for the index, which automatically updates when itemOrderSignal changes.
- * This enables position-aware updates without recreating components when items are reordered.
- * Supports multiple sibling templates (e.g., name + email without a wrapper).
- */
+/** Resolves a single array item with all its fields for declarative rendering. */
 export function resolveArrayItem<TModel extends Record<string, unknown>>(
   options: ResolveArrayItemOptions<TModel>,
 ): Observable<ResolvedArrayItem | undefined> {

--- a/packages/dynamic-forms/src/lib/utils/build-field-inputs/build-field-inputs.ts
+++ b/packages/dynamic-forms/src/lib/utils/build-field-inputs/build-field-inputs.ts
@@ -6,17 +6,6 @@ import { WrapperFieldInputs } from '../../wrappers/wrapper-field-inputs';
  * Convert a field's raw mapper outputs into the {@link WrapperFieldInputs}
  * bag consumed by wrappers and addons.
  *
- * The transformation hides write access on the underlying `FieldTree` —
- * the bag's `field` slot is a {@link ReadonlyFieldTree} view. The raw
- * `FieldTree` is still pushed to the innermost field component (which
- * legitimately needs to write); intermediaries (wrappers, addons) are
- * read-only by contract.
- *
- * Pure, dependency-injection-free — caller supplies the cache so the same
- * `ReadonlyFieldTree` view is returned for the same source `FieldTree`
- * across renders. Each `<df-dynamic-form>` instance scopes its own cache
- * (SSR-safe).
- *
  * @param rawInputs Mapper outputs (`{ key, label, props, field?: FieldTree, ... }`).
  * @param cache     `WeakMap<FieldTree, ReadonlyFieldTree>` provided via
  *                  {@link READONLY_FIELD_TREE_CACHE}.

--- a/packages/dynamic-forms/src/lib/utils/config-validation/config-validator.ts
+++ b/packages/dynamic-forms/src/lib/utils/config-validation/config-validator.ts
@@ -28,16 +28,6 @@ interface ConfigTraversalData {
  * Collects all field keys, types, and validates regex patterns from a field tree
  * by recursively traversing containers (page, row, group, array).
  *
- * Keys are scoped by their group ancestors (e.g. `address.city` instead of `city`),
- * so the same leaf key can appear inside different groups without conflict. Page and
- * row containers do not contribute to the path because they flatten their children
- * into the parent scope. Array items are excluded entirely from key collection
- * because they share template keys across items by design.
- *
- * Fields whose registered `valueHandling` is anything other than `include` (e.g.
- * buttons with `exclude`, page/row with `flatten`) are not collected: they don't
- * bind to a form-value path, so duplicate-key uniqueness isn't meaningful for them.
- *
  * @param collectKeys - When false, the entire subtree skips key collection (used
  *   when descending into an array container).
  */
@@ -98,9 +88,7 @@ function collectFieldData(
   }
 }
 
-/**
- * Validates a single regex pattern string, collecting errors rather than throwing.
- */
+/** Validates a single regex pattern string, collecting errors rather than throwing. */
 function validateRegexPattern(pattern: string, fieldKey: string, errors: string[]): void {
   try {
     new RegExp(pattern);
@@ -139,14 +127,6 @@ function validateNoDuplicateKeys(allKeys: string[]): void {
 /**
  * Validates that the underscore-projected DOM-ID namespace has no collisions.
  *
- * DOM IDs are built by underscore-joining the group ancestor path with the
- * leaf key (e.g. `address_street`). Two scoped paths can land on the same
- * DOM ID even when their form-value paths differ — e.g. a top-level key
- * `'foo_bar'` and a leaf `'bar'` inside group `'foo'` both render as
- * `id="foo_bar"`. The form-value-path check accepts this (paths are
- * `'foo_bar'` vs `'foo.bar'` — distinct) but the rendered DOM would have
- * duplicate IDs, breaking aria associations and CSS selectors.
- *
  * @throws {DynamicFormError} When two scoped paths project to the same DOM ID
  */
 function validateNoDomIdCollisions(domIds: string[]): void {
@@ -176,9 +156,6 @@ function validateNoDomIdCollisions(domIds: string[]): void {
  * Validates that every field type referenced in the config exists in the registry.
  * Logs a warning for unregistered types — unknown fields are skipped during rendering
  * rather than blocking the whole form (graceful degradation).
- *
- * Skips validation when the registry is empty (no UI adapter has been registered),
- * since the core library tests operate without a field registry.
  */
 function validateFieldTypesRegistered(allTypes: Set<string>, registry: Map<string, FieldTypeDefinition>, logger: Logger): void {
   if (registry.size === 0) return;
@@ -204,8 +181,6 @@ function validateFieldTypesRegistered(allTypes: Set<string>, registry: Map<strin
  * - Duplicate field keys (throws — this is always a developer error)
  * - Unregistered field types (warns — form degrades gracefully, skipping unknown fields)
  * - Invalid regex patterns in validators (throws — invalid regex will cause runtime errors)
- *
- * Should be called once during form setup, before fields are processed.
  *
  * @throws {DynamicFormError} When duplicate keys or invalid regex patterns are detected
  */

--- a/packages/dynamic-forms/src/lib/utils/container-utils/container-field-processors.ts
+++ b/packages/dynamic-forms/src/lib/utils/container-utils/container-field-processors.ts
@@ -8,14 +8,6 @@ import { keyBy, mapValues } from '../object-utils';
 /**
  * Creates memoized field processing functions shared across container components.
  *
- * These functions are used by both `FormStateManager` and `GroupFieldComponent`
- * to compute flattened fields, field lookups, and default values from field definitions.
- *
- * Caches are keyed on the input array's reference identity (via WeakMap) rather than
- * a derived content key. Different array instances — even ones with the same field
- * keys/types — must produce fresh results so per-field content changes (e.g. updated
- * select options) propagate through the form pipeline.
- *
  * @returns Object containing memoized processing functions
  */
 export function createContainerFieldProcessors() {
@@ -74,16 +66,6 @@ export function createContainerFieldProcessors() {
 
 /**
  * Shared container field processors injection token.
- *
- * Provided at the DynamicForm component level via `provideDynamicFormDI()` so one
- * form + all its nested groups share a single memoize cache, while different form
- * instances stay isolated.
- *
- * The `providedIn: 'root'` factory is a fallback only — it ensures tests and
- * standalone containers (e.g. a bare GroupFieldComponent in a unit test) can
- * resolve the token without an explicit provider. In a running application, the
- * component-level provider from `provideDynamicFormDI()` always shadows this root
- * instance, so each form gets its own isolated cache.
  *
  * @internal
  */

--- a/packages/dynamic-forms/src/lib/utils/container-utils/container-utils.ts
+++ b/packages/dynamic-forms/src/lib/utils/container-utils/container-utils.ts
@@ -7,8 +7,6 @@ import { ResolvedField } from '../resolve-field/resolve-field';
 /**
  * Computes the host class string for a container component.
  *
- * All containers follow the pattern: `df-field df-{type}` + optional custom class.
- *
  * @param containerType - The CSS class suffix (e.g., 'group', 'row', 'page-field')
  * @param className - Optional custom class name to append
  * @returns The computed host class string
@@ -20,13 +18,6 @@ export function computeContainerHostClasses(containerType: string, className: st
 
 /**
  * Sets up the initialization effect common to all container components.
- *
- * When resolved fields become non-empty, emits a ComponentInitializedEvent
- * via afterNextRender to signal the container is ready.
- *
- * `componentType` may be a static value or a lazy getter — the latter lets
- * virtual field types preserve their original type on the emitted event
- * instead of collapsing to the host component's type.
  *
  * @param resolvedFields - Signal of resolved fields
  * @param eventBus - EventBus for dispatching initialization events

--- a/packages/dynamic-forms/src/lib/utils/debounce/debounce.ts
+++ b/packages/dynamic-forms/src/lib/utils/debounce/debounce.ts
@@ -2,40 +2,19 @@ import { Injector, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { debounceTime, distinctUntilChanged, tap } from 'rxjs';
 
-/**
- * Default debounce duration in milliseconds.
- */
+/** Default debounce duration in milliseconds. */
 export const DEFAULT_DEBOUNCE_MS = 500;
 
 /**
  * Creates a debounced effect that triggers a callback after a signal's value
  * has stabilized for the specified duration.
  *
- * Uses Angular's `toObservable` and `toSignal` with RxJS `debounceTime` for proper debouncing.
- * This approach is cleaner than manual setTimeout management and integrates
- * well with Angular's signal-based reactivity.
- *
  * @param source - The source signal to watch for changes
  * @param callback - Function to call with the debounced value
  * @param options - Configuration options
  * @param options.ms - Debounce duration in milliseconds (default: 500)
  * @param options.injector - Angular injector for the effect context
- *
  * @returns A signal that emits the debounced value (can be ignored if only side effects are needed)
- *
- * @example
- * ```typescript
- * // In a component or service
- * const searchInput = signal('');
- *
- * createDebouncedEffect(
- *   searchInput,
- *   (value) => console.log('Debounced search:', value),
- *   { ms: 300, injector: this.injector }
- * );
- * ```
- *
- * @public
  */
 export function createDebouncedEffect<T>(
   source: Signal<T>,
@@ -57,27 +36,11 @@ export function createDebouncedEffect<T>(
  * Creates a debounced signal that emits values from the source signal
  * only after the value has stabilized for the specified duration.
  *
- * Unlike `createDebouncedEffect`, this doesn't execute a side effect callback.
- * Use this when you just need a debounced version of a signal.
- *
  * @param source - The source signal to debounce
  * @param options - Configuration options
  * @param options.ms - Debounce duration in milliseconds (default: 500)
  * @param options.injector - Angular injector for the effect context
- *
  * @returns A signal that emits the debounced value
- *
- * @example
- * ```typescript
- * const input = signal('');
- * const debouncedInput = createDebouncedSignal(input, { ms: 300, injector });
- *
- * effect(() => {
- *   console.log('Debounced value:', debouncedInput());
- * });
- * ```
- *
- * @public
  */
 export function createDebouncedSignal<T>(source: Signal<T>, options: { ms?: number; injector: Injector }): Signal<T | undefined> {
   const { ms = DEFAULT_DEBOUNCE_MS, injector } = options;

--- a/packages/dynamic-forms/src/lib/utils/default-value/default-value.ts
+++ b/packages/dynamic-forms/src/lib/utils/default-value/default-value.ts
@@ -4,31 +4,9 @@ import { FieldTypeDefinition, getFieldValueHandling } from '../../models/field-t
 /**
  * Generates appropriate default values for different field types in dynamic forms.
  *
- * Uses registry configuration to determine how each field type should handle values.
- * Supports exclude/flatten/include modes based on field type registration.
- *
  * @param field - Field definition to generate default value for
  * @param registry - Field type registry for value handling configuration
  * @returns Appropriate default value based on field type and configuration
- *
- * @example
- * ```typescript
- * // Basic input field defaults to empty string
- * getFieldDefaultValue({ type: 'input', key: 'email' }, registry); // ''
- *
- * // Excluded fields (like text/row) return undefined
- * getFieldDefaultValue({ type: 'text', key: 'label' }, registry); // undefined
- *
- * // Group field returns object with child defaults
- * getFieldDefaultValue({
- *   type: 'group',
- *   key: 'address',
- *   fields: [
- *     { type: 'input', key: 'street' },
- *     { type: 'input', key: 'city', value: 'New York' }
- *   ]
- * }, registry); // { street: '', city: 'New York' }
- * ```
  */
 export function getFieldDefaultValue(field: FieldDef<unknown>, registry: Map<string, FieldTypeDefinition>): unknown {
   const valueHandling = getFieldValueHandling(field.type, registry);

--- a/packages/dynamic-forms/src/lib/utils/deprecation-warnings.ts
+++ b/packages/dynamic-forms/src/lib/utils/deprecation-warnings.ts
@@ -10,7 +10,6 @@ import { DEV_MODE } from './dev-mode';
  * @param tracker - DI-scoped tracker to deduplicate warnings
  * @param id - Unique identifier for this deprecation (e.g., 'type:propertyDerivation')
  * @param message - Human-readable deprecation message
- *
  * @internal
  */
 export function warnDeprecated(logger: Logger, tracker: WarningTracker, id: string, message: string): void {

--- a/packages/dynamic-forms/src/lib/utils/derived-from-deferred/derived-from-deferred.ts
+++ b/packages/dynamic-forms/src/lib/utils/derived-from-deferred/derived-from-deferred.ts
@@ -4,6 +4,7 @@ import { combineLatest, defer, Observable, OperatorFunction } from 'rxjs';
 
 /**
  * Type guard to check if a value is an array of Signals.
+ *
  * @internal
  */
 function isSignalArray(value: unknown): value is readonly Signal<unknown>[] {
@@ -12,35 +13,28 @@ function isSignalArray(value: unknown): value is readonly Signal<unknown>[] {
 
 /**
  * Type guard to check if a value is a record (object) of Signals.
+ *
  * @internal
  */
 function isSignalRecord(value: unknown): value is Record<string, Signal<unknown>> {
   return typeof value === 'object' && value !== null && !Array.isArray(value) && Object.values(value).every((item) => isSignal(item));
 }
 
-/**
- * Options for derivedFromDeferred.
- */
+/** Options for derivedFromDeferred. */
 export interface DerivedFromDeferredOptions<R> {
   initialValue: R;
   injector: Injector;
 }
 
-/**
- * Type helper to extract the value type from a Signal.
- */
+/** Type helper to extract the value type from a Signal. */
 type SignalValue<T> = T extends Signal<infer V> ? V : never;
 
-/**
- * Type helper to map an array of Signals to an array of their value types.
- */
+/** Type helper to map an array of Signals to an array of their value types. */
 type SignalValues<T extends readonly Signal<unknown>[]> = {
   [K in keyof T]: SignalValue<T[K]>;
 };
 
-/**
- * Type helper to map an object of Signals to an object of their value types.
- */
+/** Type helper to map an object of Signals to an object of their value types. */
 type SignalObjectValues<T extends Record<string, Signal<unknown>>> = {
   [K in keyof T]: SignalValue<T[K]>;
 };
@@ -48,35 +42,6 @@ type SignalObjectValues<T extends Record<string, Signal<unknown>>> = {
 /**
  * Like derivedFrom from ngxtension, but uses defer() to avoid input availability issues.
  * This ensures toObservable is called at subscription time, not at field initialization.
- *
- * Supports three source types:
- * - Single signal: `derivedFromDeferred(signal, operator, options)`
- * - Array of signals: `derivedFromDeferred([signal1, signal2], operator, options)`
- * - Object of signals: `derivedFromDeferred({a: signal1, b: signal2}, operator, options)`
- *
- * @example
- * ```typescript
- * // Single signal
- * const result = derivedFromDeferred(
- *   mySignal,
- *   pipe(map(v => v * 2)),
- *   { initialValue: 0, injector }
- * );
- *
- * // Array of signals
- * const result = derivedFromDeferred(
- *   [signalA, signalB],
- *   pipe(map(([a, b]) => a + b)),
- *   { initialValue: 0, injector }
- * );
- *
- * // Object of signals
- * const result = derivedFromDeferred(
- *   { x: signalX, y: signalY },
- *   pipe(map(({ x, y }) => x + y)),
- *   { initialValue: 0, injector }
- * );
- * ```
  */
 
 // Overload: Single signal

--- a/packages/dynamic-forms/src/lib/utils/dev-mode.ts
+++ b/packages/dynamic-forms/src/lib/utils/dev-mode.ts
@@ -1,16 +1,4 @@
 declare const ngDevMode: boolean | undefined;
 
-/**
- * Dev-mode guard for tree-shakeable diagnostics.
- *
- * Angular CLI's optimizer substitutes `ngDevMode` with `false` in production builds,
- * letting terser dead-code-eliminate branches gated by this constant. Non-Angular
- * consumers fall back to `true` so warnings still fire under their bundler.
- *
- * Note: `DEV_MODE` is evaluated at module-load time and captured into the constant,
- * so it does NOT reflect later runtime calls to Angular's `enableProdMode()`. For
- * the dead-code-elimination case this is intentional (the value must be known at
- * build time). If a runtime check is needed instead, use `isDevMode()` from
- * `@angular/core` directly.
- */
+/** Dev-mode guard for tree-shakeable diagnostics. */
 export const DEV_MODE: boolean = typeof ngDevMode === 'undefined' || !!ngDevMode;

--- a/packages/dynamic-forms/src/lib/utils/dynamic-value/resolve-dynamic-value.ts
+++ b/packages/dynamic-forms/src/lib/utils/dynamic-value/resolve-dynamic-value.ts
@@ -3,28 +3,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { isObservable } from 'rxjs';
 import { DynamicValue } from '../../models/types/dynamic-value';
 
-/**
- * Normalises a {@link DynamicValue} into a `Signal<T>`.
- *
- * Accepts a static value, a `Signal<T>`, or an `Observable<T>`. The result
- * is a `Signal<T>` that reactively reflects the current value, suitable
- * for direct use in Angular templates.
- *
- * Static values yield a `computed` that always returns the same constant —
- * preferable to wrapping in `signal()` because the computed never causes
- * change-detection invalidation.
- *
- * Pass an `injector` when calling outside an Angular injection context
- * (e.g., from inside a `computed`). `toSignal` needs a `DestroyRef` to
- * unsubscribe — without an injector it falls back to `inject(DestroyRef)`,
- * which throws when called outside injection context.
- *
- * @example
- * ```typescript
- * const isHidden = resolveDynamicValue(addon().hidden, false);
- * // template: \@if (isHidden()) { ... }
- * ```
- */
+/** Normalises a {@link DynamicValue} into a `Signal<T>`. */
 export function resolveDynamicValue<T>(value: DynamicValue<T> | undefined, fallback: T, injector?: Injector): Signal<T> {
   if (value === undefined) {
     return computed(() => fallback);

--- a/packages/dynamic-forms/src/lib/utils/emit-initialization/emit-initialization.ts
+++ b/packages/dynamic-forms/src/lib/utils/emit-initialization/emit-initialization.ts
@@ -3,17 +3,11 @@ import { EventBus } from '../../events/event.bus';
 import { ComponentInitializedEvent } from '../../events/constants/component-initialized.event';
 import { DynamicFormLogger } from '../../providers/features/logger/logger.token';
 
-/**
- * Component type for initialization events.
- */
+/** Component type for initialization events. */
 export type InitializationComponentType = 'dynamic-form' | 'group' | 'page' | 'array' | 'container';
 
 /**
  * Emits a component initialization event after the next render cycle.
- *
- * This utility is used by container components (group, page, array, container) to signal
- * that their child fields have been resolved and rendered. The event is dispatched
- * through the EventBus and is used by the initialization tracking system.
  *
  * @param eventBus - The EventBus instance to dispatch the event on
  * @param componentType - The type of component being initialized

--- a/packages/dynamic-forms/src/lib/utils/field-mapper/field-mapper.ts
+++ b/packages/dynamic-forms/src/lib/utils/field-mapper/field-mapper.ts
@@ -98,10 +98,6 @@ function applyIndexSuffix(inputs: Record<string, unknown>, index: number): Recor
  * Prefixes the key with the underscored group ancestor path so that the same
  * leaf key inside different groups produces distinct DOM IDs (issue #401).
  * Form-schema keys remain clean — only the rendered `key` input is rewritten.
- *
- * Dots in the group path become underscores, then the original leaf key is
- * appended: `(groupPath='user.address', inputs.key='street')` →
- * `inputs.key = 'user_address_street'`.
  */
 function applyGroupPrefix(inputs: Record<string, unknown>, groupPath: string): Record<string, unknown> {
   const key = inputs['key'];
@@ -118,24 +114,6 @@ function applyGroupPrefix(inputs: Record<string, unknown>, groupPath: string): R
 /**
  * Main field mapper function that uses the field registry to get the appropriate mapper
  * based on the field's type property.
- *
- * This function must be called within an injection context where FIELD_SIGNAL_CONTEXT
- * is provided, as mappers inject the context to access form state.
- *
- * For componentless fields (no loadComponent and no mapper), returns undefined
- * since there's no component to bind inputs to. Callers should check for undefined
- * and skip rendering logic for such fields.
- *
- * If the field type definition specifies `propsToMeta`, the specified props
- * will be merged into the meta object (with meta taking precedence).
- *
- * When running inside an array item context (ARRAY_CONTEXT is provided), the key
- * is automatically suffixed with the item index to ensure unique DOM IDs. The form
- * schema keys remain clean (unsuffixed) so derivations and validations work correctly.
- *
- * Property overrides from the PropertyOverrideStore are applied AFTER all static
- * mapper logic, so they always take precedence. Only fields with registered property
- * derivations incur the overhead of reading from the store.
  *
  * @param fieldDef The field definition to map
  * @param fieldRegistry The registry of field type definitions

--- a/packages/dynamic-forms/src/lib/utils/flattener/field-flattener.ts
+++ b/packages/dynamic-forms/src/lib/utils/flattener/field-flattener.ts
@@ -6,14 +6,7 @@ import { isContainerTypedField } from '../../definitions/default/container-field
 import { FieldTypeDefinition, getFieldValueHandling } from '../../models/field-type';
 import { normalizeFieldsArray } from '../object-utils';
 
-/**
- * Represents a field definition that has been processed through the flattening algorithm.
- *
- * Guarantees that the field has a valid key property, either from the original
- * field definition or auto-generated during the flattening process.
- *
- * @public
- */
+/** Represents a field definition that has been processed through the flattening algorithm. */
 export interface FlattenedField extends FieldDef<unknown> {
   /** Guaranteed non-empty key for form binding and field identification */
   readonly key: string;
@@ -22,65 +15,11 @@ export interface FlattenedField extends FieldDef<unknown> {
 /**
  * Flattens a hierarchical field structure into a linear array for form processing.
  *
- * Handles different field types with specific flattening strategies:
- * - **Page fields**: Children are flattened and merged into the result (no wrapper)
- * - **Row fields**: Children are flattened and merged into the result (no wrapper), unless preserveRows=true
- * - **Group fields**: Maintains group structure with flattened children nested under the group key
- * - **Array fields**: Maintains array structure with flattened children nested under the array key
- * - **Other fields**: Pass through unchanged with guaranteed key generation
- *
- * Auto-generates keys for fields missing the key property to ensure form binding works correctly.
- *
  * @param fields - Array of field definitions that may contain nested structures
  * @param registry - Field type registry for determining value handling behavior
  * @param options - Configuration options for flattening behavior
  * @param options.preserveRows - When true, keep row fields in structure for DOM rendering (grid layout)
  * @returns Flattened array of field definitions with guaranteed keys
- *
- * @example
- * ```typescript
- * const hierarchicalFields = [
- *   {
- *     type: 'row',
- *     fields: [
- *       { type: 'input', key: 'firstName' },
- *       { type: 'input', key: 'lastName' }
- *     ]
- *   },
- *   {
- *     type: 'group',
- *     key: 'address',
- *     fields: [
- *       { type: 'input', key: 'street' },
- *       { type: 'input', key: 'city' }
- *     ]
- *   }
- * ];
- *
- * const flattened = flattenFields(hierarchicalFields, registry);
- * // Result: [
- * //   { type: 'input', key: 'firstName' },
- * //   { type: 'input', key: 'lastName' },
- * //   { type: 'group', key: 'address', fields: [...] }
- * // ]
- * ```
- *
- * @example
- * ```typescript
- * // Auto-key generation for fields without keys
- * const fieldsWithoutKeys = [
- *   { type: 'input', label: 'Name' },
- *   { type: 'button', label: 'Submit' }
- * ];
- *
- * const flattened = flattenFields(fieldsWithoutKeys, registry);
- * // Result: [
- * //   { type: 'input', label: 'Name', key: 'auto_field_0' },
- * //   { type: 'button', label: 'Submit', key: 'auto_field_1' }
- * // ]
- * ```
- *
- * @public
  */
 export function flattenFields(
   fields: FieldDef<unknown>[],

--- a/packages/dynamic-forms/src/lib/utils/form-validation/form-mode-validator.ts
+++ b/packages/dynamic-forms/src/lib/utils/form-validation/form-mode-validator.ts
@@ -12,6 +12,7 @@ import { DynamicFormError } from '../../errors/dynamic-form-error';
 export class FormModeValidator {
   /**
    * Validates a form configuration and returns detailed validation results
+   *
    * @param fields The form field definitions to validate
    * @returns Validation result with mode detection and error details
    */
@@ -47,6 +48,7 @@ export class FormModeValidator {
 
   /**
    * Validates form configuration and throws an error if invalid
+   *
    * @param fields The form field definitions to validate
    * @throws Error with detailed validation messages if form is invalid
    */
@@ -64,6 +66,7 @@ export class FormModeValidator {
 
   /**
    * Generates helpful warnings for form configurations
+   *
    * @param fields The form field definitions
    * @param modeDetection The mode detection result
    * @returns Array of warning messages
@@ -95,9 +98,7 @@ export class FormModeValidator {
   }
 }
 
-/**
- * Extended validation result including warnings
- */
+/** Extended validation result including warnings */
 export interface FormConfigurationValidationResult extends FormModeDetectionResult {
   /** Array of warning messages that don't prevent form operation */
   warnings: string[];
@@ -105,6 +106,7 @@ export interface FormConfigurationValidationResult extends FormModeDetectionResu
 
 /**
  * Convenience function for quick form mode validation
+ *
  * @param fields The form field definitions to validate
  * @returns True if form configuration is valid, false otherwise
  */

--- a/packages/dynamic-forms/src/lib/utils/grid-classes/grid-classes.ts
+++ b/packages/dynamic-forms/src/lib/utils/grid-classes/grid-classes.ts
@@ -3,28 +3,8 @@ import { FieldDef } from '../../definitions/base/field-def';
 /**
  * Generates CSS class string for responsive grid layout based on field column configuration.
  *
- * Creates Bootstrap-style column classes for implementing responsive form layouts.
- * Validates column values to ensure they fall within the standard 12-column grid system.
- *
  * @param fieldDef - Field definition containing column configuration
  * @returns CSS class string for grid layout, empty if no valid column configuration
- *
- * @example
- * ```typescript
- * // Full width field
- * const fullWidth = getGridClassString({ type: 'input', key: 'name', col: 12 });
- * // Returns: 'df-col-12'
- *
- * // Half width field
- * const halfWidth = getGridClassString({ type: 'input', key: 'email', col: 6 });
- * // Returns: 'df-col-6'
- *
- * // Invalid column value
- * const invalid = getGridClassString({ type: 'input', key: 'phone', col: 15 });
- * // Returns: ''
- * ```
- *
- * @public
  */
 export function getGridClassString(fieldDef: FieldDef<unknown>): string {
   const col = fieldDef.col;
@@ -37,32 +17,8 @@ export function getGridClassString(fieldDef: FieldDef<unknown>): string {
 /**
  * Builds a combined className string from a field definition.
  *
- * Combines user-provided className with generated grid classes into a single string.
- * Returns undefined if no classes are present (allowing conditional spreading in objects).
- *
  * @param fieldDef - Field definition containing className and col properties
  * @returns Combined class string, or undefined if no classes
- *
- * @example
- * ```typescript
- * // With both className and col
- * buildClassName({ key: 'test', type: 'group', className: 'my-class', col: 6 });
- * // Returns: 'df-col-6 my-class'
- *
- * // With only className
- * buildClassName({ key: 'test', type: 'group', className: 'my-class' });
- * // Returns: 'my-class'
- *
- * // With only col
- * buildClassName({ key: 'test', type: 'group', col: 6 });
- * // Returns: 'df-col-6'
- *
- * // With neither
- * buildClassName({ key: 'test', type: 'group' });
- * // Returns: undefined
- * ```
- *
- * @public
  */
 export function buildClassName(fieldDef: FieldDef<unknown>): string | undefined {
   const gridClass = getGridClassString(fieldDef);

--- a/packages/dynamic-forms/src/lib/utils/initialization-tracker/initialization-tracker.ts
+++ b/packages/dynamic-forms/src/lib/utils/initialization-tracker/initialization-tracker.ts
@@ -16,13 +16,7 @@ export const INITIALIZATION_TIMEOUT_MS = new InjectionToken<number>('INITIALIZAT
   factory: () => 10_000,
 });
 
-/**
- * Creates an observable that tracks component initialization progress.
- *
- * Emits once with `true` when `expectedCount` component-initialized events have
- * been seen on the bus. Used internally by {@link setupInitializationTracking}
- * and kept as a named export for focused unit testing.
- */
+/** Creates an observable that tracks component initialization progress. */
 export function createInitializationTracker(eventBus: EventBus, expectedCount: number): Observable<boolean> {
   return eventBus.on<ComponentInitializedEvent>('component-initialized').pipe(
     scan((count) => count + 1, 0),
@@ -31,9 +25,7 @@ export function createInitializationTracker(eventBus: EventBus, expectedCount: n
   );
 }
 
-/**
- * Options for setting up initialization tracking.
- */
+/** Options for setting up initialization tracking. */
 export interface InitializationTrackingOptions {
   eventBus: EventBus;
   totalComponentsCount: Signal<number>;
@@ -45,24 +37,6 @@ export interface InitializationTrackingOptions {
  * Creates an observable that tracks when all form components are initialized.
  * Uses shareReplay({ bufferSize: 1, refCount: false }) to ensure exactly one emission
  * that can be received by late subscribers and keeps the subscription alive.
- *
- * Includes a configurable timeout (default 10s via INITIALIZATION_TIMEOUT_MS)
- * so that (initialized) does not hang forever if a container component throws
- * before emitting its initialization event. On timeout, a warning is logged
- * and true is emitted as a best-effort fallback.
- *
- * @example
- * ```typescript
- * const eventBus = inject(EventBus);
- * const totalComponents = computed(() => countContainerComponents(fields));
- *
- * readonly initialized$ = setupInitializationTracking({
- *   eventBus,
- *   totalComponentsCount: totalComponents,
- *   injector: this.injector,
- *   componentId: 'dynamic-form'
- * });
- * ```
  */
 export function setupInitializationTracking(options: InitializationTrackingOptions): Observable<boolean> {
   const { eventBus, totalComponentsCount, injector, componentId } = options;

--- a/packages/dynamic-forms/src/lib/utils/inject-addon-kind-registry/inject-addon-kind-registry.ts
+++ b/packages/dynamic-forms/src/lib/utils/inject-addon-kind-registry/inject-addon-kind-registry.ts
@@ -6,16 +6,6 @@ import { resolveDefaultExport } from '../wrapper-chain/wrapper-chain';
 /**
  * Cache for resolved addon-kind components.
  *
- * Provided per-form by `provideDynamicFormDI()` so two `<df-dynamic-form>`
- * instances with conflicting `loadComponent` factories for the same kind
- * never share a stale entry. Has no `providedIn: 'root'` factory — the
- * registry consumer is always inside a form scope, and a root fallback
- * would only hide misconfiguration (an SSR cross-request hit if a future
- * code path forgot to provide it locally).
- *
- * Mirrors `COMPONENT_CACHE` (field types) and `WRAPPER_COMPONENT_CACHE`
- * (wrappers).
- *
  * @internal
  */
 export const ADDON_KIND_COMPONENT_CACHE = new InjectionToken<Map<string, Type<unknown>>>('ADDON_KIND_COMPONENT_CACHE');
@@ -34,18 +24,7 @@ export interface AddonKindRegistryRef {
   readonly raw: ReadonlyMap<string, AddonKindDefinition>;
 }
 
-/**
- * Injection function for accessing the addon kind registry.
- *
- * Usage parallels {@link injectFieldRegistry}: lookup, lazy load, cache.
- * Must be called within an injection context.
- *
- * @example
- * ```typescript
- * const addonKinds = injectAddonKindRegistry();
- * const Component = await addonKinds.loadKindComponent('prime-icon');
- * ```
- */
+/** Injection function for accessing the addon kind registry. */
 export function injectAddonKindRegistry(): AddonKindRegistryRef {
   const registry = inject(ADDON_KIND_REGISTRY);
   const componentCache = inject(ADDON_KIND_COMPONENT_CACHE);

--- a/packages/dynamic-forms/src/lib/utils/inject-addon-kind-registry/inject-fields-supporting-addons.ts
+++ b/packages/dynamic-forms/src/lib/utils/inject-addon-kind-registry/inject-fields-supporting-addons.ts
@@ -2,12 +2,7 @@ import { inject } from '@angular/core';
 import { FieldAddonSupport } from '../../models/addon/addon-kind';
 import { FIELD_REGISTRY } from '../../models/field-type';
 
-/**
- * One entry per field type that declares addon support.
- *
- * `name` is the field-type discriminant; `slots` and `allowedKinds` mirror
- * the `FieldTypeDefinition.addons` registration.
- */
+/** One entry per field type that declares addon support. */
 export interface FieldAddonSupportEntry {
   readonly name: string;
   readonly slots: FieldAddonSupport['slots'];
@@ -18,14 +13,6 @@ export interface FieldAddonSupportEntry {
  * Walk `FIELD_REGISTRY` and return every field type that opted into addons
  * (i.e., declared `addons` on its `FieldTypeDefinition`).
  *
- * Useful for tooling — admin UIs surfacing "which fields can carry addons?",
- * docs generators, MCP server cross-checks. Field types without an `addons`
- * registration ("Tier 3" — toggle, checkbox, radio, slider) are excluded.
- *
- * Must be called within an injection context.
- *
- * @example
- * ```typescript
  * @Component({ ... })
  * class FormBuilder {
  *   protected readonly addonable = injectFieldsSupportingAddons();

--- a/packages/dynamic-forms/src/lib/utils/inject-field-registry/inject-field-registry.ts
+++ b/packages/dynamic-forms/src/lib/utils/inject-field-registry/inject-field-registry.ts
@@ -6,11 +6,6 @@ import { resolveDefaultExport } from '../wrapper-chain/wrapper-chain';
 /**
  * Cache for resolved field type components.
  *
- * Using an InjectionToken with `providedIn: 'root'` ensures:
- * - SSR safety: Angular creates a fresh root injector per SSR request,
- *   so the cache is properly isolated and garbage-collected
- * - Shared across all `injectFieldRegistry()` calls within the same app/request
- *
  * @internal
  */
 export const COMPONENT_CACHE = new InjectionToken<Map<string, Type<unknown>>>('COMPONENT_CACHE', {
@@ -21,14 +16,7 @@ export const COMPONENT_CACHE = new InjectionToken<Map<string, Type<unknown>>>('C
 /**
  * Injection function for accessing the dynamic form field registry.
  *
- * Provides a convenient API for interacting with registered field types,
- * including type checking, component loading, and registration management.
- * Must be called within an injection context.
- *
  * @returns Object with methods for field registry interaction
- *
- * @example
- * ```typescript
  * @Component({...})
  * export class MyComponent {
  *   private fieldRegistry = injectFieldRegistry();
@@ -41,10 +29,6 @@ export const COMPONENT_CACHE = new InjectionToken<Map<string, Type<unknown>>>('C
  *   }
  * }
  * ```
- *
- * @example
- * ```typescript
- * // In a service
  * @Injectable()
  * export class FormBuilderService {
  *   private fieldRegistry = injectFieldRegistry();
@@ -54,8 +38,6 @@ export const COMPONENT_CACHE = new InjectionToken<Map<string, Type<unknown>>>('C
  *   }
  * }
  * ```
- *
- * @public
  */
 export function injectFieldRegistry() {
   const registry = inject(FIELD_REGISTRY);
@@ -67,14 +49,6 @@ export function injectFieldRegistry() {
      *
      * @param name - The registered name of the field type
      * @returns The field type definition if found, undefined otherwise
-     *
-     * @example
-     * ```typescript
-     * const inputType = fieldRegistry.getType('input');
-     * if (inputType) {
-     *   console.log('Input field type found:', inputType.name);
-     * }
-     * ```
      */
     getType(name: string): FieldTypeDefinition | undefined {
       return registry.get(name);
@@ -85,14 +59,6 @@ export function injectFieldRegistry() {
      *
      * @param name - The name of the field type to check
      * @returns True if the field type exists, false otherwise
-     *
-     * @example
-     * ```typescript
-     * if (fieldRegistry.hasType('custom-input')) {
-     *   // Safe to use custom-input field type
-     *   const component = await fieldRegistry.loadTypeComponent('custom-input');
-     * }
-     * ```
      */
     hasType(name: string): boolean {
       return registry.has(name);
@@ -101,24 +67,9 @@ export function injectFieldRegistry() {
     /**
      * Loads a field type component with support for lazy loading.
      *
-     * Handles both synchronous component references and asynchronous
-     * dynamic imports. Automatically extracts default exports from ES modules.
-     *
-     * Returns `undefined` for componentless field types (e.g., hidden fields)
-     * that only contribute to form values without rendering UI.
-     *
      * @param name - The name of the field type to load
      * @returns Promise resolving to the component constructor, or undefined for componentless fields
      * @throws {Error} When field type is not registered or loading fails
-     *
-     * @example
-     * ```typescript
-     * const component = await fieldRegistry.loadTypeComponent('input');
-     * if (component) {
-     *   const componentRef = vcr.createComponent(component);
-     * }
-     * // For componentless fields like 'hidden', component will be undefined
-     * ```
      */
     async loadTypeComponent(name: string): Promise<Type<unknown> | undefined> {
       const fieldType = registry.get(name);
@@ -154,12 +105,6 @@ export function injectFieldRegistry() {
     /**
      * Returns a previously loaded component from cache, or undefined if not yet loaded.
      *
-     * This enables synchronous field resolution for components that have already
-     * been loaded (e.g., after first render). Returns undefined for:
-     * - Components not yet loaded (first render)
-     * - Componentless field types (e.g., hidden)
-     * - Unregistered field types
-     *
      * @param name - The name of the field type
      * @returns The cached component constructor, or undefined
      */
@@ -171,13 +116,6 @@ export function injectFieldRegistry() {
      * Gets all registered field type definitions.
      *
      * @returns Array of all field type definitions in the registry
-     *
-     * @example
-     * ```typescript
-     * const allTypes = fieldRegistry.getTypes();
-     * const typeNames = allTypes.map(type => type.name);
-     * console.log('Available field types:', typeNames);
-     * ```
      */
     getTypes(): FieldTypeDefinition[] {
       return Array.from(registry.values());
@@ -186,19 +124,7 @@ export function injectFieldRegistry() {
     /**
      * Registers multiple field types at once.
      *
-     * Useful for bulk registration of custom field types. Overwrites
-     * existing registrations with the same name.
-     *
      * @param types - Array of field type definitions to register
-     *
-     * @example
-     * ```typescript
-     * fieldRegistry.registerTypes([
-     *   CustomInputType,
-     *   CustomSelectType,
-     *   CustomDatePickerType
-     * ]);
-     * ```
      */
     registerTypes(types: FieldTypeDefinition[]): void {
       types.forEach((type) => {
@@ -209,16 +135,7 @@ export function injectFieldRegistry() {
     /**
      * Provides direct access to the underlying registry Map.
      *
-     * Use with caution - direct modification can affect form behavior.
-     * Primarily intended for advanced use cases and debugging.
-     *
      * @returns The raw Map containing field type registrations
-     *
-     * @example
-     * ```typescript
-     * const rawRegistry = fieldRegistry.raw;
-     * console.log('Registry size:', rawRegistry.size);
-     * ```
      */
     get raw() {
       return registry;

--- a/packages/dynamic-forms/src/lib/utils/interpolate-params.ts
+++ b/packages/dynamic-forms/src/lib/utils/interpolate-params.ts
@@ -6,10 +6,6 @@ import { ValidationError } from '../models/validation-types';
  * @param message - Message template with {{param}} placeholders
  * @param error - Validation error containing parameter values
  * @returns Message with interpolated parameters
- *
- * @example
- * interpolateParams("Min value is {{min}}", { kind: 'min', min: 5 })
- * // Returns: "Min value is 5"
  */
 export function interpolateParams(message: string, error: ValidationError): string {
   let result = message;
@@ -25,6 +21,7 @@ export function interpolateParams(message: string, error: ValidationError): stri
 
 /**
  * Safely converts a value to a string, handling complex objects
+ *
  * @internal
  */
 function safeToString(value: unknown): string {
@@ -68,6 +65,7 @@ function safeToString(value: unknown): string {
 
 /**
  * Extracts parameter values from validation error
+ *
  * @internal
  */
 function extractErrorParams(error: ValidationError): Record<string, unknown> {

--- a/packages/dynamic-forms/src/lib/utils/object-utils.ts
+++ b/packages/dynamic-forms/src/lib/utils/object-utils.ts
@@ -8,27 +8,9 @@ import { DynamicFormError } from '../errors/dynamic-form-error';
 /**
  * Performs a deep equality comparison between two values.
  *
- * Handles:
- * - Primitives (including NaN via Object.is)
- * - Dates (by timestamp)
- * - Arrays (deep element comparison)
- * - Plain objects (deep property comparison)
- * - RegExp (by source and flags)
- * - Map and Set (by entries)
- * - Circular references (via WeakMap tracking)
- *
  * @param a - First value
  * @param b - Second value
  * @returns true if values are deeply equal
- *
- * @example
- * ```typescript
- * isEqual({ a: 1 }, { a: 1 }); // true
- * isEqual([1, 2], [1, 2]); // true
- * isEqual({ a: 1 }, { a: 2 }); // false
- * isEqual(new Date('2024-01-01'), new Date('2024-01-01')); // true
- * isEqual(/abc/gi, /abc/gi); // true
- * ```
  */
 export function isEqual(a: unknown, b: unknown): boolean {
   return isEqualInternal(a, b, new WeakMap(), new WeakMap());
@@ -36,6 +18,7 @@ export function isEqual(a: unknown, b: unknown): boolean {
 
 /**
  * Internal implementation with circular reference tracking.
+ *
  * @internal
  */
 function isEqualInternal(a: unknown, b: unknown, seenA: WeakMap<object, object>, seenB: WeakMap<object, object>): boolean {
@@ -149,12 +132,6 @@ function isEqualInternal(a: unknown, b: unknown, seenA: WeakMap<object, object>,
  * @param obj - Source object
  * @param keys - Keys to omit
  * @returns New object without specified keys
- *
- * @example
- * ```typescript
- * const obj = { a: 1, b: 2, c: 3 };
- * omit(obj, ['b']); // { a: 1, c: 3 }
- * ```
  */
 export function omit<T extends object, K extends keyof T>(obj: T, keys: K[]): Omit<T, K> {
   const result = { ...obj };
@@ -169,12 +146,6 @@ export function omit<T extends object, K extends keyof T>(obj: T, keys: K[]): Om
  * @param array - Source array
  * @param key - Property to use as key
  * @returns Object keyed by the specified property
- *
- * @example
- * ```typescript
- * const users = [{ id: 'a', name: 'Alice' }, { id: 'b', name: 'Bob' }];
- * keyBy(users, 'id'); // { a: { id: 'a', name: 'Alice' }, b: { id: 'b', name: 'Bob' } }
- * ```
  */
 export function keyBy<T extends object>(array: T[], key: keyof T): Record<string, T> {
   return array.reduce(
@@ -193,12 +164,6 @@ export function keyBy<T extends object>(array: T[], key: keyof T): Record<string
  * @param obj - Source object
  * @param fn - Transformation function
  * @returns New object with transformed values
- *
- * @example
- * ```typescript
- * const obj = { a: 1, b: 2 };
- * mapValues(obj, (v) => v * 2); // { a: 2, b: 4 }
- * ```
  */
 export function mapValues<T, U>(obj: Record<string, T>, fn: (value: T, key: string) => U): Record<string, U> {
   return Object.entries(obj).reduce(
@@ -215,34 +180,6 @@ export function mapValues<T, U>(obj: Record<string, T>, fn: (value: T, key: stri
  * key from `defaults` plus any overrides from `value`. Plain-object values at
  * matching keys are merged recursively; primitives, dates, and class instances
  * in `value` replace the corresponding default wholesale.
- *
- * Arrays whose lengths match between `defaults` and `value` are merged
- * positionally: when both `defaults[i]` and `value[i]` are plain objects, they
- * are deep-merged so partial array-item values don't drop sibling sub-field
- * keys. When the lengths differ — the runtime add/insert/remove case — the
- * value array is returned by reference so Signal Forms doesn't see a fresh
- * array of fresh inner objects on every form-value write (which would rebuild
- * item bindings and desync the rendered rows from their FieldTrees).
- *
- * Used by `FormStateManager.entity` so a partial input value (e.g. a nested
- * group object missing one of its declared sub-fields, or an array item missing
- * one of its declared sub-fields) does not orphan the absent sub-field in
- * Angular Signal Forms' validation graph.
- *
- * @example
- * ```typescript
- * deepMergeDefaults(
- *   { a: { line1: '', line2: '', city: '' }, b: 0 },
- *   { a: { line1: 'X', city: 'Y' }, b: 1 },
- * );
- * // { a: { line1: 'X', line2: '', city: 'Y' }, b: 1 }
- *
- * deepMergeDefaults(
- *   { items: [{ checkboxA: false, checkboxB: false }] },
- *   { items: [{ checkboxA: true }] },
- * );
- * // { items: [{ checkboxA: true, checkboxB: false }] }
- * ```
  */
 export function deepMergeDefaults<T extends Record<string, unknown>>(defaults: T, value: Record<string, unknown> | null | undefined): T {
   if (value == null) return { ...defaults };
@@ -310,9 +247,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return proto === null || proto === Object.prototype;
 }
 
-/**
- * Options for memoize function
- */
+/** Options for memoize function */
 /** Default maximum cache size for memoized functions */
 const DEFAULT_MEMOIZE_MAX_SIZE = 100;
 
@@ -329,18 +264,6 @@ export interface MemoizeOptions<TFunc extends (...args: never[]) => unknown> {
  * @param fn - Function to memoize
  * @param resolverOrOptions - Optional key resolver function or options object
  * @returns Memoized function
- *
- * @example
- * ```typescript
- * const expensive = (a: number, b: number) => a + b;
- * const memoized = memoize(expensive); // Uses default maxSize of 100
- *
- * // With custom resolver
- * const withResolver = memoize(expensive, (a, b) => `${a}-${b}`);
- *
- * // With custom maxSize
- * const small = memoize(expensive, { maxSize: 10 });
- * ```
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function memoize<TFunc extends (...args: any[]) => any>(
@@ -391,19 +314,9 @@ export function normalizeFieldsArray<T>(fields: readonly T[] | Record<string, T>
 /**
  * Gets the keys that differ between two objects.
  *
- * Compares top-level keys and returns those whose values are different.
- * Uses deep equality comparison for nested values.
- *
  * @param previous - Previous object state
  * @param current - Current object state
  * @returns Set of keys that have different values
- *
- * @example
- * ```typescript
- * const prev = { a: 1, b: 2, c: 3 };
- * const curr = { a: 1, b: 5, d: 4 };
- * getChangedKeys(prev, curr); // Set { 'b', 'c', 'd' }
- * ```
  */
 export function getChangedKeys(
   previous: Record<string, unknown> | null | undefined,
@@ -443,24 +356,7 @@ export function getChangedKeys(
   return changedKeys;
 }
 
-/**
- * Compile-time exhaustiveness check for discriminated unions.
- *
- * Place in the `default` branch of a `switch` over a union's discriminant.
- * TypeScript narrows the value to `never` only when every member is handled;
- * adding a new member without a matching `case` produces a type error here.
- *
- * At runtime, throws if somehow reached (defensive guard).
- *
- * @example
- * ```ts
- * switch (action.type) {
- *   case 'a': return handleA(action);
- *   case 'b': return handleB(action);
- *   default:  return assertNever(action);
- * }
- * ```
- */
+/** Compile-time exhaustiveness check for discriminated unions. */
 export function assertNever(value: never): never {
   throw new DynamicFormError(`Unexpected value: ${JSON.stringify(value)}`);
 }

--- a/packages/dynamic-forms/src/lib/utils/path-utils/path-utils.ts
+++ b/packages/dynamic-forms/src/lib/utils/path-utils/path-utils.ts
@@ -1,20 +1,10 @@
 /**
  * Utilities for parsing and manipulating field paths in dynamic forms.
  *
- * Field paths follow these formats:
- * - Simple: "fieldName"
- * - Nested: "parent.child.grandchild"
- * - Array indexed: "items.0.quantity" or "items[0].quantity"
- * - Array placeholder: "items.$.quantity" ($ = any index)
- *
  * @module path-utils
  */
 
-/**
- * Result of parsing an array derivation path.
- *
- * @public
- */
+/** Result of parsing an array derivation path. */
 export interface ArrayPathInfo {
   /** The array field path (e.g., "items" or "orders.lineItems") */
   arrayPath: string;
@@ -29,25 +19,8 @@ export interface ArrayPathInfo {
 /**
  * Parses an array derivation path into its components.
  *
- * Array paths use the `$` placeholder to represent "any index".
- * Format: "arrayPath.$.relativePath"
- *
  * @param path - The path to parse (e.g., "items.$.quantity")
  * @returns Parsed path info with arrayPath and relativePath
- *
- * @example
- * ```typescript
- * parseArrayPath('items.$.quantity')
- * // { arrayPath: 'items', relativePath: 'quantity', isArrayPath: true }
- *
- * parseArrayPath('orders.lineItems.$.total')
- * // { arrayPath: 'orders.lineItems', relativePath: 'total', isArrayPath: true }
- *
- * parseArrayPath('simpleField')
- * // { arrayPath: '', relativePath: '', isArrayPath: false }
- * ```
- *
- * @public
  */
 export function parseArrayPath(path: string): ArrayPathInfo {
   const ARRAY_PLACEHOLDER = '.$.';
@@ -74,17 +47,6 @@ export function parseArrayPath(path: string): ArrayPathInfo {
  * @param path - The path with $ placeholder (e.g., "items.$.quantity")
  * @param index - The array index to substitute
  * @returns Resolved path with index (e.g., "items.0.quantity")
- *
- * @example
- * ```typescript
- * resolveArrayPath('items.$.quantity', 2)
- * // 'items.2.quantity'
- *
- * resolveArrayPath('orders.lineItems.$.total', 0)
- * // 'orders.lineItems.0.total'
- * ```
- *
- * @public
  */
 export function resolveArrayPath(path: string, index: number): string {
   const info = parseArrayPath(path);
@@ -99,8 +61,6 @@ export function resolveArrayPath(path: string, index: number): string {
  *
  * @param path - The path to check
  * @returns True if the path contains .$.
- *
- * @public
  */
 export function isArrayPlaceholderPath(path: string): boolean {
   return path.includes('.$.');
@@ -111,20 +71,6 @@ export function isArrayPlaceholderPath(path: string): boolean {
  *
  * @param path - The path to extract from
  * @returns The array path, or empty string if not an array path
- *
- * @example
- * ```typescript
- * extractArrayPath('items.$.quantity')
- * // 'items'
- *
- * extractArrayPath('orders.lineItems.$.total')
- * // 'orders.lineItems'
- *
- * extractArrayPath('simpleField')
- * // ''
- * ```
- *
- * @public
  */
 export function extractArrayPath(path: string): string {
   return parseArrayPath(path).arrayPath;
@@ -133,30 +79,8 @@ export function extractArrayPath(path: string): string {
 /**
  * Splits a path into segments, supporting both dot notation and bracket notation.
  *
- * Handles:
- * - Dot notation: `parent.child.grandchild`
- * - Bracket notation: `items[0].quantity`
- * - Mixed notation: `items[0].address.city`
- *
  * @param path - The path to split
  * @returns Array of path segments
- *
- * @example
- * ```typescript
- * splitPath('parent.child.grandchild')
- * // ['parent', 'child', 'grandchild']
- *
- * splitPath('items.0.quantity')
- * // ['items', '0', 'quantity']
- *
- * splitPath('items[0].quantity')
- * // ['items', '0', 'quantity']
- *
- * splitPath('a[0][1].b')
- * // ['a', '0', '1', 'b']
- * ```
- *
- * @public
  */
 export function splitPath(path: string): string[] {
   if (!path) return [];
@@ -173,8 +97,6 @@ export function splitPath(path: string): string[] {
  *
  * @param segments - The path segments to join
  * @returns Joined path string
- *
- * @public
  */
 export function joinPath(segments: string[]): string {
   return segments.join('.');
@@ -185,17 +107,6 @@ export function joinPath(segments: string[]): string {
  *
  * @param path - The path to get parent from
  * @returns The parent path, or empty string if no parent
- *
- * @example
- * ```typescript
- * getParentPath('parent.child.grandchild')
- * // 'parent.child'
- *
- * getParentPath('topLevel')
- * // ''
- * ```
- *
- * @public
  */
 export function getParentPath(path: string): string {
   const segments = splitPath(path);
@@ -208,17 +119,6 @@ export function getParentPath(path: string): string {
  *
  * @param path - The path to get leaf from
  * @returns The last segment
- *
- * @example
- * ```typescript
- * getLeafPath('parent.child.grandchild')
- * // 'grandchild'
- *
- * getLeafPath('topLevel')
- * // 'topLevel'
- * ```
- *
- * @public
  */
 export function getLeafPath(path: string): string {
   const segments = splitPath(path);
@@ -229,11 +129,7 @@ export function getLeafPath(path: string): string {
 // Multi-Array Path Utilities
 // ============================================================================
 
-/**
- * Result of parsing a path with multiple array placeholders.
- *
- * @public
- */
+/** Result of parsing a path with multiple array placeholders. */
 export interface MultiArrayPathInfo {
   /** Whether this path contains array placeholders */
   isArrayPath: boolean;
@@ -251,40 +147,8 @@ export interface MultiArrayPathInfo {
 /**
  * Parses a path that may contain multiple array placeholders.
  *
- * This supports deeply nested array structures like `orders.$.items.$.quantity`
- * where multiple levels of arrays need to be traversed.
- *
  * @param path - Path with zero or more $ placeholders
  * @returns Parsed path information
- *
- * @example
- * ```typescript
- * parseMultiArrayPath('orders.$.items.$.quantity')
- * // {
- * //   isArrayPath: true,
- * //   placeholderCount: 2,
- * //   segments: ['orders', 'items', 'quantity'],
- * //   placeholderPositions: [1, 3]
- * // }
- *
- * parseMultiArrayPath('items.$.name')
- * // {
- * //   isArrayPath: true,
- * //   placeholderCount: 1,
- * //   segments: ['items', 'name'],
- * //   placeholderPositions: [1]
- * // }
- *
- * parseMultiArrayPath('simpleField')
- * // {
- * //   isArrayPath: false,
- * //   placeholderCount: 0,
- * //   segments: ['simpleField'],
- * //   placeholderPositions: []
- * // }
- * ```
- *
- * @public
  */
 export function parseMultiArrayPath(path: string): MultiArrayPathInfo {
   const parts = path.split('.');
@@ -310,25 +174,10 @@ export function parseMultiArrayPath(path: string): MultiArrayPathInfo {
 /**
  * Resolves a path with multiple array placeholders using provided indices.
  *
- * Each `$` placeholder is replaced with the corresponding index from the
- * indices array, in order.
- *
  * @param path - Path with $ placeholders (e.g., 'orders.$.items.$.quantity')
  * @param indices - Array of indices to substitute (e.g., [0, 2])
  * @returns Resolved path (e.g., 'orders.0.items.2.quantity')
- *
  * @throws Error if number of indices doesn't match number of placeholders
- *
- * @example
- * ```typescript
- * resolveMultiArrayPath('orders.$.items.$.quantity', [0, 2])
- * // 'orders.0.items.2.quantity'
- *
- * resolveMultiArrayPath('items.$.name', [5])
- * // 'items.5.name'
- * ```
- *
- * @public
  */
 export function resolveMultiArrayPath(path: string, indices: number[]): string {
   const parts = path.split('.');
@@ -359,20 +208,6 @@ export function resolveMultiArrayPath(path: string, indices: number[]): string {
  *
  * @param path - The path to analyze
  * @returns Number of $ placeholders in the path
- *
- * @example
- * ```typescript
- * countArrayPlaceholders('orders.$.items.$.quantity')
- * // 2
- *
- * countArrayPlaceholders('items.$.name')
- * // 1
- *
- * countArrayPlaceholders('simpleField')
- * // 0
- * ```
- *
- * @public
  */
 export function countArrayPlaceholders(path: string): number {
   return path.split('.').filter((part) => part === '$').length;

--- a/packages/dynamic-forms/src/lib/utils/resolve-field/resolve-field.ts
+++ b/packages/dynamic-forms/src/lib/utils/resolve-field/resolve-field.ts
@@ -5,9 +5,7 @@ import { FieldDef } from '../../definitions/base/field-def';
 import { FieldTypeDefinition } from '../../models/field-type';
 import { mapFieldToInputs } from '../field-mapper/field-mapper';
 
-/**
- * Resolved field ready for rendering with ngComponentOutlet / DfFieldOutlet.
- */
+/** Resolved field ready for rendering with ngComponentOutlet / DfFieldOutlet. */
 export interface ResolvedField {
   key: string;
   /** The original field definition (used by DfFieldOutlet to resolve wrappers). */
@@ -49,16 +47,6 @@ export function createRenderReadySignal(
  * types — value-bearing leaves source from the `FieldTree`'s `state.hidden()`
  * (where Angular Signal Forms cascades `hidden(path, …)`), and non-field outputs
  * (button/text/containers) source from the mapper's explicit `inputs.hidden`.
- *
- * The `@if (!field.hidden())` gate at every `*dfFieldOutlet` consumption site uses
- * this signal, removing hidden fields from the DOM. That's required to silence
- * Angular's `NG01916: Field 'X' is hidden but is being rendered` warning — and
- * is the prescribed pattern from the
- * [`hidden` API docs](https://angular.dev/api/forms/signals/hidden).
- *
- * Container internal state (e.g. an `ArrayFieldComponent`'s items + dynamic
- * templates + id counter) survives this destroy/recreate via the form-scoped
- * `ArrayItemRegistryService` keyed by array path.
  */
 export function createHiddenSignal(inputs: Signal<Record<string, unknown>>): Signal<boolean> {
   return computed(() => {
@@ -79,9 +67,7 @@ export function createHiddenSignal(inputs: Signal<Record<string, unknown>>): Sig
   });
 }
 
-/**
- * Context required to resolve a field.
- */
+/** Context required to resolve a field. */
 export interface ResolveFieldContext {
   /**
    * The field registry to load components from.
@@ -101,10 +87,6 @@ export interface ResolveFieldContext {
 /**
  * Resolves a single field definition to a ResolvedField using RxJS.
  * Loads the component asynchronously and maps inputs in the injection context.
- *
- * For componentless fields (e.g., hidden fields), returns undefined since
- * there's nothing to render. These fields still contribute to form values
- * through the form schema.
  *
  * @param fieldDef - The field definition to resolve
  * @param context - The context containing dependencies for resolution
@@ -152,9 +134,7 @@ export function resolveField(fieldDef: FieldDef<unknown>, context: ResolveFieldC
   );
 }
 
-/**
- * Context for synchronous field resolution when components are already cached.
- */
+/** Context for synchronous field resolution when components are already cached. */
 export interface SyncResolveFieldContext {
   /** Returns a previously loaded component, or undefined if not cached */
   getLoadedComponent: (type: string) => Type<unknown> | undefined;
@@ -166,9 +146,6 @@ export interface SyncResolveFieldContext {
 
 /**
  * Synchronously resolves a field definition to a ResolvedField using cached components.
- *
- * This is the fast path for fields whose components have already been loaded.
- * Returns undefined for componentless fields (e.g., hidden fields).
  *
  * @param fieldDef - The field definition to resolve
  * @param context - The context containing cached components and dependencies
@@ -202,11 +179,6 @@ export function resolveFieldSync(fieldDef: FieldDef<unknown>, context: SyncResol
 /**
  * Reconciles previous and current resolved fields to preserve injector instances
  * for fields that haven't changed type, preventing unnecessary component recreation.
- *
- * When a field's key, component, and injector all match the previous render but the
- * underlying `fieldDef` has changed (e.g. updated options/props), the existing
- * component/injector are preserved while the new `inputs` and `renderReady` signals
- * are adopted so prop updates flow through to the rendered component.
  *
  * @param prev - Previous resolved fields array
  * @param curr - Current resolved fields array

--- a/packages/dynamic-forms/src/lib/utils/resolve-wrappers/resolve-wrappers.ts
+++ b/packages/dynamic-forms/src/lib/utils/resolve-wrappers/resolve-wrappers.ts
@@ -23,14 +23,7 @@ export function isSameWrapperChain(a: readonly WrapperConfig[], b: readonly Wrap
   return true;
 }
 
-/**
- * Resolves the wrapper chain for a field.
- *
- * Merge order (outermost → innermost): auto-associations, form defaults,
- * field-level wrappers. `wrappers: null` skips all three; `skipAutoWrappers` /
- * `skipDefaultWrappers` on the field opt out of individual layers. Fresh
- * array per call — downstream memoisation is on the consuming computed.
- */
+/** Resolves the wrapper chain for a field. */
 export function resolveWrappers(
   field: Pick<FieldDef<unknown>, 'type' | 'wrappers' | 'skipAutoWrappers' | 'skipDefaultWrappers'>,
   defaultWrappers: readonly WrapperConfig[] | undefined,

--- a/packages/dynamic-forms/src/lib/utils/resource-composition/with-previous-value.ts
+++ b/packages/dynamic-forms/src/lib/utils/resource-composition/with-previous-value.ts
@@ -5,16 +5,6 @@ import { linkedSignal, Resource, ResourceSnapshot, resourceFromSnapshots } from 
  * is loading or reloading. This prevents UI flicker when params change and a new request
  * is in-flight — the consumer sees the stale value with a `loading`/`reloading` status
  * instead of `undefined`.
- *
- * Uses Angular's `resource.snapshot` + `resourceFromSnapshots` composition pattern.
- *
- * @example
- * ```typescript
- * const user = withPreviousValue(
- *   resource({ params: () => userId(), loader: ({ params }) => fetchUser(params) })
- * );
- * // user.value() keeps the old user data during loading transitions
- * ```
  */
 export function withPreviousValue<T>(input: Resource<T>): Resource<T> {
   const derived = linkedSignal<ResourceSnapshot<T>, ResourceSnapshot<T>>({

--- a/packages/dynamic-forms/src/lib/utils/safe-read-path-keys.ts
+++ b/packages/dynamic-forms/src/lib/utils/safe-read-path-keys.ts
@@ -4,10 +4,6 @@ import { FieldContext } from '@angular/forms/signals';
 /**
  * Safely reads `pathKeys` from a FieldContext.
  * Returns an empty array if `pathKeys` is not available (e.g., in tests or older Angular versions).
- *
- * Always reads with `untracked()` because `pathKeys` is stable for the lifetime of a field —
- * array items don't change index after creation, so there's no need to establish a reactive
- * dependency on this signal.
  */
 export function safeReadPathKeys(fieldContext: FieldContext<unknown>): readonly string[] {
   if (!('pathKeys' in fieldContext) || typeof fieldContext.pathKeys !== 'function') {

--- a/packages/dynamic-forms/src/lib/utils/submission-handler/submission-handler.ts
+++ b/packages/dynamic-forms/src/lib/utils/submission-handler/submission-handler.ts
@@ -34,9 +34,6 @@ export interface SubmissionHandlerOptions<
  * Wraps a submission action to handle both Promise and Observable returns.
  * Converts Observables to Promises for compatibility with Angular Signal Forms' submit().
  *
- * Errors are NOT caught here — they propagate so that submit() can reject its Promise,
- * allowing the caller's catchError to log and keep the submission stream alive.
- *
  * @param action - The submission action function
  * @returns A wrapped function that returns a Promise
  */
@@ -57,28 +54,8 @@ function wrapSubmissionAction<TModel extends Record<string, unknown>>(
 /**
  * Creates an Observable that handles form submission with optional submission action.
  *
- * This utility encapsulates the submission handling logic:
- * - Listens for submit events from the event bus
- * - If a submission.action is configured, wraps it and uses Angular Signal Forms' submit()
- * - Handles both Promise and Observable returns from the action
- * - Uses exhaustMap to ignore new submissions while one is in-flight (first-submit-wins)
- *
- * The returned Observable should be subscribed to with takeUntilDestroyed() in the component.
- *
  * @param options - Configuration options for the submission handler
  * @returns Observable that processes submissions (emits when submission completes)
- *
- * @example
- * ```typescript
- * // In component constructor
- * createSubmissionHandler({
- *   eventBus: this.eventBus,
- *   configSignal: this.config,
- *   formSignal: this.form,
- * })
- *   .pipe(takeUntilDestroyed())
- *   .subscribe();
- * ```
  */
 export function createSubmissionHandler<
   TFields extends RegisteredFieldTypes[] = RegisteredFieldTypes[],

--- a/packages/dynamic-forms/src/lib/utils/validate-form-config/addon-warning.ts
+++ b/packages/dynamic-forms/src/lib/utils/validate-form-config/addon-warning.ts
@@ -1,10 +1,4 @@
-/**
- * Reason an addon was dropped during validation.
- *
- * Each variant carries its own context fields so log messages can be both
- * actionable (registered kinds enumerated, fix suggestion present) and
- * machine-readable (admin UIs surfacing per-error guidance).
- */
+/** Reason an addon was dropped during validation. */
 export type AddonWarning =
   | { type: 'unknown-field-type'; fieldKey: string; fieldType: string }
   | { type: 'field-type-no-addon-support'; fieldKey: string; fieldType: string }
@@ -43,18 +37,7 @@ export function addonWarningKey(w: AddonWarning): string {
   }
 }
 
-/**
- * Render an `AddonWarning` to a developer-friendly message.
- *
- * Returns the bare message — the `[Dynamic Forms]` prefix is added by the
- * library's logger (`ConsoleLogger`) and by `DynamicFormError`. Pass the
- * result of this function directly into `logger.warn(...)` to get the
- * standard prefixed line; use `logAddonWarnings()` for direct
- * `console.warn` output (which prefixes manually).
- *
- * Messages are designed to be actionable: they enumerate the relevant set
- * (registered kinds, allowed slots) and suggest a likely fix.
- */
+/** Render an `AddonWarning` to a developer-friendly message. */
 export function formatAddonWarning(w: AddonWarning): string {
   switch (w.type) {
     case 'unknown-field-type':

--- a/packages/dynamic-forms/src/lib/utils/validate-form-config/validate-field-addons.ts
+++ b/packages/dynamic-forms/src/lib/utils/validate-form-config/validate-field-addons.ts
@@ -8,9 +8,6 @@ import { AddonWarning } from './addon-warning';
  * Walk a field's addons; return the survivors plus a list of warnings for
  * anything dropped.
  *
- * Pure: receives the registries as arguments (so the function is reusable
- * outside Angular's DI — tests, server-side validation, etc.).
- *
  * @param field        The field to validate.
  * @param fieldRegistry Snapshot of `FIELD_REGISTRY` map.
  * @param kindRegistry  Snapshot of `ADDON_KIND_REGISTRY` map.

--- a/packages/dynamic-forms/src/lib/utils/validate-form-config/validate-form-config.ts
+++ b/packages/dynamic-forms/src/lib/utils/validate-form-config/validate-form-config.ts
@@ -7,29 +7,16 @@ import { Logger } from '../../providers/features/logger/logger.interface';
 import { AddonWarning, formatAddonWarning } from './addon-warning';
 import { walkAndValidateAddons } from './validate-field-addons';
 
-/**
- * Options accepted by {@link sanitizeFormConfig}.
- */
+/** Options accepted by {@link sanitizeFormConfig}. */
 export interface SanitizeFormConfigOptions {
   /**
    * Whether the config originated from JSON (server-driven) or inline
    * TypeScript code.
-   *
-   * - `'inline'` (default): keeps everything; assumes the config is
-   *   authored in code and code-only constructs (inline `action`
-   *   functions, `component` kind) are intentional. The default avoids
-   *   silently stripping inline behaviour during in-process authoring.
-   * - `'json'`: drops code-only addon kinds (`component`, inline
-   *   `action: function`) with a warning, since they cannot survive
-   *   serialization. Use this when sanitising configs received from a
-   *   backend / form-builder UI.
    */
   source?: 'json' | 'inline';
 }
 
-/**
- * Result of a `sanitizeFormConfig` call.
- */
+/** Result of a `sanitizeFormConfig` call. */
 export interface SanitizedFormConfig {
   /** Sanitized config — invalid addons stripped from the field tree. */
   sanitized: FormConfig;
@@ -42,27 +29,6 @@ export interface SanitizedFormConfig {
  * `FIELD_REGISTRY` and `ADDON_KIND_REGISTRY`, and return a sanitized copy
  * plus a list of dropped-addon warnings.
  *
- * Distinct from the INTERNAL `validateFormConfig` in
- * `utils/config-validation/config-validator.ts` (which throws on
- * structural errors like duplicate keys / unknown field types). This
- * helper is the PUBLIC, lenient addon-shape pass — renamed to
- * `sanitizeFormConfig` to avoid the name collision.
- *
- * Lenient by design: invalid addons are dropped (with warnings) rather than
- * thrown. The form keeps rendering even when the backend ships an addon the
- * FE doesn't understand.
- *
- * `<df-dynamic-form>` already runs this internally at form init — calling
- * the public helper AND passing the original config to the form will
- * double-emit warnings. Use this entry point only when you need the
- * sanitized config or warning list outside the form (e.g., admin-UI
- * diagnostics, build-time lints).
- *
- * Must be called within an Angular injection context — typically inside
- * an admin-UI component or a `runInInjectionContext()` block on the server.
- *
- * @example
- * ```typescript
  * @Component({ ... })
  * class AdminFormBuilder {
  *   private readonly check = (cfg: FormConfig) => {
@@ -113,9 +79,6 @@ export function logAddonWarnings(warnings: readonly AddonWarning[], logger?: Log
  * DI-free variant of {@link sanitizeFormConfig} for tooling that lives
  * outside Angular's injector — build-time linters, MCP-side checks, CLI
  * scripts.
- *
- * Caller passes the registries explicitly; the result has the same shape
- * as the DI-bound version.
  */
 export function sanitizeFormConfigPure(
   config: FormConfig,

--- a/packages/dynamic-forms/src/lib/utils/value-filter/value-filter.ts
+++ b/packages/dynamic-forms/src/lib/utils/value-filter/value-filter.ts
@@ -56,8 +56,6 @@ function shouldExcludeField(field: FieldDef<unknown>, fieldState: FieldTree<unkn
  * Filters form values based on field reactive state (hidden, disabled, readonly)
  * and the 3-tier exclusion config hierarchy.
  *
- * Only affects submission output — internal form state and two-way binding are unaffected.
- *
  * @param rawValue - The unfiltered form value object
  * @param schemaFields - Flattened schema fields from FormSetup (groups/arrays preserved, pages/rows unwrapped)
  * @param formTree - The Angular Signal Forms FieldTree, accessed as `formInstance[key]`

--- a/packages/dynamic-forms/src/lib/utils/warning-tracker.ts
+++ b/packages/dynamic-forms/src/lib/utils/warning-tracker.ts
@@ -1,10 +1,6 @@
 /**
  * Shared shape for DI-scoped warning trackers that dedupe log output.
  *
- * Used by both the derivation-warning tracker (keys are field paths) and the
- * deprecation-warning tracker (keys are deprecation IDs). The property is
- * generic so the same shape works for any string-keyed warning domain.
- *
  * @internal
  */
 export interface WarningTracker {

--- a/packages/dynamic-forms/src/lib/utils/wrapper-chain/wrapper-chain-controller.ts
+++ b/packages/dynamic-forms/src/lib/utils/wrapper-chain/wrapper-chain-controller.ts
@@ -177,9 +177,6 @@ function resolveLoadedWrappers(state: ChainState, deps: ChainDeps): Observable<C
  *   - Gate-only flicker → no-op (preserve the mounted chain)
  *   - Structural change → beforeRebuild → vcr.clear → render fresh
  *   - Idempotent re-emission → no-op
- *
- * Returns the (possibly new) wrapper refs so the caller can track them for
- * `fieldInputs` push-through.
  */
 function applyEmission({ state, loaded }: ChainEmission, ctx: EmissionApplyContext): ComponentRef<unknown>[] {
   const { opts, deps, mounted, refs } = ctx;

--- a/packages/dynamic-forms/src/lib/utils/wrapper-chain/wrapper-chain.ts
+++ b/packages/dynamic-forms/src/lib/utils/wrapper-chain/wrapper-chain.ts
@@ -17,17 +17,6 @@ import { WrapperFieldInputs } from '../../wrappers/wrapper-field-inputs';
  * Module-level cache keyed by component class. `reflectComponentType` returns
  * immutable metadata per class, so we probe it once and reuse the resulting
  * `Set<templateName>` for every `setInputIfDeclared` call afterwards.
- *
- * We cache `templateName` (the public input name, aka alias) rather than
- * `propName` (the class field name) because `ComponentRef.setInput()` keys by
- * the public name — that's also the name wrapper configs use. An aliased
- * input declared as `input(..., { alias: 'header' })` with class field
- * `headerText` must be addressed as `'header'`; caching `propName` would
- * leave the alias out of the declared set and silently drop config values.
- *
- * SSR-safe: the WeakMap is keyed by the component class object — classes are
- * created per Angular application bootstrap and GC'd with it, so this does not
- * leak state between server renders.
  */
 const inputNamesCache = new WeakMap<Type<unknown>, Set<string>>();
 
@@ -41,25 +30,14 @@ function getDeclaredInputs(componentType: Type<unknown>): Set<string> {
   return inputs;
 }
 
-/**
- * Set an input on a ComponentRef only when the target component actually declares it.
- *
- * Angular's `ComponentRef.setInput()` throws NG0303 when the input is missing.
- * For config keys driven by user data (e.g. a wrapper config containing a prop
- * the wrapper doesn't care about) that would surface as a noisy runtime error.
- * We probe the component's metadata via `reflectComponentType` (public API),
- * cached per component class — called once per input key per emission, so
- * avoiding the reflection scan on each call is meaningful under heavy typing.
- */
+/** Set an input on a ComponentRef only when the target component actually declares it. */
 export function setInputIfDeclared(ref: ComponentRef<unknown>, inputName: string, value: unknown): void {
   if (getDeclaredInputs(ref.componentType).has(inputName)) {
     ref.setInput(inputName, value);
   }
 }
 
-/**
- * A wrapper whose component has been resolved and loaded.
- */
+/** A wrapper whose component has been resolved and loaded. */
 export interface LoadedWrapper {
   readonly config: WrapperConfig;
   readonly component: Type<unknown>;
@@ -74,16 +52,12 @@ export function hasDefaultExport<T>(value: unknown): value is { default: T } {
   return typeof value === 'object' && value !== null && 'default' in value && !!(value as { default: unknown }).default;
 }
 
-/**
- * Pick the component class out of whatever a lazy loader returned.
- */
+/** Pick the component class out of whatever a lazy loader returned. */
 export function resolveDefaultExport<T>(result: Type<T> | { default: Type<T> }): Type<T> {
   return hasDefaultExport<Type<T>>(result) ? result.default : result;
 }
 
-/**
- * Resolve a wrapper type name to its component class, with DI-scoped caching.
- */
+/** Resolve a wrapper type name to its component class, with DI-scoped caching. */
 export async function loadWrapperComponent(
   type: string,
   registry: ReadonlyMap<string, WrapperTypeDefinition>,
@@ -130,9 +104,7 @@ export function loadWrapperComponents(
   ).pipe(map((results) => (results.some((r) => r === null) ? [] : (results as LoadedWrapper[]))));
 }
 
-/**
- * Options for building a wrapper chain.
- */
+/** Options for building a wrapper chain. */
 export interface RenderWrapperChainOptions {
   readonly outerContainer: ViewContainerRef;
   readonly loadedWrappers: readonly LoadedWrapper[];
@@ -159,13 +131,6 @@ export interface RenderWrapperChainOptions {
 /**
  * Recursively create each wrapper component, threading the next one (or the
  * innermost content) into its `#fieldComponent` slot.
- *
- * Each wrapper receives:
- * - Each of its config properties (minus `type`) as an individual Angular input
- * - `fieldInputs` as a single input, if provided
- *
- * Returns the list of wrapper `ComponentRef`s — callers retain them for later
- * cleanup and for re-setting `fieldInputs` when the mapper signal emits.
  */
 export function renderWrapperChain(options: RenderWrapperChainOptions): ComponentRef<unknown>[] {
   const refs: ComponentRef<unknown>[] = [];
@@ -250,10 +215,6 @@ function resolveInnerSlot(ref: ComponentRef<unknown>): ViewContainerRef | undefi
  * Merged injector: check the field-level injector first (for tokens like
  * `ARRAY_CONTEXT` / `FIELD_SIGNAL_CONTEXT`), fall back to the element-chain
  * injector (so nested wrappers can still `inject(OuterWrapper)`).
- *
- * Precedence: a field-level token shadows a same-named token provided by an
- * outer wrapper. That matches "more specific context wins" but is worth
- * keeping in mind if a wrapper exports service tokens.
  */
 export function createWrapperAwareInjector(fieldInjector: Injector, elementInjector: Injector): Injector {
   if (fieldInjector === elementInjector) return fieldInjector;

--- a/packages/dynamic-forms/src/lib/wrappers/create-wrappers.ts
+++ b/packages/dynamic-forms/src/lib/wrappers/create-wrappers.ts
@@ -1,12 +1,6 @@
 import { LazyComponentLoader, WrapperTypeDefinition } from '../models/wrapper-type';
 
-/**
- * User-facing wrapper registration shape used with `createWrappers(...)`.
- *
- * Extends `WrapperTypeDefinition` with an optional `props` field that
- * carries the wrapper's config type (via `wrapperProps`) for later
- * inference by `InferWrapperRegistry`.
- */
+/** User-facing wrapper registration shape used with `createWrappers(...)`. */
 export interface WrapperRegistration<TName extends string = string, TConfig = unknown> {
   /** Unique identifier for the wrapper type */
   readonly wrapperName: TName;
@@ -21,14 +15,7 @@ export interface WrapperRegistration<TName extends string = string, TConfig = un
   readonly props?: TConfig;
 }
 
-/**
- * Branded bundle returned by `createWrappers(...)`.
- *
- * Carries:
- * - `ɵkind: 'wrappers'` — discriminant recognised by `provideDynamicForm(...)`
- * - `ɵregistrations` — the original registrations (type-level use for `InferWrapperRegistry`)
- * - `ɵdefinitions` — the `WrapperTypeDefinition[]` extracted for `WRAPPER_REGISTRY`
- */
+/** Branded bundle returned by `createWrappers(...)`. */
 export interface WrappersBundle<T extends readonly WrapperRegistration[] = readonly WrapperRegistration[]> {
   readonly ɵkind: 'wrappers';
   readonly ɵregistrations: T;
@@ -38,31 +25,6 @@ export interface WrappersBundle<T extends readonly WrapperRegistration[] = reado
 /**
  * Bundle wrapper registrations into a single object that can be passed to
  * `provideDynamicForm(...)`.
- *
- * @example
- * ```typescript
- * const appWrappers = createWrappers(
- *   {
- *     wrapperName: 'section',
- *     loadComponent: () => import('./section-wrapper'),
- *     props: wrapperProps<SectionWrapper>(),
- *   },
- *   {
- *     wrapperName: 'highlight',
- *     loadComponent: () => import('./highlight-wrapper'),
- *     types: ['input', 'select'],
- *     props: wrapperProps<HighlightWrapper>(),
- *   },
- * );
- *
- * declare module '@ng-forge/dynamic-forms' {
- *   interface FieldRegistryWrappers extends InferWrapperRegistry<typeof appWrappers> {}
- * }
- *
- * bootstrapApplication(AppComponent, {
- *   providers: [provideDynamicForm(appWrappers)],
- * });
- * ```
  */
 export function createWrappers<const T extends readonly WrapperRegistration[]>(...registrations: T): WrappersBundle<T> {
   return {
@@ -88,20 +50,7 @@ export function isWrappersBundle(value: unknown): value is WrappersBundle {
   );
 }
 
-/**
- * Derive the `FieldRegistryWrappers` augmentation shape from a wrapper bundle.
- *
- * Maps each registration's `wrapperName` to its `props` type (the config carried
- * by `wrapperProps<T>()`). If a registration has no `props`, falls back to the
- * minimal discriminant shape `{ readonly type: wrapperName }`.
- *
- * @example
- * ```typescript
- * declare module '@ng-forge/dynamic-forms' {
- *   interface FieldRegistryWrappers extends InferWrapperRegistry<typeof appWrappers> {}
- * }
- * ```
- */
+/** Derive the `FieldRegistryWrappers` augmentation shape from a wrapper bundle. */
 export type InferWrapperRegistry<T> =
   T extends WrappersBundle<infer R>
     ? {

--- a/packages/dynamic-forms/src/lib/wrappers/css/css-wrapper.component.ts
+++ b/packages/dynamic-forms/src/lib/wrappers/css/css-wrapper.component.ts
@@ -6,26 +6,7 @@ import { DynamicText } from '../../models/types/dynamic-text';
 import { dynamicTextToObservable } from '../../utils/dynamic-text-to-observable';
 import { WrapperFieldInputs } from '../wrapper-field-inputs';
 
-/**
- * Built-in CSS wrapper component.
- *
- * Applies CSS classes from the `cssClasses` config property to the host element,
- * wrapping the inner content (next wrapper or children) in its ViewContainerRef slot.
- *
- * Receives `cssClasses` as an individual Angular input (set by the outlet via
- * `setInput()`). `fieldInputs` carries the wrapped field's mapper outputs +
- * a read-only view of its form state (via `ReadonlyFieldTree`).
- *
- * @example
- * ```typescript
- * {
- *   type: 'container',
- *   key: 'styled',
- *   wrappers: [{ type: 'css', cssClasses: 'card p-4' }],
- *   fields: [...]
- * }
- * ```
- */
+/** Built-in CSS wrapper component. */
 @Component({
   selector: 'df-css-wrapper',
   template: `<ng-container #fieldComponent></ng-container>`,

--- a/packages/dynamic-forms/src/lib/wrappers/css/css-wrapper.type.ts
+++ b/packages/dynamic-forms/src/lib/wrappers/css/css-wrapper.type.ts
@@ -1,19 +1,6 @@
 import { DynamicText } from '../../models/types/dynamic-text';
 
-/**
- * Configuration for the built-in 'css' wrapper type.
- *
- * The CSS wrapper applies CSS classes around wrapped content via a DynamicText
- * input that resolves to space-separated class names.
- *
- * @example
- * ```typescript
- * const wrapper: CssWrapper = {
- *   type: 'css',
- *   cssClasses: 'my-css-class another-class',
- * };
- * ```
- */
+/** Configuration for the built-in 'css' wrapper type. */
 export interface CssWrapper {
   readonly type: 'css';
   /** CSS classes to apply to the wrapper */

--- a/packages/dynamic-forms/src/lib/wrappers/row/row-wrapper.component.ts
+++ b/packages/dynamic-forms/src/lib/wrappers/row/row-wrapper.component.ts
@@ -2,17 +2,7 @@ import { ChangeDetectionStrategy, Component, input, ViewContainerRef, viewChild 
 import { FieldWrapper } from '../../models/wrapper-type';
 import { WrapperFieldInputs } from '../wrapper-field-inputs';
 
-/**
- * Built-in row wrapper component.
- *
- * Applies the grid/flex layout that `{ type: 'row' }` fields historically rendered.
- * The `rowFieldMapper` synthesizes a `{ type: 'row' }` wrapper into the container
- * field so the user-facing config stays `{ type: 'row', fields: [...] }` while the
- * runtime uses the container + wrapper pipeline.
- *
- * Children use the shared `df-col-1`..`df-col-12` utilities on their own `col`
- * property to size within the flex row.
- */
+/** Built-in row wrapper component. */
 @Component({
   selector: 'df-row-wrapper',
   template: `<ng-container #fieldComponent></ng-container>`,

--- a/packages/dynamic-forms/src/lib/wrappers/row/row-wrapper.type.ts
+++ b/packages/dynamic-forms/src/lib/wrappers/row/row-wrapper.type.ts
@@ -1,18 +1,4 @@
-/**
- * Configuration for the built-in 'row' wrapper type.
- *
- * The row wrapper applies grid/flex layout to the wrapped content, providing
- * horizontal field arrangement with 12-column sizing utilities (`df-col-1`
- * through `df-col-12`) available to child fields via their own `col` property.
- *
- * Applied automatically by `rowFieldMapper` when a user writes `{ type: 'row' }` —
- * users do not construct this config directly.
- *
- * @example
- * ```typescript
- * const wrapper: RowWrapper = { type: 'row' };
- * ```
- */
+/** Configuration for the built-in 'row' wrapper type. */
 export interface RowWrapper {
   readonly type: 'row';
 }

--- a/packages/dynamic-forms/src/lib/wrappers/wrapper-field-inputs.ts
+++ b/packages/dynamic-forms/src/lib/wrappers/wrapper-field-inputs.ts
@@ -1,17 +1,6 @@
 import { ReadonlyFieldTree } from '../core/field-tree-utils';
 
-/**
- * Input shape passed to a wrapper component via the `fieldInputs` input.
- *
- * Carries the wrapped field's mapper outputs plus an optional `field`
- * read-only view. Wrappers reached through a container path (which has
- * no FieldTree of its own) receive `fieldInputs === undefined`, so any
- * wrapper that reads `fieldInputs.field` must guard for it.
- *
- * Mappers must emit new rawInputs objects per tick rather than mutating
- * the previous one — this bag is a shallow spread, so mutations to shared
- * nested values leak to downstream wrappers.
- */
+/** Input shape passed to a wrapper component via the `fieldInputs` input. */
 export interface WrapperFieldInputs {
   readonly key: string;
   /** Field-type discriminant (mirrors `FieldDef.type`) — useful for kind-aware addons. */

--- a/packages/dynamic-forms/src/lib/wrappers/wrapper-props.ts
+++ b/packages/dynamic-forms/src/lib/wrappers/wrapper-props.ts
@@ -1,26 +1,4 @@
-/**
- * Zero-cost type carrier used in wrapper registrations.
- *
- * Returns `undefined` at runtime but is typed as `T`, so TypeScript can
- * thread a wrapper's config type through `createWrappers(...)` into the
- * `InferWrapperRegistry<typeof ...>` utility without requiring users to
- * hand-write the augmentation shape.
- *
- * @example
- * ```typescript
- * const wrappers = createWrappers(
- *   {
- *     wrapperName: 'section',
- *     loadComponent: () => import('./section-wrapper'),
- *     props: wrapperProps<SectionWrapper>(),
- *   },
- * );
- *
- * declare module '@ng-forge/dynamic-forms' {
- *   interface FieldRegistryWrappers extends InferWrapperRegistry<typeof wrappers> {}
- * }
- * ```
- */
+/** Zero-cost type carrier used in wrapper registrations. */
 export function wrapperProps<T>(): T {
   return undefined as unknown as T;
 }

--- a/packages/dynamic-forms/testing/src/dynamic-form-test-utils.ts
+++ b/packages/dynamic-forms/testing/src/dynamic-form-test-utils.ts
@@ -11,33 +11,25 @@ import { BUILT_IN_FIELDS } from '../../src/lib/providers/built-in-fields';
 import { InputField, SelectField, checkboxFieldMapper, valueFieldMapper } from '@ng-forge/dynamic-forms/integration';
 import { delay } from '@ng-forge/utils';
 
-/**
- * Internal interface for field registry operations needed by test utilities
- */
+/** Internal interface for field registry operations needed by test utilities */
 interface FieldRegistryWriter {
   registerTypes(types: FieldTypeDefinition[]): void;
 }
 
-/**
- * Configuration for creating a dynamic form test
- */
+/** Configuration for creating a dynamic form test */
 export interface DynamicFormTestConfig {
   config: FormConfig;
   initialValue?: Record<string, unknown>;
   registerTestFields?: boolean;
 }
 
-/**
- * Result of creating a dynamic form test
- */
+/** Result of creating a dynamic form test */
 export interface DynamicFormTestResult {
   component: DynamicForm;
   fixture: ComponentFixture<DynamicForm>;
 }
 
-/**
- * Fluent API for building form configurations
- */
+/** Fluent API for building form configurations */
 export class FormConfigBuilder {
   private fields: FieldDef<unknown>[] = [];
 
@@ -130,20 +122,14 @@ export class FormConfigBuilder {
   }
 }
 
-/**
- * Utility class for testing dynamic forms
- */
+/** Utility class for testing dynamic forms */
 export class DynamicFormTestUtils {
-  /**
-   * Creates a new form config builder
-   */
+  /** Creates a new form config builder */
   static builder(): FormConfigBuilder {
     return new FormConfigBuilder();
   }
 
-  /**
-   * Creates a dynamic form test setup with optional test field registration
-   */
+  /** Creates a dynamic form test setup with optional test field registration */
   static async createTest(testConfig: DynamicFormTestConfig): Promise<DynamicFormTestResult> {
     const fixture = TestBed.createComponent(DynamicForm);
     const component = fixture.componentInstance;
@@ -172,6 +158,7 @@ export class DynamicFormTestUtils {
 
   /**
    * Registers common test field types including built-in types like page, row, group
+   *
    * @internal
    */
   private static registerTestFields(fieldRegistry: FieldRegistryWriter): void {
@@ -238,6 +225,7 @@ export class DynamicFormTestUtils {
   /**
    * Waits for the dynamic form to initialize.
    * Uses the initialized$ observable directly which has shareReplay for late subscribers.
+   *
    * @param fixture - The component fixture
    * @param timeoutMs - Maximum time to wait for initialization (default: 100ms)
    */
@@ -264,9 +252,7 @@ export class DynamicFormTestUtils {
     fixture.detectChanges();
   }
 
-  /**
-   * Waits for an element to appear in the DOM with retries
-   */
+  /** Waits for an element to appear in the DOM with retries */
   private static async waitForElement<T extends Element>(
     fixture: ComponentFixture<DynamicForm>,
     selector: string,
@@ -287,9 +273,7 @@ export class DynamicFormTestUtils {
     throw new Error(`[Dynamic Forms] Element not found with selector: ${selector} after ${maxAttempts} attempts`);
   }
 
-  /**
-   * Simulates user input on a field element
-   */
+  /** Simulates user input on a field element */
   static async simulateInput(fixture: ComponentFixture<DynamicForm>, selector: string, value: string): Promise<void> {
     const input = await DynamicFormTestUtils.waitForElement<HTMLInputElement>(fixture, selector);
 
@@ -299,9 +283,7 @@ export class DynamicFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates user blur on a field element
-   */
+  /** Simulates user blur on a field element */
   static async simulateBlur(fixture: ComponentFixture<DynamicForm>, selector: string): Promise<void> {
     const element = await DynamicFormTestUtils.waitForElement<Element>(fixture, selector);
 
@@ -310,9 +292,7 @@ export class DynamicFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates user selection on a select element
-   */
+  /** Simulates user selection on a select element */
   static async simulateSelect(fixture: ComponentFixture<DynamicForm>, selector: string, value: string): Promise<void> {
     const select = await DynamicFormTestUtils.waitForElement<HTMLSelectElement>(fixture, selector);
 
@@ -322,9 +302,7 @@ export class DynamicFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates checkbox toggle
-   */
+  /** Simulates checkbox toggle */
   static async simulateCheckbox(fixture: ComponentFixture<DynamicForm>, selector: string, checked: boolean): Promise<void> {
     const checkbox = await DynamicFormTestUtils.waitForElement<HTMLInputElement>(fixture, selector);
 
@@ -335,9 +313,7 @@ export class DynamicFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates button click
-   */
+  /** Simulates button click */
   static async simulateButtonClick(fixture: ComponentFixture<DynamicForm>, selector: string): Promise<void> {
     const button = await DynamicFormTestUtils.waitForElement<HTMLButtonElement>(fixture, selector);
 
@@ -346,37 +322,27 @@ export class DynamicFormTestUtils {
     await delay(0);
   }
 
-  /**
-   * Gets the current form value from the component
-   */
+  /** Gets the current form value from the component */
   static getFormValue(component: DynamicForm): Record<string, unknown> | undefined {
     return component.formValue();
   }
 
-  /**
-   * Gets validation errors from the component
-   */
+  /** Gets validation errors from the component */
   static getFormErrors(component: DynamicForm): ValidationError[] {
     return component.errors();
   }
 
-  /**
-   * Checks if the form is valid
-   */
+  /** Checks if the form is valid */
   static isFormValid(component: DynamicForm): boolean {
     return component.valid();
   }
 
-  /**
-   * Gets all field elements from the fixture
-   */
+  /** Gets all field elements from the fixture */
   static getFieldElements(fixture: ComponentFixture<DynamicForm>, fieldType: string): NodeListOf<Element> {
     return fixture.nativeElement.querySelectorAll(`df-test-${fieldType}`);
   }
 
-  /**
-   * Asserts that a field has a specific value
-   */
+  /** Asserts that a field has a specific value */
   static async assertFieldValue(fixture: ComponentFixture<DynamicForm>, fieldSelector: string, expectedValue: string): Promise<void> {
     const element = await DynamicFormTestUtils.waitForElement<HTMLInputElement>(fixture, fieldSelector);
 
@@ -386,9 +352,7 @@ export class DynamicFormTestUtils {
     }
   }
 
-  /**
-   * Asserts that the form has a specific value
-   */
+  /** Asserts that the form has a specific value */
   static assertFormValue(component: DynamicForm, expectedValue: Record<string, unknown>): void {
     const actualValue = component.formValue();
     if (JSON.stringify(actualValue) !== JSON.stringify(expectedValue)) {

--- a/packages/dynamic-forms/testing/src/harnesses/test-select.harness.ts
+++ b/packages/dynamic-forms/testing/src/harnesses/test-select.harness.ts
@@ -1,9 +1,7 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { FormField, FieldTree } from '@angular/forms/signals';
 
-/**
- * Test harness component for select fields
- */
+/** Test harness component for select fields */
 @Component({
   selector: 'df-test-select',
   template: `

--- a/packages/dynamic-forms/testing/src/mapper-test-utils.ts
+++ b/packages/dynamic-forms/testing/src/mapper-test-utils.ts
@@ -5,23 +5,15 @@ import { FieldSignalContext } from '../../src/lib/mappers/types';
 import { FormOptions } from '../../src/lib/models/form-config';
 import { ValidationMessages } from '../../src/lib/models/validation-types';
 
-/**
- * Configuration for creating a test form injector with field signal context
- */
+/** Configuration for creating a test form injector with field signal context */
 export interface TestFieldContextConfig<TModel extends Record<string, unknown> = Record<string, unknown>> {
-  /**
-   * Parent injector to use. If not provided, uses an empty injector.
-   */
+  /** Parent injector to use. If not provided, uses an empty injector. */
   parentInjector?: Injector;
 
-  /**
-   * Initial value for the form. If not provided, uses an empty object.
-   */
+  /** Initial value for the form. If not provided, uses an empty object. */
   initialValue?: Partial<TModel>;
 
-  /**
-   * Default values function. If not provided, returns the initial value.
-   */
+  /** Default values function. If not provided, returns the initial value. */
   defaultValues?: () => TModel;
 
   /**
@@ -36,38 +28,14 @@ export interface TestFieldContextConfig<TModel extends Record<string, unknown> =
    */
   formOptions?: FormOptions;
 
-  /**
-   * Custom value signal. If provided, this will be used instead of creating a new one.
-   */
+  /** Custom value signal. If provided, this will be used instead of creating a new one. */
   valueSignal?: WritableSignal<Partial<TModel> | undefined>;
 
-  /**
-   * Custom form instance. If provided, this will be used instead of creating a new one.
-   */
+  /** Custom form instance. If provided, this will be used instead of creating a new one. */
   form?: ReturnType<typeof form<TModel>>;
 }
 
-/**
- * Creates a test injector with FIELD_SIGNAL_CONTEXT provided.
- *
- * This utility simplifies testing of mappers and components that inject FIELD_SIGNAL_CONTEXT.
- *
- * @example
- * ```typescript
- * // Basic usage
- * const testInjector = createTestFormInjector();
- *
- * // With custom initial value
- * const testInjector = createTestFormInjector({
- *   initialValue: { username: 'test' }
- * });
- *
- * // With validation messages
- * const testInjector = createTestFormInjector({
- *   defaultValidationMessages: { required: 'This field is required' }
- * });
- * ```
- */
+/** Creates a test injector with FIELD_SIGNAL_CONTEXT provided. */
 export function createTestFormInjector<TModel extends Record<string, unknown> = Record<string, unknown>>(
   config: TestFieldContextConfig<TModel> = {},
 ): Injector {
@@ -119,54 +87,13 @@ export function createTestFormInjector<TModel extends Record<string, unknown> = 
   });
 }
 
-/**
- * Runs a mapper function in a test injection context.
- *
- * This is a convenience wrapper that creates a test injector and runs the mapper
- * function within it, returning the result.
- *
- * @example
- * ```typescript
- * // Test a mapper without context overrides
- * const bindings = testMapper(() => mapValueField(fieldDef));
- *
- * // Test a mapper with custom context
- * const bindings = testMapper(
- *   () => mapValueField(fieldDef),
- *   { initialValue: { username: 'test' } }
- * );
- *
- * // Test a mapper with validation messages
- * const bindings = testMapper(
- *   () => mapValueField(fieldDef),
- *   { defaultValidationMessages: { required: 'Required field' } }
- * );
- * ```
- */
+/** Runs a mapper function in a test injection context. */
 export function testMapper<T>(mapperFn: () => T, context?: TestFieldContextConfig<Record<string, unknown>>): T {
   const testInjector = createTestFormInjector(context);
   return runInInjectionContext(testInjector, mapperFn);
 }
 
-/**
- * Creates a field signal context for testing without creating an injector.
- *
- * Useful when you need to manually provide the context or test context creation logic.
- *
- * @example
- * ```typescript
- * const context = createTestFieldContext({
- *   initialValue: { name: 'test' }
- * });
- *
- * // Use in your own injector
- * const injector = Injector.create({
- *   providers: [
- *     { provide: FIELD_SIGNAL_CONTEXT, useValue: context }
- *   ]
- * });
- * ```
- */
+/** Creates a field signal context for testing without creating an injector. */
 export function createTestFieldContext<TModel extends Record<string, unknown> = Record<string, unknown>>(
   config: TestFieldContextConfig<TModel> = {},
 ): FieldSignalContext<TModel> {

--- a/packages/dynamic-forms/testing/src/mock-logger.ts
+++ b/packages/dynamic-forms/testing/src/mock-logger.ts
@@ -4,9 +4,7 @@ import { DynamicFormLogger } from '../../src/lib/providers/features/logger/logge
 import { ConsoleLogger } from '../../src/lib/providers/features/logger/console-logger';
 import { Logger } from '../../src/lib/providers/features/logger/logger.interface';
 
-/**
- * Mock logger with vitest spies for testing.
- */
+/** Mock logger with vitest spies for testing. */
 export interface MockLogger extends Logger {
   debug: Mock;
   info: Mock;

--- a/packages/dynamic-forms/testing/src/simple-test-utils.ts
+++ b/packages/dynamic-forms/testing/src/simple-test-utils.ts
@@ -12,16 +12,12 @@ import { ArrayItemRegistryService } from '../../src/lib/core/registry/array-item
 import { form } from '@angular/forms/signals';
 import { RegisteredFieldTypes } from '../../src/lib/models/registry/field-registry';
 
-/**
- * Simple form configuration interface for testing
- */
+/** Simple form configuration interface for testing */
 export interface TestFormConfig {
   fields: FieldDef<unknown>[];
 }
 
-/**
- * Configuration for creating a dynamic form test
- */
+/** Configuration for creating a dynamic form test */
 export interface SimpleTestConfig<T = Record<string, unknown>> {
   config: TestFormConfig;
   initialValue?: T;
@@ -36,9 +32,7 @@ export interface SimpleTestResult {
   fixture: ComponentFixture<DynamicForm<RegisteredFieldTypes[]>>;
 }
 
-/**
- * Fluent API for building form configurations using existing field structure
- */
+/** Fluent API for building form configurations using existing field structure */
 export class TestFormConfigBuilder<T = Record<string, unknown>> {
   private fields: FieldDef<unknown>[] = [];
 
@@ -74,20 +68,14 @@ export class TestFormConfigBuilder<T = Record<string, unknown>> {
   }
 }
 
-/**
- * Simple utility class for testing dynamic forms
- */
+/** Simple utility class for testing dynamic forms */
 export class SimpleTestUtils {
-  /**
-   * Creates a new form config builder
-   */
+  /** Creates a new form config builder */
   static builder<T = Record<string, unknown>>(): TestFormConfigBuilder<T> {
     return new TestFormConfigBuilder<T>();
   }
 
-  /**
-   * Creates a simple test component - assumes TestBed is already configured
-   */
+  /** Creates a simple test component - assumes TestBed is already configured */
   static createComponent<T = Record<string, unknown>>(config: TestFormConfig = { fields: [] }, initialValue?: T): SimpleTestResult {
     const fixture = TestBed.createComponent(DynamicForm);
     const component = fixture.componentInstance;
@@ -104,9 +92,7 @@ export class SimpleTestUtils {
     return { component, fixture } as SimpleTestResult;
   }
 
-  /**
-   * Waits for the dynamic form to initialize
-   */
+  /** Waits for the dynamic form to initialize */
   static async waitForInit(fixture: ComponentFixture<DynamicForm>): Promise<void> {
     await delay(0);
     fixture.detectChanges();
@@ -114,9 +100,7 @@ export class SimpleTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates user input on a field element
-   */
+  /** Simulates user input on a field element */
   static async simulateInput(fixture: ComponentFixture<DynamicForm>, selector: string, value: string): Promise<void> {
     const input = fixture.nativeElement.querySelector(selector) as HTMLInputElement;
     if (!input) {
@@ -129,9 +113,7 @@ export class SimpleTestUtils {
     await delay(0);
   }
 
-  /**
-   * Simulates checkbox toggle
-   */
+  /** Simulates checkbox toggle */
   static async simulateCheckbox(fixture: ComponentFixture<DynamicForm>, selector: string, checked: boolean): Promise<void> {
     const checkbox = fixture.nativeElement.querySelector(selector) as HTMLInputElement;
     if (!checkbox) {
@@ -144,23 +126,17 @@ export class SimpleTestUtils {
     await delay(0);
   }
 
-  /**
-   * Gets the current form value from the component
-   */
+  /** Gets the current form value from the component */
   static getFormValue(component: DynamicForm): Record<string, unknown> | undefined {
     return component.formValue();
   }
 
-  /**
-   * Checks if the form is valid
-   */
+  /** Checks if the form is valid */
   static isFormValid(component: DynamicForm): boolean {
     return component.valid();
   }
 
-  /**
-   * Asserts that the form has a specific value
-   */
+  /** Asserts that the form has a specific value */
   static assertFormValue(component: DynamicForm, expectedValue: Record<string, unknown>): void {
     const actualValue = component.formValue();
     if (JSON.stringify(actualValue) !== JSON.stringify(expectedValue)) {
@@ -199,9 +175,7 @@ export class TestFieldComponent {
   value = signal('test');
 }
 
-/**
- * Configuration for setting up a simple component test
- */
+/** Configuration for setting up a simple component test */
 export interface SimpleComponentTestConfig<T = unknown> {
   field: FieldDef<unknown>;
   value?: T;
@@ -210,17 +184,13 @@ export interface SimpleComponentTestConfig<T = unknown> {
   [key: string]: unknown; // Allow additional inputs for flexible component testing
 }
 
-/**
- * Result of setting up a simple component test
- */
+/** Result of setting up a simple component test */
 export interface SimpleComponentTestResult<T = unknown> {
   component: T;
   fixture: ComponentFixture<T>;
 }
 
-/**
- * Creates a simple test setup for individual field components
- */
+/** Creates a simple test setup for individual field components */
 export function setupSimpleTest<T>(componentType: Type<T>, config: SimpleComponentTestConfig): SimpleComponentTestResult<T> {
   const mockFieldType: FieldTypeDefinition = {
     name: 'test',
@@ -286,9 +256,7 @@ export function setupSimpleTest<T>(componentType: Type<T>, config: SimpleCompone
   return { component, fixture };
 }
 
-/**
- * Creates a simple test field definition
- */
+/** Creates a simple test field definition */
 export function createSimpleTestField(key: string, label: string, value?: unknown): FieldDef<unknown> {
   const field: FieldDef<unknown> = {
     key,

--- a/packages/dynamic-forms/testing/src/test-types.ts
+++ b/packages/dynamic-forms/testing/src/test-types.ts
@@ -2,9 +2,7 @@ import { ComponentFixture } from '@angular/core/testing';
 import { FormConfig } from '../../src/lib/models/form-config';
 import { FieldDef } from '../../src/lib/definitions/base/field-def';
 
-/**
- * Simple form configuration interface for testing
- */
+/** Simple form configuration interface for testing */
 export interface TestFormConfig {
   fields: FieldDef<unknown>[];
 }
@@ -28,17 +26,13 @@ export interface TestResult<T = unknown> {
   fixture: ComponentFixture<T>;
 }
 
-/**
- * Configuration for setting up individual field component tests
- */
+/** Configuration for setting up individual field component tests */
 export interface ComponentTestConfig<T = unknown> {
   field: FieldDef<unknown>;
   value?: T;
 }
 
-/**
- * Result of setting up individual field component tests
- */
+/** Result of setting up individual field component tests */
 export interface ComponentTestResult<T = unknown> {
   component: T;
   fixture: ComponentFixture<T>;

--- a/packages/openapi-generator/bin/ng-forge-generator.ts
+++ b/packages/openapi-generator/bin/ng-forge-generator.ts
@@ -1,9 +1,5 @@
 #!/usr/bin/env node
-/**
- * ng-forge OpenAPI Generator CLI
- *
- * Entry point for generating dynamic form configurations from OpenAPI specs.
- */
+/** ng-forge OpenAPI Generator CLI */
 
 import { run } from '../src/cli/cli.js';
 import { logger } from '../src/utils/logger.js';

--- a/packages/openapi-generator/src/__tests__/integration/helpers.ts
+++ b/packages/openapi-generator/src/__tests__/integration/helpers.ts
@@ -79,13 +79,6 @@ export type AdapterName = 'material' | 'bootstrap' | 'primeng' | 'ionic';
  * adapter (Material by default) registered via module augmentation. The adapter import
  * is what activates field types like `'input'` — without it the generated config fails
  * against the core-only `RegisteredFieldTypes`.
- *
- * Resolves `@ng-forge/dynamic-forms` and the adapter via tsconfig `paths` so the test
- * is self-contained. Requires `dist/packages/dynamic-forms` and
- * `dist/packages/dynamic-forms-{adapter}` to exist — `nx build dynamic-forms` and the
- * adapter build must run before.
- *
- * Returns an array of pretty-formatted diagnostics. Empty array === clean compile.
  */
 export function typecheckGeneratedForm(formFilePath: string, adapter: AdapterName = 'material'): string[] {
   const repoRoot = resolve(__dirname, '../../../../..');

--- a/packages/openapi-generator/src/cli/commands/generate.command.ts
+++ b/packages/openapi-generator/src/cli/commands/generate.command.ts
@@ -34,9 +34,7 @@ interface GenerateOptions {
   barrelExtension?: string;
 }
 
-/**
- * Register generate options directly on the given Command (no subcommand).
- */
+/** Register generate options directly on the given Command (no subcommand). */
 export function registerGenerateOptions(cmd: Command): void {
   cmd
     .requiredOption('--spec <path>', 'Path to OpenAPI spec file')
@@ -73,9 +71,7 @@ export function registerGenerateOptions(cmd: Command): void {
     .addHelpText('after', '\nNote: Generated files are not formatted. Run your project formatter (e.g. prettier) after generation.');
 }
 
-/**
- * Action handler for the generate command.
- */
+/** Action handler for the generate command. */
 export async function runGenerateAction(options: GenerateOptions): Promise<void> {
   if (options.verbose && options.quiet) {
     logger.error('Cannot use --verbose and --quiet together');

--- a/packages/openapi-generator/src/generator/barrel-generator.ts
+++ b/packages/openapi-generator/src/generator/barrel-generator.ts
@@ -2,9 +2,7 @@ export interface BarrelOptions {
   extension?: string;
 }
 
-/**
- * Generate a barrel (index.ts) file that re-exports all generated form configs.
- */
+/** Generate a barrel (index.ts) file that re-exports all generated form configs. */
 export function generateBarrel(fileNames: string[], options?: BarrelOptions): string {
   if (fileNames.length === 0) {
     return '';

--- a/packages/openapi-generator/src/mapper/schema-to-fields.ts
+++ b/packages/openapi-generator/src/mapper/schema-to-fields.ts
@@ -30,10 +30,6 @@ const NULLABLE_SUPPORTED_FIELD_TYPES = new Set([
  * Field types whose runtime definition declares `label?: never` and therefore
  * rejects any `label` assignment under `as const satisfies FormConfig`. Emitting
  * a label on these types causes TS2322 in consumers (issue #348).
- *
- * `container` is included defensively: while the schema mapper never produces it
- * directly, an `x-ng-forge-type: container` override can route through this code
- * path, and `BaseContainerField` declares the same `label?: never` constraint.
  */
 const CONTAINER_FIELD_TYPES = new Set(['group', 'array', 'row', 'page', 'container']);
 

--- a/packages/openapi-generator/src/mapper/type-mapping.ts
+++ b/packages/openapi-generator/src/mapper/type-mapping.ts
@@ -10,9 +10,7 @@ export interface FieldTypeResult {
   isPrimitiveArray?: boolean;
 }
 
-/**
- * Maps an OpenAPI schema to a dynamic form field type.
- */
+/** Maps an OpenAPI schema to a dynamic form field type. */
 export function mapSchemaToFieldType(schema: SchemaObject): FieldTypeResult {
   const rawType = schema.type;
   const type: string | undefined = Array.isArray(rawType)

--- a/packages/openapi-generator/src/utils/naming.ts
+++ b/packages/openapi-generator/src/utils/naming.ts
@@ -10,9 +10,7 @@ export function toLabel(name: string): string {
     .trim();
 }
 
-/**
- * Common acronyms that should be uppercased in labels.
- */
+/** Common acronyms that should be uppercased in labels. */
 const KNOWN_ACRONYMS = new Set([
   'id',
   'url',
@@ -98,9 +96,7 @@ export function toPascalCase(str: string): string {
     .join('');
 }
 
-/**
- * Convert a string to camelCase.
- */
+/** Convert a string to camelCase. */
 export function toCamelCase(str: string): string {
   const pascal = toPascalCase(str);
   return pascal.charAt(0).toLowerCase() + pascal.slice(1);

--- a/scripts/trim-jsdoc.mjs
+++ b/scripts/trim-jsdoc.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+// Source-level JSDoc trimmer for shipped library packages.
+//
+// Complements scripts/strip-fesm-comments.mjs: that script removes comments
+// from the published FESM at build time; this one keeps source/.d.ts lean
+// at edit time so consumers' IntelliSense doesn't pull in 500+ KB of prose.
+//
+// For each /** ... */ block in TypeScript source under packages/:
+//   1. Description (lines before the first @tag) is trimmed to the first
+//      paragraph — lines up to the first blank `*` line.
+//   2. @example blocks are removed entirely (line starting with `@example`
+//      through the next @tag line or the end of the block).
+//   3. @public tag lines are removed (redundant with the export keyword).
+//   4. Stray blank `*` separator lines left over from the cuts are
+//      collapsed; a block reduced to nothing is deleted.
+//
+// Preserved verbatim: @internal, @deprecated, @param, @returns, @see,
+// @template, @typeParam, @throws, @value — these carry semantic value the
+// type system doesn't express.
+//
+// Runs idempotently. Usage: node scripts/trim-jsdoc.mjs [path...]
+
+import { readFile, writeFile, readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const DROP_TAGS = new Set(['example', 'public']);
+const TAG_RE = /^\s*\*\s*@([a-zA-Z]+)/;
+const BLANK_STAR_RE = /^\s*\*\s*$/;
+
+async function walk(dir, out) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    if (e.name === 'node_modules' || e.name === 'dist' || e.name.startsWith('.')) continue;
+    const p = join(dir, e.name);
+    if (e.isDirectory()) await walk(p, out);
+    else if (
+      e.isFile() &&
+      e.name.endsWith('.ts') &&
+      !e.name.endsWith('.spec.ts') &&
+      !e.name.endsWith('.test.ts') &&
+      !e.name.endsWith('.type-test.ts')
+    ) {
+      out.push(p);
+    }
+  }
+}
+
+function trimBlock(block, leadingIndent) {
+  if (!block.includes('\n')) {
+    const inner = block.slice(3, -2).trim();
+    if (!inner) return '';
+    const tagMatch = inner.match(/^@([a-zA-Z]+)\b/);
+    if (tagMatch && DROP_TAGS.has(tagMatch[1])) return '';
+    return `/** ${inner} */`;
+  }
+  const lines = block.split('\n');
+  const open = lines[0];
+  const close = lines[lines.length - 1];
+  const body = lines.slice(1, -1);
+  const indent = leadingIndent;
+
+  let firstTagIdx = body.findIndex((l) => TAG_RE.test(l));
+  if (firstTagIdx === -1) firstTagIdx = body.length;
+
+  let description = body.slice(0, firstTagIdx);
+  const tagBody = body.slice(firstTagIdx);
+
+  const blankIdx = description.findIndex((l) => BLANK_STAR_RE.test(l));
+  if (blankIdx !== -1) description = description.slice(0, blankIdx);
+
+  while (description.length && BLANK_STAR_RE.test(description[description.length - 1])) {
+    description.pop();
+  }
+
+  const keptTagSections = [];
+  let current = null;
+  for (const line of tagBody) {
+    const m = line.match(TAG_RE);
+    if (m) {
+      if (current) keptTagSections.push(current);
+      current = { tag: m[1], lines: [line] };
+    } else if (current) {
+      current.lines.push(line);
+    }
+  }
+  if (current) keptTagSections.push(current);
+
+  const finalTagLines = [];
+  for (const sec of keptTagSections) {
+    if (DROP_TAGS.has(sec.tag)) continue;
+    while (sec.lines.length && BLANK_STAR_RE.test(sec.lines[sec.lines.length - 1])) {
+      sec.lines.pop();
+    }
+    finalTagLines.push(...sec.lines);
+  }
+
+  if (description.length === 0 && finalTagLines.length === 0) {
+    return '';
+  }
+
+  if (description.length === 1 && finalTagLines.length === 0) {
+    const text = description[0].replace(/^\s*\*\s?/, '').trimEnd();
+    if (text && !text.includes('*/')) {
+      return `/** ${text} */`;
+    }
+  }
+
+  const out = [open];
+  out.push(...description);
+  if (description.length && finalTagLines.length) {
+    out.push(`${indent} *`);
+  }
+  out.push(...finalTagLines);
+  out.push(close);
+  return out.join('\n');
+}
+
+function processSource(src) {
+  let out = '';
+  let i = 0;
+  let removed = 0;
+  let trimmed = 0;
+  while (i < src.length) {
+    const start = src.indexOf('/**', i);
+    if (start === -1) {
+      out += src.slice(i);
+      break;
+    }
+    if (src[start + 3] === '/') {
+      out += src.slice(i, start + 4);
+      i = start + 4;
+      continue;
+    }
+    const end = src.indexOf('*/', start + 3);
+    if (end === -1) {
+      out += src.slice(i);
+      break;
+    }
+    const block = src.slice(start, end + 2);
+    out += src.slice(i, start);
+    let lineStart = start;
+    while (lineStart > 0 && src[lineStart - 1] !== '\n') lineStart--;
+    const leadingIndent = src.slice(lineStart, start);
+    const trimmedBlock = trimBlock(block, /^[ \t]*$/.test(leadingIndent) ? leadingIndent : '');
+    if (trimmedBlock === '') {
+      removed++;
+      let consumeUntil = end + 2;
+      const after = src.slice(consumeUntil);
+      const newlineMatch = after.match(/^[ \t]*\n/);
+      if (newlineMatch) consumeUntil += newlineMatch[0].length;
+      const before = out;
+      const trailing = before.match(/\n[ \t]*$/);
+      if (trailing) {
+        out = before.slice(0, before.length - trailing[0].length) + '\n';
+      }
+      i = consumeUntil;
+    } else {
+      if (trimmedBlock !== block) trimmed++;
+      out += trimmedBlock;
+      i = end + 2;
+    }
+  }
+  return { out, removed, trimmed };
+}
+
+const roots = process.argv.slice(2);
+if (roots.length === 0) roots.push('packages');
+
+const files = [];
+for (const r of roots) {
+  const s = await stat(r).catch(() => null);
+  if (!s) continue;
+  if (s.isDirectory()) await walk(r, files);
+  else files.push(r);
+}
+
+let totalBytesBefore = 0;
+let totalBytesAfter = 0;
+let totalFilesChanged = 0;
+let totalRemoved = 0;
+let totalTrimmed = 0;
+
+for (const f of files) {
+  const src = await readFile(f, 'utf8');
+  totalBytesBefore += src.length;
+  const { out, removed, trimmed } = processSource(src);
+  totalBytesAfter += out.length;
+  if (out !== src) {
+    totalFilesChanged++;
+    totalRemoved += removed;
+    totalTrimmed += trimmed;
+    await writeFile(f, out);
+  }
+}
+
+const saved = totalBytesBefore - totalBytesAfter;
+console.log(`Files scanned:   ${files.length}`);
+console.log(`Files changed:   ${totalFilesChanged}`);
+console.log(`Blocks removed:  ${totalRemoved}`);
+console.log(`Blocks trimmed:  ${totalTrimmed}`);
+console.log(`Bytes saved:     ${saved.toLocaleString()} (${(saved / 1024).toFixed(1)} KB)`);
+console.log(`Source delta:    ${totalBytesBefore.toLocaleString()} -> ${totalBytesAfter.toLocaleString()}`);


### PR DESCRIPTION
## Summary

- Reduce source-level JSDoc by ~310 KB across 364 files in shipped packages.
- For each \`/** ... */\` block: keep the first descriptive paragraph, drop \`@example\` blocks, drop redundant \`@public\` tags. \`@internal\`, \`@deprecated\`, \`@param\`, \`@returns\`, \`@see\`, \`@typeParam\`, \`@throws\`, \`@value\`, \`@default\` are preserved verbatim.
- Complements PR #437 (FESM strip): that one cleans the published JS at build time; this one keeps source and \`.d.ts\` lean too so consumers' IntelliSense isn't pulling in pages of prose.

## Numbers

Source JSDoc bytes per package (before → after):

| package | before | after |
|---|---|---|
| dynamic-forms | 528 KB | 256 KB |
| dynamic-forms-primeng | 27 KB | 18 KB |
| dynamic-forms-material | 24 KB | 16 KB |
| dynamic-forms-ionic | 23 KB | 15 KB |
| dynamic-forms-bootstrap | 20 KB | 12 KB |
| dynamic-form-mcp | 18 KB | 10 KB |
| openapi-generator | (small) | 4 KB |

Diff: 364 files changed, 915 insertions, 10655 deletions.

## What this does NOT do

- Does not touch \`apps/\`, \`internal/\`, or anything outside \`packages/\`.
- Does not touch \`.spec.ts\`, \`.test.ts\`, \`.type-test.ts\`.
- Does not change a single line of executable code (verified with \`git diff\`).
- Does not remove \`@internal\` (212 retained) or \`@deprecated\` (38 retained).

## Tooling

\`scripts/trim-jsdoc.mjs\` is added for repeatability. Idempotent: re-running on already-trimmed source is a no-op. Usage: \`node scripts/trim-jsdoc.mjs packages\`.

## Test plan

- [x] \`pnpm build:libs\` — all 7 packages green
- [x] \`nx test dynamic-forms\` — 3070/3072 (2 pre-existing skips)
- [x] \`nx run-many -t test -p dynamic-forms-material,dynamic-forms-bootstrap,dynamic-forms-primeng,dynamic-forms-ionic,dynamic-form-mcp,openapi-generator\` — green
- [x] \`nx run-many -t lint -p <all 7>\` — green (147 pre-existing warnings, 0 errors)