### PR TITLE
fix(dynamic-forms): value/validation/derivation coverage-gap fixes and footgun guards

### DIFF
--- a/packages/dynamic-form-mcp/src/tools/data/lookup-topics.ts
+++ b/packages/dynamic-form-mcp/src/tools/data/lookup-topics.ts
@@ -2092,6 +2092,8 @@ const config = { fields: [...] } as const satisfies FormConfig;
 | \`endsWith\` | String ends with | \`'hello'.endsWith('lo')\` |
 | \`matches\` | Regex match | \`/^[0-9]+$/.test(value)\` |
 
+For \`matches\`, the value is a pattern string. Use the \`/pattern/flags\` form to pass regex flags, e.g. \`"/john/i"\` for case-insensitive matching. A plain pattern (no \`/.../\` delimiters) is matched case-sensitively with no flags.
+
 ## Combining Conditions
 
 **AND (all must be true):**

--- a/packages/dynamic-forms-bootstrap/src/lib/addons/preset-actions.spec.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/addons/preset-actions.spec.ts
@@ -12,7 +12,7 @@ function makeLogger(): Logger {
   };
 }
 
-const FORM_STUB = {} as unknown as NonNullable<AddonActionContext['form']>;
+const FORM_STUB = { disabled: signal(false) } as unknown as NonNullable<AddonActionContext['form']>;
 
 function makeCtx(overrides: Partial<AddonActionContext> = {}): AddonActionContext {
   // Default ctx is field-bound: non-null `form` + callable `setValue`.

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/input/bs-input.component.spec.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/input/bs-input.component.spec.ts
@@ -1,0 +1,56 @@
+import { Type } from '@angular/core';
+import {
+  ADDON_ACTION_REGISTRY,
+  ADDON_KIND_COMPONENT_CACHE,
+  ADDON_KIND_REGISTRY,
+  type AddonKindDefinition,
+  DynamicFormLogger,
+} from '@ng-forge/dynamic-forms';
+import { createNgForgeFieldFixture, provideTestValidationMessages } from '@ng-forge/dynamic-forms/integration';
+import { describe, expect, it, vi } from 'vitest';
+import BsInputFieldComponent from './bs-input.component';
+
+// #321: placeholder was reported as not functional across adapters. The mapper-level passthrough
+// only proves the placeholder reaches the component input — it does NOT prove the binding reaches
+// the rendered <input>. These tests pin the DOM rendering. Bootstrap renders a native
+// <input class="form-control"> with [placeholder] bound directly.
+
+function createFixture(inputs: Record<string, unknown>) {
+  return createNgForgeFieldFixture<BsInputFieldComponent, string>(BsInputFieldComponent, {
+    key: 'field-1',
+    value: '',
+    inputs,
+    providers: [
+      { provide: ADDON_KIND_REGISTRY, useValue: new Map<string, AddonKindDefinition>() },
+      { provide: ADDON_KIND_COMPONENT_CACHE, useFactory: () => new Map<string, Type<unknown>>() },
+      { provide: ADDON_ACTION_REGISTRY, useValue: new Map() },
+      { provide: DynamicFormLogger, useValue: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() } },
+      provideTestValidationMessages({}),
+    ],
+  });
+}
+
+describe('BsInputFieldComponent — placeholder rendering (#321)', () => {
+  it('binds the placeholder onto the rendered <input>', async () => {
+    const { fixture } = createFixture({ placeholder: 'Enter your name' });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const input = fixture.nativeElement.querySelector('input.form-control') as HTMLInputElement | null;
+    expect(input).toBeTruthy();
+    expect(input?.getAttribute('placeholder')).toBe('Enter your name');
+  });
+
+  it('renders an empty placeholder attribute when none is configured', async () => {
+    const { fixture } = createFixture({});
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const input = fixture.nativeElement.querySelector('input.form-control') as HTMLInputElement | null;
+    expect(input).toBeTruthy();
+    // Template falls back to '' so the attribute is always present but empty.
+    expect(input?.getAttribute('placeholder') ?? '').toBe('');
+  });
+});

--- a/packages/dynamic-forms-ionic/src/lib/addons/preset-actions.spec.ts
+++ b/packages/dynamic-forms-ionic/src/lib/addons/preset-actions.spec.ts
@@ -43,7 +43,7 @@ function makeHarness(overrides?: { value?: unknown; defaultValue?: unknown }): H
     context: {
       // Field-bound: opaque non-null form (orphan-guard discriminates on `form !== null`).
       field: { key: 'q', type: 'input' },
-      form: {} as unknown as NonNullable<AddonActionContext['form']>,
+      form: { disabled: signal(false) } as unknown as NonNullable<AddonActionContext['form']>,
       value: overrides?.value ?? '',
       setValue: spies.setValue,
     } as unknown as AddonActionContext,

--- a/packages/dynamic-forms-ionic/src/lib/fields/input/ionic-input.component.spec.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/input/ionic-input.component.spec.ts
@@ -1,0 +1,58 @@
+import type { Type } from '@angular/core';
+import { ADDON_ACTION_REGISTRY, ADDON_KIND_COMPONENT_CACHE, ADDON_KIND_REGISTRY, type AddonKindDefinition } from '@ng-forge/dynamic-forms';
+import { createNgForgeFieldFixture } from '@ng-forge/dynamic-forms/integration';
+import { describe, expect, it } from 'vitest';
+import IonicInputFieldComponent from './ionic-input.component';
+
+// #321: placeholder was reported as not functional across adapters. The mapper-level passthrough
+// only proves the placeholder reaches the component input — it does NOT prove the binding reaches
+// the rendered element. These tests pin the DOM rendering.
+//
+// Ionic-specific: the template binds [placeholder] onto the <ion-input> host element, NOT a
+// nested light-DOM <input> (the real <input> lives inside ion-input's shadow DOM, which the
+// component populates asynchronously via getInputElement()). Angular property-binding writes
+// `placeholder` as a JS property on the Stencil custom element, so we assert on the property.
+// Stencil reflects this property to an attribute too, which we check as a secondary signal.
+
+interface IonInputLike extends HTMLElement {
+  placeholder?: string;
+}
+
+function createFixture(inputs: Record<string, unknown>) {
+  return createNgForgeFieldFixture<IonicInputFieldComponent, string>(IonicInputFieldComponent, {
+    key: 'field-1',
+    value: '',
+    inputs,
+    providers: [
+      { provide: ADDON_KIND_REGISTRY, useValue: new Map<string, AddonKindDefinition>() },
+      { provide: ADDON_KIND_COMPONENT_CACHE, useFactory: () => new Map<string, Type<unknown>>() },
+      { provide: ADDON_ACTION_REGISTRY, useValue: new Map() },
+    ],
+  });
+}
+
+describe('IonicInputFieldComponent — placeholder rendering (#321)', () => {
+  it('binds the placeholder onto the rendered <ion-input>', async () => {
+    const { fixture } = createFixture({ placeholder: 'Enter your name' });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const ionInput = fixture.nativeElement.querySelector('ion-input') as IonInputLike | null;
+    expect(ionInput).toBeTruthy();
+    // Assert on the JS property — how Angular property-binding exposes it on the Stencil element.
+    expect(ionInput?.placeholder).toBe('Enter your name');
+  });
+
+  it('renders an empty placeholder when none is configured', async () => {
+    const { fixture } = createFixture({});
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const ionInput = fixture.nativeElement.querySelector('ion-input') as IonInputLike | null;
+    expect(ionInput).toBeTruthy();
+    // Template falls back to '' so the property is always present but empty.
+    expect(ionInput?.placeholder ?? '').toBe('');
+  });
+});

--- a/packages/dynamic-forms-material/src/lib/a11y-scoped-ids.spec.ts
+++ b/packages/dynamic-forms-material/src/lib/a11y-scoped-ids.spec.ts
@@ -11,7 +11,7 @@ import { withMaterialFields } from './providers/material-providers';
 
 const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-async function mountForm(config: FormConfig) {
+async function mountForm(config: FormConfig, expectedInputs: number) {
   TestBed.configureTestingModule({
     imports: [DynamicForm],
     providers: [provideAnimations(), provideDynamicForm(...withMaterialFields())],
@@ -19,13 +19,17 @@ async function mountForm(config: FormConfig) {
   const fixture = TestBed.createComponent(DynamicForm);
   fixture.componentRef.setInput('dynamic-form', config);
   fixture.detectChanges();
-  // Material field components load via dynamic import(); pump real macrotask delays + CD/effects
-  // several times so async resolution and the derivedFromDeferred pipeline settle.
-  for (let i = 0; i < 8; i++) {
-    await delay(15);
+  // Material fields load via dynamic import(); FormStateManager.ready$ isn't public API across the
+  // package boundary, so pump CD + effects until the expected inputs actually render (bounded), then
+  // one extra pass for the derivedFromDeferred pipeline. Gates on a real condition, not a fixed wait.
+  for (let i = 0; i < 40 && fixture.nativeElement.querySelectorAll('input').length < expectedInputs; i++) {
+    await delay(5);
     fixture.detectChanges();
     TestBed.flushEffects();
   }
+  await delay(5);
+  fixture.detectChanges();
+  TestBed.flushEffects();
   return fixture;
 }
 
@@ -46,7 +50,7 @@ describe('scoped DOM IDs (a11y uniqueness)', () => {
       ],
     } as unknown as FormConfig;
 
-    const fixture = await mountForm(config);
+    const fixture = await mountForm(config, 2);
     const inputIds = collectIds(fixture.nativeElement, 'input');
 
     expect(inputIds.length).toBe(2);
@@ -65,7 +69,7 @@ describe('scoped DOM IDs (a11y uniqueness)', () => {
       ],
     } as unknown as FormConfig;
 
-    const fixture = await mountForm(config);
+    const fixture = await mountForm(config, 2);
     const inputIds = collectIds(fixture.nativeElement, 'input');
 
     expect(inputIds.length).toBeGreaterThanOrEqual(2);

--- a/packages/dynamic-forms-material/src/lib/a11y-scoped-ids.spec.ts
+++ b/packages/dynamic-forms-material/src/lib/a11y-scoped-ids.spec.ts
@@ -1,0 +1,74 @@
+import { TestBed } from '@angular/core/testing';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { DynamicForm, provideDynamicForm, type FormConfig } from '@ng-forge/dynamic-forms';
+import { afterEach, describe, expect, it } from 'vitest';
+import { withMaterialFields } from './providers/material-providers';
+
+// Pass-3 audit hypothesis: errorId/hintId/inputId derive from the field key, so two groups with the
+// same leaf key (#401) — or array items reusing a template key (#219) — would render duplicate DOM
+// IDs, breaking ARIA uniqueness and label[for] association. These tests verify the actual rendered
+// IDs to confirm whether the GROUP_CONTEXT/ARRAY_CONTEXT scoping already prevents the collision.
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+async function mountForm(config: FormConfig) {
+  TestBed.configureTestingModule({
+    imports: [DynamicForm],
+    providers: [provideAnimations(), provideDynamicForm(...withMaterialFields())],
+  });
+  const fixture = TestBed.createComponent(DynamicForm);
+  fixture.componentRef.setInput('dynamic-form', config);
+  fixture.detectChanges();
+  // Material field components load via dynamic import(); pump real macrotask delays + CD/effects
+  // several times so async resolution and the derivedFromDeferred pipeline settle.
+  for (let i = 0; i < 8; i++) {
+    await delay(15);
+    fixture.detectChanges();
+    TestBed.flushEffects();
+  }
+  return fixture;
+}
+
+function collectIds(root: HTMLElement, selector: string): string[] {
+  return Array.from(root.querySelectorAll(selector))
+    .map((el) => el.getAttribute('id'))
+    .filter((id): id is string => !!id);
+}
+
+describe('scoped DOM IDs (a11y uniqueness)', () => {
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('renders unique input IDs for the same leaf key in two different groups (#401)', async () => {
+    const config = {
+      fields: [
+        { key: 'groupA', type: 'group', fields: [{ key: 'city', type: 'input', label: 'City' }] },
+        { key: 'groupB', type: 'group', fields: [{ key: 'city', type: 'input', label: 'City' }] },
+      ],
+    } as unknown as FormConfig;
+
+    const fixture = await mountForm(config);
+    const inputIds = collectIds(fixture.nativeElement, 'input');
+
+    expect(inputIds.length).toBe(2);
+    expect(new Set(inputIds).size).toBe(inputIds.length); // no duplicates
+  });
+
+  it('renders unique input IDs across array items reusing one template key (#219)', async () => {
+    const config = {
+      fields: [
+        {
+          key: 'phones',
+          type: 'array',
+          value: ['', ''],
+          template: { key: 'value', type: 'input', label: 'Phone' },
+        },
+      ],
+    } as unknown as FormConfig;
+
+    const fixture = await mountForm(config);
+    const inputIds = collectIds(fixture.nativeElement, 'input');
+
+    expect(inputIds.length).toBeGreaterThanOrEqual(2);
+    expect(new Set(inputIds).size).toBe(inputIds.length); // no duplicates across items
+  });
+});

--- a/packages/dynamic-forms-material/src/lib/addons/preset-actions.spec.ts
+++ b/packages/dynamic-forms-material/src/lib/addons/preset-actions.spec.ts
@@ -5,7 +5,7 @@ import { type PresetCollaborators, runMatPresetAction } from './preset-actions';
 
 // Field-bound stub — opaque form object; the runner discriminates on
 // `form !== null`, not on tree methods.
-const FORM_STUB = {} as unknown as NonNullable<AddonActionContext['form']>;
+const FORM_STUB = { disabled: signal(false) } as unknown as NonNullable<AddonActionContext['form']>;
 
 function makeCtx(value: unknown, setValue: (next: unknown) => void = () => undefined): AddonActionContext {
   return {

--- a/packages/dynamic-forms-material/src/lib/fields/input/mat-input.component.spec.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/input/mat-input.component.spec.ts
@@ -1,0 +1,69 @@
+import { Injector, signal, type Type } from '@angular/core';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import {
+  ADDON_ACTION_REGISTRY,
+  ADDON_KIND_COMPONENT_CACHE,
+  ADDON_KIND_REGISTRY,
+  type AddonKindDefinition,
+  DynamicFormLogger,
+  FIELD_SIGNAL_CONTEXT,
+  type FieldSignalContext,
+} from '@ng-forge/dynamic-forms';
+import { createNgForgeFieldFixture, provideTestValidationMessages } from '@ng-forge/dynamic-forms/integration';
+import { describe, expect, it, vi } from 'vitest';
+import MatInputFieldComponent from './mat-input.component';
+
+// #321: placeholder was reported as not functional across adapters. The mapper-level passthrough
+// (value-field.mapper.spec.ts) only proves the placeholder reaches the component input — it does
+// NOT prove the binding reaches the rendered <input>. These tests pin the DOM rendering.
+
+function stubFieldSignalContext(): FieldSignalContext {
+  return {
+    injector: undefined as unknown as Injector,
+    value: signal<Record<string, unknown> | undefined>({}),
+    defaultValues: () => ({}),
+    form: {} as FieldSignalContext['form'],
+  };
+}
+
+function createFixture(inputs: Record<string, unknown>) {
+  return createNgForgeFieldFixture<MatInputFieldComponent, string>(MatInputFieldComponent, {
+    key: 'field-1',
+    value: '',
+    inputs,
+    providers: [
+      provideAnimations(),
+      { provide: ADDON_KIND_REGISTRY, useValue: new Map<string, AddonKindDefinition>() },
+      { provide: ADDON_KIND_COMPONENT_CACHE, useFactory: () => new Map<string, Type<unknown>>() },
+      { provide: ADDON_ACTION_REGISTRY, useValue: new Map() },
+      { provide: FIELD_SIGNAL_CONTEXT, useFactory: stubFieldSignalContext },
+      { provide: DynamicFormLogger, useValue: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() } },
+      provideTestValidationMessages({}),
+    ],
+  });
+}
+
+describe('MatInputFieldComponent — placeholder rendering (#321)', () => {
+  it('binds the placeholder onto the rendered <input>', async () => {
+    const { fixture } = createFixture({ placeholder: 'Enter your name' });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const input = fixture.nativeElement.querySelector('input') as HTMLInputElement | null;
+    expect(input).toBeTruthy();
+    expect(input?.getAttribute('placeholder')).toBe('Enter your name');
+  });
+
+  it('renders an empty placeholder attribute when none is configured', async () => {
+    const { fixture } = createFixture({});
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const input = fixture.nativeElement.querySelector('input') as HTMLInputElement | null;
+    expect(input).toBeTruthy();
+    // Template falls back to '' so the attribute is always present but empty.
+    expect(input?.getAttribute('placeholder') ?? '').toBe('');
+  });
+});

--- a/packages/dynamic-forms-primeng/src/lib/addons/preset-actions.spec.ts
+++ b/packages/dynamic-forms-primeng/src/lib/addons/preset-actions.spec.ts
@@ -14,7 +14,7 @@ function makeLogger(): LoggerStub {
   return { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() };
 }
 
-const FORM_STUB = {} as unknown as NonNullable<AddonActionContext['form']>;
+const FORM_STUB = { disabled: signal(false) } as unknown as NonNullable<AddonActionContext['form']>;
 
 function makeCtx<T = unknown>(value: T = '' as T): AddonActionContext<T> {
   // Default ctx is field-bound: non-null `form` + callable `setValue`.

--- a/packages/dynamic-forms-primeng/src/lib/fields/input/prime-input.component.spec.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/input/prime-input.component.spec.ts
@@ -1,0 +1,56 @@
+import type { Type } from '@angular/core';
+import {
+  ADDON_ACTION_REGISTRY,
+  ADDON_KIND_COMPONENT_CACHE,
+  ADDON_KIND_REGISTRY,
+  type AddonKindDefinition,
+  DynamicFormLogger,
+} from '@ng-forge/dynamic-forms';
+import { createNgForgeFieldFixture, provideTestValidationMessages } from '@ng-forge/dynamic-forms/integration';
+import { describe, expect, it, vi } from 'vitest';
+import PrimeInputFieldComponent from './prime-input.component';
+
+// #321: placeholder was reported as not functional across adapters. The mapper-level passthrough
+// only proves the placeholder reaches the component input — it does NOT prove the binding reaches
+// the rendered <input>. These tests pin the DOM rendering. PrimeNG renders a native
+// <input pInputText> with [placeholder] bound directly.
+
+function createFixture(inputs: Record<string, unknown>) {
+  return createNgForgeFieldFixture<PrimeInputFieldComponent, string>(PrimeInputFieldComponent, {
+    key: 'field-1',
+    value: '',
+    inputs,
+    providers: [
+      { provide: ADDON_KIND_REGISTRY, useValue: new Map<string, AddonKindDefinition>() },
+      { provide: ADDON_KIND_COMPONENT_CACHE, useFactory: () => new Map<string, Type<unknown>>() },
+      { provide: ADDON_ACTION_REGISTRY, useValue: new Map() },
+      { provide: DynamicFormLogger, useValue: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() } },
+      provideTestValidationMessages({}),
+    ],
+  });
+}
+
+describe('PrimeInputFieldComponent — placeholder rendering (#321)', () => {
+  it('binds the placeholder onto the rendered <input>', async () => {
+    const { fixture } = createFixture({ placeholder: 'Enter your name' });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const input = fixture.nativeElement.querySelector('input[pinputtext]') as HTMLInputElement | null;
+    expect(input).toBeTruthy();
+    expect(input?.getAttribute('placeholder')).toBe('Enter your name');
+  });
+
+  it('renders an empty placeholder attribute when none is configured', async () => {
+    const { fixture } = createFixture({});
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const input = fixture.nativeElement.querySelector('input[pinputtext]') as HTMLInputElement | null;
+    expect(input).toBeTruthy();
+    // Template falls back to '' so the attribute is always present but empty.
+    expect(input?.getAttribute('placeholder') ?? '').toBe('');
+  });
+});

--- a/packages/dynamic-forms/src/lib/addons/run-preset-action.spec.ts
+++ b/packages/dynamic-forms/src/lib/addons/run-preset-action.spec.ts
@@ -22,7 +22,7 @@ function makeLogger(): LoggerStub {
 // Minimal ReadonlyFieldTree stub — orphan-guard discriminates on `form !== null`.
 // The runner itself never invokes methods on `ctx.form`, so an opaque object
 // is sufficient.
-const FORM_STUB = {} as unknown as NonNullable<AddonActionContext['form']>;
+const FORM_STUB = { disabled: signal(false) } as unknown as NonNullable<AddonActionContext['form']>;
 
 function makeCtx(overrides: Partial<AddonActionContext> = {}): AddonActionContext {
   // Default ctx is field-bound: non-null `form` + callable `setValue`.
@@ -78,6 +78,43 @@ describe('runPresetAction (core)', () => {
       const orphanCtx = { field: { key: '', type: 'input' }, form: null, value: 'hello' } as unknown as AddonActionContext;
       await runPresetAction('copy', orphanCtx, collab, ADAPTER, FIELD_LABEL);
       expect(writeText).toHaveBeenCalledWith('hello');
+    });
+  });
+
+  describe('disabled field guard', () => {
+    // A disabled field is non-editable; value-mutating presets (clear/reset/paste) must not change
+    // it, consistent with the rest of the library treating disabled fields as non-editable.
+    const formWith = (disabled: boolean) => ({ disabled: signal(disabled) }) as unknown as NonNullable<AddonActionContext['form']>;
+
+    it('skips clear on a disabled field and warns', async () => {
+      const fieldValueSetter = vi.fn();
+      const { collab, logger } = makeCollaborators({ fieldValueSetter });
+      await runPresetAction('clear', makeCtx({ form: formWith(true), value: 'x' }), collab, ADAPTER, FIELD_LABEL);
+      expect(fieldValueSetter).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('skips reset on a disabled field', async () => {
+      const fieldValueSetter = vi.fn();
+      const fieldDefaultValueGetter = vi.fn(() => 'default-val');
+      const { collab } = makeCollaborators({ fieldValueSetter, fieldDefaultValueGetter });
+      await runPresetAction('reset', makeCtx({ form: formWith(true), value: 'x' }), collab, ADAPTER, FIELD_LABEL);
+      expect(fieldValueSetter).not.toHaveBeenCalled();
+    });
+
+    it('still mutates an enabled field (control)', async () => {
+      const fieldValueSetter = vi.fn();
+      const { collab } = makeCollaborators({ fieldValueSetter });
+      await runPresetAction('clear', makeCtx({ form: formWith(false), value: 'x' }), collab, ADAPTER, FIELD_LABEL);
+      expect(fieldValueSetter).toHaveBeenCalledWith('');
+    });
+
+    it('still allows copy (non-mutating) on a disabled field', async () => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { readText: vi.fn(), writeText } });
+      const { collab } = makeCollaborators();
+      await runPresetAction('copy', makeCtx({ form: formWith(true), value: 'hi' }), collab, ADAPTER, FIELD_LABEL);
+      expect(writeText).toHaveBeenCalledWith('hi');
     });
   });
 

--- a/packages/dynamic-forms/src/lib/addons/run-preset-action.ts
+++ b/packages/dynamic-forms/src/lib/addons/run-preset-action.ts
@@ -56,6 +56,14 @@ export async function runPresetAction(
     return;
   }
 
+  // A disabled field is non-editable; value-mutating presets must not change it, consistent with
+  // the rest of the library treating disabled fields as non-interactive. `readonly` is not exposed
+  // on the field-bound `ReadonlyFieldTree`, so the guard is scoped to `disabled`.
+  if (ctx.form !== null && (preset === 'clear' || preset === 'reset' || preset === 'paste') && ctx.form.disabled()) {
+    collaborators.logger.warn(`preset '${String(preset)}' skipped — host '${fieldLabel}' is disabled.`);
+    return;
+  }
+
   switch (preset) {
     case 'clear': {
       // Preserve type semantics: strings clear to `''` (browser-friendly for

--- a/packages/dynamic-forms/src/lib/core/derivation/async-derivation-stream-race.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/async-derivation-stream-race.spec.ts
@@ -195,12 +195,10 @@ describe('createAsyncDerivationStream — in-flight × state-change races', () =
   // the late write can clobber their input. Reproduce-first.
   // ---------------------------------------------------------------------------
   describe('stopOnUserOverride — user edits field while async is in flight', () => {
-    it.fails('does NOT overwrite the user edit that happened during the in-flight window', () => {
-      // BUG: async-derivation-stream.ts reads dirty() only at fire-time (switchMap, lines
-      // ~117-138). When the result arrives in `next` (lines ~191-222) it applies the value
-      // with no re-check of dirty/stopOnUserOverride. A user who edits the field after the
-      // async call started but before it resolves gets their input silently overwritten by
-      // the stale derived value. Same #394-family late-write leak, dirty-state variant.
+    it('does NOT overwrite the user edit that happened during the in-flight window', () => {
+      // async-derivation-stream.ts re-reads dirty() at apply-time in the `next` handler,
+      // so a user who edits the field after the async call started but before it resolves
+      // keeps their input — stopOnUserOverride protects the late write.
       const productId = createFieldInstance('abc');
       const price = createFieldInstance(0);
 
@@ -394,10 +392,9 @@ describe('createHttpDerivationStream — in-flight × state-change races', () =>
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("target field 'rate' not found"));
   });
 
-  it.fails('does NOT overwrite a user edit that happened during the in-flight HTTP window', () => {
-    // BUG: http-derivation-stream.ts mirrors the async stream — dirty() is read at fire-time
-    // only (switchMap, lines ~104-137); the response `next` handler (lines ~201-234) applies
-    // with no dirty re-check. A user edit during the in-flight window is clobbered.
+  it('does NOT overwrite a user edit that happened during the in-flight HTTP window', () => {
+    // http-derivation-stream.ts re-reads dirty() at apply-time in the response `next`
+    // handler, so a user edit during the in-flight window is preserved.
     const country = createFieldInstance('US');
     const rate = createFieldInstance(0);
 

--- a/packages/dynamic-forms/src/lib/core/derivation/async-derivation-stream-race.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/async-derivation-stream-race.spec.ts
@@ -1,0 +1,429 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { computed, signal, WritableSignal } from '@angular/core';
+import { Subject } from 'rxjs';
+import { createAsyncDerivationStream, AsyncDerivationStreamContext } from './async-derivation-stream';
+import { createHttpDerivationStream, HttpDerivationStreamContext } from './http-derivation-stream';
+import { DerivationEntry } from './derivation-types';
+import { Logger } from '../../providers/features/logger/logger.interface';
+import { DerivationLogger } from './derivation-logger.service';
+
+/**
+ * ASYNC-IN-FLIGHT × STATE-CHANGE races.
+ *
+ * Stream cancellation (switchMap) is already covered in async-derivation-stream.spec.ts.
+ * The UNTESTED seam exercised here is what happens when an async result lands AFTER the
+ * target field's hidden-state or dirty-state changed while the call was in flight. This is
+ * the #394 family (NaN / stale value leaking into a now-hidden or user-edited field).
+ *
+ * The async function returns a Subject so the test controls EXACTLY when the result lands,
+ * after mutating form/dirty state — no real sleeps, same controllable-observable mechanism
+ * the existing spec uses.
+ */
+describe('createAsyncDerivationStream — in-flight × state-change races', () => {
+  function createMockLogger(): Logger {
+    return { log: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  }
+
+  function createMockDerivationLogger(): DerivationLogger {
+    return {
+      cycleStart: vi.fn(),
+      iteration: vi.fn(),
+      evaluation: vi.fn(),
+      summary: vi.fn(),
+      maxIterationsReached: vi.fn(),
+    };
+  }
+
+  /** Field instance matching the public Angular Signal Forms API used by the applicator. */
+  function createFieldInstance(initial: unknown): {
+    field: unknown;
+    value: WritableSignal<unknown>;
+    dirty: WritableSignal<boolean>;
+  } {
+    const value = signal(initial);
+    const dirty = signal(false);
+    const touched = signal(false);
+    const field = computed(() => ({
+      value,
+      dirty,
+      touched,
+      reset: () => {
+        dirty.set(false);
+        touched.set(false);
+      },
+    }));
+    return { field, value, dirty };
+  }
+
+  function createAsyncEntry(fieldKey: string, options: Partial<DerivationEntry> = {}): DerivationEntry {
+    return {
+      fieldKey,
+      dependsOn: options.dependsOn ?? ['productId'],
+      condition: options.condition ?? true,
+      asyncFunctionName: options.asyncFunctionName ?? 'fetchValue',
+      asyncFn: options.asyncFn,
+      trigger: options.trigger ?? 'onChange',
+      isShorthand: options.isShorthand ?? false,
+      stopOnUserOverride: options.stopOnUserOverride,
+      reEngageOnDependencyChange: options.reEngageOnDependencyChange,
+      debugName: options.debugName,
+      debounceMs: options.debounceMs,
+    };
+  }
+
+  let logger: Logger;
+  let derivationLogger: DerivationLogger;
+  let formValue$: Subject<Record<string, unknown>>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    logger = createMockLogger();
+    derivationLogger = createMockDerivationLogger();
+    formValue$ = new Subject<Record<string, unknown>>();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ---------------------------------------------------------------------------
+  // SCENARIO 1: target field becomes HIDDEN/excluded while async is in flight.
+  //
+  // Modeled at the unit seam the way the runtime models it: when a value field is
+  // hidden+excluded it is removed from the Signal Forms tree, so `rootForm[fieldKey]`
+  // no longer resolves. The stream reads `context.form()` lazily in its `next` handler
+  // (untracked), so swapping the form signal to a tree WITHOUT the field reproduces the
+  // "field gone by the time the result lands" race. applyValueToForm must then refuse to
+  // write (returns false + missing-field warning), so no stale/NaN value leaks.
+  // ---------------------------------------------------------------------------
+  describe('field hidden (removed from tree) before async resolves', () => {
+    it('does NOT leak the late result into a field that was removed while in flight', () => {
+      const productId = createFieldInstance('abc');
+      const price = createFieldInstance(0);
+
+      // Full tree (price present) at fire time.
+      const fullForm: Record<string, unknown> = { productId: productId.field, price: price.field };
+      // Tree after the field was hidden + excluded → price removed.
+      const hiddenForm: Record<string, unknown> = { productId: productId.field };
+
+      const formSignal = signal<Record<string, unknown>>(fullForm);
+      const formValueSignal = signal<Record<string, unknown>>({ productId: 'abc', price: 0 });
+
+      const resultSubject = new Subject<number>();
+      const asyncFn = vi.fn().mockReturnValue(resultSubject);
+
+      const entry = createAsyncEntry('price', { dependsOn: ['productId'] });
+      const context: AsyncDerivationStreamContext = {
+        formValue: formValueSignal,
+        form: formSignal as AsyncDerivationStreamContext['form'],
+        logger,
+        derivationLogger: signal(derivationLogger) as AsyncDerivationStreamContext['derivationLogger'],
+        asyncDerivationFunctions: () => ({ fetchValue: asyncFn }),
+      };
+
+      const stream$ = createAsyncDerivationStream(entry, formValue$, context);
+      stream$.subscribe();
+
+      // Fire the derivation: dependency changes.
+      formValue$.next({ productId: 'abc', price: 0 });
+      formValue$.next({ productId: 'xyz', price: 0 });
+      vi.advanceTimersByTime(300);
+      expect(asyncFn).toHaveBeenCalledTimes(1);
+
+      // Field becomes hidden+excluded WHILE the async call is in flight → removed from tree.
+      formSignal.set(hiddenForm);
+      formValueSignal.set({ productId: 'xyz' });
+
+      // Late result lands.
+      resultSubject.next(42);
+      resultSubject.complete();
+
+      // The now-removed field must not be written. The original value signal is untouched,
+      // and applyValueToForm logged a missing-field warning instead of leaking 42.
+      expect(price.value()).toBe(0);
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("target field 'price' not found"));
+    });
+
+    it('does NOT leak a NaN late result into a removed field (#394 family)', () => {
+      const productId = createFieldInstance('abc');
+      const qty = createFieldInstance(5);
+
+      const fullForm: Record<string, unknown> = { productId: productId.field, qty: qty.field };
+      const hiddenForm: Record<string, unknown> = { productId: productId.field };
+
+      const formSignal = signal<Record<string, unknown>>(fullForm);
+      const formValueSignal = signal<Record<string, unknown>>({ productId: 'abc', qty: 5 });
+
+      const resultSubject = new Subject<number>();
+      const asyncFn = vi.fn().mockReturnValue(resultSubject);
+
+      const entry = createAsyncEntry('qty', { dependsOn: ['productId'] });
+      const context: AsyncDerivationStreamContext = {
+        formValue: formValueSignal,
+        form: formSignal as AsyncDerivationStreamContext['form'],
+        logger,
+        derivationLogger: signal(derivationLogger) as AsyncDerivationStreamContext['derivationLogger'],
+        asyncDerivationFunctions: () => ({ fetchValue: asyncFn }),
+      };
+
+      createAsyncDerivationStream(entry, formValue$, context).subscribe();
+
+      formValue$.next({ productId: 'abc', qty: 5 });
+      formValue$.next({ productId: 'xyz', qty: 5 });
+      vi.advanceTimersByTime(300);
+
+      // Hide the field mid-flight.
+      formSignal.set(hiddenForm);
+      formValueSignal.set({ productId: 'xyz' });
+
+      // Late result is NaN (e.g. parsed from a response for a field that no longer applies).
+      resultSubject.next(NaN);
+      resultSubject.complete();
+
+      // No NaN leaked.
+      expect(Number.isNaN(qty.value() as number)).toBe(false);
+      expect(qty.value()).toBe(5);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // SCENARIO 2: stopOnUserOverride — user edits the field (dirty=true) AFTER the
+  // async fn was invoked but BEFORE the result lands.
+  //
+  // The stream checks dirty ONLY at fire-time inside switchMap, then applies the result
+  // in `next` without re-reading dirty. If the user types during the in-flight window,
+  // the late write can clobber their input. Reproduce-first.
+  // ---------------------------------------------------------------------------
+  describe('stopOnUserOverride — user edits field while async is in flight', () => {
+    it.fails('does NOT overwrite the user edit that happened during the in-flight window', () => {
+      // BUG: async-derivation-stream.ts reads dirty() only at fire-time (switchMap, lines
+      // ~117-138). When the result arrives in `next` (lines ~191-222) it applies the value
+      // with no re-check of dirty/stopOnUserOverride. A user who edits the field after the
+      // async call started but before it resolves gets their input silently overwritten by
+      // the stale derived value. Same #394-family late-write leak, dirty-state variant.
+      const productId = createFieldInstance('abc');
+      const price = createFieldInstance(0);
+
+      const formSignal = signal<Record<string, unknown>>({ productId: productId.field, price: price.field });
+      const formValueSignal = signal<Record<string, unknown>>({ productId: 'abc', price: 0 });
+
+      const resultSubject = new Subject<number>();
+      const asyncFn = vi.fn().mockReturnValue(resultSubject);
+
+      const entry = createAsyncEntry('price', { dependsOn: ['productId'], stopOnUserOverride: true });
+      const context: AsyncDerivationStreamContext = {
+        formValue: formValueSignal,
+        form: formSignal as AsyncDerivationStreamContext['form'],
+        logger,
+        derivationLogger: signal(derivationLogger) as AsyncDerivationStreamContext['derivationLogger'],
+        asyncDerivationFunctions: () => ({ fetchValue: asyncFn }),
+      };
+
+      createAsyncDerivationStream(entry, formValue$, context).subscribe();
+
+      // Fire: field is pristine, so the async call starts.
+      formValue$.next({ productId: 'abc', price: 0 });
+      formValue$.next({ productId: 'xyz', price: 0 });
+      vi.advanceTimersByTime(300);
+      expect(asyncFn).toHaveBeenCalledTimes(1);
+
+      // User types into the field WHILE the call is in flight → field becomes dirty.
+      price.value.set(777);
+      price.dirty.set(true);
+      formValueSignal.set({ productId: 'xyz', price: 777 });
+
+      // Late derived result lands.
+      resultSubject.next(42);
+      resultSubject.complete();
+
+      // The user's input must win — stopOnUserOverride should protect it.
+      expect(price.value()).toBe(777);
+    });
+
+    it('still applies the late result when the field stays pristine (control)', () => {
+      const productId = createFieldInstance('abc');
+      const price = createFieldInstance(0);
+
+      const formSignal = signal<Record<string, unknown>>({ productId: productId.field, price: price.field });
+      const formValueSignal = signal<Record<string, unknown>>({ productId: 'abc', price: 0 });
+
+      const resultSubject = new Subject<number>();
+      const asyncFn = vi.fn().mockReturnValue(resultSubject);
+
+      const entry = createAsyncEntry('price', { dependsOn: ['productId'], stopOnUserOverride: true });
+      const context: AsyncDerivationStreamContext = {
+        formValue: formValueSignal,
+        form: formSignal as AsyncDerivationStreamContext['form'],
+        logger,
+        derivationLogger: signal(derivationLogger) as AsyncDerivationStreamContext['derivationLogger'],
+        asyncDerivationFunctions: () => ({ fetchValue: asyncFn }),
+      };
+
+      createAsyncDerivationStream(entry, formValue$, context).subscribe();
+
+      formValue$.next({ productId: 'abc', price: 0 });
+      formValue$.next({ productId: 'xyz', price: 0 });
+      vi.advanceTimersByTime(300);
+
+      // No user edit — field stays pristine.
+      resultSubject.next(42);
+      resultSubject.complete();
+
+      expect(price.value()).toBe(42);
+    });
+  });
+});
+
+/**
+ * Same race class on the HTTP-derivation path. createHttpDerivationStream shares the
+ * identical seam: dirty()/stopOnUserOverride is checked at fire-time inside switchMap, and
+ * the HTTP response `next` handler applies the value with no re-check of dirty/hidden state.
+ * Controllable timing comes from the mock HttpClient returning a Subject.
+ */
+describe('createHttpDerivationStream — in-flight × state-change races', () => {
+  function createMockLogger(): Logger {
+    return { log: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  }
+
+  function createMockDerivationLogger(): DerivationLogger {
+    return {
+      cycleStart: vi.fn(),
+      iteration: vi.fn(),
+      evaluation: vi.fn(),
+      summary: vi.fn(),
+      maxIterationsReached: vi.fn(),
+    };
+  }
+
+  function createFieldInstance(initial: unknown): {
+    field: unknown;
+    value: WritableSignal<unknown>;
+    dirty: WritableSignal<boolean>;
+  } {
+    const value = signal(initial);
+    const dirty = signal(false);
+    const touched = signal(false);
+    const field = computed(() => ({
+      value,
+      dirty,
+      touched,
+      reset: () => {
+        dirty.set(false);
+        touched.set(false);
+      },
+    }));
+    return { field, value, dirty };
+  }
+
+  function createHttpEntry(fieldKey: string, options: Partial<DerivationEntry> = {}): DerivationEntry {
+    return {
+      fieldKey,
+      dependsOn: options.dependsOn ?? ['country'],
+      condition: options.condition ?? true,
+      http: options.http ?? { url: 'https://api.example.com/rate', method: 'GET' },
+      responseExpression: options.responseExpression ?? 'response.rate',
+      trigger: options.trigger ?? 'onChange',
+      debounceMs: options.debounceMs,
+      isShorthand: options.isShorthand ?? false,
+      stopOnUserOverride: options.stopOnUserOverride,
+      reEngageOnDependencyChange: options.reEngageOnDependencyChange,
+      debugName: options.debugName,
+    };
+  }
+
+  let logger: Logger;
+  let derivationLogger: DerivationLogger;
+  let formValue$: Subject<Record<string, unknown>>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    logger = createMockLogger();
+    derivationLogger = createMockDerivationLogger();
+    formValue$ = new Subject<Record<string, unknown>>();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function createContext(
+    formSignal: WritableSignal<Record<string, unknown>>,
+    formValueSignal: WritableSignal<Record<string, unknown>>,
+    httpClient: { request: ReturnType<typeof vi.fn> },
+  ): HttpDerivationStreamContext {
+    return {
+      formValue: formValueSignal,
+      form: formSignal as HttpDerivationStreamContext['form'],
+      httpClient: httpClient as unknown as HttpDerivationStreamContext['httpClient'],
+      logger,
+      derivationLogger: signal(derivationLogger) as HttpDerivationStreamContext['derivationLogger'],
+    };
+  }
+
+  it('does NOT leak the late HTTP response into a field removed while in flight', () => {
+    const country = createFieldInstance('US');
+    const rate = createFieldInstance(0);
+
+    const fullForm: Record<string, unknown> = { country: country.field, rate: rate.field };
+    const hiddenForm: Record<string, unknown> = { country: country.field };
+
+    const formSignal = signal<Record<string, unknown>>(fullForm);
+    const formValueSignal = signal<Record<string, unknown>>({ country: 'US', rate: 0 });
+
+    const responseSubject = new Subject<{ rate: number }>();
+    const httpClient = { request: vi.fn().mockReturnValue(responseSubject) };
+
+    const entry = createHttpEntry('rate', { dependsOn: ['country'] });
+    const stream$ = createHttpDerivationStream(entry, formValue$, createContext(formSignal, formValueSignal, httpClient));
+    stream$.subscribe();
+
+    formValue$.next({ country: 'US', rate: 0 });
+    formValue$.next({ country: 'DE', rate: 0 });
+    vi.advanceTimersByTime(300);
+    expect(httpClient.request).toHaveBeenCalledTimes(1);
+
+    // Field hidden + removed from tree mid-flight.
+    formSignal.set(hiddenForm);
+    formValueSignal.set({ country: 'DE' });
+
+    // Late response lands.
+    responseSubject.next({ rate: 1.5 });
+    responseSubject.complete();
+
+    expect(rate.value()).toBe(0);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("target field 'rate' not found"));
+  });
+
+  it.fails('does NOT overwrite a user edit that happened during the in-flight HTTP window', () => {
+    // BUG: http-derivation-stream.ts mirrors the async stream — dirty() is read at fire-time
+    // only (switchMap, lines ~104-137); the response `next` handler (lines ~201-234) applies
+    // with no dirty re-check. A user edit during the in-flight window is clobbered.
+    const country = createFieldInstance('US');
+    const rate = createFieldInstance(0);
+
+    const formSignal = signal<Record<string, unknown>>({ country: country.field, rate: rate.field });
+    const formValueSignal = signal<Record<string, unknown>>({ country: 'US', rate: 0 });
+
+    const responseSubject = new Subject<{ rate: number }>();
+    const httpClient = { request: vi.fn().mockReturnValue(responseSubject) };
+
+    const entry = createHttpEntry('rate', { dependsOn: ['country'], stopOnUserOverride: true });
+    createHttpDerivationStream(entry, formValue$, createContext(formSignal, formValueSignal, httpClient)).subscribe();
+
+    formValue$.next({ country: 'US', rate: 0 });
+    formValue$.next({ country: 'DE', rate: 0 });
+    vi.advanceTimersByTime(300);
+    expect(httpClient.request).toHaveBeenCalledTimes(1);
+
+    // User edits the field while the request is in flight.
+    rate.value.set(9.9);
+    rate.dirty.set(true);
+    formValueSignal.set({ country: 'DE', rate: 9.9 });
+
+    // Late response lands and clobbers the user input.
+    responseSubject.next({ rate: 1.5 });
+    responseSubject.complete();
+
+    expect(rate.value()).toBe(9.9);
+  });
+});

--- a/packages/dynamic-forms/src/lib/core/derivation/async-derivation-stream.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/async-derivation-stream.ts
@@ -207,8 +207,23 @@ export function createAsyncDerivationStream(
                 return;
               }
 
-              // Apply the value to the form
+              // Re-read dirty state at apply-time: the user may have edited the field
+              // after the async call started but before it resolved. Mirrors the
+              // fire-time stopOnUserOverride guard in the switchMap above.
               const currentForm = untracked(() => context.form());
+              if (entry.stopOnUserOverride && readFieldDirty(currentForm, entry.fieldKey)) {
+                const derivationLogger = untracked(() => context.derivationLogger());
+                derivationLogger.evaluation({
+                  debugName: entry.debugName,
+                  fieldKey: entry.fieldKey,
+                  result: 'skipped',
+                  skipReason: 'user-override',
+                });
+                subscriber.complete();
+                return;
+              }
+
+              // Apply the value to the form
               applyValueToForm(entry.fieldKey, newValue, currentForm, context.logger, context.warningTracker);
 
               const derivationLogger = untracked(() => context.derivationLogger());

--- a/packages/dynamic-forms/src/lib/core/derivation/compute-derived-value.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/compute-derived-value.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { EvaluationContext } from '../../models/expressions/evaluation-context';
+import type { Logger } from '../../providers/features/logger/logger.interface';
+import { computeValueFromEntry } from './compute-derived-value';
+
+// A sync derivation slot ('fn' / 'functionName' / 'expression') must return a plain
+// value. If a user wires an async function into the sync slot, the returned Promise
+// (or Observable) would otherwise be written into the field as its value, surfacing as
+// `[object Promise]`. The 'asyncDerivations' / HTTP-derivation paths exist for async
+// logic. These tests pin that the sync compute path refuses an async result.
+
+const makeLogger = (): Logger => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() });
+
+function makeContext(logger: Logger): EvaluationContext {
+  return {
+    fieldValue: undefined,
+    formValue: {},
+    fieldPath: 'total',
+    customFunctions: {},
+    logger,
+  };
+}
+
+describe('computeValueFromEntry — async result misuse in the sync slot', () => {
+  it('returns undefined (not the Promise) and warns when an inline fn returns a Promise', () => {
+    const logger = makeLogger();
+    const result = computeValueFromEntry({ fn: () => Promise.resolve(42) }, makeContext(logger), { subject: 'total' });
+
+    expect(result).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Promise or Observable'));
+  });
+
+  it('returns undefined and warns when an inline fn returns an Observable-like value', () => {
+    const logger = makeLogger();
+    const observableLike = { subscribe: () => ({ unsubscribe: () => undefined }) };
+    const result = computeValueFromEntry({ fn: () => observableLike }, makeContext(logger), { subject: 'total' });
+
+    expect(result).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Promise or Observable'));
+  });
+
+  it('returns a plain object result unchanged (no false positive)', () => {
+    const logger = makeLogger();
+    const value = { amount: 10 };
+    const result = computeValueFromEntry({ fn: () => value }, makeContext(logger), { subject: 'total' });
+
+    expect(result).toBe(value);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dynamic-forms/src/lib/core/derivation/compute-derived-value.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/compute-derived-value.spec.ts
@@ -3,11 +3,7 @@ import type { EvaluationContext } from '../../models/expressions/evaluation-cont
 import type { Logger } from '../../providers/features/logger/logger.interface';
 import { computeValueFromEntry } from './compute-derived-value';
 
-// A sync derivation slot ('fn' / 'functionName' / 'expression') must return a plain
-// value. If a user wires an async function into the sync slot, the returned Promise
-// (or Observable) would otherwise be written into the field as its value, surfacing as
-// `[object Promise]`. The 'asyncDerivations' / HTTP-derivation paths exist for async
-// logic. These tests pin that the sync compute path refuses an async result.
+// A sync derivation fn returning a Promise/Observable must be refused, not written as the value.
 
 const makeLogger = (): Logger => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() });
 

--- a/packages/dynamic-forms/src/lib/core/derivation/compute-derived-value.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/compute-derived-value.ts
@@ -27,13 +27,7 @@ export interface ComputeValueOptions {
   functionKind?: string;
 }
 
-/**
- * A sync derivation slot must produce a plain value, not an async primitive.
- * A Promise or Observable returned from an inline `fn` would otherwise be
- * written into the field as its value (surfacing as `[object Promise]`). Detect
- * both so the caller can warn and skip; use `asyncDerivations` or an HTTP
- * derivation for asynchronous logic.
- */
+/** True for a Promise/Observable wrongly returned into a sync derivation slot. */
 function isThenableOrObservable(value: unknown): boolean {
   if (value === null || typeof value !== 'object') return false;
   const candidate = value as { then?: unknown; subscribe?: unknown };

--- a/packages/dynamic-forms/src/lib/core/derivation/compute-derived-value.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/compute-derived-value.ts
@@ -28,6 +28,19 @@ export interface ComputeValueOptions {
 }
 
 /**
+ * A sync derivation slot must produce a plain value, not an async primitive.
+ * A Promise or Observable returned from an inline `fn` would otherwise be
+ * written into the field as its value (surfacing as `[object Promise]`). Detect
+ * both so the caller can warn and skip; use `asyncDerivations` or an HTTP
+ * derivation for asynchronous logic.
+ */
+function isThenableOrObservable(value: unknown): boolean {
+  if (value === null || typeof value !== 'object') return false;
+  const candidate = value as { then?: unknown; subscribe?: unknown };
+  return typeof candidate.then === 'function' || typeof candidate.subscribe === 'function';
+}
+
+/**
  * Single dispatch over `value` / `expression` / `functionName` shared by both
  * the value-derivation and property-derivation applicators.
  *
@@ -57,7 +70,15 @@ export function computeValueFromEntry(
       const kind = options.functionKind ?? 'Derivation function';
       throw new DynamicFormError(`${kind} '${entry.functionName}' not found in customFnConfig.derivations`);
     }
-    return fn(evalContext);
+    const result = fn(evalContext);
+    if (isThenableOrObservable(result)) {
+      evalContext.logger.warn(
+        `Derivation for '${options.subject}' returned a Promise or Observable. ` +
+          `Synchronous derivations must return a value; use 'asyncDerivations' or an HTTP derivation for asynchronous logic. Skipping.`,
+      );
+      return undefined;
+    }
+    return result;
   }
 
   throw new DynamicFormError(

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-chain-cycle.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-chain-cycle.spec.ts
@@ -1,0 +1,367 @@
+import { describe, expect, it, vi } from 'vitest';
+import { computed, signal, Signal, WritableSignal } from '@angular/core';
+import type { FieldTree } from '@angular/forms/signals';
+import { applyDerivations, DerivationApplicatorContext } from './derivation-applicator';
+import { topologicalSort } from './derivation-sorter';
+import { DerivationCollection, DerivationEntry } from './derivation-types';
+import { Logger } from '../../providers/features/logger/logger.interface';
+import { DerivationLogger } from './derivation-logger.service';
+
+/**
+ * Chain + cycle behavior of the unified derivation applicator.
+ *
+ * These exercise the iterative single-traversal loop in `applyDerivations`:
+ * - chain propagation (B reads A's NEW value in the same pass)
+ * - conditions that gate on a freshly-derived field
+ * - bidirectional A<->B cycles stabilizing via equality
+ *
+ * Harness mirrors `derivation-applicator.spec.ts` but the `formValue` signal is
+ * a LIVE computed over the same value signals the form writes to — so reads
+ * inside the applicator's iterative loop observe writes made earlier in the
+ * cycle. A static snapshot (as in some existing specs) cannot express chains.
+ */
+describe('derivation chain + cycle behavior', () => {
+  function createMockLogger(): Logger {
+    return {
+      log: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+  }
+
+  function createMockDerivationLogger(): DerivationLogger {
+    return {
+      cycleStart: vi.fn(),
+      iteration: vi.fn(),
+      evaluation: vi.fn(),
+      summary: vi.fn(),
+      maxIterationsReached: vi.fn(),
+    };
+  }
+
+  /**
+   * Builds a mock signal-form where `formValue` is a LIVE computed reflecting
+   * the per-field value signals. Writes via `applyValueToForm` mutate the
+   * signals; subsequent `formValue()` reads see the new values.
+   */
+  function createLiveForm(initialValue: Record<string, unknown>): {
+    form: FieldTree<unknown>;
+    formValue: Signal<Record<string, unknown>>;
+    valueSignals: Record<string, WritableSignal<unknown>>;
+    read: (key: string) => unknown;
+  } {
+    const form: Record<string, unknown> = {};
+    const valueSignals: Record<string, WritableSignal<unknown>> = {};
+
+    for (const key of Object.keys(initialValue)) {
+      const valueSignal = signal(initialValue[key]);
+      valueSignals[key] = valueSignal;
+      const dirtySignal = signal(false);
+      const touchedSignal = signal(false);
+      const fieldInstance = {
+        value: valueSignal,
+        dirty: dirtySignal,
+        touched: touchedSignal,
+        reset: () => {
+          dirtySignal.set(false);
+          touchedSignal.set(false);
+        },
+      };
+      form[key] = computed(() => fieldInstance);
+    }
+
+    // Live snapshot: re-reads every value signal each evaluation.
+    const formValue = computed(() => {
+      const out: Record<string, unknown> = {};
+      for (const key of Object.keys(valueSignals)) {
+        out[key] = valueSignals[key]();
+      }
+      return out;
+    });
+
+    return {
+      form: form as unknown as FieldTree<unknown>,
+      formValue,
+      valueSignals,
+      read: (key: string) => valueSignals[key](),
+    };
+  }
+
+  function createEntry(fieldKey: string, options: Partial<DerivationEntry> = {}): DerivationEntry {
+    return {
+      fieldKey,
+      dependsOn: options.dependsOn ?? [],
+      condition: options.condition ?? true,
+      value: options.value,
+      expression: options.expression,
+      functionName: options.functionName,
+      fn: options.fn,
+      trigger: options.trigger ?? 'onChange',
+      isShorthand: options.isShorthand ?? false,
+    };
+  }
+
+  function createCollection(entries: DerivationEntry[]): DerivationCollection {
+    return { entries };
+  }
+
+  function makeContext(
+    form: FieldTree<unknown>,
+    formValue: Signal<Record<string, unknown>>,
+    logger: Logger,
+    extra: Partial<DerivationApplicatorContext> = {},
+  ): DerivationApplicatorContext {
+    return {
+      formValue,
+      rootForm: form,
+      logger,
+      derivationLogger: createMockDerivationLogger(),
+      ...extra,
+    };
+  }
+
+  describe('chain propagation within a single traversal', () => {
+    it("B (B<-A) reflects A's NEW value when inputX changes (A<-inputX)", () => {
+      // inputX = 5 -> A = inputX * 2 = 10 -> B = A + 1 = 11
+      const { form, formValue, read } = createLiveForm({ inputX: 5, a: 0, b: 0 });
+
+      const collection = createCollection([
+        createEntry('a', { expression: 'formValue.inputX * 2', dependsOn: ['inputX'] }),
+        createEntry('b', { expression: 'formValue.a + 1', dependsOn: ['a'] }),
+      ]);
+
+      const logger = createMockLogger();
+      const result = applyDerivations(collection, makeContext(form, formValue, logger));
+
+      expect(read('a')).toBe(10);
+      // B must reflect A's NEW value (11), not the previous-cycle A (0 -> would be 1).
+      expect(read('b')).toBe(11);
+      expect(result.errorCount).toBe(0);
+    });
+
+    it('propagates through a 3-link chain A->B->C in one applyDerivations call', () => {
+      // inputX = 3 -> a = 3+1 = 4 -> b = a*10 = 40 -> c = b-5 = 35
+      const { form, formValue, read } = createLiveForm({ inputX: 3, a: 0, b: 0, c: 0 });
+
+      const collection = createCollection([
+        createEntry('a', { expression: 'formValue.inputX + 1', dependsOn: ['inputX'] }),
+        createEntry('b', { expression: 'formValue.a * 10', dependsOn: ['a'] }),
+        createEntry('c', { expression: 'formValue.b - 5', dependsOn: ['b'] }),
+      ]);
+
+      const logger = createMockLogger();
+      applyDerivations(collection, makeContext(form, formValue, logger));
+
+      expect(read('a')).toBe(4);
+      expect(read('b')).toBe(40);
+      expect(read('c')).toBe(35);
+    });
+
+    it('propagates the full chain when entries arrive topologically sorted (production order)', () => {
+      // Entries authored in reverse (C, B, A) but the production pipeline always
+      // runs topologicalSort at collection time before the applicator sees them.
+      // We reproduce that contract here: sort first, then apply.
+      const { form, formValue, read } = createLiveForm({ inputX: 3, a: 0, b: 0, c: 0 });
+
+      const authored = [
+        createEntry('c', { expression: 'formValue.b - 5', dependsOn: ['b'] }),
+        createEntry('b', { expression: 'formValue.a * 10', dependsOn: ['a'] }),
+        createEntry('a', { expression: 'formValue.inputX + 1', dependsOn: ['inputX'] }),
+      ];
+      const collection = createCollection(topologicalSort(authored));
+
+      const logger = createMockLogger();
+      applyDerivations(collection, makeContext(form, formValue, logger));
+
+      expect(read('a')).toBe(4);
+      expect(read('b')).toBe(40);
+      expect(read('c')).toBe(35);
+    });
+
+    it('BUG-GUARD: applicator does NOT re-sort, so a topologically-reversed input mis-derives an early link', () => {
+      // Documents the contract: the applicator relies on entries being pre-sorted
+      // by the collector. `appliedDerivations` is cycle-scoped, so an entry applied
+      // early against a stale dependency is marked done and never recomputed even
+      // though its dependency updates later in the same cycle.
+      const { form, formValue, read } = createLiveForm({ inputX: 3, a: 0, b: 0, c: 0 });
+
+      // Deliberately UNSORTED (C before its dependency B). Not a state the
+      // production pipeline produces — the collector sorts first.
+      const collection = createCollection([
+        createEntry('c', { expression: 'formValue.b - 5', dependsOn: ['b'] }),
+        createEntry('b', { expression: 'formValue.a * 10', dependsOn: ['a'] }),
+        createEntry('a', { expression: 'formValue.inputX + 1', dependsOn: ['inputX'] }),
+      ]);
+
+      const logger = createMockLogger();
+      applyDerivations(collection, makeContext(form, formValue, logger));
+
+      expect(read('a')).toBe(4);
+      expect(read('b')).toBe(40);
+      // c was computed once in iteration 1 against b=0 (-> -5) then locked by the
+      // cycle-scoped applied-set. Confirms the applicator's pre-sort dependency.
+      expect(read('c')).toBe(-5);
+    });
+
+    it('topologicalSort orders the chain so a single forward pass would suffice', () => {
+      const entryA = createEntry('a', { dependsOn: ['inputX'] });
+      const entryB = createEntry('b', { dependsOn: ['a'] });
+      const entryC = createEntry('c', { dependsOn: ['b'] });
+
+      // Shuffled input
+      const sorted = topologicalSort([entryC, entryA, entryB]);
+
+      expect(sorted.indexOf(entryA)).toBeLessThan(sorted.indexOf(entryB));
+      expect(sorted.indexOf(entryB)).toBeLessThan(sorted.indexOf(entryC));
+    });
+  });
+
+  describe('condition gating on a freshly-derived field', () => {
+    it('a derivation whose condition references a derived field sees the NEW derived value', () => {
+      // role is derived from inputX: inputX >= 10 -> "admin", else "user".
+      // banner is derived ONLY when role === "admin" (fieldValue condition on role).
+      const { form, formValue, read } = createLiveForm({ inputX: 50, role: 'user', banner: '' });
+
+      const collection = createCollection([
+        createEntry('role', {
+          expression: "formValue.inputX >= 10 ? 'admin' : 'user'",
+          dependsOn: ['inputX'],
+        }),
+        createEntry('banner', {
+          value: 'ADMIN ACCESS',
+          dependsOn: ['role'],
+          condition: { type: 'fieldValue', fieldPath: 'role', operator: 'equals', value: 'admin' },
+        }),
+      ]);
+
+      const logger = createMockLogger();
+      applyDerivations(collection, makeContext(form, formValue, logger));
+
+      // role becomes 'admin' this cycle; banner's condition must see the NEW
+      // role, not the stale 'user' it started with.
+      expect(read('role')).toBe('admin');
+      expect(read('banner')).toBe('ADMIN ACCESS');
+    });
+
+    it('condition gates OFF correctly when the freshly-derived value fails the condition', () => {
+      // inputX = 1 -> role becomes 'user'; banner condition (role === admin) is false.
+      const { form, formValue, read } = createLiveForm({ inputX: 1, role: 'admin', banner: '' });
+
+      const collection = createCollection([
+        createEntry('role', {
+          expression: "formValue.inputX >= 10 ? 'admin' : 'user'",
+          dependsOn: ['inputX'],
+        }),
+        createEntry('banner', {
+          value: 'ADMIN ACCESS',
+          dependsOn: ['role'],
+          condition: { type: 'fieldValue', fieldPath: 'role', operator: 'equals', value: 'admin' },
+        }),
+      ]);
+
+      const logger = createMockLogger();
+      applyDerivations(collection, makeContext(form, formValue, logger));
+
+      expect(read('role')).toBe('user');
+      // Condition must evaluate against the NEW role ('user') -> banner stays empty.
+      expect(read('banner')).toBe('');
+    });
+
+    it('javascript-condition referencing a derived field is evaluated against the new value', () => {
+      const { form, formValue, read } = createLiveForm({ inputX: 5, doubled: 0, flag: 'no' });
+
+      const collection = createCollection([
+        createEntry('doubled', { expression: 'formValue.inputX * 2', dependsOn: ['inputX'] }),
+        createEntry('flag', {
+          value: 'yes',
+          dependsOn: ['doubled'],
+          // doubled = 10 -> condition true
+          condition: { type: 'javascript', expression: 'formValue.doubled > 8' },
+        }),
+      ]);
+
+      const logger = createMockLogger();
+      applyDerivations(collection, makeContext(form, formValue, logger));
+
+      expect(read('doubled')).toBe(10);
+      expect(read('flag')).toBe('yes');
+    });
+  });
+
+  describe('bidirectional cycle A<->B', () => {
+    it('stabilizes via equality and does not throw or hit max iterations (integer math)', () => {
+      // A mirrors B, B mirrors A. Seed A = 7. Once both equal 7, isEqual
+      // short-circuits and no further writes occur.
+      const { form, formValue, read } = createLiveForm({ a: 7, b: 0 });
+
+      const collection = createCollection([
+        createEntry('a', { expression: 'formValue.b', dependsOn: ['b'] }),
+        createEntry('b', { expression: 'formValue.a', dependsOn: ['a'] }),
+      ]);
+
+      const logger = createMockLogger();
+      const result = applyDerivations(collection, makeContext(form, formValue, logger));
+
+      // First pass: a<-b makes a=0; b<-a makes b=0. Both 0 -> stable.
+      // (a mirrors b which started at 0; this is the documented "last writer" merge.)
+      expect(read('a')).toBe(read('b'));
+      expect(result.errorCount).toBe(0);
+      expect(result.maxIterationsReached).toBe(false);
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('USD<->EUR currency cycle converges from an inconsistent seed (integer-stable factor)', () => {
+      // amountUSD <- amountEUR * 2 ; amountEUR <- amountUSD / 2
+      // Integer factor avoids float oscillation (see applicator isEqual note).
+      // Seed inconsistent: EUR=100, USD=0 -> must converge to USD=200, EUR=100.
+      const { form, formValue, read } = createLiveForm({ amountUSD: 0, amountEUR: 100 });
+
+      const collection = createCollection([
+        createEntry('amountUSD', { expression: 'formValue.amountEUR * 2', dependsOn: ['amountEUR'] }),
+        createEntry('amountEUR', { expression: 'formValue.amountUSD / 2', dependsOn: ['amountUSD'] }),
+      ]);
+
+      const logger = createMockLogger();
+      const result = applyDerivations(collection, makeContext(form, formValue, logger));
+
+      expect(result.errorCount).toBe(0);
+      expect(result.maxIterationsReached).toBe(false);
+      expect(read('amountUSD')).toBe(200);
+      // EUR round-trips back to 100 (200/2) -> equality halts the cycle.
+      expect(read('amountEUR')).toBe(100);
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('one-directional change in a bidirectional pair settles in bounded iterations', () => {
+      // a <- b (identity), b <- a (identity). Start mismatched: a=5, b=5 already equal.
+      // Change driver: set a's source so it must propagate to b and settle.
+      const { form, formValue, read } = createLiveForm({ a: 5, b: 5 });
+
+      const collection = createCollection([
+        createEntry('a', { expression: 'formValue.b', dependsOn: ['b'] }),
+        createEntry('b', { expression: 'formValue.a', dependsOn: ['a'] }),
+      ]);
+
+      const logger = createMockLogger();
+      const result = applyDerivations(collection, makeContext(form, formValue, logger));
+
+      // Already consistent -> nothing applies, stable in iteration 1.
+      expect(read('a')).toBe(5);
+      expect(read('b')).toBe(5);
+      expect(result.appliedCount).toBe(0);
+      expect(result.maxIterationsReached).toBe(false);
+    });
+
+    it('topologicalSort keeps both bidirectional entries without throwing', () => {
+      const entryA = createEntry('a', { dependsOn: ['b'] });
+      const entryB = createEntry('b', { dependsOn: ['a'] });
+
+      const sorted = topologicalSort([entryA, entryB]);
+
+      expect(sorted).toContain(entryA);
+      expect(sorted).toContain(entryB);
+      expect(sorted.length).toBe(2);
+    });
+  });
+});

--- a/packages/dynamic-forms/src/lib/core/derivation/http-derivation-stream.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/http-derivation-stream.ts
@@ -219,8 +219,23 @@ export function createHttpDerivationStream(
                   return;
                 }
 
-                // Apply the value to the form
+                // Re-read dirty state at apply-time: the user may have edited the field
+                // after the request started but before it resolved. Mirrors the
+                // fire-time stopOnUserOverride guard in the switchMap above.
                 const currentForm = untracked(() => context.form());
+                if (entry.stopOnUserOverride && readFieldDirty(currentForm, entry.fieldKey)) {
+                  const derivationLogger = untracked(() => context.derivationLogger());
+                  derivationLogger.evaluation({
+                    debugName: entry.debugName,
+                    fieldKey: entry.fieldKey,
+                    result: 'skipped',
+                    skipReason: 'user-override',
+                  });
+                  subscriber.complete();
+                  return;
+                }
+
+                // Apply the value to the form
                 applyValueToForm(entry.fieldKey, newValue, currentForm, context.logger, context.warningTracker);
 
                 const derivationLogger = untracked(() => context.derivationLogger());

--- a/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.spec.ts
@@ -158,26 +158,27 @@ describe('condition-evaluator', () => {
         expect(evaluateCondition(expression, mockContext)).toBe(false);
       });
 
-      // LIMITATION: The `matches` operator has no API to pass regex flags. A
-      // string value is fed straight into `new RegExp(value)` with no flags, so
-      // case-insensitive matching is impossible. Inline-flag syntax `(?i)` is
-      // not valid ECMAScript and throws inside the RegExp constructor, which
-      // compareValues catches and turns into `false`. There is no way for a
-      // config author to request a case-insensitive `matches`. If flag support
-      // is ever added (e.g. `value: '/JOHN/i'` parsing or a `flags` field),
-      // flip this to a passing `it`.
-      it.fails('should support case-insensitive matching via inline (?i) flag', () => {
+      // Case-insensitive matching via the `/pattern/flags` regex-literal form.
+      it('should support case-insensitive matching via the /pattern/flags form', () => {
         const expression: ConditionalExpression = {
           type: 'fieldValue',
           fieldPath: 'email',
           operator: 'matches',
-          value: '(?i)JOHN@EXAMPLE',
+          value: '/JOHN@EXAMPLE/i',
         };
 
-        // Desired behavior: case-insensitive match succeeds. Actual: `(?i)` is
-        // an invalid JS regex token → RegExp throws → compareValues returns
-        // false, so this assertion fails (documented limitation).
         expect(evaluateCondition(expression, mockContext)).toBe(true);
+      });
+
+      it('treats a plain pattern (no /.../ delimiters) as case-sensitive', () => {
+        const expression: ConditionalExpression = {
+          type: 'fieldValue',
+          fieldPath: 'email',
+          operator: 'matches',
+          value: 'JOHN@EXAMPLE',
+        };
+
+        expect(evaluateCondition(expression, mockContext)).toBe(false);
       });
 
       it('should evaluate to false (not throw) for an invalid regex string', () => {

--- a/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.spec.ts
@@ -438,10 +438,7 @@ describe('condition-evaluator', () => {
         expect(contextChecker).toHaveBeenCalledWith(contextWithChecker);
       });
 
-      // A sync condition slot (`custom`) must return a value, not a thenable/observable.
-      // `!!promise` and `!!observable` are both truthy, so without a guard a user who
-      // wires an async function into the sync slot gets an unconditional `true` with no
-      // signal. The 'async'/'http' condition types exist for asynchronous logic.
+      // A custom fn returning a Promise/Observable must yield false, not true (both are truthy under !!).
       describe('async result misuse in the sync slot', () => {
         it('returns false (not true) and warns when a custom fn returns a Promise', () => {
           const expression: ConditionalExpression = {

--- a/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.spec.ts
@@ -131,6 +131,70 @@ describe('condition-evaluator', () => {
       });
     });
 
+    describe('matches operator (regex handling)', () => {
+      // GAP 1: `matches` builds a RegExp from the string `value` via
+      // `new RegExp(String(expected))` (no flags) in value-utils.compareValues.
+      it('should match a basic regex pattern (regression lock)', () => {
+        const expression: ConditionalExpression = {
+          type: 'fieldValue',
+          fieldPath: 'email',
+          operator: 'matches',
+          value: '^john@',
+        };
+
+        expect(evaluateCondition(expression, mockContext)).toBe(true);
+      });
+
+      it('should NOT match when the pattern requires a different case (case-sensitive by default)', () => {
+        // formValue.email is 'john@example.com'. Uppercase pattern must not match
+        // because no `i` flag is applied. This locks the case-sensitive behavior.
+        const expression: ConditionalExpression = {
+          type: 'fieldValue',
+          fieldPath: 'email',
+          operator: 'matches',
+          value: 'JOHN@EXAMPLE',
+        };
+
+        expect(evaluateCondition(expression, mockContext)).toBe(false);
+      });
+
+      // LIMITATION: The `matches` operator has no API to pass regex flags. A
+      // string value is fed straight into `new RegExp(value)` with no flags, so
+      // case-insensitive matching is impossible. Inline-flag syntax `(?i)` is
+      // not valid ECMAScript and throws inside the RegExp constructor, which
+      // compareValues catches and turns into `false`. There is no way for a
+      // config author to request a case-insensitive `matches`. If flag support
+      // is ever added (e.g. `value: '/JOHN/i'` parsing or a `flags` field),
+      // flip this to a passing `it`.
+      it.fails('should support case-insensitive matching via inline (?i) flag', () => {
+        const expression: ConditionalExpression = {
+          type: 'fieldValue',
+          fieldPath: 'email',
+          operator: 'matches',
+          value: '(?i)JOHN@EXAMPLE',
+        };
+
+        // Desired behavior: case-insensitive match succeeds. Actual: `(?i)` is
+        // an invalid JS regex token → RegExp throws → compareValues returns
+        // false, so this assertion fails (documented limitation).
+        expect(evaluateCondition(expression, mockContext)).toBe(true);
+      });
+
+      it('should evaluate to false (not throw) for an invalid regex string', () => {
+        // An unterminated group is an invalid regex. compareValues wraps the
+        // RegExp construction in try/catch and returns false on SyntaxError.
+        const expression: ConditionalExpression = {
+          type: 'fieldValue',
+          fieldPath: 'email',
+          operator: 'matches',
+          value: '(',
+        };
+
+        expect(() => evaluateCondition(expression, mockContext)).not.toThrow();
+        expect(evaluateCondition(expression, mockContext)).toBe(false);
+      });
+    });
+
     describe('javascript type', () => {
       it('should evaluate simple JavaScript expressions', () => {
         const expression: ConditionalExpression = {

--- a/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.spec.ts
@@ -438,6 +438,46 @@ describe('condition-evaluator', () => {
         expect(contextChecker).toHaveBeenCalledWith(contextWithChecker);
       });
 
+      // A sync condition slot (`custom`) must return a value, not a thenable/observable.
+      // `!!promise` and `!!observable` are both truthy, so without a guard a user who
+      // wires an async function into the sync slot gets an unconditional `true` with no
+      // signal. The 'async'/'http' condition types exist for asynchronous logic.
+      describe('async result misuse in the sync slot', () => {
+        it('returns false (not true) and warns when a custom fn returns a Promise', () => {
+          const expression: ConditionalExpression = {
+            type: 'custom',
+            fn: () => Promise.resolve(false),
+          };
+
+          const result = evaluateCondition(expression, mockContext);
+
+          expect(result).toBe(false);
+          expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Promise or Observable'));
+        });
+
+        it('returns false (not true) and warns when a custom fn returns an Observable-like value', () => {
+          const observableLike = { subscribe: () => ({ unsubscribe: () => undefined }) };
+          const expression: ConditionalExpression = {
+            type: 'custom',
+            fn: () => observableLike,
+          };
+
+          const result = evaluateCondition(expression, mockContext);
+
+          expect(result).toBe(false);
+          expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Promise or Observable'));
+        });
+
+        it('still returns true for a thenable-free object (normal truthy result)', () => {
+          const expression: ConditionalExpression = {
+            type: 'custom',
+            fn: () => ({ ok: true }),
+          };
+
+          expect(evaluateCondition(expression, mockContext)).toBe(true);
+        });
+      });
+
       describe('inline fn alternative', () => {
         it('evaluates inline fn correctly', () => {
           const inlineFn = vi.fn().mockReturnValue(true);

--- a/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.ts
@@ -10,6 +10,19 @@ import { compareValues, getNestedValue, hasNestedProperty } from './value-utils'
 import { ExpressionParser } from './parser/expression-parser';
 
 /**
+ * A sync condition slot must return a value, not an async primitive. A Promise
+ * or Observable is a truthy object, so `!!result` would silently resolve to
+ * `true` regardless of the eventual value. Detect both so the caller can warn
+ * and fall back to `false` instead. Use the `async`/`http` condition types for
+ * asynchronous logic.
+ */
+function isThenableOrObservable(value: unknown): boolean {
+  if (value === null || typeof value !== 'object') return false;
+  const candidate = value as { then?: unknown; subscribe?: unknown };
+  return typeof candidate.then === 'function' || typeof candidate.subscribe === 'function';
+}
+
+/**
  * Evaluate conditional expression
  * Uses secure AST-based parsing for JavaScript expressions
  */
@@ -42,7 +55,15 @@ export function evaluateCondition(expression: ConditionalExpression, context: Ev
       }
 
       try {
-        return !!customFn(context);
+        const result = customFn(context);
+        if (isThenableOrObservable(result)) {
+          context.logger.warn(
+            `Custom condition '${registeredName ?? '<inline>'}' returned a Promise or Observable. ` +
+              `Synchronous conditions must return a value; use an 'async' or 'http' condition type for asynchronous logic. Treating as false.`,
+          );
+          return false;
+        }
+        return !!result;
       } catch (error) {
         context.logger.error('Error executing custom function:', registeredName ?? '<inline>', error);
         return false;

--- a/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/condition-evaluator.ts
@@ -9,13 +9,7 @@ import { EvaluationContext } from '../../models/expressions/evaluation-context';
 import { compareValues, getNestedValue, hasNestedProperty } from './value-utils';
 import { ExpressionParser } from './parser/expression-parser';
 
-/**
- * A sync condition slot must return a value, not an async primitive. A Promise
- * or Observable is a truthy object, so `!!result` would silently resolve to
- * `true` regardless of the eventual value. Detect both so the caller can warn
- * and fall back to `false` instead. Use the `async`/`http` condition types for
- * asynchronous logic.
- */
+/** True for a Promise/Observable wrongly returned into a sync condition slot (truthy under `!!`). */
 function isThenableOrObservable(value: unknown): boolean {
   if (value === null || typeof value !== 'object') return false;
   const candidate = value as { then?: unknown; subscribe?: unknown };

--- a/packages/dynamic-forms/src/lib/core/expressions/value-utils.ts
+++ b/packages/dynamic-forms/src/lib/core/expressions/value-utils.ts
@@ -28,13 +28,19 @@ export function compareValues(actual: unknown, expected: unknown, operator: stri
       return String(actual).endsWith(String(expected));
     case 'matches':
       try {
-        return new RegExp(String(expected)).test(String(actual));
+        return toRegExp(String(expected)).test(String(actual));
       } catch {
         return false;
       }
     default:
       return false;
   }
+}
+
+/** Builds a RegExp, supporting the `/pattern/flags` literal form (e.g. `/john/i`) for flags like `i`. */
+function toRegExp(value: string): RegExp {
+  const literal = /^\/(.+)\/([dgimsuvy]*)$/.exec(value);
+  return literal ? new RegExp(literal[1], literal[2]) : new RegExp(value);
 }
 
 /**

--- a/packages/dynamic-forms/src/lib/core/form-mapping.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/form-mapping.spec.ts
@@ -1295,6 +1295,36 @@ describe('form-mapping', () => {
         });
       });
 
+      // `excludeValueIfHidden` (value knob) and `validateWhenHidden` (validation knob)
+      // are independent. Keeping a hidden field's value does NOT opt it into validation —
+      // a hidden group with excludeValueIfHidden:false + a required child + default
+      // validateWhenHidden(false) keeps the value but still skips its validation. This
+      // documents the decoupling so the two knobs aren't assumed to move together.
+      it('keeps validation skipped for a hidden required child even when its value is retained (excludeValueIfHidden:false)', () => {
+        runInInjectionContext(injector, () => {
+          const formValue = signal({ address: { street: '' } });
+          const groupField: FieldDef = {
+            key: 'address',
+            type: 'group',
+            hidden: true,
+            excludeValueIfHidden: false,
+            fields: [{ key: 'street', type: 'input', required: true } as FieldDef & FieldWithValidation],
+          };
+
+          const formInstance = form(
+            formValue,
+            schema<typeof formValue>((path) => {
+              mapFieldToForm(groupField, path.address);
+            }),
+          );
+          mockFormSignal.set(formInstance);
+
+          // Value is retained, but validation is governed by validateWhenHidden (default
+          // false), not by excludeValueIfHidden — so required does not fire.
+          expect(formInstance().valid()).toBe(true);
+        });
+      });
+
       it('should let a child override and become inert when its parent says validate-when-hidden', () => {
         runInInjectionContext(injector, () => {
           const formValue = signal({ address: { street: '' } });
@@ -1480,6 +1510,58 @@ describe('form-mapping', () => {
 
           expect(formInstance().valid()).toBe(true);
         });
+      });
+    });
+
+    // ng-forge defaults number inputs to NaN so signal-forms uses valueAsNumber;
+    // clearing a number input also yields NaN (see default-value.ts). These pin the
+    // resulting validation + wire-serialization contract, inspired by formly #3813
+    // (a non-required number throwing after type-then-clear) and #3698 (nullability).
+    describe('number-input NaN contract', () => {
+      it('does not make a NON-required number field invalid when its value is NaN (cleared)', () => {
+        runInInjectionContext(injector, () => {
+          const formValue = signal({ age: NaN });
+          const fieldDef: FieldDef & FieldWithValidation = { key: 'age', type: 'input', props: { type: 'number' } };
+
+          const formInstance = form(
+            formValue,
+            schema<typeof formValue>((path) => {
+              mapFieldToForm(fieldDef, path.age);
+            }),
+          );
+          mockFormSignal.set(formInstance);
+
+          expect(formInstance().valid()).toBe(true);
+        });
+      });
+
+      it('treats a NaN value as empty for a REQUIRED number field (cleared = unsatisfied)', () => {
+        runInInjectionContext(injector, () => {
+          const formValue = signal({ age: NaN });
+          const fieldDef: FieldDef & FieldWithValidation = {
+            key: 'age',
+            type: 'input',
+            required: true,
+            props: { type: 'number' },
+          };
+
+          const formInstance = form(
+            formValue,
+            schema<typeof formValue>((path) => {
+              mapFieldToForm(fieldDef, path.age);
+            }),
+          );
+          mockFormSignal.set(formInstance);
+
+          expect(formInstance().valid()).toBe(false);
+        });
+      });
+
+      it('serializes a NaN number value to null over the wire (JSON contract)', () => {
+        // The in-memory model value is NaN, but JSON.stringify maps NaN to null, so a
+        // cleared number reaches an HTTP backend as null, not NaN. Documented so consumers
+        // reading the bound value (NaN) vs the submitted payload (null) know they differ.
+        expect(JSON.stringify({ age: NaN })).toBe('{"age":null}');
       });
     });
   });

--- a/packages/dynamic-forms/src/lib/core/form-mapping.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/form-mapping.spec.ts
@@ -1295,11 +1295,7 @@ describe('form-mapping', () => {
         });
       });
 
-      // `excludeValueIfHidden` (value knob) and `validateWhenHidden` (validation knob)
-      // are independent. Keeping a hidden field's value does NOT opt it into validation —
-      // a hidden group with excludeValueIfHidden:false + a required child + default
-      // validateWhenHidden(false) keeps the value but still skips its validation. This
-      // documents the decoupling so the two knobs aren't assumed to move together.
+      // excludeValueIfHidden (value) and validateWhenHidden (validation) are independent knobs.
       it('keeps validation skipped for a hidden required child even when its value is retained (excludeValueIfHidden:false)', () => {
         runInInjectionContext(injector, () => {
           const formValue = signal({ address: { street: '' } });
@@ -1319,8 +1315,7 @@ describe('form-mapping', () => {
           );
           mockFormSignal.set(formInstance);
 
-          // Value is retained, but validation is governed by validateWhenHidden (default
-          // false), not by excludeValueIfHidden — so required does not fire.
+          // Validation is governed by validateWhenHidden, not excludeValueIfHidden.
           expect(formInstance().valid()).toBe(true);
         });
       });
@@ -1513,10 +1508,7 @@ describe('form-mapping', () => {
       });
     });
 
-    // ng-forge defaults number inputs to NaN so signal-forms uses valueAsNumber;
-    // clearing a number input also yields NaN (see default-value.ts). These pin the
-    // resulting validation + wire-serialization contract, inspired by formly #3813
-    // (a non-required number throwing after type-then-clear) and #3698 (nullability).
+    // Number inputs default to NaN (see default-value.ts); these pin its validity + wire contract.
     describe('number-input NaN contract', () => {
       it('does not make a NON-required number field invalid when its value is NaN (cleared)', () => {
         runInInjectionContext(injector, () => {
@@ -1558,9 +1550,7 @@ describe('form-mapping', () => {
       });
 
       it('serializes a NaN number value to null over the wire (JSON contract)', () => {
-        // The in-memory model value is NaN, but JSON.stringify maps NaN to null, so a
-        // cleared number reaches an HTTP backend as null, not NaN. Documented so consumers
-        // reading the bound value (NaN) vs the submitted payload (null) know they differ.
+        // In-memory value is NaN, but JSON.stringify maps it to null on the wire.
         expect(JSON.stringify({ age: NaN })).toBe('{"age":null}');
       });
     });

--- a/packages/dynamic-forms/src/lib/core/form-mapping.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/form-mapping.spec.ts
@@ -1365,6 +1365,66 @@ describe('form-mapping', () => {
         });
       });
 
+      // T3: page is a flatten container (children hoisted to the parent path). These pin that a
+      // hidden PAGE cascades its hidden-state to descendant validation the same way a hidden GROUP
+      // does — i.e. the page wrapper is dropped at flatten time but the cascade context survives.
+      it('should skip required validation on a leaf inside a statically hidden page by default', () => {
+        runInInjectionContext(injector, () => {
+          const formValue = signal({ street: '' });
+          const pageField: FieldDef = {
+            type: 'page',
+            hidden: true,
+            fields: [
+              {
+                key: 'street',
+                type: 'input',
+                required: true,
+              } as FieldDef & FieldWithValidation,
+            ],
+          };
+
+          const formInstance = form(
+            formValue,
+            schema<typeof formValue>((path) => {
+              mapFieldToForm(pageField, path as any);
+            }),
+          );
+          mockFormSignal.set(formInstance);
+
+          // Hidden page → descendant's required is skipped by default (mirrors hidden group).
+          expect(formInstance().valid()).toBe(true);
+        });
+      });
+
+      it('should propagate page validateWhenHidden=true to descendants without overrides', () => {
+        runInInjectionContext(injector, () => {
+          const formValue = signal({ street: '' });
+          const pageField: FieldDef = {
+            type: 'page',
+            hidden: true,
+            validateWhenHidden: true,
+            fields: [
+              {
+                key: 'street',
+                type: 'input',
+                required: true,
+              } as FieldDef & FieldWithValidation,
+            ],
+          };
+
+          const formInstance = form(
+            formValue,
+            schema<typeof formValue>((path) => {
+              mapFieldToForm(pageField, path as any);
+            }),
+          );
+          mockFormSignal.set(formInstance);
+
+          // Hidden page + page-level validate-when-hidden → descendant's required runs.
+          expect(formInstance().valid()).toBe(false);
+        });
+      });
+
       it('should skip validators on a leaf with logic-based static hidden=true condition', () => {
         // A logic condition of `true` resolves to "always hidden" through the
         // cascade's ancestorAlwaysHidden short-circuit. The validator should never

--- a/packages/dynamic-forms/src/lib/core/schema-builder.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/schema-builder.spec.ts
@@ -774,6 +774,32 @@ describe('schema-builder', () => {
         expect(result).toEqual({});
       });
 
+      it('should keep same-key fields in different groups independent (#401)', () => {
+        // #401: two groups each containing a field with the SAME key must hold
+        // INDEPENDENT values. Nested grouping namespaces each child under its
+        // group key, so groupA.name and groupB.name must not collide.
+        const fields: FieldDef<any>[] = [
+          {
+            type: 'group',
+            key: 'groupA',
+            fields: [{ type: 'input', key: 'name', value: 'Alice' }],
+          },
+          {
+            type: 'group',
+            key: 'groupB',
+            fields: [{ type: 'input', key: 'name', value: 'Bob' }],
+          },
+        ];
+        const result = fieldsToDefaultValues(fields, registry);
+        expect(result).toEqual({
+          groupA: { name: 'Alice' },
+          groupB: { name: 'Bob' },
+        });
+        // Explicit independence assertions: neither value leaked into the other group.
+        expect((result as { groupA: { name: string } }).groupA.name).toBe('Alice');
+        expect((result as { groupB: { name: string } }).groupB.name).toBe('Bob');
+      });
+
       it('should handle deeply nested structures', () => {
         const fields: FieldDef<any>[] = [
           {

--- a/packages/dynamic-forms/src/lib/dynamic-form.component.spec.ts
+++ b/packages/dynamic-forms/src/lib/dynamic-form.component.spec.ts
@@ -2188,7 +2188,7 @@ describe('DynamicFormComponent', () => {
     // and whose default value is '' (empty). The old `status` field was a free-text input
     // holding 'hello'. On swap, the form value for `status` must be the SELECT's default
     // (''), NOT the stale free-text 'hello'.
-    it.fails('does not leak stale value into a same-key field whose type changed (input → select)', async () => {
+    it('does not leak stale value into a same-key field whose type changed (input → select)', async () => {
       const initialConfig: TestFormConfig = {
         fields: [{ key: 'status', type: 'input', label: 'Status', value: 'hello' }],
       };
@@ -2214,19 +2214,17 @@ describe('DynamicFormComponent', () => {
 
       await swapConfig(fixture, newConfig);
 
-      // BUG: FormStateManager captures the old form value before teardown and, in the
-      // RestoreValues effect, restores any captured key whose key is still present in the
-      // new config (validKeys is key-only, type-blind — see form-state-machine.ts
-      // RestoreValues + form-state-manager.ts restoreValue). So the stale free-text
-      // 'hello' is merged back onto the new `select` field, which has no such option.
-      // Expected: the new field initializes to its own default (''), not the stale value.
+      // The RestoreValues effect computes validKeys by intersecting key AND field type between
+      // the old (currentFormSetup) and new (pendingFormSetup) schemaFields, so a retyped key is
+      // excluded from restoration and the new `select` field initializes to its own default ('')
+      // rather than inheriting the stale free-text 'hello' (which is not a valid option).
       expect(component.formValue()).toEqual({ status: '' });
     });
 
     // Same intent as above but with a clearer "default wins" assertion: the new field of a
     // different type declares its OWN explicit default, which must take precedence over the
     // stale value carried by the same key from the previous config.
-    it.fails('initializes a retyped same-key field to its own declared default, not the stale value', async () => {
+    it('initializes a retyped same-key field to its own declared default, not the stale value', async () => {
       const initialConfig: TestFormConfig = {
         fields: [{ key: 'flag', type: 'input', label: 'Flag', value: 'hello' }],
       };
@@ -2241,8 +2239,8 @@ describe('DynamicFormComponent', () => {
 
       await swapConfig(fixture, newConfig);
 
-      // BUG: stale string 'hello' is restored onto the checkbox field instead of its
-      // declared boolean default `false`.
+      // The type changed (input → checkbox), so the captured 'hello' is dropped during restore
+      // and the checkbox initializes to its declared boolean default `false`.
       expect(component.formValue()).toEqual({ flag: false });
     });
 

--- a/packages/dynamic-forms/src/lib/dynamic-form.component.spec.ts
+++ b/packages/dynamic-forms/src/lib/dynamic-form.component.spec.ts
@@ -1,5 +1,5 @@
 import { vi } from 'vitest';
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DynamicForm } from './dynamic-form.component';
 import { delay } from '@ng-forge/utils';
 import { SimpleTestUtils } from '../../testing/src/simple-test-utils';
@@ -2168,16 +2168,19 @@ describe('DynamicFormComponent', () => {
   // These exercise the real component harness — the only level that drives a full config
   // swap through field resolution + reconcileFields + value capture/restore.
   describe('Whole-config swap reconciliation', () => {
-    // Drives a full config swap to completion by waiting for the state machine to settle
-    // back to `ready`, then flushing render/effects. Mirrors the wait pattern used by the
-    // existing "should add new fields when config changes to include them" test, which
-    // awaits `stateManager.ready$` rather than guessing at fixed delays.
-    const swapConfig = async (fixture: any, newConfig: TestFormConfig) => {
+    // Drives a full config swap to completion. ready$ replays the current (pre-swap) ready
+    // state via toObservable, so awaiting it would resolve before the swap even starts. Instead
+    // gate on activeConfig flipping to the new config reference (only true once the state machine
+    // reaches it), then settle render + value restore.
+    const swapConfig = async (fixture: ComponentFixture<DynamicForm>, newConfig: TestFormConfig) => {
       const stateManager = fixture.debugElement.injector.get(FormStateManager);
-      const ready = firstValueFrom(stateManager.ready$);
       fixture.componentRef.setInput('dynamic-form', newConfig);
       fixture.detectChanges();
-      await ready;
+      for (let i = 0; i < 40 && stateManager.activeConfig() !== newConfig; i++) {
+        await delay(5);
+        fixture.detectChanges();
+        TestBed.flushEffects();
+      }
       await waitForDynamicComponents(fixture);
     };
 

--- a/packages/dynamic-forms/src/lib/dynamic-form.component.spec.ts
+++ b/packages/dynamic-forms/src/lib/dynamic-form.component.spec.ts
@@ -2080,7 +2080,7 @@ describe('DynamicFormComponent', () => {
     // Skip: Config changes that replace fields have timing issues in unit tests due to
     // afterNextRender callbacks and component destruction order. This is verified in E2E tests:
     // "rapid config changes settle to final config" in essential-tests.spec.ts
-    it.skip('should handle rapid config changes (latest wins)', async () => {
+    it('should handle rapid config changes (latest wins)', async () => {
       const config1: TestFormConfig = {
         fields: [{ key: 'fieldA', type: 'input', label: 'A', value: 'a' }],
       };
@@ -2089,30 +2089,27 @@ describe('DynamicFormComponent', () => {
       await waitForDynamicComponents(fixture);
       expect(component.formValue()).toEqual({ fieldA: 'a' });
 
-      // Rapid successive config changes
       const config2: TestFormConfig = {
         fields: [{ key: 'fieldB', type: 'input', label: 'B', value: 'b' }],
       };
-
       const config3: TestFormConfig = {
         fields: [{ key: 'fieldC', type: 'input', label: 'C', value: 'c' }],
       };
 
-      // Fire them rapidly
+      // Fire two swaps without awaiting between them; the state machine processes them
+      // sequentially and the latest config must win. Settle deterministically on activeConfig.
+      const stateManager = fixture.debugElement.injector.get(FormStateManager);
       fixture.componentRef.setInput('dynamic-form', config2);
       fixture.detectChanges();
       fixture.componentRef.setInput('dynamic-form', config3);
       fixture.detectChanges();
+      for (let i = 0; i < 60 && stateManager.activeConfig() !== config3; i++) {
+        await delay(5);
+        fixture.detectChanges();
+        TestBed.flushEffects();
+      }
+      await waitForDynamicComponents(fixture);
 
-      // Wait for transitions to complete
-      await delay();
-      fixture.detectChanges();
-      await delay();
-      fixture.detectChanges();
-      await delay();
-      fixture.detectChanges();
-
-      // Should end up with the last config (config3)
       expect(component.formValue()).toEqual({ fieldC: 'c' });
     });
 
@@ -2131,9 +2128,7 @@ describe('DynamicFormComponent', () => {
       expect(component.formValue()).toEqual({ firstName: 'John' });
     });
 
-    // Skip: Config changes that replace fields have timing issues in unit tests due to
-    // afterNextRender callbacks and component destruction order. This is verified in E2E tests.
-    it.skip('should transition through phases when config changes', async () => {
+    it('should transition through phases when config changes', async () => {
       const config1: TestFormConfig = {
         fields: [{ key: 'fieldA', type: 'input', label: 'A', value: 'a' }],
       };
@@ -2146,18 +2141,18 @@ describe('DynamicFormComponent', () => {
         fields: [{ key: 'fieldB', type: 'input', label: 'B', value: 'b' }],
       };
 
+      // Swap and settle deterministically until the new config is active (ready → teardown
+      // → applying → restoring → ready), then assert it ended back in the render phase.
+      const stateManager = fixture.debugElement.injector.get(FormStateManager);
       fixture.componentRef.setInput('dynamic-form', config2);
       fixture.detectChanges();
+      for (let i = 0; i < 60 && stateManager.activeConfig() !== config2; i++) {
+        await delay(5);
+        fixture.detectChanges();
+        TestBed.flushEffects();
+      }
+      await waitForDynamicComponents(fixture);
 
-      // Wait for transition to complete (goes through teardown → render)
-      await delay();
-      fixture.detectChanges();
-      await delay();
-      fixture.detectChanges();
-      await delay();
-      fixture.detectChanges();
-
-      // Should be back to render phase with new config applied
       expect(component.renderPhase()).toBe('render');
       expect(component.formValue()).toEqual({ fieldB: 'b' });
     });

--- a/packages/dynamic-forms/src/lib/dynamic-form.component.spec.ts
+++ b/packages/dynamic-forms/src/lib/dynamic-form.component.spec.ts
@@ -2163,6 +2163,152 @@ describe('DynamicFormComponent', () => {
     });
   });
 
+  // Integration coverage for swapping the ENTIRE `dynamic-form` config input at runtime
+  // (state machine: ready → transitioning[teardown → applying → restoring] → ready).
+  // These exercise the real component harness — the only level that drives a full config
+  // swap through field resolution + reconcileFields + value capture/restore.
+  describe('Whole-config swap reconciliation', () => {
+    // Drives a full config swap to completion by waiting for the state machine to settle
+    // back to `ready`, then flushing render/effects. Mirrors the wait pattern used by the
+    // existing "should add new fields when config changes to include them" test, which
+    // awaits `stateManager.ready$` rather than guessing at fixed delays.
+    const swapConfig = async (fixture: any, newConfig: TestFormConfig) => {
+      const stateManager = fixture.debugElement.injector.get(FormStateManager);
+      const ready = firstValueFrom(stateManager.ready$);
+      fixture.componentRef.setInput('dynamic-form', newConfig);
+      fixture.detectChanges();
+      await ready;
+      await waitForDynamicComponents(fixture);
+    };
+
+    // Scenario 1 (overlapping key, TYPE changes): a stale value from the old field type
+    // must not corrupt the new field; the new field must initialize to its own default.
+    //
+    // The new `status` field is a `select` whose only valid options are 'active'/'inactive'
+    // and whose default value is '' (empty). The old `status` field was a free-text input
+    // holding 'hello'. On swap, the form value for `status` must be the SELECT's default
+    // (''), NOT the stale free-text 'hello'.
+    it.fails('does not leak stale value into a same-key field whose type changed (input → select)', async () => {
+      const initialConfig: TestFormConfig = {
+        fields: [{ key: 'status', type: 'input', label: 'Status', value: 'hello' }],
+      };
+
+      const { component, fixture } = createComponent(initialConfig);
+      await waitForDynamicComponents(fixture);
+      expect(component.formValue()).toEqual({ status: 'hello' });
+
+      const newConfig: TestFormConfig = {
+        fields: [
+          {
+            key: 'status',
+            type: 'select',
+            label: 'Status',
+            options: [
+              { value: 'active', label: 'Active' },
+              { value: 'inactive', label: 'Inactive' },
+            ],
+            // no `value` declared → select default is '' (empty)
+          },
+        ],
+      };
+
+      await swapConfig(fixture, newConfig);
+
+      // BUG: FormStateManager captures the old form value before teardown and, in the
+      // RestoreValues effect, restores any captured key whose key is still present in the
+      // new config (validKeys is key-only, type-blind — see form-state-machine.ts
+      // RestoreValues + form-state-manager.ts restoreValue). So the stale free-text
+      // 'hello' is merged back onto the new `select` field, which has no such option.
+      // Expected: the new field initializes to its own default (''), not the stale value.
+      expect(component.formValue()).toEqual({ status: '' });
+    });
+
+    // Same intent as above but with a clearer "default wins" assertion: the new field of a
+    // different type declares its OWN explicit default, which must take precedence over the
+    // stale value carried by the same key from the previous config.
+    it.fails('initializes a retyped same-key field to its own declared default, not the stale value', async () => {
+      const initialConfig: TestFormConfig = {
+        fields: [{ key: 'flag', type: 'input', label: 'Flag', value: 'hello' }],
+      };
+
+      const { component, fixture } = createComponent(initialConfig);
+      await waitForDynamicComponents(fixture);
+      expect(component.formValue()).toEqual({ flag: 'hello' });
+
+      const newConfig: TestFormConfig = {
+        fields: [{ key: 'flag', type: 'checkbox', label: 'Flag', value: false }],
+      };
+
+      await swapConfig(fixture, newConfig);
+
+      // BUG: stale string 'hello' is restored onto the checkbox field instead of its
+      // declared boolean default `false`.
+      expect(component.formValue()).toEqual({ flag: false });
+    });
+
+    // Scenario 2 (key present in OLD config, absent in NEW): its value must be dropped,
+    // not leaked into the new form value.
+    it('drops the value of a key that exists in the old config but not the new one', async () => {
+      const initialConfig: TestFormConfig = {
+        fields: [
+          { key: 'keep', type: 'input', label: 'Keep', value: 'kept' },
+          { key: 'gone', type: 'input', label: 'Gone', value: 'leaked' },
+        ],
+      };
+
+      const { component, fixture } = createComponent(initialConfig);
+      await waitForDynamicComponents(fixture);
+      expect(component.formValue()).toEqual({ keep: 'kept', gone: 'leaked' });
+
+      const newConfig: TestFormConfig = {
+        fields: [{ key: 'keep', type: 'input', label: 'Keep', value: '' }],
+      };
+
+      await swapConfig(fixture, newConfig);
+
+      // `gone` is absent from the new config, so its value must not leak. `keep` is the
+      // only key in the new form value, and its preserved value survives the swap.
+      const formValue = component.formValue();
+      expect('gone' in formValue).toBe(false);
+      expect(formValue['keep']).toBe('kept');
+      expect(formValue).toEqual({ keep: 'kept' });
+    });
+
+    // Scenario 3 (same key, type/component changes → component is replaced): reconcileFields
+    // keys identity on key + component + injector, so a different component for the same key
+    // must produce a brand-new resolved field (replaced, not reused). Verified by asserting
+    // the rendered DOM swaps from the input harness to the select harness.
+    it('replaces the rendered component when a same-key field changes type', async () => {
+      const initialConfig: TestFormConfig = {
+        fields: [{ key: 'mode', type: 'input', label: 'Mode', value: 'x' }],
+      };
+
+      const { fixture } = createComponent(initialConfig);
+      await waitForDynamicComponents(fixture);
+
+      // Sanity: the input harness rendered for the `mode` field.
+      expect(fixture.debugElement.query((de: DebugElement) => de.componentInstance instanceof TestInputHarnessComponent)).not.toBeNull();
+      expect(fixture.debugElement.query((de: DebugElement) => de.componentInstance instanceof TestSelectHarnessComponent)).toBeNull();
+
+      const newConfig: TestFormConfig = {
+        fields: [
+          {
+            key: 'mode',
+            type: 'select',
+            label: 'Mode',
+            options: [{ value: 'a', label: 'A' }],
+          },
+        ],
+      };
+
+      await swapConfig(fixture, newConfig);
+
+      // Component replaced: input harness gone, select harness present.
+      expect(fixture.debugElement.query((de: DebugElement) => de.componentInstance instanceof TestInputHarnessComponent)).toBeNull();
+      expect(fixture.debugElement.query((de: DebugElement) => de.componentInstance instanceof TestSelectHarnessComponent)).not.toBeNull();
+    });
+  });
+
   describe('Row and Group Field Support', () => {
     it('should handle row definitions with multiple child definitions', async () => {
       const config: TestFormConfig = {

--- a/packages/dynamic-forms/src/lib/fields/array/array-field.component.spec.ts
+++ b/packages/dynamic-forms/src/lib/fields/array/array-field.component.spec.ts
@@ -1397,4 +1397,148 @@ describe('ArrayFieldComponent', () => {
       expect(component.resolvedItems()).toHaveLength(3);
     });
   });
+
+  describe('per-item state under structural mutation (regression)', () => {
+    /**
+     * Characterization tests for ARRAY field per-item state binding when the
+     * array is structurally mutated (remove middle, remove index 0, reorder, and
+     * a hide → show cycle for a dynamically added item).
+     *
+     * Observable in this unit harness:
+     *  - Per-item VALUE: read from the parent form value array (context.value()['items']).
+     *    Each item value is an object like { item: 'A' }, so value-follows-item is precise.
+     *  - Item ORDER: position in that array.
+     *  - Item IDENTITY: resolvedItems()[i].id — stable references only survive a MOVE
+     *    (splice reorder). REMOVAL is implemented as a 'recreate' (see
+     *    determineDifferentialOperation: newLength < currentLength → 'recreate'), so ids
+     *    are intentionally regenerated on remove; this suite does NOT assert id stability
+     *    across removals.
+     *
+     * NOT observable here (E2E-only gap): per-item dirty / touched / validation-error
+     * state is owned by the rendered adapter field component (TestFieldComponent is a
+     * stub). Those are exercised in the array-fields E2E suite, not in this unit context.
+     */
+
+    function valuesOf(context: FieldSignalContext<Record<string, unknown>>): unknown[] {
+      const items = context.value()['items'] as unknown[];
+      return items.map((entry) => (entry as Record<string, unknown>)['item']);
+    }
+
+    it('remove middle (index 1) → remaining values are [A, C] in order', async () => {
+      const field: ArrayField<unknown> = {
+        key: 'items',
+        type: 'array',
+        fields: [
+          [createSimpleTestField('item', 'Item', 'A')],
+          [createSimpleTestField('item', 'Item', 'B')],
+          [createSimpleTestField('item', 'Item', 'C')],
+        ],
+      };
+
+      const { component, fixture } = setupArrayTest(field);
+      const eventBus = TestBed.inject(EventBus);
+      const context = TestBed.inject(FIELD_SIGNAL_CONTEXT) as FieldSignalContext<Record<string, unknown>>;
+
+      await waitForItems(component, fixture, (n) => n >= 3);
+      expect(valuesOf(context)).toEqual(['A', 'B', 'C']);
+
+      eventBus.dispatch(RemoveAtIndexEvent, 'items', 1);
+      await waitForItems(component, fixture, (n) => n <= 2);
+
+      expect(component.resolvedItems()).toHaveLength(2);
+      // C's value must follow C — it must not stick to the slot index that B vacated.
+      expect(valuesOf(context)).toEqual(['A', 'C']);
+    });
+
+    it('remove index 0 → remaining values are [B, C] in order', async () => {
+      const field: ArrayField<unknown> = {
+        key: 'items',
+        type: 'array',
+        fields: [
+          [createSimpleTestField('item', 'Item', 'A')],
+          [createSimpleTestField('item', 'Item', 'B')],
+          [createSimpleTestField('item', 'Item', 'C')],
+        ],
+      };
+
+      const { component, fixture } = setupArrayTest(field);
+      const eventBus = TestBed.inject(EventBus);
+      const context = TestBed.inject(FIELD_SIGNAL_CONTEXT) as FieldSignalContext<Record<string, unknown>>;
+
+      await waitForItems(component, fixture, (n) => n >= 3);
+      expect(valuesOf(context)).toEqual(['A', 'B', 'C']);
+
+      eventBus.dispatch(RemoveAtIndexEvent, 'items', 0);
+      await waitForItems(component, fixture, (n) => n <= 2);
+
+      expect(component.resolvedItems()).toHaveLength(2);
+      // Both B and C shift down one slot; their values must shift with them.
+      expect(valuesOf(context)).toEqual(['B', 'C']);
+    });
+
+    it('reorder (move index 0 → 2) → values reorder and identity travels with the moved item', async () => {
+      const field: ArrayField<unknown> = {
+        key: 'items',
+        type: 'array',
+        fields: [
+          [createSimpleTestField('item', 'Item', 'A')],
+          [createSimpleTestField('item', 'Item', 'B')],
+          [createSimpleTestField('item', 'Item', 'C')],
+        ],
+      };
+
+      const { component, fixture } = setupArrayTest(field);
+      const eventBus = TestBed.inject(EventBus);
+      const context = TestBed.inject(FIELD_SIGNAL_CONTEXT) as FieldSignalContext<Record<string, unknown>>;
+
+      await waitForItems(component, fixture, (n) => n >= 3);
+      const originalItems = component.resolvedItems();
+      const itemA = originalItems[0];
+
+      eventBus.dispatch(MoveArrayItemEvent, 'items', 0, 2);
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(component.resolvedItems()).toHaveLength(3);
+      // Values reorder: A moves to the end.
+      expect(valuesOf(context)).toEqual(['B', 'C', 'A']);
+      // Move preserves object identity (splice reorder, no recreate), so A's per-item
+      // state object travels with it to its new slot.
+      const movedItems = component.resolvedItems();
+      expect(movedItems[2]).toBe(itemA);
+    });
+
+    it('dynamically added item survives a hide → show cycle', async () => {
+      const field: ArrayField<unknown> = {
+        key: 'items',
+        type: 'array',
+        fields: [[createSimpleTestField('item', 'Item', 'A')]],
+      };
+
+      const { component, fixture } = setupArrayTest(field);
+      const eventBus = TestBed.inject(EventBus);
+      const context = TestBed.inject(FIELD_SIGNAL_CONTEXT) as FieldSignalContext<Record<string, unknown>>;
+
+      await waitForItems(component, fixture, (n) => n >= 1);
+
+      // Dynamically append a second item (registers its template in the slot).
+      eventBus.dispatch(AppendArrayItemEvent, 'items', [createSimpleTestField('item', 'Item', 'B')]);
+      await waitForItems(component, fixture, (n) => n >= 2);
+      expect(valuesOf(context)).toEqual(['A', 'B']);
+
+      // Hide the array, then show it again. The slot survival path (case 'initial')
+      // should rehydrate the dynamically-added item from the stored templates/itemOrder.
+      fixture.componentRef.setInput('hidden', true);
+      fixture.detectChanges();
+      TestBed.flushEffects();
+
+      fixture.componentRef.setInput('hidden', false);
+      fixture.detectChanges();
+      TestBed.flushEffects();
+      await waitForItems(component, fixture, (n) => n >= 2);
+
+      expect(component.resolvedItems()).toHaveLength(2);
+      expect(valuesOf(context)).toEqual(['A', 'B']);
+    });
+  });
 });

--- a/packages/dynamic-forms/src/lib/state/form-state-machine.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-machine.ts
@@ -403,7 +403,18 @@ export class FormStateMachine<TFields extends RegisteredFieldTypes[] = Registere
             this.config.logger.warn('RestoreValues effect: pendingFormSetup was not set — falling back to recomputing.');
           }
           const formSetup = state.pendingFormSetup ?? this.config.createFormSetup(state.pendingConfig);
-          const validKeys = new Set(formSetup.schemaFields.map((f) => f.key).filter((key): key is string => key !== undefined));
+
+          // Restore a captured value only when the key survives the swap AND the field's type
+          // is unchanged. A retyped key (e.g. input → select) must initialize to the new field's
+          // declared default rather than inheriting the stale value from the old field type.
+          const oldTypeByKey = new Map<string, string>();
+          for (const f of state.currentFormSetup.schemaFields) {
+            if (f.key !== undefined) oldTypeByKey.set(f.key, f.type);
+          }
+          const validKeys = new Set<string>();
+          for (const f of formSetup.schemaFields) {
+            if (f.key !== undefined && oldTypeByKey.get(f.key) === f.type) validKeys.add(f.key);
+          }
 
           this.config.restoreValue(effect.values, validKeys);
           this.dispatch({ type: Action.RestoreComplete });

--- a/packages/dynamic-forms/src/lib/state/form-state-machine.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-machine.ts
@@ -407,6 +407,7 @@ export class FormStateMachine<TFields extends RegisteredFieldTypes[] = Registere
           // Restore a captured value only when the key survives the swap AND the field's type
           // is unchanged. A retyped key (e.g. input → select) must initialize to the new field's
           // declared default rather than inheriting the stale value from the old field type.
+          // Keyed on top-level schemaFields, so a retype of a nested-group child is not tracked here.
           const oldTypeByKey = new Map<string, string>();
           for (const f of state.currentFormSetup.schemaFields) {
             if (f.key !== undefined) oldTypeByKey.set(f.key, f.type);

--- a/packages/dynamic-forms/src/lib/state/form-state-manager.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-manager.ts
@@ -842,9 +842,18 @@ export class FormStateManager<
             filtered[key] = val;
           }
         }
-        if (Object.keys(filtered).length > 0) {
-          this.deps.value.update((current) => ({ ...current, ...filtered }) as Partial<TModel>);
-        }
+        // Strip any captured key that did NOT survive the swap (dropped or retyped). The stale
+        // value lingers in `deps.value` from before teardown, and `entity` layers it on top of
+        // the new field's default — so a retyped key would otherwise inherit the old value
+        // instead of initializing to its declared default. `values` is the full captured
+        // snapshot, so any captured key absent from `validKeys` must be removed from the model.
+        this.deps.value.update((current) => {
+          const next = { ...current, ...filtered } as Record<string, unknown>;
+          for (const key of Object.keys(values)) {
+            if (!validKeys.has(key)) delete next[key];
+          }
+          return next as Partial<TModel>;
+        });
       },
       onTransition: (transition) => {
         this.logger.debug('State transition:', transition.from.type, '→', transition.to.type, transition.action.type);

--- a/packages/dynamic-forms/src/lib/utils/config-validation/config-validator.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/config-validation/config-validator.spec.ts
@@ -331,10 +331,7 @@ describe('validateFormConfig', () => {
     });
   });
 
-  // Nesting is expressed structurally via `group` fields, never via a dotted key.
-  // A leaf field keyed `'address.city'` does a literal `pathRecord['address.city']`
-  // lookup (undefined), so it silently mis-binds rather than nesting. Reject it at
-  // bootstrap so a Formly-style dotted-key config fails loudly instead.
+  // Dotted keys silently mis-bind (literal pathRecord lookup), so reject them at bootstrap.
   describe('dotted field keys', () => {
     it('throws when a value-bearing leaf field key contains a dot', () => {
       const fields: FieldDef<unknown>[] = [{ key: 'address.city', type: 'input' }];

--- a/packages/dynamic-forms/src/lib/utils/config-validation/config-validator.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/config-validation/config-validator.spec.ts
@@ -330,4 +330,26 @@ describe('validateFormConfig', () => {
       expect(() => validateFormConfig(fields, registryWith('page', 'group', 'input'), mockLogger())).not.toThrow();
     });
   });
+
+  // Nesting is expressed structurally via `group` fields, never via a dotted key.
+  // A leaf field keyed `'address.city'` does a literal `pathRecord['address.city']`
+  // lookup (undefined), so it silently mis-binds rather than nesting. Reject it at
+  // bootstrap so a Formly-style dotted-key config fails loudly instead.
+  describe('dotted field keys', () => {
+    it('throws when a value-bearing leaf field key contains a dot', () => {
+      const fields: FieldDef<unknown>[] = [{ key: 'address.city', type: 'input' }];
+      expect(() => validateFormConfig(fields, emptyRegistry(), mockLogger())).toThrow(DynamicFormError);
+      expect(() => validateFormConfig(fields, emptyRegistry(), mockLogger())).toThrow('address.city');
+    });
+
+    it('throws when a group field key contains a dot', () => {
+      const fields = [{ key: 'a.b', type: 'group', fields: [{ key: 'x', type: 'input' }] }] as unknown as FieldDef<unknown>[];
+      expect(() => validateFormConfig(fields, registryWith('group', 'input'), mockLogger())).toThrow(DynamicFormError);
+    });
+
+    it('does not throw for the same structure expressed via nested group fields', () => {
+      const fields = [{ key: 'address', type: 'group', fields: [{ key: 'city', type: 'input' }] }] as unknown as FieldDef<unknown>[];
+      expect(() => validateFormConfig(fields, registryWith('group', 'input'), mockLogger())).not.toThrow();
+    });
+  });
 });

--- a/packages/dynamic-forms/src/lib/utils/config-validation/config-validator.ts
+++ b/packages/dynamic-forms/src/lib/utils/config-validation/config-validator.ts
@@ -22,11 +22,7 @@ interface ConfigTraversalData {
   domIds: string[];
   types: Set<string>;
   regexErrors: string[];
-  /**
-   * Own keys (not scoped paths) of value-bearing fields that contain a dot.
-   * Nesting must be expressed with `group` fields — a dotted key like
-   * `'address.city'` is looked up literally and silently mis-binds.
-   */
+  /** Own keys of value-bearing fields containing a dot (unsupported — nest via group fields). */
   dottedKeys: string[];
 }
 
@@ -51,9 +47,7 @@ function collectFieldData(
     const valueHandling = field.type ? getFieldValueHandling(field.type, registry) : 'include';
     const participatesInValue = valueHandling !== 'exclude' && valueHandling !== 'flatten';
 
-    // A value-bearing field's own key must not contain a dot (checked regardless
-    // of `collectKeys` so array-item template keys are covered too). Dotted keys
-    // never nest — nesting is structural via `group` fields.
+    // Dotted keys never nest (checked regardless of collectKeys, to cover array templates).
     if (field.key && field.key.includes('.') && participatesInValue) {
       data.dottedKeys.push(field.key);
     }

--- a/packages/dynamic-forms/src/lib/utils/config-validation/config-validator.ts
+++ b/packages/dynamic-forms/src/lib/utils/config-validation/config-validator.ts
@@ -22,6 +22,12 @@ interface ConfigTraversalData {
   domIds: string[];
   types: Set<string>;
   regexErrors: string[];
+  /**
+   * Own keys (not scoped paths) of value-bearing fields that contain a dot.
+   * Nesting must be expressed with `group` fields — a dotted key like
+   * `'address.city'` is looked up literally and silently mis-binds.
+   */
+  dottedKeys: string[];
 }
 
 /**
@@ -44,6 +50,13 @@ function collectFieldData(
     // mis-registered field type doesn't silently drop from collision checks.
     const valueHandling = field.type ? getFieldValueHandling(field.type, registry) : 'include';
     const participatesInValue = valueHandling !== 'exclude' && valueHandling !== 'flatten';
+
+    // A value-bearing field's own key must not contain a dot (checked regardless
+    // of `collectKeys` so array-item template keys are covered too). Dotted keys
+    // never nest — nesting is structural via `group` fields.
+    if (field.key && field.key.includes('.') && participatesInValue) {
+      data.dottedKeys.push(field.key);
+    }
 
     if (collectKeys && field.key && participatesInValue) {
       const scopedKey = pathPrefix ? `${pathPrefix}.${field.key}` : field.key;
@@ -190,9 +203,20 @@ export function validateFormConfig(fields: FieldDef<unknown>[], registry: Map<st
     domIds: [],
     types: new Set<string>(),
     regexErrors: [],
+    dottedKeys: [],
   };
 
   collectFieldData(fields, data, registry, '');
+
+  if (data.dottedKeys.length > 0) {
+    const list = Array.from(new Set(data.dottedKeys))
+      .map((k) => `'${k}'`)
+      .join(', ');
+    throw new DynamicFormError(
+      `Field key(s) contain a dot: ${list}. Dotted keys are not supported — express nesting with 'group' fields ` +
+        `(e.g. { type: 'group', key: 'address', fields: [{ type: 'input', key: 'city' }] }).`,
+    );
+  }
 
   validateNoDuplicateKeys(data.keys);
   validateNoDomIdCollisions(data.domIds);

--- a/packages/dynamic-forms/src/lib/utils/create-resolved-errors-signal.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/create-resolved-errors-signal.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { Injector, runInInjectionContext, signal } from '@angular/core';
 import type { FieldTree, SchemaPath } from '@angular/forms/signals';
-import { form, schema } from '@angular/forms/signals';
+import { form, schema, validate, requiredError } from '@angular/forms/signals';
 import { createResolvedErrorsSignal } from '@ng-forge/dynamic-forms/integration';
 import { ValidationMessages } from '../models/validation-types';
 import { applyValidator } from '../core/validation/validator-factory';
@@ -189,6 +189,59 @@ describe('createResolvedErrorsSignal', () => {
         TestBed.flushEffects();
 
         expect(resolvedErrors()).toEqual([{ kind: 'min', message: 'Default: Minimum value is 18' }]);
+      });
+    });
+
+    it('should let a configured field-level message win over a validator-provided message', () => {
+      // GAP 3(a): precedence field-level > validator-provided error.message.
+      // The validator attaches its own human-readable message via
+      // requiredError({ message }); the field-level config must still win.
+      runInInjectionContext(injector, () => {
+        const initialValue = signal({ email: '' });
+        const testForm = form(
+          initialValue,
+          schema<{ email: string }>((path) => {
+            validate(path.email as SchemaPath<string>, () => requiredError({ message: 'Validator: required from validator' }));
+          }),
+        );
+
+        const emailField = signal((testForm as unknown as Record<string, FieldTree<string>>)['email']);
+
+        const fieldMessages = signal<ValidationMessages>({
+          required: 'Field-level: Email is required',
+        });
+        const defaultMessages = signal<ValidationMessages>({});
+
+        const resolvedErrors = createResolvedErrorsSignal(emailField, fieldMessages, defaultMessages);
+
+        TestBed.flushEffects();
+
+        expect(resolvedErrors()).toEqual([{ kind: 'required', message: 'Field-level: Email is required' }]);
+      });
+    });
+
+    it('should fall back to the validator-provided message when no field-level or default message exists', () => {
+      // GAP 3: lowest configured layer — error.message from the validator is
+      // used when neither field-level nor default messages are provided.
+      runInInjectionContext(injector, () => {
+        const initialValue = signal({ email: '' });
+        const testForm = form(
+          initialValue,
+          schema<{ email: string }>((path) => {
+            validate(path.email as SchemaPath<string>, () => requiredError({ message: 'Validator: required from validator' }));
+          }),
+        );
+
+        const emailField = signal((testForm as unknown as Record<string, FieldTree<string>>)['email']);
+
+        const fieldMessages = signal<ValidationMessages>({});
+        const defaultMessages = signal<ValidationMessages>({});
+
+        const resolvedErrors = createResolvedErrorsSignal(emailField, fieldMessages, defaultMessages);
+
+        TestBed.flushEffects();
+
+        expect(resolvedErrors()).toEqual([{ kind: 'required', message: 'Validator: required from validator' }]);
       });
     });
   });

--- a/packages/dynamic-forms/src/lib/utils/flattener/field-flattener.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/flattener/field-flattener.spec.ts
@@ -269,6 +269,57 @@ describe('field-flattener', () => {
 
         expect(result).toEqual([{ type: 'input', key: 'test' }]);
       });
+
+      it('should propagate a hidden page state onto its hoisted children', () => {
+        const fields: FieldDef<any>[] = [
+          {
+            type: 'page',
+            hidden: true,
+            fields: [
+              { type: 'input', key: 'name' },
+              { type: 'input', key: 'email' },
+            ],
+          },
+        ];
+
+        const result = flattenFields(fields, registry) as Array<FieldDef<any> & { inheritedExclusionState?: unknown }>;
+
+        expect(result).toHaveLength(2);
+        expect(result[0].inheritedExclusionState).toEqual({ hidden: true, disabled: false, readonly: false });
+        expect(result[1].inheritedExclusionState).toEqual({ hidden: true, disabled: false, readonly: false });
+      });
+
+      it('should propagate a page excludeValueIfHidden config onto children (child override wins)', () => {
+        const fields: FieldDef<any>[] = [
+          {
+            type: 'page',
+            excludeValueIfHidden: true,
+            fields: [
+              { type: 'input', key: 'inherits' },
+              { type: 'input', key: 'overrides', excludeValueIfHidden: false },
+            ],
+          },
+        ];
+
+        const result = flattenFields(fields, registry) as Array<FieldDef<any>>;
+
+        expect(result[0].excludeValueIfHidden).toBe(true);
+        expect(result[1].excludeValueIfHidden).toBe(false);
+      });
+
+      it('should not annotate children when the page carries no exclusion config', () => {
+        const fields: FieldDef<any>[] = [
+          {
+            type: 'page',
+            fields: [{ type: 'input', key: 'plain' }],
+          },
+        ];
+
+        const result = flattenFields(fields, registry);
+
+        // Identity preserved — no extra exclusion keys added.
+        expect(result).toEqual([{ type: 'input', key: 'plain' }]);
+      });
     });
 
     describe('group field handling', () => {

--- a/packages/dynamic-forms/src/lib/utils/flattener/field-flattener.ts
+++ b/packages/dynamic-forms/src/lib/utils/flattener/field-flattener.ts
@@ -10,6 +10,63 @@ import { normalizeFieldsArray } from '../object-utils';
 export interface FlattenedField extends FieldDef<unknown> {
   /** Guaranteed non-empty key for form binding and field identification */
   readonly key: string;
+
+  /**
+   * Static hidden/disabled/readonly state inherited from a discarded flatten
+   * container (page/row) ancestor. Set only when a hoisted child's ancestor
+   * declared the state; the child's own state still wins for everything else.
+   *
+   * Read exclusively by the value-exclusion path (`filterFormValue`) so a hidden
+   * page drops its hoisted children's values — mirroring how a hidden group
+   * drops its preserved subtree. NOT consumed by schema building or rendering,
+   * which keeps this purely a value-exclusion concern with no validation side
+   * effects.
+   */
+  readonly inheritedExclusionState?: {
+    readonly hidden?: boolean;
+    readonly disabled?: boolean;
+    readonly readonly?: boolean;
+  };
+}
+
+/**
+ * Propagates a discarded flatten-container's (page/row) exclusion-relevant config
+ * onto a hoisted child so the value-exclusion path can still drop the child's value
+ * when the container was hidden/disabled/readonly.
+ *
+ * - Static state (`hidden`/`disabled`/`readonly`) is OR-accumulated into the child's
+ *   `inheritedExclusionState`, so nested flatten containers compound correctly.
+ * - `excludeValueIf*` config is applied only where the child has not declared its own
+ *   (child override wins), matching the group-cascade resolution model.
+ *
+ * Returns the child unchanged when the container carries no exclusion-relevant config,
+ * preserving object identity for the common case.
+ */
+function inheritContainerExclusion(container: FieldDef<unknown>, child: FlattenedField): FlattenedField {
+  const inheritedHidden = container.hidden === true || child.inheritedExclusionState?.hidden === true;
+  const inheritedDisabled = container.disabled === true || child.inheritedExclusionState?.disabled === true;
+  const inheritedReadonly = container.readonly === true || child.inheritedExclusionState?.readonly === true;
+
+  const hasInheritedState = inheritedHidden || inheritedDisabled || inheritedReadonly;
+  const containerExcludeConfig =
+    container.excludeValueIfHidden !== undefined ||
+    container.excludeValueIfDisabled !== undefined ||
+    container.excludeValueIfReadonly !== undefined;
+
+  if (!hasInheritedState && !containerExcludeConfig) {
+    return child;
+  }
+
+  return {
+    ...child,
+    ...(hasInheritedState
+      ? { inheritedExclusionState: { hidden: inheritedHidden, disabled: inheritedDisabled, readonly: inheritedReadonly } }
+      : {}),
+    // Child override wins; otherwise inherit the container's exclusion config.
+    excludeValueIfHidden: child.excludeValueIfHidden ?? container.excludeValueIfHidden,
+    excludeValueIfDisabled: child.excludeValueIfDisabled ?? container.excludeValueIfDisabled,
+    excludeValueIfReadonly: child.excludeValueIfReadonly ?? container.excludeValueIfReadonly,
+  };
 }
 
 /**
@@ -59,9 +116,13 @@ export function flattenFields(
         const fields = field.fields as FieldDef<unknown>[] | Record<string, FieldDef<unknown>>;
         const flattenedChildren = flattenFields(normalizeFieldsArray(fields), registry, options);
 
-        // Spread children directly into result - the container field itself is discarded
-        // This is used for page fields (form structure) and row fields (form values)
-        result.push(...flattenedChildren);
+        // Spread children directly into result - the container field itself is discarded.
+        // Because the container (page/row) is dropped, its exclusion-relevant state would
+        // otherwise be lost. Propagate it onto each hoisted child so a hidden/disabled/
+        // readonly page drops its children's values during value exclusion — mirroring how
+        // a hidden group drops its preserved subtree. The child's own config still wins.
+        // This is used for page fields (form structure) and row fields (form values).
+        result.push(...flattenedChildren.map((child) => inheritContainerExclusion(field, child)));
       }
     } else if (isGroupField(field)) {
       // Step 4: Handle group fields - preserve structure for nested form values

--- a/packages/dynamic-forms/src/lib/utils/submission-handler/submission-handler.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/submission-handler/submission-handler.spec.ts
@@ -1,0 +1,89 @@
+import { TestBed } from '@angular/core/testing';
+import { Injector, runInInjectionContext, signal, type Signal } from '@angular/core';
+import { form, type FieldTree } from '@angular/forms/signals';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Subscription } from 'rxjs';
+import { EventBus } from '../../events/event.bus';
+import { SubmitEvent } from '../../events/constants/submit.event';
+import type { FormConfig } from '../../models/form-config';
+import type { Logger } from '../../providers/features/logger/logger.interface';
+import { createSubmissionHandler } from './submission-handler';
+
+// The submission handler had no dedicated coverage. These tests pin its guard contract:
+// the configured submission.action runs only when the form is valid. Angular Signal Forms
+// reports valid() === false while async validators are pending, so "not valid" here also
+// covers the submit-while-async-pending case (issue: pending async at submit time).
+
+type Model = { email: string };
+
+const makeLogger = (): Logger => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() });
+const tick = (ms = 0) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+describe('createSubmissionHandler', () => {
+  let injector: Injector;
+  let eventBus: EventBus;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [EventBus] });
+    injector = TestBed.inject(Injector);
+    eventBus = TestBed.inject(EventBus);
+  });
+
+  function start(valid: boolean, action?: (form: FieldTree<Model>) => unknown): Subscription {
+    return runInInjectionContext(injector, () => {
+      const formInstance = form(signal<Model>({ email: 'a@b.com' }));
+      const config = { fields: [], submission: action ? { action } : undefined } as unknown as FormConfig;
+      const handler$ = createSubmissionHandler({
+        eventBus,
+        configSignal: signal(config),
+        formSignal: signal(formInstance) as unknown as Signal<FieldTree<Record<string, unknown>>>,
+        validSignal: signal(valid),
+        logger: makeLogger(),
+      });
+      return handler$.subscribe();
+    });
+  }
+
+  const dispatchSubmit = () => runInInjectionContext(injector, () => eventBus.dispatch(new SubmitEvent()));
+
+  it('skips the submission action when the form is not valid (invalid OR pending async validators)', async () => {
+    const action = vi.fn().mockResolvedValue(undefined);
+    const sub = start(false, action);
+    dispatchSubmit();
+    await tick(15);
+    expect(action).not.toHaveBeenCalled();
+    sub.unsubscribe();
+  });
+
+  it('runs the submission action when the form is valid', async () => {
+    const action = vi.fn().mockResolvedValue(undefined);
+    const sub = start(true, action);
+    dispatchSubmit();
+    await tick(25);
+    expect(action).toHaveBeenCalledTimes(1);
+    sub.unsubscribe();
+  });
+
+  it('does nothing (no throw) when no submission.action is configured', async () => {
+    const sub = start(true, undefined);
+    expect(() => dispatchSubmit()).not.toThrow();
+    await tick(15);
+    sub.unsubscribe();
+  });
+
+  it('drops a second submit while the first is in-flight (exhaustMap first-wins)', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+    const action = vi.fn().mockReturnValue(gate);
+    const sub = start(true, action);
+    runInInjectionContext(injector, () => {
+      eventBus.dispatch(new SubmitEvent());
+      eventBus.dispatch(new SubmitEvent());
+    });
+    await tick(15);
+    expect(action).toHaveBeenCalledTimes(1);
+    release();
+    await tick(15);
+    sub.unsubscribe();
+  });
+});

--- a/packages/dynamic-forms/src/lib/utils/value-filter/value-filter.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/value-filter/value-filter.spec.ts
@@ -429,6 +429,113 @@ describe('filterFormValue', () => {
     });
   });
 
+  // ───────────────────────────────────────────────────────────────────────
+  // Regression / characterization: value-exclusion on hidden CONTAINER fields
+  // ───────────────────────────────────────────────────────────────────────
+  describe('hidden container fields (exclusion)', () => {
+    it('should omit the whole group value when group is hidden + excludeValueIfHidden', () => {
+      const rawValue = { profile: { firstName: 'Jane', lastName: 'Doe' } };
+      const fields: FieldDef<unknown>[] = [
+        {
+          key: 'profile',
+          type: 'group',
+          fields: [
+            { key: 'firstName', type: 'input' },
+            { key: 'lastName', type: 'input' },
+          ],
+        } as FieldDef<unknown>,
+      ];
+      const formTree = {
+        profile: createFieldState({ hidden: true }),
+      } as unknown as Record<string, FieldTree<unknown>>;
+
+      const result = filterFormValue(rawValue, fields, formTree, registry, ALL_ENABLED, undefined);
+
+      expect(result).toEqual({});
+    });
+
+    it('should omit the whole array value when array is hidden + excludeValueIfHidden', () => {
+      const rawValue = { contacts: [{ name: 'A' }, { name: 'B' }] };
+      const fields: FieldDef<unknown>[] = [
+        { key: 'contacts', type: 'array', fields: [[{ key: 'name', type: 'input' }]] } as FieldDef<unknown>,
+      ];
+      const formTree = {
+        contacts: createFieldState({ hidden: true }),
+      } as unknown as Record<string, FieldTree<unknown>>;
+
+      const result = filterFormValue(rawValue, fields, formTree, registry, ALL_ENABLED, undefined);
+
+      expect(result).toEqual({});
+    });
+
+    it('should NOT filter per-item: a hidden child field inside a visible array keeps the array whole (v1: no per-item filtering)', () => {
+      // The array item template declares a 'secret' child marked hidden + excludeValueIfHidden.
+      // Documented v1 behavior: arrays are included wholesale when the array itself is not excluded.
+      const rawValue = {
+        contacts: [
+          { name: 'A', secret: 's1' },
+          { name: 'B', secret: 's2' },
+        ],
+      };
+      const fields: FieldDef<unknown>[] = [
+        {
+          key: 'contacts',
+          type: 'array',
+          fields: [
+            [
+              { key: 'name', type: 'input' },
+              { key: 'secret', type: 'input', hidden: true, excludeValueIfHidden: true },
+            ],
+          ],
+        } as FieldDef<unknown>,
+      ];
+      const formTree = {
+        contacts: createFieldState(),
+      } as unknown as Record<string, FieldTree<unknown>>;
+
+      const result = filterFormValue(rawValue, fields, formTree, registry, ALL_ENABLED, undefined);
+
+      // Whole array (including per-item 'secret') survives — per-item filtering is not implemented.
+      expect(result).toEqual({
+        contacts: [
+          { name: 'A', secret: 's1' },
+          { name: 'B', secret: 's2' },
+        ],
+      });
+    });
+
+    // BUG: page-level excludeValueIfHidden is ignored.
+    //
+    // Pages have valueHandling 'flatten'. By the time filterFormValue sees them, flattenFields
+    // (field-flattener.ts:55-65) has already DISCARDED the page wrapper and HOISTED its children
+    // to the top level of `schemaFields`. The page's `hidden` / `excludeValueIfHidden` flags are
+    // dropped in the process and are NOT propagated onto the hoisted children. (Even if the page
+    // entry survived, value-filter.ts:83 would skip it as 'flatten' before exclusion is checked.)
+    //
+    // Net effect: hiding a page does NOT drop its hoisted child values. This test models the real
+    // flattened input (no page wrapper, child not individually hidden) and asserts the CORRECT
+    // behavior (subtree dropped). It is expected to FAIL today, documenting the gap; a future fix
+    // that propagates page exclusion to children flips it green.
+    it.fails('should drop the subtree when a page is hidden + excludeValueIfHidden', () => {
+      // Post-flatten schemaFields: the page wrapper is gone, its child is hoisted to top level.
+      const rawValue = { step1Field: 'value-from-hidden-page', visibleField: 'keep' };
+      const fields: FieldDef<unknown>[] = [
+        { key: 'step1Field', type: 'input' },
+        { key: 'visibleField', type: 'input' },
+      ];
+      // The hoisted child is NOT itself hidden — only the (now-discarded) page was hidden.
+      const formTree = {
+        step1Field: createFieldState(),
+        visibleField: createFieldState(),
+      } as unknown as Record<string, FieldTree<unknown>>;
+
+      const result = filterFormValue(rawValue, fields, formTree, registry, ALL_ENABLED, undefined);
+
+      // CORRECT behavior: the hidden page's hoisted child value should be dropped.
+      expect(result).toEqual({ visibleField: 'keep' });
+    });
+  });
+
   describe('missing raw values', () => {
     it('should skip fields whose key is not in rawValue', () => {
       const rawValue = { name: 'John' };

--- a/packages/dynamic-forms/src/lib/utils/value-filter/value-filter.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/value-filter/value-filter.spec.ts
@@ -504,23 +504,19 @@ describe('filterFormValue', () => {
       });
     });
 
-    // BUG: page-level excludeValueIfHidden is ignored.
+    // Page-level excludeValueIfHidden drops the hoisted child's value.
     //
-    // Pages have valueHandling 'flatten'. By the time filterFormValue sees them, flattenFields
-    // (field-flattener.ts:55-65) has already DISCARDED the page wrapper and HOISTED its children
-    // to the top level of `schemaFields`. The page's `hidden` / `excludeValueIfHidden` flags are
-    // dropped in the process and are NOT propagated onto the hoisted children. (Even if the page
-    // entry survived, value-filter.ts:83 would skip it as 'flatten' before exclusion is checked.)
-    //
-    // Net effect: hiding a page does NOT drop its hoisted child values. This test models the real
-    // flattened input (no page wrapper, child not individually hidden) and asserts the CORRECT
-    // behavior (subtree dropped). It is expected to FAIL today, documenting the gap; a future fix
-    // that propagates page exclusion to children flips it green.
-    it.fails('should drop the subtree when a page is hidden + excludeValueIfHidden', () => {
-      // Post-flatten schemaFields: the page wrapper is gone, its child is hoisted to top level.
+    // Pages have valueHandling 'flatten'. flattenFields discards the page wrapper and hoists its
+    // children to the top level of `schemaFields`, propagating the page's exclusion-relevant state
+    // onto each hoisted child via `inheritedExclusionState` (mirroring how a hidden group drops its
+    // preserved subtree). value-filter then reads that inherited state, so hiding a page drops its
+    // hoisted child values even though the child is not individually hidden.
+    it('should drop the subtree when a page is hidden + excludeValueIfHidden', () => {
+      // Post-flatten schemaFields: the page wrapper is gone, its child is hoisted to top level and
+      // carries the page's inherited hidden state.
       const rawValue = { step1Field: 'value-from-hidden-page', visibleField: 'keep' };
       const fields: FieldDef<unknown>[] = [
-        { key: 'step1Field', type: 'input' },
+        { key: 'step1Field', type: 'input', inheritedExclusionState: { hidden: true } } as FieldDef<unknown>,
         { key: 'visibleField', type: 'input' },
       ];
       // The hoisted child is NOT itself hidden — only the (now-discarded) page was hidden.

--- a/packages/dynamic-forms/src/lib/utils/value-filter/value-filter.ts
+++ b/packages/dynamic-forms/src/lib/utils/value-filter/value-filter.ts
@@ -27,24 +27,38 @@ export function resolveExclusionConfig(
 }
 
 /**
+ * Static exclusion state a field may have inherited from a discarded flatten
+ * container (page/row) ancestor during flattening. See `FlattenedField`.
+ */
+interface FieldWithInheritedExclusion {
+  readonly inheritedExclusionState?: {
+    readonly hidden?: boolean;
+    readonly disabled?: boolean;
+    readonly readonly?: boolean;
+  };
+}
+
+/**
  * Determines whether a field's value should be excluded based on its reactive state,
- * the field def's static state (for fields whose `state.hidden()` isn't wired — e.g. groups),
- * and the resolved exclusion config.
+ * the field def's static state (for fields whose `state.hidden()` isn't wired — e.g. groups,
+ * or state inherited from a hidden page/row container that was flattened away), and the
+ * resolved exclusion config.
  */
 function shouldExcludeField(field: FieldDef<unknown>, fieldState: FieldTree<unknown>, config: ResolvedValueExclusionConfig): boolean {
   const state = fieldState();
+  const inherited = (field as FieldWithInheritedExclusion).inheritedExclusionState;
 
-  const isHidden = state.hidden() || field.hidden === true;
+  const isHidden = state.hidden() || field.hidden === true || inherited?.hidden === true;
   if (config.excludeValueIfHidden && isHidden) {
     return true;
   }
 
-  const isDisabled = state.disabled() || field.disabled === true;
+  const isDisabled = state.disabled() || field.disabled === true || inherited?.disabled === true;
   if (config.excludeValueIfDisabled && isDisabled) {
     return true;
   }
 
-  const isReadonly = state.readonly() || field.readonly === true;
+  const isReadonly = state.readonly() || field.readonly === true || inherited?.readonly === true;
   if (config.excludeValueIfReadonly && isReadonly) {
     return true;
   }
@@ -96,10 +110,11 @@ export function filterFormValue<T extends Record<string, unknown>>(
     // Componentless field (no FieldTree) — decide from the static field def alone, then include if not excluded.
     const fieldState = formTree[key] as FieldTree<unknown> | undefined;
     if (!fieldState || typeof fieldState !== 'function') {
+      const inherited = (field as FieldWithInheritedExclusion).inheritedExclusionState;
       const staticallyExcluded =
-        (resolvedConfig.excludeValueIfHidden && field.hidden === true) ||
-        (resolvedConfig.excludeValueIfDisabled && field.disabled === true) ||
-        (resolvedConfig.excludeValueIfReadonly && field.readonly === true);
+        (resolvedConfig.excludeValueIfHidden && (field.hidden === true || inherited?.hidden === true)) ||
+        (resolvedConfig.excludeValueIfDisabled && (field.disabled === true || inherited?.disabled === true)) ||
+        (resolvedConfig.excludeValueIfReadonly && (field.readonly === true || inherited?.readonly === true));
       if (!staticallyExcluded) {
         result[key] = rawValue[key];
       }


### PR DESCRIPTION
## Summary

Adds a reproduce-first test sweep of the value, validation, derivation, array, and config-swap paths in the core library and the four input adapters, then fixes the bugs and footguns that sweep uncovered. Coverage near recent issues #321, #390, #394, #401, #410. A later pass mined common form-library edge cases (async expressions, dotted keys, optional-container required-ness, number nullability) and added guards plus characterization locks for the ones that applied here.

Each bug fix is paired with the test that pinned it, so every fix ships with its regression lock.

## Bugs fixed

1. **Page-level `excludeValueIfHidden` was ignored.** Pages and rows are flattened (`field-flattener.ts`); the container and its `hidden`/`excludeValueIfHidden` flags were discarded before `filterFormValue` ran, so hiding a page never excluded its values. The flattener now propagates a discarded container's exclusion-relevant state onto each hoisted child via an internal marker that only the value-exclusion path reads. Schema building, validation, and rendering are untouched (they use the separate preserve-rows path). A hidden page now drops its children's values the same way a hidden group drops its preserved subtree.
2. **Whole-config swap leaked a stale value onto a retyped overlapping key.** `RestoreValues` (`form-state-machine.ts`) computed valid keys by key only, so an old value was restored onto a same-key field whose `type` had changed (for example `input "hello"` becoming a `select`, yielding a value with no valid option). Valid keys now also require the field type to be unchanged, and `restoreValue` strips any captured key that did not survive the swap, so a retyped field initializes to its declared default.
3. **`stopOnUserOverride` late-write clobbered user input.** Both the async and HTTP derivation streams checked dirty state only at fire-time inside `switchMap`, not when the result landed, so a user edit during the in-flight window was overwritten by the stale derived value. Both streams now re-read dirty state when the result lands and skip the write if the user has since edited the field.
4. **Addon presets mutated disabled fields.** The value-mutating presets (`clear`, `reset`, `paste`) wrote to the host field with no state guard, so they could change a disabled field. `runPresetAction` now skips those presets and warns when the host field is disabled, consistent with the library treating disabled fields as non-interactive (`copy` and `toggle-password-visibility` are unaffected). Found via a TDD sweep of the addon system.

## Footgun guards

5. **Async result in a synchronous condition or derivation slot.** A `custom` condition `fn` returning a Promise or Observable hit `!!result`, which is always truthy, so the condition silently resolved to `true` regardless of the eventual value. A synchronous derivation `fn` returning one was written into the field as its value, surfacing as `[object Promise]`. Both paths (`condition-evaluator.ts`, `compute-derived-value.ts`) now detect a thenable or observable, warn (pointing authors at the `async` / `http` / `asyncDerivations` variants), and fall back safely: the condition returns `false`, the derivation skips the write.
6. **Dotted field keys silently mis-bound.** Nesting is expressed structurally via `group` fields. A leaf or container field keyed `'address.city'` did a literal `pathRecord['address.city']` lookup, which returns undefined, so the field never bound to a real path. `validateFormConfig` now collects value-bearing field keys containing a dot and throws a descriptive `DynamicFormError` at bootstrap, telling the author to nest with `group` fields instead.

## Operator enhancement

- **`matches` now supports regex flags via the `/pattern/flags` form** (for example `"/john/i"` for case-insensitive matching). A plain pattern stays case-sensitive. Previously the value was fed into `new RegExp()` with no flags, so case-insensitive matching was impossible (the limitation was pinned with an `it.fails`). MCP condition docs updated.
- Un-skips the two config-swap tests (rapid changes / latest-wins, and phase transition) that were skipped for timing flakiness; they are now gated deterministically on the swap reaching the new config rather than fixed delays.

## Breaking / behavioral changes

- **Dotted field keys now throw at bootstrap.** A value-bearing field keyed with a dot (for example `'address.city'`) previously did a literal path lookup and silently mis-bound (its value never reached the model). `validateFormConfig` now throws a `DynamicFormError` for such keys. The mis-bind was already a bug, but apps that unknowingly shipped a dotted key will now fail to initialize until the key is expressed as a nested `group`. Highest-impact change in the PR.
- **Addon presets are warn-only on disabled fields.** The value-mutating presets (`clear`, `reset`, `paste`) now skip and log a warning when the host field is disabled, instead of mutating it. Apps that programmatically cleared or reset a disabled field through a preset will see no value change (a warning is logged). `copy` and `toggle-password-visibility` are unaffected.

## Verified non-issues (regression-locked)

- **Duplicate DOM IDs.** A hypothesis suspected duplicate `errorId`/`inputId` for the same leaf key across two groups, or across array items reusing a template key, which would break ARIA uniqueness and `label[for]`. A reproduce-first test mounting both shapes shows the IDs are already unique: `GROUP_CONTEXT.groupPath` and `ARRAY_CONTEXT` scoping prevent the collision. The test stays as a regression lock.
- **Number-input `NaN` contract.** Number inputs default to `NaN` so signal forms use `valueAsNumber`, and clearing a number input yields `NaN`. Locked behavior: a cleared non-required number stays valid (no spurious type error), a cleared required number is treated as empty and is unsatisfied, and `JSON.stringify` maps the `NaN` to `null` on the wire (in-memory value and submitted payload differ by design).
- **`excludeValueIfHidden` and `validateWhenHidden` are independent.** A hidden group with `excludeValueIfHidden: false` and a required child keeps the value but still skips the child's validation under the default `validateWhenHidden: false`. The two knobs do not move together; a test documents the decoupling.

## Coverage added

| Area | File | Notes |
|---|---|---|
| Value exclusion on hidden containers | `value-filter.spec.ts` | hidden group / array / page subtrees |
| Container flatten exclusion marker | `field-flattener.spec.ts` | propagation and identity preservation |
| Hidden-page validation cascade | `form-mapping.spec.ts` | skip-by-default and `validateWhenHidden` propagation |
| Array per-item state | `array-field.component.spec.ts` | value/order/identity under mid-index removal and reorder |
| Whole-config swap | `dynamic-form.component.spec.ts` | reconciliation of overlapping/dropped/retyped keys |
| Derivation chains and cycles | `derivation-chain-cycle.spec.ts` | chain propagation, condition-on-derived, bidirectional stability |
| Async/HTTP derivation races | `async-derivation-stream-race.spec.ts` | in-flight result vs hidden field and user override |
| Async result in sync condition/derivation | `condition-evaluator.spec.ts`, `compute-derived-value.spec.ts` | Promise/Observable detection and safe fallback |
| Dotted field keys | `config-validator.spec.ts` | leaf and container keys rejected at bootstrap |
| Number `NaN` contract | `form-mapping.spec.ts` | validity for required/non-required and wire serialization |
| `matches` operator | `condition-evaluator.spec.ts` | regex handling and limitation |
| Same-key in different groups | `schema-builder.spec.ts` | value independence (#401) |
| Validation message precedence | `create-resolved-errors-signal.spec.ts` | field over default over validator-provided |
| Placeholder rendering | `{mat,bs,prime,ionic}-input.component.spec.ts` | binding reaches the rendered element (#321) |

## Verification

- `dynamic-forms` full suite: 155 files, 3136 passed, 0 expected-fail, 0 skipped.
- Four adapter placeholder specs: 8 passed.
- MCP server: 345 passed.
- ESLint on the changed files: 0 errors.

## Follow-ups (not in this PR)

- Port one advanced-logic suite (HTTP/async/cascading validation, expression logic, multi-page) to a styled adapter; today these run only in the core E2E adapter.
- Field-level async-validator pending UI per adapter.
- Ionic accessibility depth (label association, error-announcement ARIA).
- Evaluate whether property-derivation streams should honor `stopOnUserOverride` (they currently have no such guard).
