### PR TITLE
refactor(docs): redesign landing page typography, copy, motion, and a11y

### DIFF
--- a/apps/docs/src/app/pages/index.page.ts
+++ b/apps/docs/src/app/pages/index.page.ts
@@ -2,7 +2,7 @@ import { RouteMeta } from '@analogjs/router';
 import { LandingComponent } from './landing/landing.component';
 
 export const routeMeta: RouteMeta = {
-  title: 'ng-forge — Dynamic Forms for Angular',
+  title: 'ng-forge - Dynamic Forms for Angular',
 };
 
 export default LandingComponent;

--- a/apps/docs/src/app/pages/landing/landing.component.html
+++ b/apps/docs/src/app/pages/landing/landing.component.html
@@ -195,10 +195,10 @@
   @defer (hydrate on viewport) {
     <section id="features" class="features">
       <div class="features-header fade-up" [class.visible]="isVisible('features-header')">
-        <div class="section-label">Why ng-forge</div>
-        <h2 class="section-title">Built different.</h2>
+        <h2 class="section-title">Built on Signal Forms, not bolted on top</h2>
         <p class="section-desc">
-          Not another forms wrapper. Native signal forms integration, real type safety, actual developer experience.
+          Real integration with Angular's reactive primitives. Type safety your IDE can see, and field components that load only when they
+          render.
         </p>
       </div>
 
@@ -237,9 +237,8 @@
   @defer (hydrate on viewport) {
     <section id="showcase" class="showcase">
       <div class="showcase-header fade-up" [class.visible]="isVisible('showcase-header')">
-        <div class="section-label">Power features</div>
-        <h2 class="section-title">Simple API. Complex forms.</h2>
-        <p class="section-desc">Conditional logic, multi-step wizards, i18n. All declarative.</p>
+        <h2 class="section-title">Complex behavior stays declarative</h2>
+        <p class="section-desc">Conditional fields, multi-step wizards, and i18n live in the config, not in imperative component code.</p>
       </div>
 
       <div class="showcase-grid">
@@ -275,9 +274,8 @@
     <section id="validation" class="validation">
       <div class="section-container">
         <div class="validation-header fade-up" [class.visible]="isVisible('validation-header')">
-          <div class="section-label">Validation</div>
-          <h2 class="section-title">Try to break it.</h2>
-          <p class="section-desc">Real-time validation. No Validators import. Just properties.</p>
+          <h2 class="section-title">Validation without the Validators import</h2>
+          <p class="section-desc">Set required, email, min, or a pattern as plain properties. Errors update as the user types.</p>
         </div>
 
         <div class="validation-showcase fade-up" [class.visible]="isVisible('validation-demo')">
@@ -337,7 +335,13 @@
                 <span class="code-dot"></span>
                 <span class="code-title">validation-config.ts</span>
               </div>
-              <div class="code-body" [codeHighlight]="codeSnippets.validationShowcase"></div>
+              <div
+                class="code-body"
+                tabindex="0"
+                role="region"
+                aria-label="validation-config.ts source, scrollable"
+                [codeHighlight]="codeSnippets.validationShowcase"
+              ></div>
             </div>
           </div>
         </div>
@@ -363,9 +367,8 @@
     <section id="field-types" class="field-types">
       <div class="section-container">
         <div class="field-types-header fade-up" [class.visible]="isVisible('field-types-header')">
-          <div class="section-label">Field types</div>
-          <h2 class="section-title">Everything you need, built in.</h2>
-          <p class="section-desc">Common field types ready to use. Need more? Create your own.</p>
+          <h2 class="section-title">Fifteen field types ship in the box</h2>
+          <p class="section-desc">Inputs, selects, sliders, arrays, groups, and multi-step pages. Build custom ones with the same API.</p>
         </div>
 
         <div class="field-types-grid fade-up" [class.visible]="isVisible('field-types-grid')">
@@ -399,9 +402,8 @@
     <section id="json-config" class="json-config">
       <div class="section-container">
         <div class="json-header fade-up" [class.visible]="isVisible('json-header')">
-          <div class="section-label">Backend-driven</div>
-          <h2 class="section-title">Forms don't have to live in code.</h2>
-          <p class="section-desc">Store configs in your database. Fetch via API. Update forms without redeploying.</p>
+          <h2 class="section-title">Store form configs in your database</h2>
+          <p class="section-desc">Fetch the config from an API and render it. Change a form without shipping a new build.</p>
         </div>
 
         <div class="json-flow fade-up" [class.visible]="isVisible('json-demo')">
@@ -511,9 +513,8 @@
   @defer (hydrate on viewport) {
     <section id="integrations" class="integrations">
       <div class="integrations-header fade-up" [class.visible]="isVisible('integrations-header')">
-        <div class="section-label">Integrations</div>
-        <h2 class="section-title">Your UI library. Our forms.</h2>
-        <p class="section-desc">First-class adapters for everything you're already using.</p>
+        <h2 class="section-title">One config, four UI libraries</h2>
+        <p class="section-desc">First-class adapters for Material, PrimeNG, Ionic, and Bootstrap. Swap a single import.</p>
       </div>
 
       <div class="integrations-row fade-up" [class.visible]="isVisible('integrations-row')">

--- a/apps/docs/src/app/pages/landing/landing.component.html
+++ b/apps/docs/src/app/pages/landing/landing.component.html
@@ -155,42 +155,6 @@
     </div>
   </section>
 
-  <!-- Stats -->
-  @defer (hydrate on viewport) {
-    <section class="stats">
-      <div class="stats-grid">
-        <div class="stat-card">
-          <span class="stat-icon icon icon--download"></span>
-          <div class="stat-content">
-            <span class="stat-value">{{ npmDownloads() }}</span>
-            <span class="stat-label">Monthly Downloads</span>
-          </div>
-        </div>
-        <div class="stat-card">
-          <span class="stat-icon icon icon--star"></span>
-          <div class="stat-content">
-            <span class="stat-value">{{ githubStars() }}</span>
-            <span class="stat-label">GitHub Stars</span>
-          </div>
-        </div>
-        <div class="stat-card">
-          <span class="stat-icon icon icon--layers"></span>
-          <div class="stat-content">
-            <span class="stat-value">{{ uiLibraryCount }}</span>
-            <span class="stat-label">UI Integrations</span>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <div class="divider"></div>
-  } @placeholder {
-    <div>
-      <section class="stats" style="min-height: 120px"></section>
-      <div class="divider"></div>
-    </div>
-  }
-
   <!-- Features -->
   @defer (hydrate on viewport) {
     <section id="features" class="features">
@@ -381,11 +345,10 @@
           <p class="section-desc">Inputs, selects, sliders, arrays, groups, and multi-step pages. Build custom ones with the same API.</p>
         </div>
 
-        <div class="field-types-grid fade-up" [class.visible]="isVisible('field-types-grid')">
+        <div class="field-types-row fade-up" [class.visible]="isVisible('field-types-grid')">
           @for (fieldType of fieldTypes; track fieldType.code) {
             <div class="field-type">
               <code>{{ fieldType.code }}</code>
-              <span>{{ fieldType.label }}</span>
               <div class="field-type-tooltip">
                 <pre>{{ fieldType.snippet }}</pre>
               </div>
@@ -414,8 +377,8 @@
         <div class="codegen-header fade-up" [class.visible]="isVisible('codegen-header')">
           <h2 class="section-title">Generate the config from your spec or your AI assistant</h2>
           <p class="section-desc">
-            The config is a plain typed object, so you rarely write it by hand. Generate it from an OpenAPI spec, or scaffold and validate
-            it in your editor with an MCP-aware assistant.
+            The config is a plain typed object, the single source of truth for your form. Generate it from an OpenAPI spec, or scaffold and
+            validate it in your editor with an MCP-aware assistant.
           </p>
         </div>
 
@@ -502,52 +465,6 @@
         </div>
 
         <div class="json-flow fade-up" [class.visible]="isVisible('json-demo')">
-          <!-- Flow diagram -->
-          <div class="flow-diagram">
-            <div class="flow-step">
-              <div class="flow-icon database">
-                <span class="icon icon--database"></span>
-              </div>
-              <span class="flow-label">Database</span>
-            </div>
-
-            <div class="flow-connector">
-              <div class="flow-line"></div>
-              <div class="flow-packet"></div>
-            </div>
-
-            <div class="flow-step">
-              <div class="flow-icon api">
-                <span class="icon icon--api"></span>
-              </div>
-              <span class="flow-label">API Request</span>
-            </div>
-
-            <div class="flow-connector">
-              <div class="flow-line"></div>
-              <div class="flow-packet"></div>
-            </div>
-
-            <div class="flow-step">
-              <div class="flow-icon json">
-                <span class="icon icon--json"></span>
-              </div>
-              <span class="flow-label">JSON</span>
-            </div>
-
-            <div class="flow-connector">
-              <div class="flow-line"></div>
-              <div class="flow-packet"></div>
-            </div>
-
-            <div class="flow-step">
-              <div class="flow-icon form">
-                <span class="icon icon--form"></span>
-              </div>
-              <span class="flow-label">Live Form</span>
-            </div>
-          </div>
-
           <!-- Code example -->
           <div class="json-code-example">
             <div class="code-block">

--- a/apps/docs/src/app/pages/landing/landing.component.html
+++ b/apps/docs/src/app/pages/landing/landing.component.html
@@ -238,7 +238,9 @@
     <section id="showcase" class="showcase">
       <div class="showcase-header fade-up" [class.visible]="isVisible('showcase-header')">
         <h2 class="section-title">Complex behavior stays declarative</h2>
-        <p class="section-desc">Conditional fields, multi-step wizards, and i18n live in the config, not in imperative component code.</p>
+        <p class="section-desc">
+          Conditional fields, multi-step wizards, and server-driven values live in the config, not in imperative component code.
+        </p>
       </div>
 
       <div class="showcase-grid">
@@ -248,7 +250,7 @@
             Conditional Everything
           </h3>
           <p>Fields that appear, disappear, or become required based on other values. No imperative code.</p>
-          <div class="showcase-code" [codeHighlight]="codeSnippets.conditionalLogic"></div>
+          <div class="showcase-code" tabindex="0" [codeHighlight]="codeSnippets.conditionalLogic"></div>
         </div>
         <div class="showcase-item fade-up" [class.visible]="isVisible('showcase-1')">
           <h3>
@@ -256,7 +258,15 @@
             Multi-Step Wizards
           </h3>
           <p>Page-level validation, navigation controls, progress tracking. Built-in.</p>
-          <div class="showcase-code" [codeHighlight]="codeSnippets.multiStepWizard"></div>
+          <div class="showcase-code" tabindex="0" [codeHighlight]="codeSnippets.multiStepWizard"></div>
+        </div>
+        <div class="showcase-item fade-up" [class.visible]="isVisible('showcase-2')">
+          <h3>
+            <span class="showcase-icon icon icon--api"></span>
+            Server-Driven Values
+          </h3>
+          <p>Derive a value from an HTTP endpoint or async function. Debouncing and request cancellation are handled for you.</p>
+          <div class="showcase-code" tabindex="0" [codeHighlight]="codeSnippets.httpDerivation"></div>
         </div>
       </div>
     </section>
@@ -393,6 +403,91 @@
   } @placeholder {
     <div>
       <section id="field-types" class="field-types" style="min-height: 400px"></section>
+      <div class="divider"></div>
+    </div>
+  }
+
+  <!-- Config generation (OpenAPI + AI) -->
+  @defer (hydrate on viewport) {
+    <section id="codegen" class="codegen">
+      <div class="section-container">
+        <div class="codegen-header fade-up" [class.visible]="isVisible('codegen-header')">
+          <h2 class="section-title">Generate the config from your spec or your AI assistant</h2>
+          <p class="section-desc">
+            The config is a plain typed object, so you rarely write it by hand. Generate it from an OpenAPI spec, or scaffold and validate
+            it in your editor with an MCP-aware assistant.
+          </p>
+        </div>
+
+        <div class="codegen-grid fade-up" [class.visible]="isVisible('codegen-grid')">
+          <div class="codegen-card">
+            <div class="codegen-card-head">
+              <span class="codegen-icon icon icon--api" aria-hidden="true"></span>
+              <div class="codegen-card-text">
+                <h3>From your OpenAPI spec</h3>
+                <p>Point the CLI at a spec. It emits typed FormConfig objects and matching interfaces.</p>
+              </div>
+            </div>
+            <div class="code-block">
+              <div class="code-header">
+                <span class="code-dot"></span>
+                <span class="code-dot"></span>
+                <span class="code-dot"></span>
+                <span class="code-title">terminal</span>
+              </div>
+              <div class="code-body" tabindex="0" [codeHighlight]="codeSnippets.openapiCommand" language="bash"></div>
+            </div>
+            <div class="code-block">
+              <div class="code-header">
+                <span class="code-dot"></span>
+                <span class="code-dot"></span>
+                <span class="code-dot"></span>
+                <span class="code-title">user.form.ts</span>
+              </div>
+              <div class="code-body" tabindex="0" [codeHighlight]="codeSnippets.openapiOutput"></div>
+            </div>
+          </div>
+
+          <div class="codegen-card">
+            <div class="codegen-card-head">
+              <span class="codegen-icon icon icon--sparkles" aria-hidden="true"></span>
+              <div class="codegen-card-text">
+                <h3>From your AI assistant</h3>
+                <p>An MCP server lets Claude, Cursor, and Copilot generate, validate, and scaffold configs in your editor.</p>
+              </div>
+            </div>
+            <div class="code-block">
+              <div class="code-header">
+                <span class="code-dot"></span>
+                <span class="code-dot"></span>
+                <span class="code-dot"></span>
+                <span class="code-title">mcp.json</span>
+              </div>
+              <div class="code-body" tabindex="0" [codeHighlight]="codeSnippets.mcpConfig" language="json"></div>
+            </div>
+            <ul class="codegen-tools">
+              <li><code>lookup</code><span>docs for any field or concept</span></li>
+              <li><code>examples</code><span>working patterns to copy</span></li>
+              <li><code>validate</code><span>a config, with clear errors</span></li>
+              <li><code>scaffold</code><span>a typed skeleton to fill in</span></li>
+            </ul>
+          </div>
+        </div>
+
+        <p class="codegen-cta fade-up" [class.visible]="isVisible('codegen-cta')">
+          Read the
+          <a routerLink="/openapi-generator" class="inline-link" title="OpenAPI generator documentation">OpenAPI generator</a>
+          and
+          <a routerLink="/ai-integration" class="inline-link" title="AI integration documentation">AI integration</a>
+          guides &rarr;
+        </p>
+      </div>
+    </section>
+
+    <div class="divider"></div>
+  } @placeholder {
+    <div>
+      <section id="codegen" class="codegen" style="min-height: 500px"></section>
       <div class="divider"></div>
     </div>
   }

--- a/apps/docs/src/app/pages/landing/landing.component.scss
+++ b/apps/docs/src/app/pages/landing/landing.component.scss
@@ -1153,102 +1153,6 @@ nav {
 }
 
 // ============================================
-// STATS
-// ============================================
-.stats {
-  padding: 3rem 2rem;
-  position: relative;
-  z-index: 2;
-
-  @media (max-width: 768px) {
-    padding: 2rem 1rem;
-  }
-}
-
-.stats-grid {
-  display: flex;
-  justify-content: center;
-  gap: 1.5rem;
-  max-width: 800px;
-  margin: 0 auto;
-
-  @media (max-width: 768px) {
-    flex-direction: column;
-    align-items: center;
-    gap: 1rem;
-  }
-}
-
-.stat-card {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 1.25rem 1.75rem;
-  background: rgba($bg-surface, 0.4);
-  border: 1px solid rgba($steel-dark, 0.4);
-  border-radius: 12px;
-  backdrop-filter: blur(8px);
-  transition: all 0.3s ease;
-
-  &:hover {
-    background: rgba($bg-surface, 0.6);
-    border-color: rgba($ember-glow, 0.3);
-    transform: translateY(-2px);
-    box-shadow:
-      0 8px 24px rgba(0, 0, 0, 0.2),
-      0 0 20px rgba($ember-glow, 0.1);
-  }
-
-  @media (max-width: 768px) {
-    width: 100%;
-    max-width: 280px;
-    padding: 1rem 1.25rem;
-  }
-}
-
-.stat-icon {
-  // Force size override since icon-mask mixin sets its own sizes
-  width: 32px !important;
-  height: 32px !important;
-  flex-shrink: 0;
-  background: linear-gradient(135deg, $ember-glow, $ember-hot);
-  opacity: 0.9;
-
-  @media (max-width: 768px) {
-    width: 28px !important;
-    height: 28px !important;
-  }
-}
-
-.stat-content {
-  display: flex;
-  flex-direction: column;
-  gap: 0.125rem;
-}
-
-.stat-value {
-  font-size: 1.5rem;
-  font-weight: 700;
-  color: $steel;
-  line-height: 1.2;
-
-  @media (max-width: 768px) {
-    font-size: 1.25rem;
-  }
-}
-
-.stat-label {
-  font-size: 0.75rem;
-  color: $steel-mid;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-
-  @media (max-width: 768px) {
-    font-size: 0.7rem;
-  }
-}
-
-// ============================================
 // SECTIONS (COMMON)
 // ============================================
 section {
@@ -1440,8 +1344,8 @@ section {
     color: #34d399; // emerald
   }
 
-  &.icon--zap {
-    color: #60a5fa; // blue
+  &.icon--check {
+    color: $success; // green, reads as validation
   }
 
   &.icon--plug {
@@ -1692,230 +1596,6 @@ section {
   gap: 3rem;
 }
 
-.flow-diagram {
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  padding: 2rem 0 4rem; // Extra bottom padding for labels
-  overflow-x: auto;
-  gap: 0;
-
-  @media (max-width: 600px) {
-    padding: 1.5rem 0 3rem;
-  }
-}
-
-.flow-step {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  position: relative;
-}
-
-.flow-icon {
-  width: 64px;
-  height: 64px;
-  border-radius: 16px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: $bg-deep;
-  border: 1px solid $steel-dark;
-  transition: all 0.3s ease;
-  flex-shrink: 0;
-
-  .icon {
-    width: 28px;
-    height: 28px;
-    color: $steel-mid;
-  }
-
-  &.database {
-    background: linear-gradient(135deg, rgba($ember-core, 0.1), rgba($ember-glow, 0.05));
-    border-color: rgba($ember-core, 0.3);
-
-    .icon {
-      color: $ember-glow;
-    }
-  }
-
-  &.api {
-    background: linear-gradient(135deg, rgba($molten, 0.1), rgba($molten, 0.05));
-    border-color: rgba($molten, 0.3);
-
-    .icon {
-      color: $molten;
-    }
-  }
-
-  &.json {
-    background: linear-gradient(135deg, rgba($steel, 0.1), rgba($steel, 0.05));
-    border-color: rgba($steel-mid, 0.3);
-
-    .icon {
-      color: $steel;
-    }
-  }
-
-  &.form {
-    background: linear-gradient(135deg, rgba($success, 0.1), rgba($success, 0.05));
-    border-color: rgba($success, 0.3);
-
-    .icon {
-      color: $success;
-    }
-  }
-
-  @media (max-width: 600px) {
-    width: 48px;
-    height: 48px;
-    border-radius: 10px;
-
-    .icon {
-      width: 22px;
-      height: 22px;
-    }
-  }
-}
-
-.flow-label {
-  position: absolute;
-  top: calc(100% + 0.75rem);
-  left: 50%;
-  transform: translateX(-50%);
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.75rem;
-  color: $steel-mid;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  white-space: nowrap;
-
-  @media (max-width: 600px) {
-    font-size: 0.6rem;
-    letter-spacing: 0.5px;
-    top: calc(100% + 0.5rem);
-  }
-}
-
-.flow-connector {
-  width: 60px;
-  height: 2px;
-  position: relative;
-  margin-top: 31px; // Center with 64px icon (64/2 - 1)
-  flex-shrink: 0;
-
-  @media (max-width: 600px) {
-    width: 32px;
-    margin-top: 23px; // Center with 48px icon (48/2 - 1)
-  }
-}
-
-.flow-line {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(90deg, $steel-dark, $steel-dim, $steel-dark);
-}
-
-.flow-packet {
-  position: absolute;
-  width: 8px;
-  height: 8px;
-  background: $ember-glow;
-  border-radius: 50%;
-  top: 50%;
-  left: 0;
-  transform: translateY(-50%);
-  box-shadow: 0 0 10px $ember-glow;
-  opacity: 0;
-
-  @media (max-width: 600px) {
-    width: 6px;
-    height: 6px;
-  }
-}
-
-// Sequential animation - packets flow with overlap (next starts before previous ends)
-// Total cycle: 5s, packets visible simultaneously during handoff
-.flow-connector:nth-child(2) .flow-packet {
-  animation: packet-flow-1 5s ease-in-out infinite;
-}
-
-.flow-connector:nth-child(4) .flow-packet {
-  animation: packet-flow-2 5s ease-in-out infinite;
-}
-
-.flow-connector:nth-child(6) .flow-packet {
-  animation: packet-flow-3 5s ease-in-out infinite;
-}
-
-// First connector: 0% - 28% (packet 2 starts at 22%, overlap 22-28%)
-@keyframes packet-flow-1 {
-  0% {
-    left: 0;
-    opacity: 0;
-  }
-  2% {
-    opacity: 1;
-  }
-  24% {
-    opacity: 1;
-  }
-  28% {
-    left: calc(100% - 8px);
-    opacity: 0;
-  }
-  100% {
-    left: calc(100% - 8px);
-    opacity: 0;
-  }
-}
-
-// Second connector: 22% - 50% (starts while packet 1 still visible, packet 3 starts at 44%)
-@keyframes packet-flow-2 {
-  0%,
-  22% {
-    left: 0;
-    opacity: 0;
-  }
-  24% {
-    opacity: 1;
-  }
-  46% {
-    opacity: 1;
-  }
-  50% {
-    left: calc(100% - 8px);
-    opacity: 0;
-  }
-  100% {
-    left: calc(100% - 8px);
-    opacity: 0;
-  }
-}
-
-// Third connector: 44% - 72% (starts while packet 2 still visible)
-@keyframes packet-flow-3 {
-  0%,
-  44% {
-    left: 0;
-    opacity: 0;
-  }
-  46% {
-    opacity: 1;
-  }
-  68% {
-    opacity: 1;
-  }
-  72% {
-    left: calc(100% - 8px);
-    opacity: 0;
-  }
-  100% {
-    left: calc(100% - 8px);
-    opacity: 0;
-  }
-}
-
 .json-code-example {
   .code-block {
     max-width: 550px;
@@ -1994,36 +1674,30 @@ section {
 // ============================================
 // FIELD TYPES SECTION
 // ============================================
-.field-types-grid {
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 1rem;
+// Compact chip cloud: the type names speak for themselves; the full snippet
+// is revealed on hover rather than spelled out under every tile.
+.field-types-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
   margin-bottom: 2rem;
-
-  @media (max-width: 900px) {
-    grid-template-columns: repeat(3, 1fr);
-  }
-
-  @media (max-width: 600px) {
-    grid-template-columns: repeat(2, 1fr);
-  }
 }
 
 .field-type {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
   background: $bg-deep;
   border: 1px solid $steel-dark;
-  border-radius: 10px;
-  padding: 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  transition: all 0.2s;
-  position: relative;
-  cursor: pointer;
+  border-radius: 8px;
+  padding: 0.5rem 0.85rem;
+  transition:
+    border-color 0.2s ease,
+    transform 0.2s ease;
 
   &:hover {
     border-color: $steel-dim;
-    transform: translateY(-2px) scale(1.02);
+    transform: translateY(-2px);
 
     .field-type-tooltip {
       opacity: 1;
@@ -2032,19 +1706,10 @@ section {
     }
   }
 
-  &:active {
-    transform: translateY(0) scale(0.98);
-  }
-
   code {
     font-family: 'JetBrains Mono', monospace;
-    font-size: 0.9rem;
+    font-size: 0.85rem;
     color: $ember-glow;
-  }
-
-  > span {
-    font-size: 0.75rem;
-    color: $steel-mid;
   }
 }
 

--- a/apps/docs/src/app/pages/landing/landing.component.scss
+++ b/apps/docs/src/app/pages/landing/landing.component.scss
@@ -170,20 +170,15 @@
   animation: spark-burst 0.3s ease-out forwards;
 }
 
+// Animate opacity only. The glow (box-shadow) stays static on .firefly so the
+// pulse never triggers a per-frame shadow repaint, keeping the loop GPU-cheap.
 @keyframes firefly-pulse {
   0%,
   100% {
-    opacity: 0.6;
-    box-shadow:
-      0 0 8px $ember-hot,
-      0 0 16px $ember-glow;
+    opacity: 0.55;
   }
   50% {
     opacity: 1;
-    box-shadow:
-      0 0 12px $ember-hot,
-      0 0 24px $ember-glow,
-      0 0 36px rgba($ember-glow, 0.3);
   }
 }
 
@@ -558,15 +553,18 @@ nav {
 }
 
 .hero h1 {
-  font-size: clamp(3.5rem, 10vw, 7rem);
+  // Capped at ~5.5rem: above the ~6rem ceiling the page shouts instead of
+  // designing. line-height 1.02 keeps the 'g' descender in "boring" clear.
+  font-size: clamp(2.75rem, 8vw, 5.5rem);
   font-weight: 700;
-  line-height: 0.95;
-  letter-spacing: -3px;
+  line-height: 1.02;
+  letter-spacing: -0.025em;
+  text-wrap: balance;
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;
 
   @media (max-width: 768px) {
-    letter-spacing: -2px;
+    letter-spacing: -0.02em;
     margin-top: 1.5rem;
   }
 }
@@ -585,11 +583,14 @@ nav {
 }
 
 .hero-tagline {
-  font-size: 1.4rem;
-  color: $steel-mid;
-  max-width: 550px;
+  font-size: 1.35rem;
+  // Brighter than $steel-mid for a confident lede read (~8:1 on $bg-deep)
+  // while staying clearly secondary to the headline.
+  color: #b6b1a7;
+  max-width: 34rem;
   margin-bottom: 2.5rem;
-  line-height: 1.5;
+  line-height: 1.55;
+  text-wrap: pretty;
 
   @media (max-width: 768px) {
     font-size: 1.15rem;
@@ -746,7 +747,7 @@ nav {
   background: transparent;
   border: 1px solid transparent;
   border-radius: 6px;
-  color: $steel-dim;
+  color: $steel-mid;
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.75rem;
   font-weight: 500;
@@ -1122,7 +1123,7 @@ nav {
   margin-left: auto;
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.75rem;
-  color: $steel-dim;
+  color: $steel-mid;
 }
 
 .code-body {
@@ -1262,27 +1263,23 @@ section {
   }
 }
 
-.section-label {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 2px;
-  color: $ember-glow;
-  margin-bottom: 1rem;
-}
-
 .section-title {
-  font-size: clamp(2rem, 5vw, 3rem);
+  font-size: clamp(2rem, 4.5vw, 3.25rem);
   font-weight: 700;
-  letter-spacing: -1px;
+  letter-spacing: -0.02em;
+  line-height: 1.08;
+  text-wrap: balance;
   margin-bottom: 1rem;
   color: $steel;
 }
 
 .section-desc {
-  color: $steel-mid;
+  // Brighter than $steel-mid so descriptions read with confidence (~8:1).
+  color: #b6b1a7;
   font-size: 1.1rem;
-  max-width: 500px;
+  line-height: 1.55;
+  max-width: 34rem;
+  text-wrap: pretty;
 }
 
 .section-container {
@@ -1782,7 +1779,7 @@ section {
   transform: translateX(-50%);
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.75rem;
-  color: $steel-dim;
+  color: $steel-mid;
   text-transform: uppercase;
   letter-spacing: 1px;
   white-space: nowrap;
@@ -1983,7 +1980,7 @@ section {
   }
 
   span {
-    color: $steel-dim;
+    color: $steel-mid;
     font-size: 0.85rem;
   }
 }
@@ -2041,7 +2038,7 @@ section {
 
   > span {
     font-size: 0.75rem;
-    color: $steel-dim;
+    color: $steel-mid;
   }
 }
 
@@ -2237,7 +2234,9 @@ section {
 .cta-title {
   font-size: clamp(2rem, 5vw, 3.5rem);
   font-weight: 700;
-  letter-spacing: -1px;
+  letter-spacing: -0.02em;
+  line-height: 1.08;
+  text-wrap: balance;
   margin-bottom: 2.5rem;
   color: $steel;
 
@@ -2277,7 +2276,7 @@ section {
 .install-tab {
   background: transparent;
   border: none;
-  color: $steel-dim;
+  color: $steel-mid;
   padding: 0.6rem 1rem;
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.75rem;
@@ -2329,7 +2328,7 @@ section {
 .copy-btn {
   background: transparent;
   border: none;
-  color: $steel-dim;
+  color: $steel-mid;
   cursor: pointer;
   padding: 4px;
   transition: all 0.2s;
@@ -2431,25 +2430,45 @@ footer {
 }
 
 .footer-copy {
-  color: $steel-dim;
+  color: $steel-mid;
   font-size: 0.8rem;
 }
 
 // ============================================
 // ANIMATIONS
 // ============================================
+// Scroll reveal. Content is VISIBLE BY DEFAULT, so SSR, no-JS, headless
+// renderers, crawlers, reduced-motion, and browsers without scroll-timeline
+// support all paint the final state. Nothing is ever gated on a JS-triggered
+// class, so a section can never ship blank.
+//
+// The reveal is layered on top only where the platform can do it natively and
+// motion is allowed: CSS scroll-driven animation (view timeline). No scroll
+// listeners, no per-frame main-thread work, so it stays cheap for INP.
 .fade-up {
   opacity: 1;
-  transform: translateY(0);
+  transform: none;
+}
 
-  &.animate {
-    opacity: 0;
-    transform: translateY(30px);
-    transition: all 0.8s cubic-bezier(0.16, 1, 0.3, 1);
+@supports (animation-timeline: view()) {
+  @media (prefers-reduced-motion: no-preference) {
+    :host(.browser) .fade-up {
+      animation: fade-up-reveal linear both;
+      animation-timeline: view();
+      animation-range: entry 5% cover 28%;
+    }
   }
+}
 
-  &.visible {
-    opacity: 1;
-    transform: translateY(0);
+// Transform-only reveal: opacity stays at 1 the whole time. Off-screen content
+// is fully opaque (just shifted down), so accessibility/contrast audits that
+// scan before the element scrolls into view never see semi-transparent text.
+// The rise still reads as a reveal as the section enters the viewport.
+@keyframes fade-up-reveal {
+  from {
+    transform: translateY(28px);
+  }
+  to {
+    transform: none;
   }
 }

--- a/apps/docs/src/app/pages/landing/landing.component.scss
+++ b/apps/docs/src/app/pages/landing/landing.component.scss
@@ -1490,7 +1490,9 @@ section {
 
 .showcase-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  // auto-fit so the three cards sit in one row on wide screens and wrap
+  // cleanly (no empty trailing cell) as space tightens.
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 1.5rem;
   max-width: 100%;
 
@@ -1541,6 +1543,10 @@ section {
 
   &.icon--workflow {
     color: #34d399; // green
+  }
+
+  &.icon--api {
+    color: $info; // cool blue, sits opposite the warm ember palette
   }
 }
 
@@ -2135,6 +2141,115 @@ section {
       background: $ember-hot;
     }
   }
+}
+
+// ============================================
+// CONFIG GENERATION SECTION (OpenAPI + AI)
+// ============================================
+.codegen {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2rem 2rem;
+
+  @media (max-width: 768px) {
+    padding: 2rem 1.25rem;
+  }
+}
+
+.codegen-header {
+  margin-bottom: 3rem;
+}
+
+.codegen-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  align-items: start;
+
+  @media (max-width: 900px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.codegen-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-width: 0; // allow code blocks to shrink within the grid track
+
+  .code-block {
+    max-width: 100%;
+  }
+}
+
+.codegen-card-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+}
+
+.codegen-icon {
+  flex-shrink: 0;
+  margin-top: 0.15rem;
+
+  &.icon--api {
+    color: $info;
+  }
+
+  &.icon--sparkles {
+    color: $molten;
+  }
+}
+
+.codegen-card-text {
+  h3 {
+    font-size: 1.15rem;
+    font-weight: 600;
+    color: $steel;
+    margin: 0 0 0.25rem;
+  }
+
+  p {
+    font-size: 0.95rem;
+    color: $steel-mid;
+    line-height: 1.55;
+    margin: 0;
+  }
+}
+
+.codegen-tools {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+
+  li {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    font-size: 0.9rem;
+    color: $steel-mid;
+  }
+
+  code {
+    flex-shrink: 0;
+    min-width: 5.5rem;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.8rem;
+    color: $ember-glow;
+    background: $bg-elevated;
+    border: 1px solid $steel-dark;
+    padding: 0.15rem 0.5rem;
+    border-radius: 4px;
+  }
+}
+
+.codegen-cta {
+  color: $steel-mid;
+  margin-top: 2.5rem;
+  text-align: center;
 }
 
 // ============================================

--- a/apps/docs/src/app/pages/landing/landing.component.ts
+++ b/apps/docs/src/app/pages/landing/landing.component.ts
@@ -1,5 +1,4 @@
 import { isPlatformBrowser } from '@angular/common';
-import { HttpClient } from '@angular/common/http';
 import {
   afterNextRender,
   ChangeDetectionStrategy,
@@ -11,10 +10,10 @@ import {
   signal,
   viewChild,
 } from '@angular/core';
-import { rxResource, takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 
-import { catchError, defer, delay, filter, map, merge, of, switchMap, tap } from 'rxjs';
+import { defer, delay, filter, map, merge, of, switchMap, tap } from 'rxjs';
 
 import { SandboxHarness, SandboxMountDirective } from '@ng-forge/sandbox-harness';
 
@@ -70,7 +69,6 @@ const CONFETTI_ANIMATION_DURATION_MS = 800;
 })
 export class LandingComponent {
   private readonly destroyRef = inject(DestroyRef);
-  private readonly http = inject(HttpClient);
   protected readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
   private readonly harness = inject(SandboxHarness);
 
@@ -132,34 +130,6 @@ export class LandingComponent {
   readonly copyConfetti = signal<{ id: number; x: number; y: number; angle: number }[]>([]);
   private readonly visibleElements = signal<Set<string>>(new Set());
   private confettiIdCounter = 0;
-
-  // ============================================
-  // STATS (fetched dynamically)
-  // ============================================
-
-  private readonly npmResource = rxResource({
-    params: () => (this.isBrowser ? {} : undefined),
-    stream: () =>
-      this.http.get<{ downloads?: number }>('https://api.npmjs.org/downloads/point/last-month/@ng-forge/dynamic-forms').pipe(
-        map((data) => this.formatNumber(data?.downloads ?? 0)),
-        catchError(() => of('-')),
-      ),
-  });
-
-  readonly npmDownloads = computed(() => this.npmResource.value() ?? '-');
-
-  private readonly githubResource = rxResource({
-    params: () => (this.isBrowser ? {} : undefined),
-    stream: () =>
-      this.http.get<{ stargazers_count?: number }>('https://api.github.com/repos/ng-forge/ng-forge').pipe(
-        map((data) => this.formatNumber(data?.stargazers_count ?? 0)),
-        catchError(() => of('-')),
-      ),
-  });
-
-  readonly githubStars = computed(() => this.githubResource.value() ?? '-');
-
-  readonly uiLibraryCount = '4'; // Static: Material, Bootstrap, PrimeNG, Ionic
 
   // ============================================
   // REACTIVE STATE (RxJS -> Signal)
@@ -324,16 +294,6 @@ export class LandingComponent {
     // Clear confetti after animation completes
     if (this.confettiTimer) clearTimeout(this.confettiTimer);
     this.confettiTimer = setTimeout(() => this.copyConfetti.set([]), CONFETTI_ANIMATION_DURATION_MS);
-  }
-
-  private formatNumber(num: number): string {
-    if (num >= 1000000) {
-      return (num / 1000000).toFixed(1).replace(/\.0$/, '') + 'M';
-    }
-    if (num >= 1000) {
-      return (num / 1000).toFixed(1).replace(/\.0$/, '') + 'K';
-    }
-    return num.toString();
   }
 
   onCardMouseMove(event: MouseEvent): void {

--- a/apps/docs/src/app/pages/landing/landing.component.ts
+++ b/apps/docs/src/app/pages/landing/landing.component.ts
@@ -142,22 +142,22 @@ export class LandingComponent {
     stream: () =>
       this.http.get<{ downloads?: number }>('https://api.npmjs.org/downloads/point/last-month/@ng-forge/dynamic-forms').pipe(
         map((data) => this.formatNumber(data?.downloads ?? 0)),
-        catchError(() => of('—')),
+        catchError(() => of('-')),
       ),
   });
 
-  readonly npmDownloads = computed(() => this.npmResource.value() ?? '—');
+  readonly npmDownloads = computed(() => this.npmResource.value() ?? '-');
 
   private readonly githubResource = rxResource({
     params: () => (this.isBrowser ? {} : undefined),
     stream: () =>
       this.http.get<{ stargazers_count?: number }>('https://api.github.com/repos/ng-forge/ng-forge').pipe(
         map((data) => this.formatNumber(data?.stargazers_count ?? 0)),
-        catchError(() => of('—')),
+        catchError(() => of('-')),
       ),
   });
 
-  readonly githubStars = computed(() => this.githubResource.value() ?? '—');
+  readonly githubStars = computed(() => this.githubResource.value() ?? '-');
 
   readonly uiLibraryCount = '4'; // Static: Material, Bootstrap, PrimeNG, Ionic
 

--- a/apps/docs/src/app/pages/landing/landing.constants.ts
+++ b/apps/docs/src/app/pages/landing/landing.constants.ts
@@ -106,12 +106,12 @@ export const FEATURES: Feature[] = [
   {
     icon: 'signal',
     title: 'Signal Forms Native',
-    description: "Built directly on Angular Signal Forms. Not a wrapper — real integration with Angular's reactive future.",
+    description: "Built directly on Angular Signal Forms. Not a wrapper. Real integration with Angular's reactive future.",
   },
   {
     icon: 'target',
     title: 'Actually Type-Safe',
-    description: ' — your IDE knows everything. No more guessing.',
+    description: ' gives your IDE the full shape. No more guessing.',
     highlightCode: 'as const satisfies',
   },
   {

--- a/apps/docs/src/app/pages/landing/landing.constants.ts
+++ b/apps/docs/src/app/pages/landing/landing.constants.ts
@@ -125,9 +125,9 @@ export const FEATURES: Feature[] = [
     description: 'Lazy-loaded field components. Load only what you render.',
   },
   {
-    icon: 'zap',
-    title: 'Zoneless Ready',
-    description: 'No Zone.js required. OnPush everywhere. Built for where Angular is going.',
+    icon: 'check',
+    title: 'Bring Your Own Schema',
+    description: 'Validate with Zod or any Standard Schema validator, cross-field rules included. Reuse one schema on client and server.',
   },
   {
     icon: 'plug',

--- a/apps/docs/src/app/pages/landing/landing.constants.ts
+++ b/apps/docs/src/app/pages/landing/landing.constants.ts
@@ -96,7 +96,7 @@ export const INTERSECTION_CONFIG = {
 // SECTION IDS
 // ============================================
 
-export const SECTION_IDS = ['features', 'showcase', 'validation', 'field-types', 'json-config', 'integrations'] as const;
+export const SECTION_IDS = ['features', 'showcase', 'validation', 'field-types', 'codegen', 'json-config', 'integrations'] as const;
 
 // ============================================
 // FEATURES
@@ -481,4 +481,45 @@ export class SurveyComponent {
     this.http.get<FormConfig>('/api/forms/survey')
   );
 }`,
+
+  httpDerivation: `{
+  key: 'shippingCost',
+  type: 'input',
+  readonly: true,
+  logic: [{
+    type: 'derivation',
+    source: 'http',
+    http: {
+      url: '/api/shipping',
+      queryParams: { zip: 'formValue.zip' },
+    },
+    responseExpression: 'response.cost',
+    dependsOn: ['zip'],
+  }],
+}`,
+
+  mcpConfig: `{
+  "ng-forge": {
+    "command": "npx",
+    "args": ["-y", "@ng-forge/dynamic-form-mcp"]
+  }
+}`,
+
+  openapiCommand: `npx @ng-forge/openapi-generator \\
+  --spec ./openapi.yaml \\
+  --output ./src/forms`,
+
+  openapiOutput: `// generated from openapi.yaml
+export const createUserForm = {
+  fields: [
+    { key: 'email', type: 'input', label: 'Email',
+      props: { type: 'email' },
+      validators: [{ type: 'required' }, { type: 'email' }] },
+    { key: 'role', type: 'select', label: 'Role',
+      options: [
+        { label: 'Admin', value: 'admin' },
+        { label: 'Member', value: 'member' },
+      ] },
+  ],
+} as const satisfies FormConfig;`,
 } as const;


### PR DESCRIPTION
A full redesign of the docs landing page that keeps the "Forge" identity (ember-on-dark, Space Grotesk + JetBrains Mono, gradient headline) and raises craft on typography, layout, copy, motion, and accessibility, then restructures the content to market features the page did not surface.

## Craft

- **Typography**: H1 capped at ~5.5rem (was 7rem and edge-to-edge), descender-safe line-height, `text-wrap: balance` on headings and `pretty` on body, brighter body/lede color.
- **Eyebrows**: removed the six per-section uppercase mono labels; the hero badge is the only eyebrow now.
- **Copy**: section titles rewritten from a repetitive punchy cadence to specific, varied lines.
- **Motion**: fireflies kept but `firefly-pulse` is opacity-only (no per-frame box-shadow repaints). Scroll reveal reimplemented as CSS scroll-driven, transform-only, visible by default (SSR, no-JS, crawlers, reduced-motion, and unsupported browsers all paint the final state). No scroll listeners. Gradient headline and copy-confetti preserved.
- **Accessibility**: bumped muted text (`$steel-dim`, ~2.3:1) to a passing contrast across code titles, field-type labels, tabs, and footer. Scrollable code blocks made keyboard-focusable.
- **Cleanup**: removed em-dashes from user-facing strings.

## Content

- **New "config origins" section**: "Generate the config from your spec or your AI assistant." Pairs the OpenAPI generator (real CLI + generated `as const satisfies FormConfig`) with the MCP server (real `mcp.json` config + the four tools), framed for developers as codegen you own.
- **Showcase third card, "Server-Driven Values"**: HTTP/async derivations.
- **"Bring Your Own Schema" feature card**: Zod / Standard Schema validation, replacing the softer "Zoneless Ready" card.
- **Trimmed**: removed the vanity stats section (and the npm/GitHub HTTP calls that fired on every load), compressed the 15-tile field-type grid into a chip row, removed the decorative JSON flow diagram.
- **Platform framing**: the config is presented as the single source of truth that you generate, store, render in any UI, and extend.

All code snippets were verified against the docs (`ai-integration.md`, `openapi-generator.md`, `dynamic-behavior/derivation/async.md`); doc links resolve to real routes.

## Verification

- axe-core (WCAG 2.0/2.1 A + AA): 0 violations, 30 passes.
- `nx build docs` on Node 24: passes ("Successfully ran target build for project docs and 22 tasks").
- Checked at 1440px and 390px.

Note: `nx build docs` needs `NODE_OPTIONS=--max-old-space-size=8192` to prerender all routes without an OOM.
