### PR TITLE
fix(openapi-generator): map numeric enums to select instead of number input

### DIFF
--- a/packages/openapi-generator/src/__tests__/integration/__fixtures__/numeric-enum.yaml
+++ b/packages/openapi-generator/src/__tests__/integration/__fixtures__/numeric-enum.yaml
@@ -1,0 +1,88 @@
+openapi: '3.0.3'
+info:
+  title: Test
+  version: '1.0.0'
+paths:
+  /policies:
+    post:
+      operationId: createPolicy
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyResponseDto'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    PolicyResponseDto:
+      type: object
+      properties:
+        id:
+          type: string
+          description: A primary generated column in `uuid` format.
+          nullable: false
+          example: bcdc0cb5-2167-46df-889a-003d3d54e510
+        userId:
+          type: string
+          description: The user id in `uuid` format.
+          nullable: true
+          example: 0ea06dca-ad7d-4c3d-85cd-843c3a6bdd20
+          default: null
+        name:
+          type: string
+          description: The name of the policy. For e.g. GDPR.
+          nullable: false
+          example: GDPR
+        description:
+          type: string
+          description: The description of the policy.
+          nullable: true
+          default: null
+        clientId:
+          type: string
+          description: The id of the client.
+          nullable: true
+          example: bcdc0cb5-2167-46df-889a-003d3d54e510
+          default: null
+        createdAt:
+          format: date-time
+          type: string
+          description: Date on which the data record was created.
+          nullable: false
+          example: '2025-02-26T10:28:56.990Z'
+        updatedAt:
+          format: date-time
+          type: string
+          description: Date on which the data record was last updated.
+          nullable: false
+          example: '2025-02-26T10:28:56.990Z'
+        deletedAt:
+          format: date-time
+          type: string
+          description: Date on which the data record was soft-deleted.
+          nullable: true
+          example: '2025-02-26T10:28:56.990Z'
+          default: null
+        region:
+          type: string
+          description: The region or the country of the policy. For e.g. California.
+          nullable: false
+          example: California
+        responseTime:
+          type: number
+          description: The response time of the policy. For e.g. 30 days.
+          nullable: true
+          enum:
+            - 20
+            - 31
+            - 45
+            - 30
+          example: '30'
+      required:
+        - id
+        - name
+        - createdAt
+        - region

--- a/packages/openapi-generator/src/__tests__/integration/generate-pipeline.integration.spec.ts
+++ b/packages/openapi-generator/src/__tests__/integration/generate-pipeline.integration.spec.ts
@@ -161,6 +161,27 @@ describe('Enums', () => {
     expect(form).toContain("key: 'tags'");
     expect(form).toContain("type: 'multi-checkbox'");
   });
+
+  it('should map a numeric enum to select with options, not a number input (issue #445)', async () => {
+    await generate('numeric-enum.yaml');
+
+    const form = await readGenerated(outputDir, 'forms', 'create-policy.form.ts');
+    const block = form.slice(form.indexOf("key: 'responseTime'"));
+    expect(block).toContain("type: 'select'");
+    expect(block).toContain("value: '20'");
+    expect(block).toContain("value: '30'");
+    // The numeric input shape must NOT leak onto the select.
+    expect(block).not.toContain('type: "number"');
+  });
+
+  it('should produce a form file that compiles against the published types (regression for #445)', async () => {
+    await generate('numeric-enum.yaml');
+
+    const formPath = join(outputDir, 'forms', 'create-policy.form.ts');
+    const diagnostics = typecheckGeneratedForm(formPath);
+
+    expect(diagnostics, `Generated form should type-check cleanly. Errors:\n${diagnostics.join('\n')}`).toEqual([]);
+  }, 30_000); // tsc program creation + type-check is slow in CI
 });
 
 // ─── D. Nested Objects ───────────────────────────────────────────────

--- a/packages/openapi-generator/src/mapper/schema-to-fields.spec.ts
+++ b/packages/openapi-generator/src/mapper/schema-to-fields.spec.ts
@@ -88,6 +88,32 @@ describe('mapSchemaToFields', () => {
     ]);
   });
 
+  it('should map number enum to select with options, not a number input (issue #445)', () => {
+    const schema: SchemaObject = {
+      type: 'object',
+      properties: {
+        responseTime: {
+          type: 'number',
+          description: 'The response time of the policy. For e.g. 30 days.',
+          nullable: true,
+          enum: [20, 31, 45, 30],
+        } as unknown as SchemaObject,
+      },
+    };
+
+    const result = mapSchemaToFields(schema, []);
+    const field = result.fields[0];
+    expect(field.type).toBe('select');
+    expect(field.props?.['type']).toBeUndefined();
+    expect(field.nullable).toBe(true);
+    expect(field.options).toEqual([
+      { label: '20', value: '20' },
+      { label: '31', value: '31' },
+      { label: '45', value: '45' },
+      { label: '30', value: '30' },
+    ]);
+  });
+
   it('should disable fields when editable is false', () => {
     const schema: SchemaObject = {
       type: 'object',

--- a/packages/openapi-generator/src/mapper/type-mapping.spec.ts
+++ b/packages/openapi-generator/src/mapper/type-mapping.spec.ts
@@ -124,6 +124,31 @@ describe('mapSchemaToFieldType', () => {
       expect(result.isAmbiguous).toBe(true);
       expect(result.ambiguousScope).toBe('numeric');
     });
+
+    it('should map number+enum to select with ambiguous flag (issue #445)', () => {
+      const result = mapSchemaToFieldType({ type: 'number', enum: [20, 31, 45, 30] } as SchemaObject);
+      expect(result.fieldType).toBe('select');
+      expect(result.props).toBeUndefined();
+      expect(result.isAmbiguous).toBe(true);
+      expect(result.ambiguousScope).toBe('single-select');
+      expect(result.defaultAlternative).toBe('radio');
+    });
+
+    it('should map integer+enum to select with ambiguous flag (issue #445)', () => {
+      const result = mapSchemaToFieldType({ type: 'integer', enum: [1, 2, 3] } as SchemaObject);
+      expect(result.fieldType).toBe('select');
+      expect(result.props).toBeUndefined();
+      expect(result.isAmbiguous).toBe(true);
+      expect(result.ambiguousScope).toBe('single-select');
+      expect(result.defaultAlternative).toBe('radio');
+    });
+
+    it('should map nullable number+enum (3.1 type array) to select (issue #445)', () => {
+      const result = mapSchemaToFieldType({ type: ['number', 'null'], enum: [20, 31, 45, 30] } as unknown as SchemaObject);
+      expect(result.fieldType).toBe('select');
+      expect(result.isAmbiguous).toBe(true);
+      expect(result.ambiguousScope).toBe('single-select');
+    });
   });
 
   describe('boolean type', () => {

--- a/packages/openapi-generator/src/mapper/type-mapping.ts
+++ b/packages/openapi-generator/src/mapper/type-mapping.ts
@@ -18,8 +18,8 @@ export function mapSchemaToFieldType(schema: SchemaObject): FieldTypeResult {
     : (rawType as string | undefined);
   const format = schema.format;
 
-  // string + enum → select (ambiguous with radio)
-  if (type === 'string' && schema.enum) {
+  // scalar + enum → select (ambiguous with radio). Issue #445: numeric enums too.
+  if ((type === 'string' || type === 'number' || type === 'integer') && schema.enum) {
     return {
       fieldType: 'select',
       isContainer: false,


### PR DESCRIPTION
## Summary

Fixes #445. A `number`/`integer` schema property carrying an `enum` was generated as a number input **plus** an `options` array — an invalid combination that triggers `TS2353: ... 'options' does not exist` in consumers.

## Root cause

In `type-mapping.ts`, only `string + enum` was routed to `select`. Numeric schemas fell through to the `integer | number` branch and returned `input` + `props: { type: 'number' }`, while the enum-options block in `schema-to-fields.ts` attaches `options` whenever `schema.enum` is present — regardless of field type. The result was the broken hybrid reported in the issue.

## Fix

Broaden the enum→select branch to cover `string`, `number`, and `integer` scalars (one condition change). Enum values are already stringified by the options block, so the output matches the issue's "Expected Behavior" exactly: `type: 'select'`, `options`, `nullable: true`, no stray `props.type: 'number'`. Numeric-enum **arrays** are unaffected — they still route to `multi-checkbox` upstream.

## Tests

- `type-mapping.spec.ts`: number / integer / nullable-3.1 numeric enums → `select`
- `schema-to-fields.spec.ts`: end-to-end test mirroring the issue's exact `responseTime` schema

## Test plan

- [x] `nx test openapi-generator` — 379 passing