### PR TITLE
fix(dynamic-forms): align primeng to @primeuix/themes + wire test-schematics into CI

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -230,6 +230,9 @@ jobs:
       - name: Test affected projects
         run: pnpm nx affected -t test --base=origin/main --configuration=ci --coverage
 
+      - name: Test schematics (affected)
+        run: pnpm nx affected -t test-schematics --base=origin/main
+
       - name: Type test affected projects
         run: pnpm nx affected -t type-test --base=origin/main
 

--- a/apps/docs/src/app/components/integration-view/integration-view.component.ts
+++ b/apps/docs/src/app/components/integration-view/integration-view.component.ts
@@ -75,13 +75,13 @@ export const appConfig: ApplicationConfig = {
     ],
   },
   primeng: {
-    packages: '@ng-forge/dynamic-forms @ng-forge/dynamic-forms-primeng primeng @primeng/themes primeicons',
+    packages: '@ng-forge/dynamic-forms @ng-forge/dynamic-forms-primeng primeng @primeuix/themes primeicons',
     stylesCode: `// styles.scss
 @import 'primeicons/primeicons.css';`,
     setupCode: `import { provideDynamicForm, withLegacyStatusClasses } from '@ng-forge/dynamic-forms';
 import { withPrimeNGFields } from '@ng-forge/dynamic-forms-primeng';
 import { providePrimeNG } from 'primeng/config';
-import Aura from '@primeng/themes/aura';
+import Aura from '@primeuix/themes/aura';
 import { provideAnimations } from '@angular/platform-browser/animations';
 
 export const appConfig: ApplicationConfig = {

--- a/packages/dynamic-forms-primeng/README.md
+++ b/packages/dynamic-forms-primeng/README.md
@@ -34,7 +34,7 @@ PrimeNG field components for [@ng-forge/dynamic-forms](https://www.npmjs.com/pac
 ## Installation
 
 ```bash
-npm install @ng-forge/dynamic-forms @ng-forge/dynamic-forms-primeng primeng @primeng/themes primeicons
+npm install @ng-forge/dynamic-forms @ng-forge/dynamic-forms-primeng primeng @primeuix/themes primeicons
 ```
 
 ## Setup
@@ -42,7 +42,7 @@ npm install @ng-forge/dynamic-forms @ng-forge/dynamic-forms-primeng primeng @pri
 ```typescript
 // app.config.ts
 import { providePrimeNG } from 'primeng/config';
-import Aura from '@primeng/themes/aura';
+import Aura from '@primeuix/themes/aura';
 import { provideDynamicForm } from '@ng-forge/dynamic-forms';
 import { withPrimeNGFields } from '@ng-forge/dynamic-forms-primeng';
 

--- a/packages/dynamic-forms/schematics/ng-add/index.spec.ts
+++ b/packages/dynamic-forms/schematics/ng-add/index.spec.ts
@@ -45,7 +45,7 @@ const EXPECTATIONS: Record<Exclude<Adapter, 'none'>, AdapterExpectations> = {
     providerNeedles: ['provideAnimations', 'provideDynamicForm', 'withBootstrapFields', 'withLegacyStatusClasses'],
   },
   primeng: {
-    packages: ['@ng-forge/dynamic-forms', '@ng-forge/dynamic-forms-primeng', 'primeng', '@primeng/themes', 'primeicons'],
+    packages: ['@ng-forge/dynamic-forms', '@ng-forge/dynamic-forms-primeng', 'primeng', '@primeuix/themes', 'primeicons'],
     styleNeedles: ['primeicons/primeicons.css'],
     providerNeedles: ['provideAnimations', 'providePrimeNG', 'Aura', 'provideDynamicForm', 'withPrimeNGFields', 'withLegacyStatusClasses'],
   },
@@ -177,7 +177,7 @@ describe('ng-add', () => {
       const twice = await runner.runSchematic('ng-add', { adapter: 'primeng' }, once);
 
       const config = twice.readContent(`${APP_DIR}/src/app/app.config.ts`);
-      expect(config.match(/import Aura from '@primeng\/themes\/aura'/g)?.length).toBe(1);
+      expect(config.match(/import Aura from '@primeuix\/themes\/aura'/g)?.length).toBe(1);
       expect(config.match(/providePrimeNG\s*\(/g)?.length).toBe(1);
     });
   });
@@ -242,12 +242,12 @@ describe('ng-add', () => {
       const { runner, tree } = await makeAppTree();
       const configPath = `${APP_DIR}/src/app/app.config.ts`;
       const original = tree.readContent(configPath);
-      tree.overwrite(configPath, "// import Aura from '@primeng/themes/aura';\n" + original);
+      tree.overwrite(configPath, "// import Aura from '@primeuix/themes/aura';\n" + original);
 
       const result = await runner.runSchematic('ng-add', { adapter: 'primeng' }, tree);
       const config = result.readContent(configPath);
       // The real default import was added (commented one did not block it).
-      expect(config.match(/^[^/]*import Aura from '@primeng\/themes\/aura'/m)).not.toBeNull();
+      expect(config.match(/^[^/]*import Aura from '@primeuix\/themes\/aura'/m)).not.toBeNull();
     });
   });
 

--- a/packages/dynamic-forms/schematics/ng-add/recipes.ts
+++ b/packages/dynamic-forms/schematics/ng-add/recipes.ts
@@ -49,12 +49,12 @@ export const RECIPES: Record<Adapter, AdapterRecipe> = {
   },
   primeng: {
     label: 'PrimeNG',
-    packages: [v('@ng-forge/dynamic-forms-primeng'), v('primeng'), v('@primeng/themes'), v('primeicons')],
+    packages: [v('@ng-forge/dynamic-forms-primeng'), v('primeng'), v('@primeuix/themes'), v('primeicons')],
     styles: ['primeicons/primeicons.css'],
     adapterProviders: [
       {
         marker: 'providePrimeNG',
-        defaultImports: [{ symbol: 'Aura', from: '@primeng/themes/aura' }],
+        defaultImports: [{ symbol: 'Aura', from: '@primeuix/themes/aura' }],
         builder: ({ code, external }) => code`${external('providePrimeNG', 'primeng/config')}({ theme: { preset: Aura } })`,
       },
     ],

--- a/packages/dynamic-forms/schematics/ng-add/recipes.ts
+++ b/packages/dynamic-forms/schematics/ng-add/recipes.ts
@@ -14,11 +14,8 @@ export interface DefaultImportSpec {
 }
 
 export interface AdapterProviderSpec {
-  /** Symbol name used to detect existing providers and skip insertion. */
   marker: string;
-  /** Default imports the provider expression depends on (e.g. `import Aura from '@primeng/themes/aura'`). */
   defaultImports: DefaultImportSpec[];
-  /** Builds the provider expression using addRootProvider's CodeBlock helper. */
   builder: CodeBlockCallback;
 }
 

--- a/packages/dynamic-forms/schematics/versions.ts
+++ b/packages/dynamic-forms/schematics/versions.ts
@@ -32,7 +32,7 @@ export const VERSIONS = {
   '@angular/cdk': ANGULAR,
   bootstrap: THIRD_PARTY['bootstrap'] ?? '^5.3.0',
   primeng: THIRD_PARTY['primeng'] ?? '^21.0.0',
-  '@primeng/themes': THIRD_PARTY['@primeng/themes'] ?? '^21.0.0',
+  '@primeuix/themes': THIRD_PARTY['@primeuix/themes'] ?? '^2.0.0',
   primeicons: THIRD_PARTY['primeicons'] ?? '^7.0.0',
   '@ionic/angular': THIRD_PARTY['@ionic/angular'] ?? '^8.8.0',
 } satisfies Record<string, string>;

--- a/scripts/finalize-dynamic-forms-schematics.mjs
+++ b/scripts/finalize-dynamic-forms-schematics.mjs
@@ -12,10 +12,7 @@ const workspaceManifest = 'package.json';
 // Third-party UI lib install ranges are sourced from the workspace root
 // at build time and embedded under `ngForgeSchematicDeps`. The schematic
 // reads this field from its own manifest at runtime — no hardcoded values.
-const SCHEMATIC_DEPS_KEYS = ['bootstrap', 'primeng', '@primeng/themes', 'primeicons', '@ionic/angular'];
-const HARDCODED_FALLBACKS = {
-  '@primeng/themes': '^21.0.0',
-};
+const SCHEMATIC_DEPS_KEYS = ['bootstrap', 'primeng', '@primeuix/themes', 'primeicons', '@ionic/angular'];
 
 writeFileSync(cjsMarker, JSON.stringify({ type: 'commonjs' }) + '\n');
 
@@ -34,7 +31,7 @@ if (existsSync(distManifest) && existsSync(workspaceManifest)) {
   const wsAll = { ...(ws.dependencies ?? {}), ...(ws.devDependencies ?? {}) };
   const schematicDeps = {};
   for (const key of SCHEMATIC_DEPS_KEYS) {
-    const spec = wsAll[key] ?? HARDCODED_FALLBACKS[key];
+    const spec = wsAll[key];
     if (!spec) continue;
     schematicDeps[key] = toInstallRange(spec);
   }


### PR DESCRIPTION
Two small follow-ups carved out of #443.

## 1. Align PrimeNG schematic + docs to `@primeuix/themes`

The schematic emitted `import Aura from '@primeng/themes/aura'` and the docs `integration-view` recommended installing `@primeng/themes`, but the codebase itself uses `@primeuix/themes/aura` everywhere — `internal/styling/src/primeng.ts`, `internal/sandbox-adapter-primeng/src/lib/factory.ts`, `internal/examples-primeng/src/docs-app-factory.ts`, and the StackBlitz template in `apps/docs/src/app/components/live-example/stackblitz-project.ts`. Users following the schematic/docs would install a package we don't test against.

This switches all schematic-emitted code and docs strings to `@primeuix/themes`. Since `@primeuix/themes` is already declared in workspace `dependencies` at `^2.0.3`, the build-time version resolver picks it up automatically and the hardcoded fallback for `@primeng/themes` is removed entirely.

**Verified**
- `nx test-schematics dynamic-forms` — 27 tests pass (primeng-related tests updated to expect the `@primeuix` import).
- `nx lint dynamic-forms` + `nx lint docs` — clean.
- Live `nx g @ng-forge/dynamic-forms:add --adapter=primeng` in the smoke Nx workspace: `@primeuix/themes@^2.0.3` written into `package.json`, `import Aura from '@primeuix/themes/aura'` written into `app.config.ts`, npm install clean.
- Dist manifest `ngForgeSchematicDeps` now carries `@primeuix/themes: ^2.0.3`; `@primeng/themes` no longer present.

## 2. Wire `test-schematics` into PR check

The dedicated `test-schematics` target wasn't picked up by `nx affected -t test` because its target name differs from `test`. Adds an explicit step in the **Lint & Test** job so schematic regressions gate PRs alongside the rest of the test suite. `test-schematics` already depends on `build-schematics` → `compile`, both of which the cache from the upstream **Build & Verify** job will hit.

## Test plan
- [x] `nx run dynamic-forms:build` — green.
- [x] `nx run dynamic-forms:test-schematics` — 27/27.
- [x] `nx lint dynamic-forms` + `nx lint docs` — clean.
- [x] Live primeng install + `app.config.ts` shape verified.
- [ ] CI on this PR confirms the new `test-schematics` step runs (this is itself the first run that exercises the new workflow step).