### PR TITLE
feat(dynamic-forms): add ng add schematic + Nx generator for adapter setup

### DIFF
--- a/apps/docs/public/content/getting-started.md
+++ b/apps/docs/public/content/getting-started.md
@@ -17,6 +17,8 @@ In an existing Angular 21+ workspace:
 
 Also works in Nx — click the **Nx** tab above for the equivalent command. You'll be prompted for a UI adapter. The schematic installs the adapter package and its peers, imports the required CSS into your global styles file, and wires `provideAnimations`, the adapter provider (where applicable), and `provideDynamicForm(...withXxxFields(), withLegacyStatusClasses())` into your `ApplicationConfig`.
 
+In multi-app workspaces, pass `--project=<name>` to target a specific app — same as any other Nx generator. Angular CLI users will be told which app names to choose from if more than one application is present.
+
 Prefer to wire things by hand? The full manual setup is below.
 
 ## 1. Choose Your UI Library

--- a/apps/docs/public/content/getting-started.md
+++ b/apps/docs/public/content/getting-started.md
@@ -9,6 +9,20 @@ description: 'Install ng-forge, pick a UI adapter (Material, Bootstrap, PrimeNG,
 
 ng-forge generates fully working Angular forms from a single configuration object — validation, conditional logic, and multi-step wizards included. Here's how to set it up.
 
+## Quick setup
+
+In an existing Angular 21+ workspace:
+
+```bash
+ng add @ng-forge/dynamic-forms
+```
+
+You'll be prompted for a UI adapter. The schematic installs the adapter package and its peers, imports the required CSS into `styles.scss`, and wires `provideAnimations`, the adapter provider (where applicable), and `provideDynamicForm(...withXxxFields(), withLegacyStatusClasses())` into `app.config.ts`. Pass `--defaults` to skip prompts in CI.
+
+In Nx workspaces use `nx g @ng-forge/dynamic-forms:ng-add --adapter=material` (same flags).
+
+Prefer to wire things by hand? The full manual setup is below.
+
 ## 1. Choose Your UI Library
 
 <docs-adapter-picker></docs-adapter-picker>

--- a/apps/docs/public/content/getting-started.md
+++ b/apps/docs/public/content/getting-started.md
@@ -13,13 +13,9 @@ ng-forge generates fully working Angular forms from a single configuration objec
 
 In an existing Angular 21+ workspace:
 
-```bash
-ng add @ng-forge/dynamic-forms
-```
+<docs-cli-command package="@ng-forge/dynamic-forms"></docs-cli-command>
 
-You'll be prompted for a UI adapter. The schematic installs the adapter package and its peers, imports the required CSS into your global styles file, and wires `provideAnimations`, the adapter provider (where applicable), and `provideDynamicForm(...withXxxFields(), withLegacyStatusClasses())` into your `ApplicationConfig`. Pass `--defaults` to skip prompts in CI.
-
-In Nx workspaces use `nx g @ng-forge/dynamic-forms:ng-add --adapter=material` (same flags).
+Also works in Nx — click the **Nx** tab above for the equivalent command. You'll be prompted for a UI adapter. The schematic installs the adapter package and its peers, imports the required CSS into your global styles file, and wires `provideAnimations`, the adapter provider (where applicable), and `provideDynamicForm(...withXxxFields(), withLegacyStatusClasses())` into your `ApplicationConfig`.
 
 Prefer to wire things by hand? The full manual setup is below.
 

--- a/apps/docs/public/content/getting-started.md
+++ b/apps/docs/public/content/getting-started.md
@@ -15,11 +15,9 @@ In an existing Angular 21+ workspace:
 
 <docs-cli-command package="@ng-forge/dynamic-forms"></docs-cli-command>
 
-Also works in Nx — click the **Nx** tab above for the equivalent command. You'll be prompted for a UI adapter. The schematic installs the adapter package and its peers, imports the required CSS into your global styles file, and wires `provideAnimations`, the adapter provider (where applicable), and `provideDynamicForm(...withXxxFields(), withLegacyStatusClasses())` into your `ApplicationConfig`.
+Pick an adapter when prompted. Works in Nx too — toggle the **Nx** tab.
 
-In multi-app workspaces, pass `--project=<name>` to target a specific app — same as any other Nx generator. Angular CLI users will be told which app names to choose from if more than one application is present.
-
-Prefer to wire things by hand? The full manual setup is below.
+Prefer to wire things by hand? Manual setup is below.
 
 ## 1. Choose Your UI Library
 

--- a/apps/docs/public/content/getting-started.md
+++ b/apps/docs/public/content/getting-started.md
@@ -17,7 +17,7 @@ In an existing Angular 21+ workspace:
 ng add @ng-forge/dynamic-forms
 ```
 
-You'll be prompted for a UI adapter. The schematic installs the adapter package and its peers, imports the required CSS into `styles.scss`, and wires `provideAnimations`, the adapter provider (where applicable), and `provideDynamicForm(...withXxxFields(), withLegacyStatusClasses())` into `app.config.ts`. Pass `--defaults` to skip prompts in CI.
+You'll be prompted for a UI adapter. The schematic installs the adapter package and its peers, imports the required CSS into your global styles file, and wires `provideAnimations`, the adapter provider (where applicable), and `provideDynamicForm(...withXxxFields(), withLegacyStatusClasses())` into your `ApplicationConfig`. Pass `--defaults` to skip prompts in CI.
 
 In Nx workspaces use `nx g @ng-forge/dynamic-forms:ng-add --adapter=material` (same flags).
 

--- a/apps/docs/src/app/components/cli-command/cli-command.component.html
+++ b/apps/docs/src/app/components/cli-command/cli-command.component.html
@@ -1,0 +1,21 @@
+<div class="cli-command">
+  <div class="cli-command__tabs" role="tablist" aria-label="CLI">
+    @for (cli of clis; track cli.id) {
+      <button
+        role="tab"
+        class="cli-command__tab"
+        [class.active]="selected() === cli.id"
+        [attr.aria-selected]="selected() === cli.id"
+        (click)="select(cli.id)"
+      >
+        {{ cli.label }}
+      </button>
+    }
+  </div>
+  <div class="cli-command__body">
+    <docs-copy-button [code]="command()" />
+    <div class="cli-command__scroll">
+      <div [codeHighlight]="command()" language="bash"></div>
+    </div>
+  </div>
+</div>

--- a/apps/docs/src/app/components/cli-command/cli-command.component.html
+++ b/apps/docs/src/app/components/cli-command/cli-command.component.html
@@ -1,18 +1,28 @@
 <div class="cli-command">
-  <div class="cli-command__tabs" role="tablist" aria-label="CLI">
+  <div
+    class="cli-command__tabs"
+    role="tablist"
+    aria-label="CLI"
+    [docsTabKeyboard]="clis"
+    [current]="selected()"
+    (selectChange)="select($event)"
+  >
     @for (cli of clis; track cli.id) {
       <button
         role="tab"
         class="cli-command__tab"
-        [class.active]="selected() === cli.id"
+        [id]="tabId(cli.id)"
+        [attr.aria-controls]="panelId"
         [attr.aria-selected]="selected() === cli.id"
+        [tabindex]="selected() === cli.id ? 0 : -1"
+        [class.active]="selected() === cli.id"
         (click)="select(cli.id)"
       >
         {{ cli.label }}
       </button>
     }
   </div>
-  <div class="cli-command__body">
+  <div class="cli-command__body" role="tabpanel" [id]="panelId" [attr.aria-labelledby]="tabId(selected())">
     <docs-copy-button [code]="command()" />
     <div class="cli-command__scroll">
       <div [codeHighlight]="command()" language="bash"></div>

--- a/apps/docs/src/app/components/cli-command/cli-command.component.scss
+++ b/apps/docs/src/app/components/cli-command/cli-command.component.scss
@@ -1,5 +1,5 @@
 @use 'command-box' as cb;
 
-.install-command {
+.cli-command {
   @include cb.command-box;
 }

--- a/apps/docs/src/app/components/cli-command/cli-command.component.ts
+++ b/apps/docs/src/app/components/cli-command/cli-command.component.ts
@@ -1,0 +1,27 @@
+import { ChangeDetectionStrategy, Component, computed, input, signal } from '@angular/core';
+import { CodeHighlightDirective } from '../../directives/code-highlight.directive';
+import { CopyButtonComponent } from '../copy-button/copy-button.component';
+
+type Cli = 'angular' | 'nx';
+
+@Component({
+  selector: 'docs-cli-command',
+  templateUrl: './cli-command.component.html',
+  styleUrl: './cli-command.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CodeHighlightDirective, CopyButtonComponent],
+})
+export class DocsCliCommandComponent {
+  readonly package = input<string>('@ng-forge/dynamic-forms');
+  readonly selected = signal<Cli>('angular');
+  readonly clis: { id: Cli; label: string }[] = [
+    { id: 'angular', label: 'Angular CLI' },
+    { id: 'nx', label: 'Nx' },
+  ];
+  readonly command = computed(() => (this.selected() === 'angular' ? `ng add ${this.package()}` : `nx g ${this.package()}:add`));
+  select(c: Cli): void {
+    this.selected.set(c);
+  }
+}
+
+export default DocsCliCommandComponent;

--- a/apps/docs/src/app/components/cli-command/cli-command.component.ts
+++ b/apps/docs/src/app/components/cli-command/cli-command.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, input, signal } from '@angular/core';
 import { CodeHighlightDirective } from '../../directives/code-highlight.directive';
+import { DocsTabKeyboardDirective } from '../../directives/tab-keyboard.directive';
 import { CopyButtonComponent } from '../copy-button/copy-button.component';
 
 type Cli = 'angular' | 'nx';
@@ -9,7 +10,7 @@ type Cli = 'angular' | 'nx';
   templateUrl: './cli-command.component.html',
   styleUrl: './cli-command.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CodeHighlightDirective, CopyButtonComponent],
+  imports: [CodeHighlightDirective, CopyButtonComponent, DocsTabKeyboardDirective],
 })
 export class DocsCliCommandComponent {
   readonly package = input<string>('@ng-forge/dynamic-forms');
@@ -19,6 +20,16 @@ export class DocsCliCommandComponent {
     { id: 'nx', label: 'Nx' },
   ];
   readonly command = computed(() => (this.selected() === 'angular' ? `ng add ${this.package()}` : `nx g ${this.package()}:add`));
+
+  // Per-instance id base — Math.random per-call is SSR-safe (no shared
+  // module-level state).
+  private readonly uid = `cli-${Math.random().toString(36).slice(2, 8)}`;
+
+  tabId(id: Cli): string {
+    return `${this.uid}-tab-${id}`;
+  }
+  readonly panelId = `${this.uid}-panel`;
+
   select(c: Cli): void {
     this.selected.set(c);
   }

--- a/apps/docs/src/app/components/cli-command/cli-command.component.ts
+++ b/apps/docs/src/app/components/cli-command/cli-command.component.ts
@@ -1,6 +1,7 @@
-import { ChangeDetectionStrategy, Component, computed, input, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, signal } from '@angular/core';
 import { CodeHighlightDirective } from '../../directives/code-highlight.directive';
 import { DocsTabKeyboardDirective } from '../../directives/tab-keyboard.directive';
+import { UidService } from '../../services/uid.service';
 import { CopyButtonComponent } from '../copy-button/copy-button.component';
 
 type Cli = 'angular' | 'nx';
@@ -21,9 +22,7 @@ export class DocsCliCommandComponent {
   ];
   readonly command = computed(() => (this.selected() === 'angular' ? `ng add ${this.package()}` : `nx g ${this.package()}:add`));
 
-  // Per-instance id base — Math.random per-call is SSR-safe (no shared
-  // module-level state).
-  private readonly uid = `cli-${Math.random().toString(36).slice(2, 8)}`;
+  private readonly uid = inject(UidService).next('cli');
 
   tabId(id: Cli): string {
     return `${this.uid}-tab-${id}`;

--- a/apps/docs/src/app/components/install-command/install-command.component.html
+++ b/apps/docs/src/app/components/install-command/install-command.component.html
@@ -1,18 +1,28 @@
 <div class="install-command">
-  <div class="install-command__tabs" role="tablist" aria-label="Package manager">
-    @for (pm of managers; track pm) {
+  <div
+    class="install-command__tabs"
+    role="tablist"
+    aria-label="Package manager"
+    [docsTabKeyboard]="managers"
+    [current]="pmService.pm()"
+    (selectChange)="select($event)"
+  >
+    @for (pm of managers; track pm.id) {
       <button
         role="tab"
         class="install-command__tab"
-        [class.active]="pmService.pm() === pm"
-        [attr.aria-selected]="pmService.pm() === pm"
-        (click)="select(pm)"
+        [id]="tabId(pm.id)"
+        [attr.aria-controls]="panelId"
+        [attr.aria-selected]="pmService.pm() === pm.id"
+        [tabindex]="pmService.pm() === pm.id ? 0 : -1"
+        [class.active]="pmService.pm() === pm.id"
+        (click)="select(pm.id)"
       >
-        {{ pm }}
+        {{ pm.label }}
       </button>
     }
   </div>
-  <div class="install-command__body">
+  <div class="install-command__body" role="tabpanel" [id]="panelId" [attr.aria-labelledby]="tabId(pmService.pm())">
     <docs-copy-button [code]="command()" />
     <div class="install-command__scroll">
       <div [codeHighlight]="command()" language="bash"></div>

--- a/apps/docs/src/app/components/install-command/install-command.component.ts
+++ b/apps/docs/src/app/components/install-command/install-command.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { PackageManagerService } from '../../services/package-manager.service';
+import { UidService } from '../../services/uid.service';
 import { CodeHighlightDirective } from '../../directives/code-highlight.directive';
 import { DocsTabKeyboardDirective } from '../../directives/tab-keyboard.directive';
 import { CopyButtonComponent } from '../copy-button/copy-button.component';
@@ -35,7 +36,7 @@ export class DocsInstallCommandComponent {
     return `${binary} ${subcommand} ${this.packages()}`;
   });
 
-  private readonly uid = `pm-${Math.random().toString(36).slice(2, 8)}`;
+  private readonly uid = inject(UidService).next('pm');
 
   tabId(id: PackageManager): string {
     return `${this.uid}-tab-${id}`;

--- a/apps/docs/src/app/components/install-command/install-command.component.ts
+++ b/apps/docs/src/app/components/install-command/install-command.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { PackageManagerService } from '../../services/package-manager.service';
 import { CodeHighlightDirective } from '../../directives/code-highlight.directive';
+import { DocsTabKeyboardDirective } from '../../directives/tab-keyboard.directive';
 import { CopyButtonComponent } from '../copy-button/copy-button.component';
 
 type PackageManager = 'npm' | 'pnpm' | 'yarn';
@@ -16,19 +17,30 @@ const PM_COMMANDS: Record<PackageManager, { binary: string; subcommand: string }
   templateUrl: './install-command.component.html',
   styleUrl: './install-command.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CodeHighlightDirective, CopyButtonComponent],
+  imports: [CodeHighlightDirective, CopyButtonComponent, DocsTabKeyboardDirective],
 })
 export class DocsInstallCommandComponent {
   readonly packages = input.required<string>();
 
   readonly pmService = inject(PackageManagerService);
 
-  readonly managers: PackageManager[] = ['npm', 'pnpm', 'yarn'];
+  readonly managers: { id: PackageManager; label: PackageManager }[] = [
+    { id: 'npm', label: 'npm' },
+    { id: 'pnpm', label: 'pnpm' },
+    { id: 'yarn', label: 'yarn' },
+  ];
 
   readonly command = computed(() => {
     const { binary, subcommand } = PM_COMMANDS[this.pmService.pm()];
     return `${binary} ${subcommand} ${this.packages()}`;
   });
+
+  private readonly uid = `pm-${Math.random().toString(36).slice(2, 8)}`;
+
+  tabId(id: PackageManager): string {
+    return `${this.uid}-tab-${id}`;
+  }
+  readonly panelId = `${this.uid}-panel`;
 
   select(pm: PackageManager): void {
     this.pmService.pm.set(pm);

--- a/apps/docs/src/app/directives/content-components.directive.ts
+++ b/apps/docs/src/app/directives/content-components.directive.ts
@@ -36,6 +36,12 @@ const COMPONENT_REGISTRY: ComponentRegistration[] = [
     extractInputs: (attrs) => ({ packages: attrs['packages'] ?? '' }),
   },
   {
+    selector: 'docs-cli-command',
+    defer: true,
+    loadComponent: () => import('../components/cli-command/cli-command.component'),
+    extractInputs: (attrs) => ({ package: attrs['package'] ?? '@ng-forge/dynamic-forms' }),
+  },
+  {
     selector: 'docs-adapter-picker',
     defer: true,
     loadComponent: () => import('../components/adapter-picker/adapter-picker.component'),

--- a/apps/docs/src/app/directives/tab-keyboard.directive.ts
+++ b/apps/docs/src/app/directives/tab-keyboard.directive.ts
@@ -1,18 +1,6 @@
 import { Directive, ElementRef, inject, input, output } from '@angular/core';
 
-/**
- * WAI-ARIA tablist keyboard handler for tab strips that follow the
- * "automatic activation" pattern (Arrow keys move both focus AND
- * selection). Apply to the element with `role="tablist"`. The directive
- * assumes the tab buttons are descendants matching `[role="tab"]`.
- *
- *  - Arrow Left / Up   → previous tab (wraps)
- *  - Arrow Right / Down → next tab (wraps)
- *  - Home              → first tab
- *  - End               → last tab
- *
- * Reference: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
- */
+// https://www.w3.org/WAI/ARIA/apg/patterns/tabs/ (automatic activation)
 @Directive({
   selector: '[docsTabKeyboard]',
   host: {
@@ -52,12 +40,7 @@ export class DocsTabKeyboardDirective<T extends string> {
     }
 
     event.preventDefault();
-    const next = items[nextIdx];
-    this.selectChange.emit(next.id);
-
-    // Move focus to the newly-active tab. focus() works on a tabindex=-1
-    // element, so we don't need to wait for the [tabindex] binding to
-    // update before focusing.
+    this.selectChange.emit(items[nextIdx].id);
     const tabs = this.host.nativeElement.querySelectorAll<HTMLButtonElement>('[role="tab"]');
     tabs[nextIdx]?.focus();
   }

--- a/apps/docs/src/app/directives/tab-keyboard.directive.ts
+++ b/apps/docs/src/app/directives/tab-keyboard.directive.ts
@@ -1,0 +1,66 @@
+import { Directive, ElementRef, inject, input, output } from '@angular/core';
+
+/**
+ * WAI-ARIA tablist keyboard handler for tab strips that follow the
+ * "automatic activation" pattern (Arrow keys move both focus AND
+ * selection). Apply to the element with `role="tablist"`. The directive
+ * assumes the tab buttons are descendants matching `[role="tab"]`.
+ *
+ *  - Arrow Left / Up   → previous tab (wraps)
+ *  - Arrow Right / Down → next tab (wraps)
+ *  - Home              → first tab
+ *  - End               → last tab
+ *
+ * Reference: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
+ */
+@Directive({
+  selector: '[docsTabKeyboard]',
+  host: {
+    '(keydown)': 'onKeydown($event)',
+  },
+})
+export class DocsTabKeyboardDirective<T extends string> {
+  readonly items = input.required<readonly { id: T }[]>({ alias: 'docsTabKeyboard' });
+  readonly current = input.required<T>();
+  readonly selectChange = output<T>();
+
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+
+  onKeydown(event: KeyboardEvent): void {
+    const items = this.items();
+    if (items.length === 0) return;
+    const currentIdx = items.findIndex((i) => i.id === this.current());
+
+    let nextIdx: number;
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        nextIdx = (currentIdx + 1) % items.length;
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        nextIdx = (currentIdx - 1 + items.length) % items.length;
+        break;
+      case 'Home':
+        nextIdx = 0;
+        break;
+      case 'End':
+        nextIdx = items.length - 1;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    const next = items[nextIdx];
+    this.selectChange.emit(next.id);
+
+    // Move focus to the newly-active tab. focus() works on a tabindex=-1
+    // element, so we don't need to wait for the [tabindex] binding to
+    // update before focusing.
+    const tabs = this.host.nativeElement.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    tabs[nextIdx]?.focus();
+  }
+}
+
+export default DocsTabKeyboardDirective;

--- a/apps/docs/src/app/services/uid.service.ts
+++ b/apps/docs/src/app/services/uid.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class UidService {
+  private readonly counters = new Map<string, number>();
+
+  next(prefix: string): string {
+    const n = (this.counters.get(prefix) ?? 0) + 1;
+    this.counters.set(prefix, n);
+    return `${prefix}-${n}`;
+  }
+}

--- a/internal/styling/src/_command-box.scss
+++ b/internal/styling/src/_command-box.scss
@@ -1,0 +1,91 @@
+@use 'tokens' as *;
+@use 'themes' as *;
+@use 'mixins' as mix;
+
+// ============================================
+// COMMAND BOX (tabbed + scrollable code block)
+// ============================================
+// Shared visual treatment for docs components that render a CLI command
+// behind a tab strip: `docs-install-command` (npm/pnpm/yarn) and
+// `docs-cli-command` (Angular CLI / Nx). Include from within a BEM block
+// so the modifier selectors compose under the consumer's root class.
+
+@mixin command-box {
+  border-radius: $radius-md;
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+
+  &__tabs {
+    display: flex;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-surface);
+    border-radius: $radius-md $radius-md 0 0;
+  }
+
+  &__tab {
+    padding: $space-2 $space-4;
+    font-size: $text-xs;
+    font-family: $font-mono;
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: color $transition-fast;
+
+    &:hover {
+      color: var(--text-primary);
+    }
+
+    &.active {
+      color: $ember-glow;
+      border-bottom: 2px solid $ember-glow;
+    }
+  }
+
+  &__body {
+    position: relative;
+
+    &:hover docs-copy-button {
+      opacity: 1;
+    }
+  }
+
+  &__scroll {
+    padding: $space-3 $space-4;
+    overflow-x: auto;
+    white-space: nowrap;
+    font-size: $text-sm;
+    mask-image: linear-gradient(to right, black calc(100% - 3rem), transparent 100%);
+    border-radius: 0 0 $radius-md $radius-md;
+
+    @include mix.mobile {
+      font-size: $text-xs;
+      padding: $space-2 $space-3;
+    }
+
+    // Shiki wraps output in a <pre>, flatten it to fit our container.
+    // !important overrides the global `.doc-page-content pre.shiki code`
+    // rule which has higher specificity than emulated encapsulation.
+    ::ng-deep pre {
+      margin: 0;
+      padding: 0;
+      background: transparent !important;
+      border: none;
+      // Do NOT use min-width: max-content — it makes the pre wider than the
+      // viewport, which triggers WebKit/iOS text autosizing (font inflation).
+      font-size: $text-sm !important;
+
+      @include mix.mobile {
+        font-size: $text-xs !important;
+      }
+    }
+
+    ::ng-deep pre code {
+      font-size: $text-sm !important;
+
+      @include mix.mobile {
+        font-size: $text-xs !important;
+      }
+    }
+  }
+}

--- a/internal/styling/src/_command-box.scss
+++ b/internal/styling/src/_command-box.scss
@@ -28,12 +28,15 @@
     font-family: $font-mono;
     background: transparent;
     border: none;
-    color: var(--text-secondary);
+    color: var(--text-primary);
+    opacity: 0.65;
     cursor: pointer;
-    transition: color $transition-fast;
+    transition:
+      opacity $transition-fast,
+      color $transition-fast;
 
     &:hover {
-      color: var(--text-primary);
+      opacity: 1;
     }
 
     &:focus-visible {
@@ -43,6 +46,7 @@
 
     &.active {
       color: $ember-glow;
+      opacity: 1;
       border-bottom: 2px solid $ember-glow;
     }
   }

--- a/internal/styling/src/_command-box.scss
+++ b/internal/styling/src/_command-box.scss
@@ -36,6 +36,11 @@
       color: var(--text-primary);
     }
 
+    &:focus-visible {
+      outline: 2px solid $ember-glow;
+      outline-offset: -2px;
+    }
+
     &.active {
       color: $ember-glow;
       border-bottom: 2px solid $ember-glow;

--- a/packages/dynamic-forms/eslint.config.mjs
+++ b/packages/dynamic-forms/eslint.config.mjs
@@ -9,8 +9,17 @@ export default [
       '@nx/dependency-checks': [
         'error',
         {
-          ignoredFiles: ['{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}'],
-          ignoredDependencies: ['vite', '@analogjs/vite-plugin-angular', '@nx/vite', '@vitest/browser-playwright', 'vitest'],
+          ignoredFiles: ['{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}', '{projectRoot}/schematics/**/*'],
+          ignoredDependencies: [
+            'vite',
+            '@analogjs/vite-plugin-angular',
+            '@nx/vite',
+            '@vitest/browser-playwright',
+            'vitest',
+            '@angular-devkit/schematics',
+            '@schematics/angular',
+            '@nx/devkit',
+          ],
         },
       ],
     },

--- a/packages/dynamic-forms/ng-package.json
+++ b/packages/dynamic-forms/ng-package.json
@@ -4,6 +4,9 @@
   "lib": {
     "entryFile": "src/index.ts"
   },
-  "assets": [".npmignore"],
+  "assets": [
+    ".npmignore",
+    { "glob": "**/*.json", "input": "schematics", "output": "schematics", "ignore": ["tsconfig.json", "node_modules/**"] }
+  ],
   "allowedNonPeerDependencies": ["ngxtension"]
 }

--- a/packages/dynamic-forms/package.json
+++ b/packages/dynamic-forms/package.json
@@ -30,6 +30,8 @@
     "config-driven"
   ],
   "sideEffects": false,
+  "schematics": "./schematics/collection.json",
+  "generators": "./schematics/generators.json",
   "engines": {
     "node": ">=20"
   },

--- a/packages/dynamic-forms/project.json
+++ b/packages/dynamic-forms/project.json
@@ -35,10 +35,7 @@
       "inputs": ["{projectRoot}/schematics/**/*", "!{projectRoot}/schematics/**/*.spec.ts"],
       "dependsOn": ["compile"],
       "options": {
-        "commands": [
-          "tsc -p packages/dynamic-forms/schematics/tsconfig.json",
-          "node -e \"require('node:fs').writeFileSync('dist/packages/dynamic-forms/schematics/package.json', JSON.stringify({type:'commonjs'}) + '\\n')\""
-        ],
+        "commands": ["tsc -p packages/dynamic-forms/schematics/tsconfig.json", "node scripts/finalize-dynamic-forms-schematics.mjs"],
         "parallel": false,
         "cwd": "{workspaceRoot}"
       }

--- a/packages/dynamic-forms/project.json
+++ b/packages/dynamic-forms/project.json
@@ -18,7 +18,7 @@
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/dist/{projectRoot}"],
       "inputs": ["production", "^production"],
-      "dependsOn": ["compile"],
+      "dependsOn": ["compile", "build-schematics"],
       "options": {
         "command": "node scripts/strip-fesm-comments.mjs dist/packages/dynamic-forms",
         "cwd": "{workspaceRoot}"
@@ -28,6 +28,28 @@
         "development": {}
       },
       "defaultConfiguration": "production"
+    },
+    "build-schematics": {
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/dist/{projectRoot}/schematics"],
+      "inputs": ["{projectRoot}/schematics/**/*", "!{projectRoot}/schematics/**/*.spec.ts"],
+      "dependsOn": ["compile"],
+      "options": {
+        "commands": [
+          "tsc -p packages/dynamic-forms/schematics/tsconfig.json",
+          "node -e \"require('node:fs').writeFileSync('dist/packages/dynamic-forms/schematics/package.json', JSON.stringify({type:'commonjs'}) + '\\n')\""
+        ],
+        "parallel": false,
+        "cwd": "{workspaceRoot}"
+      }
+    },
+    "test-schematics": {
+      "executor": "@nx/vitest:test",
+      "inputs": ["{projectRoot}/schematics/**/*", "{workspaceRoot}/dist/{projectRoot}/schematics/**/*"],
+      "dependsOn": ["build-schematics"],
+      "options": {
+        "configFile": "packages/dynamic-forms/schematics/vitest.config.ts"
+      }
     },
     "compile": {
       "executor": "@nx/angular:package",

--- a/packages/dynamic-forms/schematics/collection.json
+++ b/packages/dynamic-forms/schematics/collection.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "ng-add": {
+      "description": "Set up @ng-forge/dynamic-forms with a UI adapter (Material, Bootstrap, PrimeNG, Ionic, or none).",
+      "factory": "./ng-add/index#default",
+      "schema": "./ng-add/schema.json"
+    }
+  }
+}

--- a/packages/dynamic-forms/schematics/generators.json
+++ b/packages/dynamic-forms/schematics/generators.json
@@ -3,7 +3,7 @@
   "name": "@ng-forge/dynamic-forms",
   "version": "0.0.1",
   "generators": {
-    "ng-add": {
+    "add": {
       "factory": "./ng-add/nx-wrapper#default",
       "schema": "./ng-add/schema.json",
       "description": "Set up @ng-forge/dynamic-forms with a UI adapter (Material, Bootstrap, PrimeNG, Ionic, or none)."

--- a/packages/dynamic-forms/schematics/generators.json
+++ b/packages/dynamic-forms/schematics/generators.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "../../../node_modules/nx/schemas/generators-schema.json",
+  "name": "@ng-forge/dynamic-forms",
+  "version": "0.0.1",
+  "generators": {
+    "ng-add": {
+      "factory": "./ng-add/nx-wrapper#default",
+      "schema": "./ng-add/schema.json",
+      "description": "Set up @ng-forge/dynamic-forms with a UI adapter (Material, Bootstrap, PrimeNG, Ionic, or none)."
+    }
+  }
+}

--- a/packages/dynamic-forms/schematics/ng-add/index.spec.ts
+++ b/packages/dynamic-forms/schematics/ng-add/index.spec.ts
@@ -218,4 +218,41 @@ describe('ng-add', () => {
       expect(result.exists('/projects/test-app/src/app/app.config.ts')).toBe(false);
     });
   });
+
+  describe('multiple application projects', () => {
+    async function makeMultiAppTree(): Promise<{ runner: SchematicTestRunner; tree: UnitTestTree }> {
+      const runner = new SchematicTestRunner('@ng-forge/dynamic-forms', collectionPath);
+      let tree = await runner.runExternalSchematic(NG_SCHEMATICS, 'workspace', {
+        name: 'multi-ws',
+        newProjectRoot: 'projects',
+        version: '21.0.0',
+      });
+      for (const name of ['app-one', 'app-two']) {
+        tree = await runner.runExternalSchematic(
+          NG_SCHEMATICS,
+          'application',
+          { name, standalone: true, style: 'scss', routing: false, inlineTemplate: false, inlineStyle: false },
+          tree,
+        );
+      }
+      return { runner, tree };
+    }
+
+    it('throws with the app list when --project is omitted', async () => {
+      const { runner, tree } = await makeMultiAppTree();
+      await expect(runner.runSchematic('ng-add', { adapter: 'material' }, tree)).rejects.toThrow(
+        /Multiple application projects found.*app-one.*app-two.*--project=/s,
+      );
+    });
+
+    it('wires the selected project when --project is passed', async () => {
+      const { runner, tree } = await makeMultiAppTree();
+      const result = await runner.runSchematic('ng-add', { adapter: 'material', project: 'app-two' }, tree);
+      // Wired into app-two only.
+      const twoConfig = result.readContent('/projects/app-two/src/app/app.config.ts');
+      expect(twoConfig).toContain('withMaterialFields');
+      const oneConfig = result.readContent('/projects/app-one/src/app/app.config.ts');
+      expect(oneConfig).not.toContain('withMaterialFields');
+    });
+  });
 });

--- a/packages/dynamic-forms/schematics/ng-add/index.spec.ts
+++ b/packages/dynamic-forms/schematics/ng-add/index.spec.ts
@@ -1,0 +1,167 @@
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import type { Adapter } from './schema';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const collectionPath = path.resolve(here, '../../../../dist/packages/dynamic-forms/schematics/collection.json');
+const NG_SCHEMATICS = '@schematics/angular';
+const APP_NAME = 'test-app';
+const APP_DIR = `/projects/${APP_NAME}`;
+
+async function makeAppTree(): Promise<{ runner: SchematicTestRunner; tree: UnitTestTree }> {
+  const runner = new SchematicTestRunner('@ng-forge/dynamic-forms', collectionPath);
+  let tree = await runner.runExternalSchematic(NG_SCHEMATICS, 'workspace', {
+    name: 'test-ws',
+    newProjectRoot: 'projects',
+    version: '21.0.0',
+  });
+  tree = await runner.runExternalSchematic(
+    NG_SCHEMATICS,
+    'application',
+    { name: APP_NAME, standalone: true, style: 'scss', routing: false, inlineTemplate: false, inlineStyle: false },
+    tree,
+  );
+  return { runner, tree };
+}
+
+interface AdapterExpectations {
+  packages: string[];
+  styleNeedles: string[];
+  providerNeedles: string[];
+}
+
+const EXPECTATIONS: Record<Exclude<Adapter, 'none'>, AdapterExpectations> = {
+  material: {
+    packages: ['@ng-forge/dynamic-forms', '@ng-forge/dynamic-forms-material', '@angular/material', '@angular/cdk'],
+    styleNeedles: ['@angular/material/prebuilt-themes/azure-blue.css'],
+    providerNeedles: ['provideAnimations', 'provideDynamicForm', 'withMaterialFields', 'withLegacyStatusClasses'],
+  },
+  bootstrap: {
+    packages: ['@ng-forge/dynamic-forms', '@ng-forge/dynamic-forms-bootstrap', 'bootstrap'],
+    styleNeedles: ['bootstrap/dist/css/bootstrap.min.css'],
+    providerNeedles: ['provideAnimations', 'provideDynamicForm', 'withBootstrapFields', 'withLegacyStatusClasses'],
+  },
+  primeng: {
+    packages: ['@ng-forge/dynamic-forms', '@ng-forge/dynamic-forms-primeng', 'primeng', '@primeng/themes', 'primeicons'],
+    styleNeedles: ['primeicons/primeicons.css'],
+    providerNeedles: ['provideAnimations', 'providePrimeNG', 'Aura', 'provideDynamicForm', 'withPrimeNGFields', 'withLegacyStatusClasses'],
+  },
+  ionic: {
+    packages: ['@ng-forge/dynamic-forms', '@ng-forge/dynamic-forms-ionic', '@ionic/angular'],
+    styleNeedles: ['@ionic/angular/css/core.css', '@ionic/angular/css/normalize.css'],
+    providerNeedles: ['provideAnimations', 'provideIonicAngular', 'provideDynamicForm', 'withIonicFields', 'withLegacyStatusClasses'],
+  },
+};
+
+describe('ng-add', () => {
+  for (const adapter of Object.keys(EXPECTATIONS) as Array<keyof typeof EXPECTATIONS>) {
+    describe(adapter, () => {
+      let result: UnitTestTree;
+      let runner: SchematicTestRunner;
+
+      beforeAll(async () => {
+        const { runner: r, tree: appTree } = await makeAppTree();
+        runner = r;
+        result = await runner.runSchematic('ng-add', { adapter }, appTree);
+      });
+
+      it('adds expected packages to package.json', () => {
+        const pkg = JSON.parse(result.readContent('/package.json'));
+        for (const name of EXPECTATIONS[adapter].packages) {
+          expect(pkg.dependencies?.[name], `expected ${name} in dependencies`).toBeDefined();
+        }
+      });
+
+      it('adds expected style imports', () => {
+        const styles = result.readContent(`${APP_DIR}/src/styles.scss`);
+        for (const needle of EXPECTATIONS[adapter].styleNeedles) {
+          expect(styles).toContain(needle);
+        }
+      });
+
+      it('wires expected providers in app.config.ts', () => {
+        const config = result.readContent(`${APP_DIR}/src/app/app.config.ts`);
+        for (const needle of EXPECTATIONS[adapter].providerNeedles) {
+          expect(config).toContain(needle);
+        }
+      });
+    });
+  }
+
+  describe('none', () => {
+    let result: UnitTestTree;
+
+    beforeAll(async () => {
+      const { runner, tree } = await makeAppTree();
+      result = await runner.runSchematic('ng-add', { adapter: 'none' }, tree);
+    });
+
+    it('adds only core package', () => {
+      const pkg = JSON.parse(result.readContent('/package.json'));
+      expect(pkg.dependencies?.['@ng-forge/dynamic-forms']).toBeDefined();
+    });
+
+    it('does not write adapter style imports', () => {
+      const styles = result.readContent(`${APP_DIR}/src/styles.scss`);
+      expect(styles).not.toContain('@angular/material');
+      expect(styles).not.toContain('bootstrap/dist');
+    });
+
+    it('wires provideDynamicForm with no adapter', () => {
+      const config = result.readContent(`${APP_DIR}/src/app/app.config.ts`);
+      expect(config).toContain('provideDynamicForm');
+      expect(config).not.toContain('withMaterialFields');
+      expect(config).not.toContain('withBootstrapFields');
+    });
+  });
+
+  describe('flag interactions', () => {
+    it('--skipStyles leaves styles.scss untouched', async () => {
+      const { runner, tree } = await makeAppTree();
+      const before = tree.readContent(`${APP_DIR}/src/styles.scss`);
+      const result = await runner.runSchematic('ng-add', { adapter: 'material', skipStyles: true }, tree);
+      const after = result.readContent(`${APP_DIR}/src/styles.scss`);
+      expect(after).toBe(before);
+    });
+
+    it('--skipProviders leaves app.config.ts untouched', async () => {
+      const { runner, tree } = await makeAppTree();
+      const before = tree.readContent(`${APP_DIR}/src/app/app.config.ts`);
+      const result = await runner.runSchematic('ng-add', { adapter: 'material', skipProviders: true }, tree);
+      const after = result.readContent(`${APP_DIR}/src/app/app.config.ts`);
+      expect(after).toBe(before);
+    });
+
+    it('--legacyStatusClasses=false omits withLegacyStatusClasses()', async () => {
+      const { runner, tree } = await makeAppTree();
+      const result = await runner.runSchematic('ng-add', { adapter: 'material', legacyStatusClasses: false }, tree);
+      const config = result.readContent(`${APP_DIR}/src/app/app.config.ts`);
+      expect(config).toContain('withMaterialFields');
+      expect(config).not.toContain('withLegacyStatusClasses');
+    });
+  });
+
+  describe('idempotency', () => {
+    it('re-running ng-add does not duplicate entries', async () => {
+      const { runner, tree } = await makeAppTree();
+      const once = await runner.runSchematic('ng-add', { adapter: 'material' }, tree);
+      const twice = await runner.runSchematic('ng-add', { adapter: 'material' }, once);
+
+      const styles = twice.readContent(`${APP_DIR}/src/styles.scss`);
+      expect(styles.match(/azure-blue\.css/g)?.length).toBe(1);
+
+      const config = twice.readContent(`${APP_DIR}/src/app/app.config.ts`);
+      expect(config.match(/withMaterialFields\s*\(/g)?.length).toBe(1);
+      expect(config.match(/provideDynamicForm\s*\(/g)?.length).toBe(1);
+      expect(config.match(/provideAnimations\s*\(/g)?.length).toBe(1);
+      expect(config.match(/withLegacyStatusClasses\s*\(/g)?.length).toBe(1);
+
+      const pkg = JSON.parse(twice.readContent('/package.json'));
+      const deps = pkg.dependencies as Record<string, string>;
+      expect(Object.keys(deps).filter((k) => k === '@angular/material')).toHaveLength(1);
+    });
+  });
+});

--- a/packages/dynamic-forms/schematics/ng-add/index.spec.ts
+++ b/packages/dynamic-forms/schematics/ng-add/index.spec.ts
@@ -197,6 +197,58 @@ describe('ng-add', () => {
       // and still above the first real rule
       expect(importIdx).toBeLessThan(styles.indexOf('body {'));
     });
+
+    it('walks past a multi-line block comment with unprefixed interior lines', async () => {
+      const { runner, tree } = await makeAppTree();
+      tree.overwrite(
+        `${APP_DIR}/src/styles.scss`,
+        [
+          '/*',
+          'This is a block comment',
+          'spanning multiple lines',
+          'with no leading * on interior lines.',
+          '*/',
+          "@use 'sass:math';",
+          '',
+          'body { margin: 0; }',
+          '',
+        ].join('\n'),
+      );
+      const result = await runner.runSchematic('ng-add', { adapter: 'material' }, tree);
+      const styles = result.readContent(`${APP_DIR}/src/styles.scss`);
+
+      const useIdx = styles.indexOf('@use');
+      const importIdx = styles.indexOf("@import '@angular/material");
+      expect(importIdx).toBeGreaterThan(useIdx); // after @use
+      expect(importIdx).toBeLessThan(styles.indexOf('body {')); // before first real rule
+    });
+  });
+
+  describe('marker detection ignores comments', () => {
+    it('does not skip wiring when provideDynamicForm appears only in a comment', async () => {
+      const { runner, tree } = await makeAppTree();
+      const configPath = `${APP_DIR}/src/app/app.config.ts`;
+      const original = tree.readContent(configPath);
+      tree.overwrite(configPath, '// provideDynamicForm() — TODO wire this up\n' + original);
+
+      const result = await runner.runSchematic('ng-add', { adapter: 'material' }, tree);
+      const config = result.readContent(configPath);
+      // The real provideDynamicForm(...) call was added (commented marker did not block it).
+      expect(config.match(/^[^/]*provideDynamicForm\s*\(/m)).not.toBeNull();
+      expect(config).toContain('withMaterialFields');
+    });
+
+    it('does not skip a default import when its module appears only in a comment', async () => {
+      const { runner, tree } = await makeAppTree();
+      const configPath = `${APP_DIR}/src/app/app.config.ts`;
+      const original = tree.readContent(configPath);
+      tree.overwrite(configPath, "// import Aura from '@primeng/themes/aura';\n" + original);
+
+      const result = await runner.runSchematic('ng-add', { adapter: 'primeng' }, tree);
+      const config = result.readContent(configPath);
+      // The real default import was added (commented one did not block it).
+      expect(config.match(/^[^/]*import Aura from '@primeng\/themes\/aura'/m)).not.toBeNull();
+    });
   });
 
   describe('no application project', () => {

--- a/packages/dynamic-forms/schematics/ng-add/index.spec.ts
+++ b/packages/dynamic-forms/schematics/ng-add/index.spec.ts
@@ -35,7 +35,7 @@ interface AdapterExpectations {
 
 const EXPECTATIONS: Record<Exclude<Adapter, 'none'>, AdapterExpectations> = {
   material: {
-    packages: ['@ng-forge/dynamic-forms', '@ng-forge/dynamic-forms-material', '@angular/material', '@angular/cdk'],
+    packages: ['@ng-forge/dynamic-forms', '@angular/animations', '@ng-forge/dynamic-forms-material', '@angular/material', '@angular/cdk'],
     styleNeedles: ['@angular/material/prebuilt-themes/azure-blue.css'],
     providerNeedles: ['provideAnimations', 'provideDynamicForm', 'withMaterialFields', 'withLegacyStatusClasses'],
   },
@@ -99,9 +99,11 @@ describe('ng-add', () => {
       result = await runner.runSchematic('ng-add', { adapter: 'none' }, tree);
     });
 
-    it('adds only core package', () => {
+    it('adds core + animations but no adapter package', () => {
       const pkg = JSON.parse(result.readContent('/package.json'));
       expect(pkg.dependencies?.['@ng-forge/dynamic-forms']).toBeDefined();
+      expect(pkg.dependencies?.['@angular/animations']).toBeDefined();
+      expect(pkg.dependencies?.['@ng-forge/dynamic-forms-material']).toBeUndefined();
     });
 
     it('does not write adapter style imports', () => {
@@ -127,12 +129,17 @@ describe('ng-add', () => {
       expect(after).toBe(before);
     });
 
-    it('--skipProviders leaves app.config.ts untouched', async () => {
+    it('--skipProviders leaves app.config.ts untouched and skips @angular/animations', async () => {
       const { runner, tree } = await makeAppTree();
       const before = tree.readContent(`${APP_DIR}/src/app/app.config.ts`);
       const result = await runner.runSchematic('ng-add', { adapter: 'material', skipProviders: true }, tree);
       const after = result.readContent(`${APP_DIR}/src/app/app.config.ts`);
       expect(after).toBe(before);
+
+      // animations is a provider-side dep; skipping providers must skip it too
+      const pkg = JSON.parse(result.readContent('/package.json'));
+      expect(pkg.dependencies?.['@angular/animations']).toBeUndefined();
+      expect(pkg.dependencies?.['@angular/material']).toBeDefined();
     });
 
     it('--legacyStatusClasses=false omits withLegacyStatusClasses()', async () => {

--- a/packages/dynamic-forms/schematics/ng-add/index.spec.ts
+++ b/packages/dynamic-forms/schematics/ng-add/index.spec.ts
@@ -170,5 +170,52 @@ describe('ng-add', () => {
       const deps = pkg.dependencies as Record<string, string>;
       expect(Object.keys(deps).filter((k) => k === '@angular/material')).toHaveLength(1);
     });
+
+    it('re-running primeng does not duplicate the default Aura import', async () => {
+      const { runner, tree } = await makeAppTree();
+      const once = await runner.runSchematic('ng-add', { adapter: 'primeng' }, tree);
+      const twice = await runner.runSchematic('ng-add', { adapter: 'primeng' }, once);
+
+      const config = twice.readContent(`${APP_DIR}/src/app/app.config.ts`);
+      expect(config.match(/import Aura from '@primeng\/themes\/aura'/g)?.length).toBe(1);
+      expect(config.match(/providePrimeNG\s*\(/g)?.length).toBe(1);
+    });
+  });
+
+  describe('SCSS @use ordering', () => {
+    it('inserts @import after leading @use/@forward, not above them', async () => {
+      const { runner, tree } = await makeAppTree();
+      tree.overwrite(`${APP_DIR}/src/styles.scss`, "@use 'sass:math';\n@forward 'tokens';\n\nbody { margin: 0; }\n");
+      const result = await runner.runSchematic('ng-add', { adapter: 'material' }, tree);
+      const styles = result.readContent(`${APP_DIR}/src/styles.scss`);
+
+      const useIdx = styles.indexOf('@use');
+      const forwardIdx = styles.indexOf('@forward');
+      const importIdx = styles.indexOf("@import '@angular/material");
+      expect(importIdx).toBeGreaterThan(useIdx);
+      expect(importIdx).toBeGreaterThan(forwardIdx);
+      // and still above the first real rule
+      expect(importIdx).toBeLessThan(styles.indexOf('body {'));
+    });
+  });
+
+  describe('no application project', () => {
+    it('completes without throwing and skips provider wiring', async () => {
+      const runner = new SchematicTestRunner('@ng-forge/dynamic-forms', collectionPath);
+      // Bare workspace — no application project at all.
+      const wsTree = await runner.runExternalSchematic(NG_SCHEMATICS, 'workspace', {
+        name: 'empty-ws',
+        newProjectRoot: 'projects',
+        version: '21.0.0',
+      });
+
+      const result = await runner.runSchematic('ng-add', { adapter: 'material' }, wsTree);
+
+      // Core package is still added (so the dep is tracked)...
+      const pkg = JSON.parse(result.readContent('/package.json'));
+      expect(pkg.dependencies?.['@ng-forge/dynamic-forms']).toBeDefined();
+      // ...but there is no app.config.ts to wire.
+      expect(result.exists('/projects/test-app/src/app/app.config.ts')).toBe(false);
+    });
   });
 });

--- a/packages/dynamic-forms/schematics/ng-add/index.ts
+++ b/packages/dynamic-forms/schematics/ng-add/index.ts
@@ -3,30 +3,35 @@ import { getWorkspace } from '@schematics/angular/utility/workspace';
 
 import { NgAddOptions } from './schema';
 import { AdapterRecipe, RECIPES } from './recipes';
-import { addPackages } from './rules/add-packages';
+import { addPackages, InstallState } from './rules/add-packages';
 import { addStyles } from './rules/add-styles';
 import { addProviders } from './rules/add-providers';
 
 export default function ngAdd(options: NgAddOptions): Rule {
   return async (tree: Tree, ctx: SchematicContext) => {
     if (!options.adapter) {
-      throw new SchematicsException('[ng-forge] No adapter selected. Pass --adapter=<material|bootstrap|primeng|ionic|none>.');
+      throw new SchematicsException('No adapter selected. Pass --adapter=<material|bootstrap|primeng|ionic|none>.');
     }
     if (!(options.adapter in RECIPES)) {
-      throw new SchematicsException(`[ng-forge] Unknown adapter "${options.adapter}".`);
+      throw new SchematicsException(`Unknown adapter "${options.adapter}".`);
     }
 
     const recipe = RECIPES[options.adapter];
     const projectName = await resolveProjectName(tree, options.project);
     const legacyStatusClasses = options.legacyStatusClasses !== false;
 
-    ctx.logger.info(`[ng-forge] Setting up dynamic-forms with ${recipe.label}${projectName ? ` (project: ${projectName})` : ''}.`);
+    // Shared across rules: addPackages records how many deps it queued so the
+    // final summary can show the install hint only when an install was actually
+    // scheduled (e.g. not on an idempotent re-run).
+    const installState: InstallState = { added: 0 };
+
+    ctx.logger.info(`Setting up @ng-forge/dynamic-forms with ${recipe.label}${projectName ? ` (project: ${projectName})` : ''}.`);
 
     return chain([
-      addPackages(recipe, !options.skipProviders),
+      addPackages(recipe, !options.skipProviders, installState),
       options.skipStyles ? noopRule() : addStyles(recipe, projectName),
       options.skipProviders ? noopRule() : addProviders(recipe, legacyStatusClasses, projectName),
-      summarize(recipe, options, projectName),
+      summarize(recipe, options, projectName, installState),
     ]);
   };
 }
@@ -56,17 +61,18 @@ async function resolveProjectName(tree: Tree, requested: string | undefined): Pr
   }
 }
 
-function summarize(recipe: AdapterRecipe, options: NgAddOptions, projectName: string | undefined): Rule {
+function summarize(recipe: AdapterRecipe, options: NgAddOptions, projectName: string | undefined, installState: InstallState): Rule {
   return (_tree: Tree, ctx: SchematicContext) => {
+    const providersStatus = options.skipProviders ? 'skipped' : projectName ? 'wired' : 'skipped (no application project found)';
     const lines: string[] = [];
-    lines.push('[ng-forge] Done.');
+    lines.push('@ng-forge/dynamic-forms setup complete.');
     lines.push(`  adapter: ${recipe.label}`);
     if (projectName) {
       lines.push(`  project: ${projectName}`);
     }
     lines.push(`  styles:    ${options.skipStyles ? 'skipped' : recipe.styles.length === 0 ? 'n/a' : 'imported'}`);
-    lines.push(`  providers: ${options.skipProviders ? 'skipped' : 'wired'}`);
-    if (recipe.packages.length > 0) {
+    lines.push(`  providers: ${providersStatus}`);
+    if (installState.added > 0) {
       lines.push("  Run `npm install` if it didn't run automatically.");
     }
     lines.push('  Docs: https://ng-forge.com/dynamic-forms/getting-started');

--- a/packages/dynamic-forms/schematics/ng-add/index.ts
+++ b/packages/dynamic-forms/schematics/ng-add/index.ts
@@ -44,21 +44,37 @@ async function resolveProjectName(tree: Tree, requested: string | undefined): Pr
   if (requested) {
     return requested;
   }
+  let workspace: Awaited<ReturnType<typeof getWorkspace>>;
   try {
-    const workspace = await getWorkspace(tree);
-    const explicitDefault = workspace.extensions['defaultProject'];
-    if (typeof explicitDefault === 'string' && workspace.projects.has(explicitDefault)) {
-      return explicitDefault;
-    }
-    for (const [name, project] of workspace.projects) {
-      if (project.extensions['projectType'] === 'application') {
-        return name;
-      }
-    }
-    return undefined;
+    workspace = await getWorkspace(tree);
   } catch {
     return undefined;
   }
+
+  const explicitDefault = workspace.extensions['defaultProject'];
+  if (typeof explicitDefault === 'string' && workspace.projects.has(explicitDefault)) {
+    return explicitDefault;
+  }
+
+  const apps: string[] = [];
+  for (const [name, project] of workspace.projects) {
+    if (project.extensions['projectType'] === 'application') {
+      apps.push(name);
+    }
+  }
+
+  if (apps.length === 0) {
+    return undefined;
+  }
+  if (apps.length === 1) {
+    return apps[0];
+  }
+  // Multiple apps and no --project: silently picking one would wire
+  // ng-forge into a random project. Fail loudly with the list so the user
+  // can re-run with --project=<name>.
+  throw new SchematicsException(
+    `Multiple application projects found (${apps.join(', ')}). Pass --project=<name> to choose which one to set up.`,
+  );
 }
 
 function summarize(recipe: AdapterRecipe, options: NgAddOptions, projectName: string | undefined, installState: InstallState): Rule {

--- a/packages/dynamic-forms/schematics/ng-add/index.ts
+++ b/packages/dynamic-forms/schematics/ng-add/index.ts
@@ -23,7 +23,7 @@ export default function ngAdd(options: NgAddOptions): Rule {
     ctx.logger.info(`[ng-forge] Setting up dynamic-forms with ${recipe.label}${projectName ? ` (project: ${projectName})` : ''}.`);
 
     return chain([
-      addPackages(recipe),
+      addPackages(recipe, !options.skipProviders),
       options.skipStyles ? noopRule() : addStyles(recipe, projectName),
       options.skipProviders ? noopRule() : addProviders(recipe, legacyStatusClasses, projectName),
       summarize(recipe, options, projectName),

--- a/packages/dynamic-forms/schematics/ng-add/index.ts
+++ b/packages/dynamic-forms/schematics/ng-add/index.ts
@@ -1,0 +1,75 @@
+import { Rule, SchematicContext, SchematicsException, Tree, chain } from '@angular-devkit/schematics';
+import { getWorkspace } from '@schematics/angular/utility/workspace';
+
+import { NgAddOptions } from './schema';
+import { AdapterRecipe, RECIPES } from './recipes';
+import { addPackages } from './rules/add-packages';
+import { addStyles } from './rules/add-styles';
+import { addProviders } from './rules/add-providers';
+
+export default function ngAdd(options: NgAddOptions): Rule {
+  return async (tree: Tree, ctx: SchematicContext) => {
+    if (!options.adapter) {
+      throw new SchematicsException('[ng-forge] No adapter selected. Pass --adapter=<material|bootstrap|primeng|ionic|none>.');
+    }
+    if (!(options.adapter in RECIPES)) {
+      throw new SchematicsException(`[ng-forge] Unknown adapter "${options.adapter}".`);
+    }
+
+    const recipe = RECIPES[options.adapter];
+    const projectName = await resolveProjectName(tree, options.project);
+    const legacyStatusClasses = options.legacyStatusClasses !== false;
+
+    ctx.logger.info(`[ng-forge] Setting up dynamic-forms with ${recipe.label}${projectName ? ` (project: ${projectName})` : ''}.`);
+
+    return chain([
+      addPackages(recipe),
+      options.skipStyles ? noopRule() : addStyles(recipe, projectName),
+      options.skipProviders ? noopRule() : addProviders(recipe, legacyStatusClasses, projectName),
+      summarize(recipe, options, projectName),
+    ]);
+  };
+}
+
+function noopRule(): Rule {
+  return (tree) => tree;
+}
+
+async function resolveProjectName(tree: Tree, requested: string | undefined): Promise<string | undefined> {
+  if (requested) {
+    return requested;
+  }
+  try {
+    const workspace = await getWorkspace(tree);
+    const explicitDefault = workspace.extensions['defaultProject'];
+    if (typeof explicitDefault === 'string' && workspace.projects.has(explicitDefault)) {
+      return explicitDefault;
+    }
+    for (const [name, project] of workspace.projects) {
+      if (project.extensions['projectType'] === 'application') {
+        return name;
+      }
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function summarize(recipe: AdapterRecipe, options: NgAddOptions, projectName: string | undefined): Rule {
+  return (_tree: Tree, ctx: SchematicContext) => {
+    const lines: string[] = [];
+    lines.push('[ng-forge] Done.');
+    lines.push(`  adapter: ${recipe.label}`);
+    if (projectName) {
+      lines.push(`  project: ${projectName}`);
+    }
+    lines.push(`  styles:    ${options.skipStyles ? 'skipped' : recipe.styles.length === 0 ? 'n/a' : 'imported'}`);
+    lines.push(`  providers: ${options.skipProviders ? 'skipped' : 'wired'}`);
+    if (recipe.packages.length > 0) {
+      lines.push("  Run `npm install` if it didn't run automatically.");
+    }
+    lines.push('  Docs: https://ng-forge.com/dynamic-forms/getting-started');
+    ctx.logger.info(lines.join('\n'));
+  };
+}

--- a/packages/dynamic-forms/schematics/ng-add/nx-wrapper.ts
+++ b/packages/dynamic-forms/schematics/ng-add/nx-wrapper.ts
@@ -1,0 +1,3 @@
+import { wrapAngularDevkitSchematic } from '@nx/devkit/ngcli-adapter';
+
+export default wrapAngularDevkitSchematic('@ng-forge/dynamic-forms', 'ng-add');

--- a/packages/dynamic-forms/schematics/ng-add/recipes.ts
+++ b/packages/dynamic-forms/schematics/ng-add/recipes.ts
@@ -1,0 +1,88 @@
+import { CodeBlockCallback } from '@schematics/angular/utility/standalone';
+
+import { Adapter } from './schema';
+import { VERSIONS, KnownPackage } from '../versions';
+
+export interface PackageSpec {
+  name: KnownPackage | string;
+  version: string;
+}
+
+export interface DefaultImportSpec {
+  symbol: string;
+  from: string;
+}
+
+export interface AdapterProviderSpec {
+  /** Symbol name used to detect existing providers and skip insertion. */
+  marker: string;
+  /** Default imports the provider expression depends on (e.g. `import Aura from '@primeng/themes/aura'`). */
+  defaultImports: DefaultImportSpec[];
+  /** Builds the provider expression using addRootProvider's CodeBlock helper. */
+  builder: CodeBlockCallback;
+}
+
+export interface AdapterRecipe {
+  label: string;
+  packages: PackageSpec[];
+  styles: string[];
+  adapterProviders: AdapterProviderSpec[];
+  withFields: { from: string; symbol: string } | null;
+}
+
+const v = (name: KnownPackage): PackageSpec => ({ name, version: VERSIONS[name] });
+
+export const RECIPES: Record<Adapter, AdapterRecipe> = {
+  material: {
+    label: 'Angular Material',
+    packages: [v('@ng-forge/dynamic-forms-material'), v('@angular/material'), v('@angular/cdk')],
+    styles: ['@angular/material/prebuilt-themes/azure-blue.css'],
+    adapterProviders: [],
+    withFields: { from: '@ng-forge/dynamic-forms-material', symbol: 'withMaterialFields' },
+  },
+  bootstrap: {
+    label: 'Bootstrap',
+    packages: [v('@ng-forge/dynamic-forms-bootstrap'), v('bootstrap')],
+    styles: ['bootstrap/dist/css/bootstrap.min.css'],
+    adapterProviders: [],
+    withFields: { from: '@ng-forge/dynamic-forms-bootstrap', symbol: 'withBootstrapFields' },
+  },
+  primeng: {
+    label: 'PrimeNG',
+    packages: [v('@ng-forge/dynamic-forms-primeng'), v('primeng'), v('@primeng/themes'), v('primeicons')],
+    styles: ['primeicons/primeicons.css'],
+    adapterProviders: [
+      {
+        marker: 'providePrimeNG',
+        defaultImports: [{ symbol: 'Aura', from: '@primeng/themes/aura' }],
+        builder: ({ code, external }) => code`${external('providePrimeNG', 'primeng/config')}({ theme: { preset: Aura } })`,
+      },
+    ],
+    withFields: { from: '@ng-forge/dynamic-forms-primeng', symbol: 'withPrimeNGFields' },
+  },
+  ionic: {
+    label: 'Ionic',
+    packages: [v('@ng-forge/dynamic-forms-ionic'), v('@ionic/angular')],
+    styles: [
+      '@ionic/angular/css/core.css',
+      '@ionic/angular/css/normalize.css',
+      '@ionic/angular/css/structure.css',
+      '@ionic/angular/css/typography.css',
+    ],
+    adapterProviders: [
+      {
+        marker: 'provideIonicAngular',
+        defaultImports: [],
+        builder: ({ code, external }) => code`${external('provideIonicAngular', '@ionic/angular/standalone')}({ mode: 'md' })`,
+      },
+    ],
+    withFields: { from: '@ng-forge/dynamic-forms-ionic', symbol: 'withIonicFields' },
+  },
+  none: {
+    label: 'Core only',
+    packages: [],
+    styles: [],
+    adapterProviders: [],
+    withFields: null,
+  },
+};

--- a/packages/dynamic-forms/schematics/ng-add/rules/add-packages.ts
+++ b/packages/dynamic-forms/schematics/ng-add/rules/add-packages.ts
@@ -5,6 +5,15 @@ import { NodeDependencyType, addPackageJsonDependency, getPackageJsonDependency 
 import { AdapterRecipe, PackageSpec } from '../recipes';
 import { VERSIONS } from '../../versions';
 
+/**
+ * Shared across the rule chain: how many dependencies addPackages queued, so
+ * the final summary shows the install hint only when an install was actually
+ * scheduled (not on an idempotent re-run).
+ */
+export interface InstallState {
+  added: number;
+}
+
 const CORE_PACKAGE: PackageSpec = {
   name: '@ng-forge/dynamic-forms',
   version: VERSIONS['@ng-forge/dynamic-forms'],
@@ -18,7 +27,7 @@ const ANIMATIONS_PACKAGE: PackageSpec = {
   version: VERSIONS['@angular/animations'],
 };
 
-export function addPackages(recipe: AdapterRecipe, includeAnimations: boolean): Rule {
+export function addPackages(recipe: AdapterRecipe, includeAnimations: boolean, state: InstallState): Rule {
   return (tree: Tree, ctx: SchematicContext) => {
     const all = [CORE_PACKAGE, ...(includeAnimations ? [ANIMATIONS_PACKAGE] : []), ...recipe.packages];
     // @angular/animations ships from the core monorepo and pins @angular/core
@@ -32,7 +41,7 @@ export function addPackages(recipe: AdapterRecipe, includeAnimations: boolean): 
     for (const pkg of all) {
       const existing = getPackageJsonDependency(tree, pkg.name);
       if (existing) {
-        ctx.logger.info(`[ng-forge] ${pkg.name} already declared (${existing.version}); leaving as-is.`);
+        ctx.logger.info(`${pkg.name} already declared (${existing.version}); leaving as-is.`);
         continue;
       }
       const version = pkg.name === '@angular/animations' && angularVersion ? angularVersion : pkg.version;
@@ -48,6 +57,7 @@ export function addPackages(recipe: AdapterRecipe, includeAnimations: boolean): 
     if (added > 0) {
       ctx.addTask(new NodePackageInstallTask());
     }
+    state.added = added;
 
     return tree;
   };

--- a/packages/dynamic-forms/schematics/ng-add/rules/add-packages.ts
+++ b/packages/dynamic-forms/schematics/ng-add/rules/add-packages.ts
@@ -22,6 +22,9 @@ const CORE_PACKAGE: PackageSpec = {
 // provideAnimations() (wired unless providers are skipped) imports from
 // @angular/platform-browser/animations, which needs @angular/animations —
 // not present in a fresh Angular app.
+// This is installed even for the `none` (core-only) adapter, because the
+// schematic still wires provideAnimations() unconditionally on the providers
+// path. Pass --skipProviders to opt out of both the wiring and the install.
 const ANIMATIONS_PACKAGE: PackageSpec = {
   name: '@angular/animations',
   version: VERSIONS['@angular/animations'],

--- a/packages/dynamic-forms/schematics/ng-add/rules/add-packages.ts
+++ b/packages/dynamic-forms/schematics/ng-add/rules/add-packages.ts
@@ -1,0 +1,39 @@
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+import { NodeDependencyType, addPackageJsonDependency, getPackageJsonDependency } from '@schematics/angular/utility/dependencies';
+
+import { AdapterRecipe, PackageSpec } from '../recipes';
+import { VERSIONS } from '../../versions';
+
+const CORE_PACKAGE: PackageSpec = {
+  name: '@ng-forge/dynamic-forms',
+  version: VERSIONS['@ng-forge/dynamic-forms'],
+};
+
+export function addPackages(recipe: AdapterRecipe): Rule {
+  return (tree: Tree, ctx: SchematicContext) => {
+    const all = [CORE_PACKAGE, ...recipe.packages];
+    let added = 0;
+
+    for (const pkg of all) {
+      const existing = getPackageJsonDependency(tree, pkg.name);
+      if (existing) {
+        ctx.logger.info(`[ng-forge] ${pkg.name} already declared (${existing.version}); leaving as-is.`);
+        continue;
+      }
+      addPackageJsonDependency(tree, {
+        type: NodeDependencyType.Default,
+        name: pkg.name,
+        version: pkg.version,
+        overwrite: false,
+      });
+      added++;
+    }
+
+    if (added > 0) {
+      ctx.addTask(new NodePackageInstallTask());
+    }
+
+    return tree;
+  };
+}

--- a/packages/dynamic-forms/schematics/ng-add/rules/add-packages.ts
+++ b/packages/dynamic-forms/schematics/ng-add/rules/add-packages.ts
@@ -10,9 +10,23 @@ const CORE_PACKAGE: PackageSpec = {
   version: VERSIONS['@ng-forge/dynamic-forms'],
 };
 
-export function addPackages(recipe: AdapterRecipe): Rule {
+// provideAnimations() (wired unless providers are skipped) imports from
+// @angular/platform-browser/animations, which needs @angular/animations —
+// not present in a fresh Angular app.
+const ANIMATIONS_PACKAGE: PackageSpec = {
+  name: '@angular/animations',
+  version: VERSIONS['@angular/animations'],
+};
+
+export function addPackages(recipe: AdapterRecipe, includeAnimations: boolean): Rule {
   return (tree: Tree, ctx: SchematicContext) => {
-    const all = [CORE_PACKAGE, ...recipe.packages];
+    const all = [CORE_PACKAGE, ...(includeAnimations ? [ANIMATIONS_PACKAGE] : []), ...recipe.packages];
+    // @angular/animations ships from the core monorepo and pins @angular/core
+    // to its EXACT patch version. So it must match the installed core exactly,
+    // otherwise npm resolves the range to a newer patch and the peer check
+    // fails (e.g. animations@21.2.15 vs core@21.2.14). Material/CDK are a
+    // separate train (peer `^21.0.0`) and keep their declared range.
+    const angularVersion = getInstalledAngularVersion(tree);
     let added = 0;
 
     for (const pkg of all) {
@@ -21,10 +35,11 @@ export function addPackages(recipe: AdapterRecipe): Rule {
         ctx.logger.info(`[ng-forge] ${pkg.name} already declared (${existing.version}); leaving as-is.`);
         continue;
       }
+      const version = pkg.name === '@angular/animations' && angularVersion ? angularVersion : pkg.version;
       addPackageJsonDependency(tree, {
         type: NodeDependencyType.Default,
         name: pkg.name,
-        version: pkg.version,
+        version,
         overwrite: false,
       });
       added++;
@@ -36,4 +51,24 @@ export function addPackages(recipe: AdapterRecipe): Rule {
 
     return tree;
   };
+}
+
+/**
+ * Exact installed @angular/core version (e.g. "21.2.14"), so @angular/*
+ * packages we add lockstep with it. Prefers the resolved version in
+ * node_modules; falls back to the spec in package.json; null if neither.
+ */
+function getInstalledAngularVersion(tree: Tree): string | null {
+  const corePkgPath = '/node_modules/@angular/core/package.json';
+  if (tree.exists(corePkgPath)) {
+    try {
+      const json = JSON.parse(tree.read(corePkgPath)!.toString('utf-8')) as { version?: unknown };
+      if (typeof json.version === 'string' && json.version.length > 0) {
+        return json.version;
+      }
+    } catch {
+      // fall through to package.json spec
+    }
+  }
+  return getPackageJsonDependency(tree, '@angular/core')?.version ?? null;
 }

--- a/packages/dynamic-forms/schematics/ng-add/rules/add-providers.ts
+++ b/packages/dynamic-forms/schematics/ng-add/rules/add-providers.ts
@@ -1,0 +1,114 @@
+import { Rule, SchematicContext, Tree, chain, noop } from '@angular-devkit/schematics';
+import { insertImport } from '@schematics/angular/utility/ast-utils';
+import { addRootProvider } from '@schematics/angular/utility/standalone/rules';
+import { findAppConfig } from '@schematics/angular/utility/standalone/app_config';
+import {
+  applyChangesToFile,
+  findBootstrapApplicationCall,
+  getMainFilePath,
+  getSourceFile,
+} from '@schematics/angular/utility/standalone/util';
+
+import { AdapterProviderSpec, AdapterRecipe } from '../recipes';
+
+const DEFAULT_PROJECT = 'default';
+
+export function addProviders(recipe: AdapterRecipe, legacyStatusClasses: boolean, projectName: string | undefined): Rule {
+  return () => {
+    const project = projectName ?? DEFAULT_PROJECT;
+
+    return chain([
+      maybeAddRootProvider(
+        project,
+        'provideAnimations',
+        ({ code, external }) => code`${external('provideAnimations', '@angular/platform-browser/animations')}()`,
+      ),
+      ...recipe.adapterProviders.flatMap((spec) => adapterProviderRules(project, spec, projectName)),
+      maybeAddRootProvider(project, 'provideDynamicForm', ({ code, external }) => {
+        const provide = external('provideDynamicForm', '@ng-forge/dynamic-forms');
+        if (recipe.withFields === null) {
+          return code`${provide}()`;
+        }
+        const withFields = external(recipe.withFields.symbol, recipe.withFields.from);
+        if (legacyStatusClasses) {
+          const withLegacy = external('withLegacyStatusClasses', '@ng-forge/dynamic-forms');
+          return code`${provide}(...${withFields}(), ${withLegacy}())`;
+        }
+        return code`${provide}(...${withFields}())`;
+      }),
+    ]);
+  };
+}
+
+function adapterProviderRules(project: string, spec: AdapterProviderSpec, projectName: string | undefined): Rule[] {
+  return [
+    ...spec.defaultImports.map((imp) => addDefaultImportRule(imp.symbol, imp.from, projectName)),
+    maybeAddRootProvider(project, spec.marker, spec.builder),
+  ];
+}
+
+function addDefaultImportRule(symbol: string, module: string, projectName: string | undefined): Rule {
+  return async (tree: Tree, ctx: SchematicContext) => {
+    let mainFilePath: string;
+    try {
+      mainFilePath = await getMainFilePath(tree, projectName ?? DEFAULT_PROJECT);
+    } catch {
+      ctx.logger.warn(`[ng-forge] Could not locate main.ts; skipping default import for ${symbol}.`);
+      return tree;
+    }
+
+    let filePath = mainFilePath;
+    try {
+      const bootstrapCall = findBootstrapApplicationCall(tree, mainFilePath);
+      const appConfig = findAppConfig(bootstrapCall, tree, mainFilePath);
+      if (appConfig) {
+        filePath = appConfig.filePath;
+      }
+    } catch {
+      // fall back to main.ts
+    }
+
+    const source = getSourceFile(tree, filePath);
+    const change = insertImport(source, filePath, symbol, module, true);
+    applyChangesToFile(tree, filePath, [change]);
+    return tree;
+  };
+}
+
+function maybeAddRootProvider(project: string, marker: string, callback: Parameters<typeof addRootProvider>[1]): Rule {
+  return async (tree: Tree, ctx: SchematicContext) => {
+    const present = await isProviderPresent(tree, project, marker);
+    if (present) {
+      ctx.logger.info(`[ng-forge] ${marker}(...) already present in providers; skipping.`);
+      return noop();
+    }
+    return addRootProvider(project, callback);
+  };
+}
+
+async function isProviderPresent(tree: Tree, project: string, marker: string): Promise<boolean> {
+  let mainFilePath: string;
+  try {
+    mainFilePath = await getMainFilePath(tree, project);
+  } catch {
+    return false;
+  }
+
+  let filePath = mainFilePath;
+  try {
+    const bootstrapCall = findBootstrapApplicationCall(tree, mainFilePath);
+    const appConfig = findAppConfig(bootstrapCall, tree, mainFilePath);
+    if (appConfig) {
+      filePath = appConfig.filePath;
+    }
+  } catch {
+    return false;
+  }
+
+  const buffer = tree.read(filePath);
+  if (!buffer) {
+    return false;
+  }
+  const source = buffer.toString('utf-8');
+  return new RegExp(`\\b${marker}\\s*\\(`).test(source);
+}

--- a/packages/dynamic-forms/schematics/ng-add/rules/add-providers.ts
+++ b/packages/dynamic-forms/schematics/ng-add/rules/add-providers.ts
@@ -11,11 +11,20 @@ import {
 
 import { AdapterProviderSpec, AdapterRecipe } from '../recipes';
 
-const DEFAULT_PROJECT = 'default';
-
 export function addProviders(recipe: AdapterRecipe, legacyStatusClasses: boolean, projectName: string | undefined): Rule {
-  return () => {
-    const project = projectName ?? DEFAULT_PROJECT;
+  return (tree: Tree, ctx: SchematicContext) => {
+    // No target project (workspace has no application, or the workspace file
+    // couldn't be read). Don't guess a name — addRootProvider would throw and
+    // abort the whole ng-add. Warn and skip, mirroring addStyles' behaviour.
+    if (!projectName) {
+      ctx.logger.warn(
+        'No application project found; skipping provider wiring. ' +
+          'Add provideDynamicForm(...) to your ApplicationConfig manually — see ' +
+          'https://ng-forge.com/dynamic-forms/getting-started',
+      );
+      return tree;
+    }
+    const project = projectName;
 
     return chain([
       maybeAddRootProvider(
@@ -23,7 +32,7 @@ export function addProviders(recipe: AdapterRecipe, legacyStatusClasses: boolean
         'provideAnimations',
         ({ code, external }) => code`${external('provideAnimations', '@angular/platform-browser/animations')}()`,
       ),
-      ...recipe.adapterProviders.flatMap((spec) => adapterProviderRules(project, spec, projectName)),
+      ...recipe.adapterProviders.flatMap((spec) => adapterProviderRules(project, spec)),
       maybeAddRootProvider(project, 'provideDynamicForm', ({ code, external }) => {
         const provide = external('provideDynamicForm', '@ng-forge/dynamic-forms');
         if (recipe.withFields === null) {
@@ -40,20 +49,20 @@ export function addProviders(recipe: AdapterRecipe, legacyStatusClasses: boolean
   };
 }
 
-function adapterProviderRules(project: string, spec: AdapterProviderSpec, projectName: string | undefined): Rule[] {
+function adapterProviderRules(project: string, spec: AdapterProviderSpec): Rule[] {
   return [
-    ...spec.defaultImports.map((imp) => addDefaultImportRule(imp.symbol, imp.from, projectName)),
+    ...spec.defaultImports.map((imp) => addDefaultImportRule(imp.symbol, imp.from, project)),
     maybeAddRootProvider(project, spec.marker, spec.builder),
   ];
 }
 
-function addDefaultImportRule(symbol: string, module: string, projectName: string | undefined): Rule {
+function addDefaultImportRule(symbol: string, module: string, project: string): Rule {
   return async (tree: Tree, ctx: SchematicContext) => {
     let mainFilePath: string;
     try {
-      mainFilePath = await getMainFilePath(tree, projectName ?? DEFAULT_PROJECT);
+      mainFilePath = await getMainFilePath(tree, project);
     } catch {
-      ctx.logger.warn(`[ng-forge] Could not locate main.ts; skipping default import for ${symbol}.`);
+      ctx.logger.warn(`Could not locate main.ts; skipping default import for ${symbol}.`);
       return tree;
     }
 
@@ -68,6 +77,15 @@ function addDefaultImportRule(symbol: string, module: string, projectName: strin
       // fall back to main.ts
     }
 
+    // insertImport throws (rather than no-op'ing) for an already-present
+    // DEFAULT import, so guard idempotency ourselves before calling it.
+    const existing = tree.read(filePath)?.toString('utf-8') ?? '';
+    const moduleSpecifier = new RegExp(`from\\s+['"]${escapeRegExp(module)}['"]`);
+    if (moduleSpecifier.test(existing)) {
+      ctx.logger.info(`import ${symbol} from '${module}' already present; skipping.`);
+      return tree;
+    }
+
     const source = getSourceFile(tree, filePath);
     const change = insertImport(source, filePath, symbol, module, true);
     applyChangesToFile(tree, filePath, [change]);
@@ -75,11 +93,15 @@ function addDefaultImportRule(symbol: string, module: string, projectName: strin
   };
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function maybeAddRootProvider(project: string, marker: string, callback: Parameters<typeof addRootProvider>[1]): Rule {
   return async (tree: Tree, ctx: SchematicContext) => {
     const present = await isProviderPresent(tree, project, marker);
     if (present) {
-      ctx.logger.info(`[ng-forge] ${marker}(...) already present in providers; skipping.`);
+      ctx.logger.info(`${marker}(...) already present in providers; skipping.`);
       return noop();
     }
     return addRootProvider(project, callback);

--- a/packages/dynamic-forms/schematics/ng-add/rules/add-providers.ts
+++ b/packages/dynamic-forms/schematics/ng-add/rules/add-providers.ts
@@ -79,7 +79,9 @@ function addDefaultImportRule(symbol: string, module: string, project: string): 
 
     // insertImport throws (rather than no-op'ing) for an already-present
     // DEFAULT import, so guard idempotency ourselves before calling it.
-    const existing = tree.read(filePath)?.toString('utf-8') ?? '';
+    // Strip comments first so a commented-out import doesn't suppress the
+    // real insertion.
+    const existing = stripJsComments(tree.read(filePath)?.toString('utf-8') ?? '');
     const moduleSpecifier = new RegExp(`from\\s+['"]${escapeRegExp(module)}['"]`);
     if (moduleSpecifier.test(existing)) {
       ctx.logger.info(`import ${symbol} from '${module}' already present; skipping.`);
@@ -95,6 +97,16 @@ function addDefaultImportRule(symbol: string, module: string, project: string): 
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Strips line and block comments from JS/TS source for token-presence
+ * checks. Naive: doesn't account for `//` or `/*` characters that appear
+ * inside string/template literals — those would be unusual and aren't a
+ * realistic concern for the call-expression markers we're scanning for.
+ */
+function stripJsComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
 }
 
 function maybeAddRootProvider(project: string, marker: string, callback: Parameters<typeof addRootProvider>[1]): Rule {
@@ -131,6 +143,8 @@ async function isProviderPresent(tree: Tree, project: string, marker: string): P
   if (!buffer) {
     return false;
   }
-  const source = buffer.toString('utf-8');
+  // Strip comments so a commented-out reference (e.g. `// provideDynamicForm()`)
+  // doesn't cause the schematic to skip real wiring.
+  const source = stripJsComments(buffer.toString('utf-8'));
   return new RegExp(`\\b${marker}\\s*\\(`).test(source);
 }

--- a/packages/dynamic-forms/schematics/ng-add/rules/add-styles.ts
+++ b/packages/dynamic-forms/schematics/ng-add/rules/add-styles.ts
@@ -1,0 +1,89 @@
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { getWorkspace } from '@schematics/angular/utility/workspace';
+
+import { AdapterRecipe } from '../recipes';
+
+const FALLBACK_STYLES_PATHS = ['src/styles.scss', 'src/styles.css'];
+
+export function addStyles(recipe: AdapterRecipe, projectName: string | undefined): Rule {
+  return async (tree: Tree, ctx: SchematicContext) => {
+    if (recipe.styles.length === 0) {
+      return tree;
+    }
+
+    const stylesPath = await resolveStylesPath(tree, projectName);
+    if (!stylesPath) {
+      ctx.logger.warn(
+        '[ng-forge] Could not locate a global styles file from angular.json. Skipping style imports. ' +
+          'Add the following imports manually:\n' +
+          recipe.styles.map((p) => `  @import '${p}';`).join('\n'),
+      );
+      return tree;
+    }
+
+    const buffer = tree.read(stylesPath);
+    const current = buffer ? buffer.toString('utf-8') : '';
+    const additions: string[] = [];
+
+    for (const style of recipe.styles) {
+      if (current.includes(style)) {
+        ctx.logger.info(`[ng-forge] ${style} already imported; skipping.`);
+        continue;
+      }
+      additions.push(`@import '${style}';`);
+    }
+
+    if (additions.length === 0) {
+      return tree;
+    }
+
+    const block = additions.join('\n');
+    const updated = current.length > 0 ? `${block}\n${current}` : `${block}\n`;
+    tree.overwrite(stylesPath, updated);
+    ctx.logger.info(`[ng-forge] Added ${additions.length} style import(s) to ${stylesPath}.`);
+    return tree;
+  };
+}
+
+async function resolveStylesPath(tree: Tree, projectName: string | undefined): Promise<string | null> {
+  try {
+    const workspace = await getWorkspace(tree);
+    const project = projectName ? workspace.projects.get(projectName) : firstApplicationProject(workspace);
+    if (!project) {
+      return firstFallback(tree);
+    }
+    const buildTarget = project.targets.get('build');
+    const stylesOption = buildTarget?.options?.['styles'];
+    if (Array.isArray(stylesOption)) {
+      for (const entry of stylesOption) {
+        if (typeof entry === 'string' && tree.exists(entry)) {
+          return entry;
+        }
+        if (entry && typeof entry === 'object' && 'input' in entry && typeof entry.input === 'string' && tree.exists(entry.input)) {
+          return entry.input;
+        }
+      }
+    }
+    return firstFallback(tree);
+  } catch {
+    return firstFallback(tree);
+  }
+}
+
+function firstApplicationProject(workspace: Awaited<ReturnType<typeof getWorkspace>>) {
+  for (const [, project] of workspace.projects) {
+    if (project.extensions['projectType'] === 'application') {
+      return project;
+    }
+  }
+  return null;
+}
+
+function firstFallback(tree: Tree): string | null {
+  for (const candidate of FALLBACK_STYLES_PATHS) {
+    if (tree.exists(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}

--- a/packages/dynamic-forms/schematics/ng-add/rules/add-styles.ts
+++ b/packages/dynamic-forms/schematics/ng-add/rules/add-styles.ts
@@ -58,10 +58,24 @@ function insertImports(current: string, block: string): string {
 
   const lines = current.split('\n');
   let insertAt = 0;
+  let inBlockComment = false;
   for (let i = 0; i < lines.length; i++) {
     const trimmed = lines[i].trim();
-    if (trimmed === '' || trimmed.startsWith('//') || trimmed.startsWith('/*') || trimmed.startsWith('*')) {
-      continue; // skip blank lines and comments while scanning the header
+    if (inBlockComment) {
+      if (trimmed.endsWith('*/')) {
+        inBlockComment = false;
+      }
+      continue;
+    }
+    if (trimmed === '' || trimmed.startsWith('//')) {
+      continue;
+    }
+    if (trimmed.startsWith('/*')) {
+      // Single-line block comment (e.g. `/* foo */`) stays out of block mode.
+      if (!trimmed.endsWith('*/')) {
+        inBlockComment = true;
+      }
+      continue;
     }
     if (trimmed.startsWith('@use ') || trimmed.startsWith('@forward ')) {
       insertAt = i + 1; // insert after the last leading @use/@forward

--- a/packages/dynamic-forms/schematics/ng-add/rules/add-styles.ts
+++ b/packages/dynamic-forms/schematics/ng-add/rules/add-styles.ts
@@ -14,7 +14,7 @@ export function addStyles(recipe: AdapterRecipe, projectName: string | undefined
     const stylesPath = await resolveStylesPath(tree, projectName);
     if (!stylesPath) {
       ctx.logger.warn(
-        '[ng-forge] Could not locate a global styles file from angular.json. Skipping style imports. ' +
+        'Could not locate a global styles file from angular.json. Skipping style imports. ' +
           'Add the following imports manually:\n' +
           recipe.styles.map((p) => `  @import '${p}';`).join('\n'),
       );
@@ -27,7 +27,7 @@ export function addStyles(recipe: AdapterRecipe, projectName: string | undefined
 
     for (const style of recipe.styles) {
       if (current.includes(style)) {
-        ctx.logger.info(`[ng-forge] ${style} already imported; skipping.`);
+        ctx.logger.info(`${style} already imported; skipping.`);
         continue;
       }
       additions.push(`@import '${style}';`);
@@ -38,11 +38,44 @@ export function addStyles(recipe: AdapterRecipe, projectName: string | undefined
     }
 
     const block = additions.join('\n');
-    const updated = current.length > 0 ? `${block}\n${current}` : `${block}\n`;
+    const updated = insertImports(current, block);
     tree.overwrite(stylesPath, updated);
-    ctx.logger.info(`[ng-forge] Added ${additions.length} style import(s) to ${stylesPath}.`);
+    ctx.logger.info(`Added ${additions.length} style import(s) to ${stylesPath}.`);
     return tree;
   };
+}
+
+/**
+ * Inserts the import block near the top, but AFTER any leading `@use` /
+ * `@forward` rules. In SCSS those must precede all other statements, so blindly
+ * prepending `@import` above them is a compile error. Plain CSS has no such
+ * constraint, so for a file with no `@use`/`@forward` this just prepends.
+ */
+function insertImports(current: string, block: string): string {
+  if (current.length === 0) {
+    return `${block}\n`;
+  }
+
+  const lines = current.split('\n');
+  let insertAt = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed === '' || trimmed.startsWith('//') || trimmed.startsWith('/*') || trimmed.startsWith('*')) {
+      continue; // skip blank lines and comments while scanning the header
+    }
+    if (trimmed.startsWith('@use ') || trimmed.startsWith('@forward ')) {
+      insertAt = i + 1; // insert after the last leading @use/@forward
+      continue;
+    }
+    break; // first real rule — stop
+  }
+
+  if (insertAt === 0) {
+    return `${block}\n${current}`;
+  }
+  const head = lines.slice(0, insertAt);
+  const tail = lines.slice(insertAt);
+  return [...head, block, ...tail].join('\n');
 }
 
 async function resolveStylesPath(tree: Tree, projectName: string | undefined): Promise<string | null> {

--- a/packages/dynamic-forms/schematics/ng-add/schema.d.ts
+++ b/packages/dynamic-forms/schematics/ng-add/schema.d.ts
@@ -1,0 +1,9 @@
+export type Adapter = 'material' | 'bootstrap' | 'primeng' | 'ionic' | 'none';
+
+export interface NgAddOptions {
+  project?: string;
+  adapter: Adapter;
+  legacyStatusClasses?: boolean;
+  skipStyles?: boolean;
+  skipProviders?: boolean;
+}

--- a/packages/dynamic-forms/schematics/ng-add/schema.json
+++ b/packages/dynamic-forms/schematics/ng-add/schema.json
@@ -36,14 +36,12 @@
     "skipStyles": {
       "type": "boolean",
       "default": false,
-      "description": "Do not modify styles.scss / styles.css.",
-      "x-prompt": "Skip importing adapter styles into styles.scss?"
+      "description": "Do not modify the global styles file."
     },
     "skipProviders": {
       "type": "boolean",
       "default": false,
-      "description": "Do not modify app.config.ts.",
-      "x-prompt": "Skip wiring providers in app.config.ts?"
+      "description": "Do not modify the host ApplicationConfig."
     }
   },
   "required": ["adapter"]

--- a/packages/dynamic-forms/schematics/ng-add/schema.json
+++ b/packages/dynamic-forms/schematics/ng-add/schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "NgForgeDynamicFormsNgAdd",
+  "title": "ng-forge dynamic-forms ng-add",
+  "type": "object",
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "Project to target. Defaults to the workspace default project.",
+      "$default": {
+        "$source": "projectName"
+      }
+    },
+    "adapter": {
+      "type": "string",
+      "description": "Which UI adapter to wire up.",
+      "enum": ["material", "bootstrap", "primeng", "ionic", "none"],
+      "x-prompt": {
+        "message": "Which UI adapter should ng-forge use?",
+        "type": "list",
+        "items": [
+          { "value": "material", "label": "Angular Material" },
+          { "value": "bootstrap", "label": "Bootstrap" },
+          { "value": "primeng", "label": "PrimeNG" },
+          { "value": "ionic", "label": "Ionic" },
+          { "value": "none", "label": "Core only (no adapter)" }
+        ]
+      }
+    },
+    "legacyStatusClasses": {
+      "type": "boolean",
+      "default": true,
+      "description": "Add withLegacyStatusClasses() to enable legacy .ng-touched / .ng-invalid CSS classes.",
+      "x-prompt": "Enable legacy .ng-touched / .ng-invalid CSS classes? (recommended)"
+    },
+    "skipStyles": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not modify styles.scss / styles.css.",
+      "x-prompt": "Skip importing adapter styles into styles.scss?"
+    },
+    "skipProviders": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not modify app.config.ts.",
+      "x-prompt": "Skip wiring providers in app.config.ts?"
+    }
+  },
+  "required": ["adapter"]
+}

--- a/packages/dynamic-forms/schematics/tsconfig.json
+++ b/packages/dynamic-forms/schematics/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": ["es2022"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "outDir": "../../../dist/packages/dynamic-forms/schematics",
+    "rootDir": ".",
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2022",
+    "declaration": false,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["**/*.spec.ts", "vitest.config.ts"]
+}

--- a/packages/dynamic-forms/schematics/versions.ts
+++ b/packages/dynamic-forms/schematics/versions.ts
@@ -1,19 +1,56 @@
-export const NG_FORGE_VERSION = '~0.9.0';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
+interface Manifest {
+  version?: string;
+  peerDependencies?: Record<string, string>;
+}
+
+/**
+ * Reads the published @ng-forge/dynamic-forms manifest that ships next to the
+ * compiled schematic (dist/packages/dynamic-forms/package.json, one dir up
+ * from this file). Reading at runtime — rather than baking values in at build
+ * time — keeps versions correct regardless of release ordering: the published
+ * tarball's package.json is the source of truth by definition.
+ */
+function readOwnManifest(): Manifest {
+  try {
+    return JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8')) as Manifest;
+  } catch {
+    return {};
+  }
+}
+
+const manifest = readOwnManifest();
+
+// All @ng-forge/* packages release in lockstep, so they share the core
+// version. Fall back to a sane default only if the manifest can't be read.
+const NG_FORGE = manifest.version ? `~${manifest.version}` : '~0.9.0';
+
+// @angular/material, @angular/cdk and @angular/animations track the Angular
+// major.minor we peer-depend on. animations is additionally pinned to the
+// exact installed @angular/core at install time (see add-packages); this is
+// the fallback range.
+const ANGULAR = manifest.peerDependencies?.['@angular/core'] ?? '~21.2.0';
+
+// Third-party UI libs aren't tight peers of our adapters (their declared peer
+// ranges are intentionally loose, e.g. "primeng>=17"). These curated defaults
+// install a recent version compatible with the wired provider setup (Aura
+// preset, Ionic standalone, etc.).
 export const VERSIONS = {
-  '@ng-forge/dynamic-forms': NG_FORGE_VERSION,
-  '@ng-forge/dynamic-forms-material': NG_FORGE_VERSION,
-  '@ng-forge/dynamic-forms-bootstrap': NG_FORGE_VERSION,
-  '@ng-forge/dynamic-forms-primeng': NG_FORGE_VERSION,
-  '@ng-forge/dynamic-forms-ionic': NG_FORGE_VERSION,
-  '@angular/animations': '~21.2.0',
-  '@angular/material': '~21.2.0',
-  '@angular/cdk': '~21.2.0',
+  '@ng-forge/dynamic-forms': NG_FORGE,
+  '@ng-forge/dynamic-forms-material': NG_FORGE,
+  '@ng-forge/dynamic-forms-bootstrap': NG_FORGE,
+  '@ng-forge/dynamic-forms-primeng': NG_FORGE,
+  '@ng-forge/dynamic-forms-ionic': NG_FORGE,
+  '@angular/animations': ANGULAR,
+  '@angular/material': ANGULAR,
+  '@angular/cdk': ANGULAR,
   bootstrap: '^5.3.0',
   primeng: '^21.0.0',
   '@primeng/themes': '^21.0.0',
   primeicons: '^7.0.0',
   '@ionic/angular': '^8.8.0',
-} as const;
+} satisfies Record<string, string>;
 
 export type KnownPackage = keyof typeof VERSIONS;

--- a/packages/dynamic-forms/schematics/versions.ts
+++ b/packages/dynamic-forms/schematics/versions.ts
@@ -4,15 +4,9 @@ import { join } from 'node:path';
 interface Manifest {
   version?: string;
   peerDependencies?: Record<string, string>;
+  ngForgeSchematicDeps?: Record<string, string>;
 }
 
-/**
- * Reads the published @ng-forge/dynamic-forms manifest that ships next to the
- * compiled schematic (dist/packages/dynamic-forms/package.json, one dir up
- * from this file). Reading at runtime — rather than baking values in at build
- * time — keeps versions correct regardless of release ordering: the published
- * tarball's package.json is the source of truth by definition.
- */
 function readOwnManifest(): Manifest {
   try {
     return JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8')) as Manifest;
@@ -23,20 +17,10 @@ function readOwnManifest(): Manifest {
 
 const manifest = readOwnManifest();
 
-// All @ng-forge/* packages release in lockstep, so they share the core
-// version. Fall back to a sane default only if the manifest can't be read.
 const NG_FORGE = manifest.version ? `~${manifest.version}` : '~0.9.0';
-
-// @angular/material, @angular/cdk and @angular/animations track the Angular
-// major.minor we peer-depend on. animations is additionally pinned to the
-// exact installed @angular/core at install time (see add-packages); this is
-// the fallback range.
 const ANGULAR = manifest.peerDependencies?.['@angular/core'] ?? '~21.2.0';
+const THIRD_PARTY = manifest.ngForgeSchematicDeps ?? {};
 
-// Third-party UI libs aren't tight peers of our adapters (their declared peer
-// ranges are intentionally loose, e.g. "primeng>=17"). These curated defaults
-// install a recent version compatible with the wired provider setup (Aura
-// preset, Ionic standalone, etc.).
 export const VERSIONS = {
   '@ng-forge/dynamic-forms': NG_FORGE,
   '@ng-forge/dynamic-forms-material': NG_FORGE,
@@ -46,11 +30,11 @@ export const VERSIONS = {
   '@angular/animations': ANGULAR,
   '@angular/material': ANGULAR,
   '@angular/cdk': ANGULAR,
-  bootstrap: '^5.3.0',
-  primeng: '^21.0.0',
-  '@primeng/themes': '^21.0.0',
-  primeicons: '^7.0.0',
-  '@ionic/angular': '^8.8.0',
+  bootstrap: THIRD_PARTY['bootstrap'] ?? '^5.3.0',
+  primeng: THIRD_PARTY['primeng'] ?? '^21.0.0',
+  '@primeng/themes': THIRD_PARTY['@primeng/themes'] ?? '^21.0.0',
+  primeicons: THIRD_PARTY['primeicons'] ?? '^7.0.0',
+  '@ionic/angular': THIRD_PARTY['@ionic/angular'] ?? '^8.8.0',
 } satisfies Record<string, string>;
 
 export type KnownPackage = keyof typeof VERSIONS;

--- a/packages/dynamic-forms/schematics/versions.ts
+++ b/packages/dynamic-forms/schematics/versions.ts
@@ -6,6 +6,7 @@ export const VERSIONS = {
   '@ng-forge/dynamic-forms-bootstrap': NG_FORGE_VERSION,
   '@ng-forge/dynamic-forms-primeng': NG_FORGE_VERSION,
   '@ng-forge/dynamic-forms-ionic': NG_FORGE_VERSION,
+  '@angular/animations': '~21.2.0',
   '@angular/material': '~21.2.0',
   '@angular/cdk': '~21.2.0',
   bootstrap: '^5.3.0',

--- a/packages/dynamic-forms/schematics/versions.ts
+++ b/packages/dynamic-forms/schematics/versions.ts
@@ -1,0 +1,18 @@
+export const NG_FORGE_VERSION = '~0.9.0';
+
+export const VERSIONS = {
+  '@ng-forge/dynamic-forms': NG_FORGE_VERSION,
+  '@ng-forge/dynamic-forms-material': NG_FORGE_VERSION,
+  '@ng-forge/dynamic-forms-bootstrap': NG_FORGE_VERSION,
+  '@ng-forge/dynamic-forms-primeng': NG_FORGE_VERSION,
+  '@ng-forge/dynamic-forms-ionic': NG_FORGE_VERSION,
+  '@angular/material': '~21.2.0',
+  '@angular/cdk': '~21.2.0',
+  bootstrap: '^5.3.0',
+  primeng: '^21.0.0',
+  '@primeng/themes': '^21.0.0',
+  primeicons: '^7.0.0',
+  '@ionic/angular': '^8.8.0',
+} as const;
+
+export type KnownPackage = keyof typeof VERSIONS;

--- a/packages/dynamic-forms/schematics/vitest.config.ts
+++ b/packages/dynamic-forms/schematics/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(here, '../../..');
+
+export default defineConfig({
+  root: here,
+  cacheDir: resolve(workspaceRoot, 'node_modules/.vite/dynamic-forms-schematics'),
+  test: {
+    environment: 'node',
+    pool: 'forks',
+    include: ['**/*.spec.ts'],
+    globals: false,
+    reporters: ['default'],
+  },
+});

--- a/scripts/finalize-dynamic-forms-schematics.mjs
+++ b/scripts/finalize-dynamic-forms-schematics.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+// Post-build step for @ng-forge/dynamic-forms schematics.
+//
+// 1. Writes dist/packages/dynamic-forms/schematics/package.json with
+//    `"type":"commonjs"` so Node loads the compiled .js files as CJS
+//    (the parent package.json declares `"type":"module"`).
+// 2. Patches dist/packages/dynamic-forms/.npmignore so the CJS marker
+//    is NOT stripped from the published tarball — ng-packagr's default
+//    .npmignore contains `**/package.json` to drop dev-time secondary
+//    entrypoint manifests, which would also drop our CJS marker.
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const distRoot = 'dist/packages/dynamic-forms';
+const schematicsDir = join(distRoot, 'schematics');
+const cjsMarker = join(schematicsDir, 'package.json');
+const npmignore = join(distRoot, '.npmignore');
+
+writeFileSync(cjsMarker, JSON.stringify({ type: 'commonjs' }) + '\n');
+
+if (existsSync(npmignore)) {
+  const current = readFileSync(npmignore, 'utf-8');
+  const marker = '!schematics/package.json';
+  if (!current.includes(marker)) {
+    const next = current.endsWith('\n') ? current + marker + '\n' : current + '\n' + marker + '\n';
+    writeFileSync(npmignore, next);
+  }
+}

--- a/scripts/finalize-dynamic-forms-schematics.mjs
+++ b/scripts/finalize-dynamic-forms-schematics.mjs
@@ -1,20 +1,21 @@
 #!/usr/bin/env node
-// Post-build step for @ng-forge/dynamic-forms schematics.
-//
-// 1. Writes dist/packages/dynamic-forms/schematics/package.json with
-//    `"type":"commonjs"` so Node loads the compiled .js files as CJS
-//    (the parent package.json declares `"type":"module"`).
-// 2. Patches dist/packages/dynamic-forms/.npmignore so the CJS marker
-//    is NOT stripped from the published tarball — ng-packagr's default
-//    .npmignore contains `**/package.json` to drop dev-time secondary
-//    entrypoint manifests, which would also drop our CJS marker.
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 const distRoot = 'dist/packages/dynamic-forms';
 const schematicsDir = join(distRoot, 'schematics');
 const cjsMarker = join(schematicsDir, 'package.json');
+const distManifest = join(distRoot, 'package.json');
 const npmignore = join(distRoot, '.npmignore');
+const workspaceManifest = 'package.json';
+
+// Third-party UI lib install ranges are sourced from the workspace root
+// at build time and embedded under `ngForgeSchematicDeps`. The schematic
+// reads this field from its own manifest at runtime — no hardcoded values.
+const SCHEMATIC_DEPS_KEYS = ['bootstrap', 'primeng', '@primeng/themes', 'primeicons', '@ionic/angular'];
+const HARDCODED_FALLBACKS = {
+  '@primeng/themes': '^21.0.0',
+};
 
 writeFileSync(cjsMarker, JSON.stringify({ type: 'commonjs' }) + '\n');
 
@@ -25,4 +26,27 @@ if (existsSync(npmignore)) {
     const next = current.endsWith('\n') ? current + marker + '\n' : current + '\n' + marker + '\n';
     writeFileSync(npmignore, next);
   }
+}
+
+if (existsSync(distManifest) && existsSync(workspaceManifest)) {
+  const dist = JSON.parse(readFileSync(distManifest, 'utf-8'));
+  const ws = JSON.parse(readFileSync(workspaceManifest, 'utf-8'));
+  const wsAll = { ...(ws.dependencies ?? {}), ...(ws.devDependencies ?? {}) };
+  const schematicDeps = {};
+  for (const key of SCHEMATIC_DEPS_KEYS) {
+    const spec = wsAll[key] ?? HARDCODED_FALLBACKS[key];
+    if (!spec) continue;
+    schematicDeps[key] = toInstallRange(spec);
+  }
+  dist.ngForgeSchematicDeps = schematicDeps;
+  writeFileSync(distManifest, JSON.stringify(dist, null, 2) + '\n');
+}
+
+function toInstallRange(spec) {
+  if (typeof spec !== 'string' || spec.length === 0) return spec;
+  if (/^[~^>=<]/.test(spec) || spec.startsWith('git') || spec.startsWith('file:') || spec.startsWith('npm:')) {
+    return spec;
+  }
+  if (/^\d/.test(spec)) return `^${spec}`;
+  return spec;
 }


### PR DESCRIPTION
## Summary

- New `ng add @ng-forge/dynamic-forms` schematic and `nx g @ng-forge/dynamic-forms:add` generator. Same code path; the Nx side is a one-line wrapper via `wrapAngularDevkitSchematic`. (Angular CLI dispatches to a schematic named `ng-add`, which is fixed convention; only the Nx-side label is `add`.)
- One-command setup for all four adapters (Material, Bootstrap, PrimeNG, Ionic) plus core-only. Installs packages and peer deps, prepends adapter CSS into the global styles file, and wires `provideAnimations`, the adapter provider (where applicable), and `provideDynamicForm(...withXxxFields(), withLegacyStatusClasses())` into the host `ApplicationConfig`.
- Two interactive prompts: `--adapter` and `--legacyStatusClasses`. Other flags (`--project`, `--skipStyles`, `--skipProviders`) are flag-only and don't prompt.
- Docs: a new `<docs-cli-command>` toggle on **Getting Started** renders the Angular CLI / Nx command side-by-side. Tabbed-box styles extracted into `internal/styling/src/_command-box.scss` and shared with the existing `docs-install-command`.

## How it works

Per-adapter data records live in `recipes.ts` and mirror the strings in `apps/docs/src/app/components/integration-view/integration-view.component.ts`, so the schematic produces exactly what the docs describe. Rules are factored into `add-packages`, `add-styles`, `add-providers`.

Providers use `addRootProvider` from `@schematics/angular/utility/standalone`; default imports (e.g. PrimeNG's `Aura`) are added via `insertImport` from `@schematics/angular/utility/ast-utils`. Idempotency is enforced by detection: deps via `getPackageJsonDependency`, styles via string-match, providers via a regex marker scan against the resolved `app.config.ts` (with JS comments stripped first), default imports via a `from '<module>'` check on the same comment-stripped source.

Versions: the schematic reads its own published manifest at runtime (`dist/packages/dynamic-forms/package.json` next to the compiled schematic) for the `@ng-forge/*` ranges and the `@angular/core` peer range — no hardcoded values to drift. `@angular/animations` is pinned to the **exact installed** `@angular/core` patch (it's in the core monorepo and peer-pins core exactly); `@angular/material` and `@angular/cdk` use the peer range (separate release train, peer `^21.0.0`). Third-party UI libs (`bootstrap`, `primeng`, `@primeng/themes`, `primeicons`, `@ionic/angular`) are curated defaults — their declared peer ranges are intentionally loose.

SCSS imports are inserted **after** a leading `@use`/`@forward` block, walking past line comments and multi-line block comments correctly (SCSS forbids `@import` above `@use`).

Build pipeline: schematics compile via `tsc` to CommonJS into `dist/packages/dynamic-forms/schematics/`. A post-build step writes `{"type":"commonjs"}` next to the schematic output (so Node loads it correctly under the package's ESM root) and patches `.npmignore` so that marker survives ng-packagr's default `**/package.json` exclusion in the published tarball. `ng-package.json` `assets` copies the static JSON (collection, generators, schema). The `package.json` of the published lib gains `schematics` and `generators` fields pointing at the collections.

## Edge cases handled

- **No application project** (workspace with no app): `addStyles` and `addProviders` both warn and skip rather than throwing; core dep is still added.
- **Multiple application projects** in Angular CLI workspaces: schematic throws with the app list ("Multiple application projects found (foo, bar). Pass `--project=<name>`…"). In Nx, the standard `$source: projectName` resolution fills `--project` from `nx.json`'s `defaultProject` — same convention every other Nx generator follows; users pass `--project` for explicit targeting in multi-app workspaces. This is a **behavior change**: prior to this PR the schematic would silently wire into the first application it found. Anyone scripting against the implicit-pick behavior should now pass `--project` explicitly.
- **SCSS files starting with `@use`/`@forward`** (incl. preceded by a multi-line block comment whose interior lines don't start with `*`): imports are inserted after the leading directives block.
- **Default-import idempotency** (e.g. PrimeNG's `Aura`): guarded with a `from '<module>'` check before calling `insertImport`, which throws (not no-ops) on a duplicate default import.
- **Commented-out marker references**: provider and default-import idempotency checks strip JS comments before matching, so a `// provideDynamicForm()` left in `app.config.ts` no longer suppresses real wiring.
- **`@angular/*` peer lockstep**: animations pinned to exact installed core to avoid `21.2.15 vs 21.2.14` peer conflicts.

## Test plan

- [x] `nx test-schematics dynamic-forms` — 27 tests pass: all 4 adapters + none, `--skipStyles`, `--skipProviders`, `--no-legacyStatusClasses`, idempotency (Material + PrimeNG default-import), SCSS `@use` ordering (with and without leading block comments), comment-stripped marker detection (both providers and default imports), no-application-project graceful skip, multi-app throws + multi-app `--project` selects.
- [x] `nx build dynamic-forms` — clean; dist contains the schematic + CJS marker (verified in tarball via `npm pack`).
- [x] `nx lint dynamic-forms` — clean.
- [x] `nx typecheck dynamic-forms` — clean.
- [x] `nx build docs --configuration=development` — green (new component + extracted SCSS compile).
- [x] **Angular CLI live**: all 4 adapters wired correctly via `ng generate @ng-forge/dynamic-forms:ng-add` in a fresh `ng new` workspace; Material dev build green.
- [x] **Nx live**: Material wired + dev build green; PrimeNG double-run idempotency clean.
- [x] **Nx multi-app live**: `--project=app-two` wires `app-two/` only; `base-nx` (the other app) byte-identical to its pristine baseline.

## Follow-ups (intentionally out of scope)

- **`test-schematics` not wired into CI**: it's a dedicated `@nx/vitest:test` target outside the standard `nx affected -t test` flow. Wiring it in would gate the schematic on the same checks as the rest of the codebase.

## Notes

- Material setup is intentionally minimal (prebuilt theme `azure-blue.css`, no font/typography wiring). Users wanting full Material theming should run `ng add @angular/material` separately.
- Ionic setup imports the four core CSS files and `provideIonicAngular({ mode: 'md' })` — no Capacitor scaffolding.
- Module-based (non-standalone) apps are not handled; `addRootProvider` requires standalone bootstrap.
