### PR TITLE
fix(dynamic-forms): allow array fields as children of group fields

### DIFF
--- a/apps/docs/public/content/prebuilt/form-groups.md
+++ b/apps/docs/public/content/prebuilt/form-groups.md
@@ -134,6 +134,7 @@ Groups can contain:
 
 - Leaf fields (input, select, checkbox, etc.)
 - Row fields (for horizontal layouts within the group)
+- Array fields (for repeating sections nested under the group's key)
 
 See [Type Safety & Inference](/recipes/type-safety) for details on how groups affect type inference.
 

--- a/packages/dynamic-form-mcp/src/registry/field-types.ts
+++ b/packages/dynamic-form-mcp/src/registry/field-types.ts
@@ -394,7 +394,7 @@ export const FIELD_TYPES: FieldTypeInfo[] = [
       fields: {
         name: 'fields',
         type: 'GroupAllowedChildren[]',
-        description: 'Child fields in the group. Allowed: rows, leaf fields (NOT pages or other groups)',
+        description: 'Child fields in the group. Allowed: rows, arrays, leaf fields (NOT pages or other groups)',
         required: true,
       },
     },
@@ -404,6 +404,7 @@ export const FIELD_TYPES: FieldTypeInfo[] = [
     notAllowedIn: ['group'],
     canContain: [
       'row',
+      'array',
       'input',
       'textarea',
       'select',

--- a/packages/dynamic-form-mcp/src/tools/data/lookup-topics.ts
+++ b/packages/dynamic-form-mcp/src/tools/data/lookup-topics.ts
@@ -319,7 +319,7 @@ Included in form value but not rendered.
 - Adding \`label\` to group (not allowed)
 - Using non-hidden logic types on group (only \`hidden\` is supported, apply other logic types to child fields instead)
 
-**Can contain:** rows, leaf fields (NOT pages, NOT nested groups)`,
+**Can contain:** rows, arrays, leaf fields (NOT pages, NOT nested groups)`,
   },
 
   row: {
@@ -1768,7 +1768,7 @@ provideDynamicForm({
 | Container | Label? | Logic? | Allowed Children | Notes |
 |-----------|--------|--------|------------------|-------|
 | page | NO | YES (hidden only) | rows, groups, arrays, leaf fields, buttons | Nav buttons go INSIDE |
-| group | NO | YES (hidden only) | rows, leaf fields (NOT pages, groups) | Creates nested object |
+| group | NO | YES (hidden only) | rows, arrays, leaf fields (NOT pages, groups) | Creates nested object |
 | array | NO | YES (hidden only) | rows, groups, leaf fields (NOT pages, arrays) | Two APIs: \`template\`+\`value\` (simplified) or \`fields\` (full) |
 | row | NO | YES (hidden only) | groups, arrays, containers, nested rows, hidden fields, leaf fields (NOT pages) | Layout only |
 

--- a/packages/dynamic-forms/src/lib/definitions/default/group-field.type-test.ts
+++ b/packages/dynamic-forms/src/lib/definitions/default/group-field.type-test.ts
@@ -218,4 +218,38 @@ describe('GroupField - Usage Tests', () => {
 
     expectTypeOf(field.col).toEqualTypeOf<6>();
   });
+
+  it('should accept group containing an array child', () => {
+    const field = {
+      key: 'dockerCompose',
+      type: 'group',
+      fields: [
+        { key: 'action', type: 'hidden', value: '' },
+        {
+          key: 'env',
+          type: 'array',
+          fields: [{ key: 'value', type: 'hidden', value: '' }],
+        },
+      ],
+    } as const satisfies GroupField;
+
+    expectTypeOf(field.fields[1].type).toEqualTypeOf<'array'>();
+  });
+
+  it('should accept group containing a simplified array child', () => {
+    const field = {
+      key: 'tagsGroup',
+      type: 'group',
+      fields: [
+        {
+          key: 'tags',
+          type: 'array',
+          template: { key: 'tag', type: 'hidden', value: '' },
+          value: ['angular'],
+        },
+      ],
+    } as const satisfies GroupField;
+
+    expectTypeOf(field.fields[0].type).toEqualTypeOf<'array'>();
+  });
 });

--- a/packages/dynamic-forms/src/lib/models/types/nesting-constraints.ts
+++ b/packages/dynamic-forms/src/lib/models/types/nesting-constraints.ts
@@ -17,9 +17,9 @@ export type PageAllowedChildren = LeafFieldTypes | RowField | GroupField | Array
 
 /**
  * Fields that are allowed as children of Group fields
- * Groups can contain: rows and leaf fields (but NOT pages or other groups)
+ * Groups can contain: rows, arrays, and leaf fields (but NOT pages or other groups)
  */
-export type GroupAllowedChildren = LeafFieldTypes | RowField | ContainerField;
+export type GroupAllowedChildren = LeafFieldTypes | RowField | ArrayField | SimplifiedArrayField | ContainerField;
 
 /**
  * Fields that are allowed as children of Array fields


### PR DESCRIPTION
## Summary

Closes #446.

`GroupAllowedChildren` listed only leaf fields, rows, and containers, so a `group` with an `array` child failed to typecheck (`TS2322`). This blocked configs the OpenAPI generator already emits for objects that contain array properties.

The restriction was type-only. At runtime arrays nested in groups already work:
- the field flattener treats an array as an opaque container under its own key (it does not flatten the array template into the group)
- form mapping registers the array as a `FormArray` under the group's `FormGroup`
- the group component resolves child fields generically

This adds `ArrayField | SimplifiedArrayField` to `GroupAllowedChildren` and brings docs and MCP registry metadata in line.

## Changes

- `nesting-constraints.ts`: `GroupAllowedChildren` now includes `ArrayField` and `SimplifiedArrayField`
- `group-field.type-test.ts`: added type tests for a group containing a full-API array child and a simplified array child
- `prebuilt/form-groups.md`: "Allowed Children" now lists array fields
- `dynamic-form-mcp`: group `canContain`, field description, and lookup-topic strings now include arrays

## Test plan

- [x] `nx type-test dynamic-forms` (536 passed, no type errors)
- [x] `nx build dynamic-forms`
- [x] `nx test dynamic-form-mcp`
- [x] `nx build dynamic-form-mcp`