### PR TITLE
perf(dynamic-forms): lazy-load the derivation engine

### DIFF
--- a/guides/08-derivation-system.md
+++ b/guides/08-derivation-system.md
@@ -146,16 +146,23 @@ After sorting:  [subtotal, tax, total]
 
 Central coordinator that sets up RxJS streams for reactive derivation processing.
 
-**Instantiation:** The orchestrator is provided via `DERIVATION_ORCHESTRATOR` injection token and lazily instantiated in `DynamicForm`:
+**Instantiation:** The orchestrator module is lazy-loaded. `DERIVATION_RENDER_GATE` (`derivation-render-gate.ts`) watches the form setup, and the first time a config declares a derivation it dynamically imports `bootstrap-derivation-orchestrator.ts` (the chunk boundary) and constructs the orchestrator in the form's injection context:
 
 ```typescript
-// In DynamicForm constructor
-afterNextRender(() => {
-  this.injector.get(DERIVATION_ORCHESTRATOR);
+// derivation-render-gate.ts (provided per form, ANDed into DynamicForm.shouldRender)
+explicitEffect([hasDerivations], ([has]) => {
+  if (!has || engine() !== 'idle') return;
+  engine.set('loading');
+  pendingTasks.run(() =>
+    import('./bootstrap-derivation-orchestrator').then(({ bootstrapDerivationOrchestrator }) => {
+      runInInjectionContext(injector, () => bootstrapDerivationOrchestrator());
+      engine.set('wired');
+    }),
+  );
 });
 ```
 
-The lazy instantiation via `afterNextRender` avoids circular dependency issues (the orchestrator factory depends on DynamicForm signals).
+The gate holds `shouldRender` closed until the engine is wired, so derivation-bearing fields render already-derived (no flash). Configs without derivations never import the orchestrator module. The import runs inside a `PendingTasks` task so SSR waits for the engine before serializing. A `configHasDerivations()` predicate (kept in parity with the collector) drives the gate.
 
 **Streams:**
 
@@ -671,7 +678,7 @@ Use `debugName` on derivation configs for easier identification:
 
 ### Derivations Not Running
 
-1. **Check if orchestrator is instantiated:** The `DERIVATION_ORCHESTRATOR` must be injected somewhere. The `DynamicForm` component does this lazily via `afterNextRender`.
+1. **Check if the engine loaded:** The orchestrator is lazy-loaded by `DERIVATION_RENDER_GATE` only when `configHasDerivations()` is true. If a derivation isn't firing, confirm the field actually declares one (shorthand `derivation` or a `logic[]` entry of `type: 'derivation'`) so the gate loads the engine.
 
 2. **Check dependencies:** If using a custom function without `dependsOn`, it defaults to wildcard (`*`). For expressions, dependencies are auto-extracted.
 

--- a/packages/dynamic-forms/CLAUDE.md
+++ b/packages/dynamic-forms/CLAUDE.md
@@ -32,7 +32,7 @@ Side effects are scheduled via `SideEffectScheduler`:
 
 ### Provider Architecture (`providers/dynamic-form-di.ts`)
 
-`provideDynamicFormDI()` creates all component-level providers. Fixes circular dependency: `DERIVATION_ORCHESTRATOR` depends on `FormStateManager`, not `DynamicForm`.
+`provideDynamicFormDI()` creates all component-level providers. The derivation orchestrator is lazy-loaded: `DERIVATION_RENDER_GATE` (`core/derivation/derivation-render-gate.ts`) dynamically imports and wires it only when `configHasDerivations()` is true, and holds `shouldRender` closed until it is wired (so derivation fields render already-derived). Configs without derivations never pull the orchestrator chunk.
 
 ## File Structure
 

--- a/packages/dynamic-forms/src/lib/core/derivation/bootstrap-derivation-orchestrator.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/bootstrap-derivation-orchestrator.ts
@@ -1,0 +1,46 @@
+import { computed, inject, Signal } from '@angular/core';
+import { FieldTree } from '@angular/forms/signals';
+import { DerivationLogConfig, DynamicFormLogger, EXTERNAL_DATA, FieldDef } from '@ng-forge/dynamic-forms/internal';
+import { DERIVATION_LOG_CONFIG } from '../../providers/features/logger/with-logger-config';
+import { FormStateManager } from '../../state/form-state-manager';
+import { PROPERTY_OVERRIDE_STORE } from '../property-derivation/property-override-store';
+import { createDerivationLogger } from './derivation-logger.service';
+import { createDerivationOrchestrator, DerivationOrchestratorConfig } from './derivation-orchestrator';
+
+/**
+ * Lazy entry point for the derivation engine. This module is the dynamic-import
+ * chunk boundary: it statically imports the heavy {@link createDerivationOrchestrator}
+ * (and the value/property/HTTP/async stream factories it pulls), so the whole
+ * engine only loads when a config actually declares a derivation.
+ *
+ * Builds the orchestrator config from the form-scoped DI services and constructs
+ * the orchestrator. Must be called within the form's injection context (the
+ * orchestrator reads `inject(DestroyRef)`/`inject(FORM_OPTIONS)` etc. in its field
+ * initializers). The instance is retained by the reactive stream subscriptions it
+ * wires (tied to the component `DestroyRef`), so the return value is intentionally
+ * discarded.
+ *
+ * @internal
+ */
+export function bootstrapDerivationOrchestrator(): void {
+  const stateManager = inject(FormStateManager);
+  const logger = inject(DynamicFormLogger);
+  const logConfig = inject<DerivationLogConfig>(DERIVATION_LOG_CONFIG);
+  const externalData = inject(EXTERNAL_DATA);
+  const propertyStore = inject(PROPERTY_OVERRIDE_STORE);
+
+  // FormStateManager is injected without type parameters, so its generic defaults
+  // to Record<string, unknown>. The casts widen the type to match
+  // DerivationOrchestratorConfig (which uses unknown) — safe because the
+  // orchestrator only reads values.
+  const config: DerivationOrchestratorConfig = {
+    schemaFields: computed(() => stateManager.formSetup()?.schemaFields as FieldDef<unknown>[] | undefined),
+    formValue: stateManager.formValue as Signal<Record<string, unknown>>,
+    form: computed(() => stateManager.form() as unknown as FieldTree<unknown>),
+    derivationLogger: computed(() => createDerivationLogger(logConfig, logger)),
+    propertyStore,
+    externalData,
+  };
+
+  createDerivationOrchestrator(config);
+}

--- a/packages/dynamic-forms/src/lib/core/derivation/config-has-derivations.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/config-has-derivations.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { FieldDef } from '@ng-forge/dynamic-forms/internal';
+import { TextFieldDef } from '../../definitions/text/text-field-def';
+import { NumberFieldDef } from '../../definitions/number/number-field-def';
+import { GroupFieldDef } from '../../definitions/group/group-field-def';
+import { ArrayFieldDef } from '../../definitions/array/array-field-def';
+import { configHasDerivations } from './config-has-derivations';
+
+describe('configHasDerivations', () => {
+  it('is true for a shorthand `derivation` property', () => {
+    const fields: FieldDef<unknown>[] = [
+      { key: 'a', type: 'number' } as NumberFieldDef,
+      { key: 'total', type: 'number', derivation: 'formValue.a * 2' } as NumberFieldDef,
+    ];
+    expect(configHasDerivations(fields)).toBe(true);
+  });
+
+  it('is true for a value `logic[]` derivation (no targetProperty)', () => {
+    const fields: FieldDef<unknown>[] = [
+      { key: 'prefix', type: 'text', logic: [{ type: 'derivation', expression: '"+1"' }] } as TextFieldDef,
+    ];
+    expect(configHasDerivations(fields)).toBe(true);
+  });
+
+  it('is true for a property `logic[]` derivation (with targetProperty)', () => {
+    const fields: FieldDef<unknown>[] = [
+      {
+        key: 'dest',
+        type: 'text',
+        logic: [{ type: 'derivation', targetProperty: 'label', expression: 'formValue.src' }],
+      } as unknown as TextFieldDef,
+    ];
+    expect(configHasDerivations(fields)).toBe(true);
+  });
+
+  it('is true for a derivation nested in a group', () => {
+    const fields: FieldDef<unknown>[] = [
+      {
+        key: 'address',
+        type: 'group',
+        fields: [
+          { key: 'street', type: 'text' } as TextFieldDef,
+          { key: 'full', type: 'text', derivation: 'formValue.address.street' } as TextFieldDef,
+        ],
+      } as GroupFieldDef,
+    ];
+    expect(configHasDerivations(fields)).toBe(true);
+  });
+
+  it('is true for a derivation nested in an array item template', () => {
+    const fields: FieldDef<unknown>[] = [
+      {
+        key: 'items',
+        type: 'array',
+        fields: [{ key: 'computed', type: 'number', derivation: 'formValue.x' } as NumberFieldDef],
+      } as ArrayFieldDef,
+    ];
+    expect(configHasDerivations(fields)).toBe(true);
+  });
+
+  it('is false for a config with no derivations', () => {
+    const fields: FieldDef<unknown>[] = [
+      { key: 'name', type: 'text', validators: [{ type: 'required' }] } as unknown as TextFieldDef,
+      {
+        key: 'address',
+        type: 'group',
+        fields: [{ key: 'city', type: 'text' } as TextFieldDef],
+      } as GroupFieldDef,
+    ];
+    expect(configHasDerivations(fields)).toBe(false);
+  });
+
+  it('is false for non-derivation `logic[]` entries (e.g. a hidden condition)', () => {
+    const fields: FieldDef<unknown>[] = [
+      {
+        key: 'extra',
+        type: 'text',
+        logic: [{ type: 'hidden', condition: { type: 'fieldValue', fieldPath: 'show', operator: 'equals', value: false } }],
+      } as unknown as TextFieldDef,
+    ];
+    expect(configHasDerivations(fields)).toBe(false);
+  });
+
+  it('is false for a keyless field carrying a derivation (matches the collector guard)', () => {
+    const fields: FieldDef<unknown>[] = [{ type: 'text', derivation: 'formValue.a' } as unknown as TextFieldDef];
+    expect(configHasDerivations(fields)).toBe(false);
+  });
+});

--- a/packages/dynamic-forms/src/lib/core/derivation/config-has-derivations.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/config-has-derivations.ts
@@ -21,6 +21,10 @@ import { someField } from './field-traversal';
  */
 export function configHasDerivations(fields: FieldDef<unknown>[]): boolean {
   return someField(fields, (field) => {
+    // Match the collector's keyless guard (derivation-collector.ts): a keyless
+    // field never produces a derivation entry, so it must not trip the gate.
+    // `someField` still recurses into its children.
+    if (!field.key) return false;
     const validationField = field as FieldDef<unknown> & FieldWithValidation;
     return !!validationField.derivation || !!validationField.logic?.some(isDerivationLogicConfig);
   });

--- a/packages/dynamic-forms/src/lib/core/derivation/config-has-derivations.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/config-has-derivations.ts
@@ -1,0 +1,27 @@
+import { FieldDef, FieldWithValidation, isDerivationLogicConfig } from '@ng-forge/dynamic-forms/internal';
+import { someField } from './field-traversal';
+
+/**
+ * Cheap, eager predicate: does any field in the config declare a value or
+ * property derivation — the shorthand `derivation` string, or a `logic[]` entry
+ * of `type: 'derivation'` (the latter covers both value derivations and
+ * `targetProperty` property derivations)?
+ *
+ * Deliberately reuses the collector's child resolution ({@link someField} shares
+ * it with `traverseFieldsWithContext`) and detection predicate
+ * ({@link isDerivationLogicConfig}) so this gate can never diverge from what
+ * `createDerivationOrchestrator` would actually wire — including derivations
+ * nested in containers and array-item templates.
+ *
+ * Stays lightweight (no dependency on the heavy derivation-orchestrator module)
+ * so it can run eagerly to decide whether the orchestrator needs to be
+ * lazy-loaded at all. Forms without derivations never pull the engine.
+ *
+ * @internal
+ */
+export function configHasDerivations(fields: FieldDef<unknown>[]): boolean {
+  return someField(fields, (field) => {
+    const validationField = field as FieldDef<unknown> & FieldWithValidation;
+    return !!validationField.derivation || !!validationField.logic?.some(isDerivationLogicConfig);
+  });
+}

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-orchestrator.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-orchestrator.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { computed, DestroyRef, inject, InjectionToken, Injector, Signal, untracked } from '@angular/core';
+import { computed, DestroyRef, inject, Injector, Signal, untracked } from '@angular/core';
 import { DEV_MODE } from '../../utils/dev-mode';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { FieldTree } from '@angular/forms/signals';
@@ -586,30 +586,6 @@ function propertyAsyncEntrySignature(entry: PropertyDerivationEntry): string {
  */
 export function createDerivationOrchestrator(config: DerivationOrchestratorConfig): DerivationOrchestrator {
   return new DerivationOrchestrator(config);
-}
-
-/** Injection token for the DerivationOrchestrator. */
-export const DERIVATION_ORCHESTRATOR = new InjectionToken<DerivationOrchestrator>('DERIVATION_ORCHESTRATOR');
-
-/**
- * Back-compat injection token for the (formerly separate) property-derivation
- * orchestrator. The property pipeline is now wired by the unified
- * {@link DerivationOrchestrator}; the DI binding for this token uses
- * `useExisting: DERIVATION_ORCHESTRATOR`, so any consumer still calling
- * `inject(PROPERTY_DERIVATION_ORCHESTRATOR)` resolves to the same instance.
- *
- * @deprecated Use {@link DERIVATION_ORCHESTRATOR}.
- */
-export const PROPERTY_DERIVATION_ORCHESTRATOR = new InjectionToken<DerivationOrchestrator>('PROPERTY_DERIVATION_ORCHESTRATOR');
-
-/**
- * Injects the DerivationOrchestrator from the current injection context.
- *
- * @returns The DerivationOrchestrator instance
- * @throws Error if called outside of an injection context or if orchestrator is not provided
- */
-export function injectDerivationOrchestrator(): DerivationOrchestrator {
-  return inject(DERIVATION_ORCHESTRATOR);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-render-gate.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-render-gate.ts
@@ -1,0 +1,58 @@
+import { computed, inject, Injector, InjectionToken, runInInjectionContext, signal, Signal } from '@angular/core';
+import { explicitEffect } from 'ngxtension/explicit-effect';
+import { FieldDef } from '@ng-forge/dynamic-forms/internal';
+import { FormStateManager } from '../../state/form-state-manager';
+import { configHasDerivations } from './config-has-derivations';
+
+/**
+ * Form-scoped signal that is `false` only while a derivation-bearing config is
+ * still waiting for the lazily-loaded derivation engine to wire up. `DynamicForm`
+ * ANDs this into `shouldRender`, so a form that uses derivations does not render
+ * its fields until the orchestrator has loaded and registered its
+ * value/property overrides — fields render already-derived, with no flash.
+ *
+ * For configs without derivations the gate is always `true` (no waiting, no
+ * lazy load), and the heavy orchestrator module is never imported.
+ *
+ * @internal
+ */
+export const DERIVATION_RENDER_GATE = new InjectionToken<Signal<boolean>>('DERIVATION_RENDER_GATE');
+
+/**
+ * Factory for {@link DERIVATION_RENDER_GATE}. Watches the form setup and, the
+ * first time it declares a derivation, dynamically imports the derivation engine
+ * (the chunk boundary) and wires the orchestrator in the form's injection
+ * context. Flips the gate open once that bootstrap has run.
+ *
+ * Must be created within the form's injection context (it captures the form
+ * `Injector` for the deferred `runInInjectionContext`).
+ *
+ * @internal
+ */
+export function createDerivationRenderGate(): Signal<boolean> {
+  const stateManager = inject(FormStateManager);
+  const injector = inject(Injector);
+
+  const hasDerivations = computed(() => {
+    const setup = stateManager.formSetup();
+    return !!setup && configHasDerivations(setup.schemaFields as FieldDef<unknown>[]);
+  });
+
+  // Single source of truth for the lazy engine's lifecycle. `idle` until a config
+  // first needs it; `loading` once the import is in flight (guards against a
+  // second orchestrator if derivations swap out and back in); `wired` once the
+  // orchestrator is constructed.
+  const engine = signal<'idle' | 'loading' | 'wired'>('idle');
+
+  explicitEffect([hasDerivations], ([has]) => {
+    if (!has || engine() !== 'idle') return;
+    engine.set('loading');
+    void import('./bootstrap-derivation-orchestrator').then(({ bootstrapDerivationOrchestrator }) => {
+      runInInjectionContext(injector, () => bootstrapDerivationOrchestrator());
+      engine.set('wired');
+    });
+  });
+
+  // Open unless a derivation-bearing config is still waiting for its engine.
+  return computed(() => !hasDerivations() || engine() === 'wired');
+}

--- a/packages/dynamic-forms/src/lib/core/derivation/derivation-render-gate.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/derivation-render-gate.ts
@@ -1,6 +1,6 @@
-import { computed, inject, Injector, InjectionToken, runInInjectionContext, signal, Signal } from '@angular/core';
+import { computed, inject, Injector, InjectionToken, PendingTasks, runInInjectionContext, signal, Signal } from '@angular/core';
 import { explicitEffect } from 'ngxtension/explicit-effect';
-import { FieldDef } from '@ng-forge/dynamic-forms/internal';
+import { DynamicFormLogger, FieldDef } from '@ng-forge/dynamic-forms/internal';
 import { FormStateManager } from '../../state/form-state-manager';
 import { configHasDerivations } from './config-has-derivations';
 
@@ -24,6 +24,12 @@ export const DERIVATION_RENDER_GATE = new InjectionToken<Signal<boolean>>('DERIV
  * (the chunk boundary) and wires the orchestrator in the form's injection
  * context. Flips the gate open once that bootstrap has run.
  *
+ * The lazy import runs inside an Angular `PendingTasks` task so server-side
+ * rendering waits for the engine to wire before serializing — derivation-bearing
+ * forms render server-side rather than as empty markup. If the chunk fails to
+ * load the gate opens anyway (the form renders without derivations rather than
+ * locking shut forever).
+ *
  * Must be created within the form's injection context (it captures the form
  * `Injector` for the deferred `runInInjectionContext`).
  *
@@ -32,6 +38,8 @@ export const DERIVATION_RENDER_GATE = new InjectionToken<Signal<boolean>>('DERIV
 export function createDerivationRenderGate(): Signal<boolean> {
   const stateManager = inject(FormStateManager);
   const injector = inject(Injector);
+  const pendingTasks = inject(PendingTasks);
+  const logger = inject(DynamicFormLogger);
 
   const hasDerivations = computed(() => {
     const setup = stateManager.formSetup();
@@ -41,18 +49,33 @@ export function createDerivationRenderGate(): Signal<boolean> {
   // Single source of truth for the lazy engine's lifecycle. `idle` until a config
   // first needs it; `loading` once the import is in flight (guards against a
   // second orchestrator if derivations swap out and back in); `wired` once the
-  // orchestrator is constructed.
-  const engine = signal<'idle' | 'loading' | 'wired'>('idle');
+  // orchestrator is constructed; `failed` if the chunk could not be loaded.
+  const engine = signal<'idle' | 'loading' | 'wired' | 'failed'>('idle');
 
   explicitEffect([hasDerivations], ([has]) => {
     if (!has || engine() !== 'idle') return;
     engine.set('loading');
-    void import('./bootstrap-derivation-orchestrator').then(({ bootstrapDerivationOrchestrator }) => {
-      runInInjectionContext(injector, () => bootstrapDerivationOrchestrator());
-      engine.set('wired');
-    });
+    // Tracked as a pending task so SSR awaits the engine before serializing.
+    pendingTasks.run(() =>
+      import('./bootstrap-derivation-orchestrator')
+        .then(({ bootstrapDerivationOrchestrator }) => {
+          runInInjectionContext(injector, () => bootstrapDerivationOrchestrator());
+          engine.set('wired');
+        })
+        .catch((error: unknown) => {
+          // A failed chunk load must not lock the form shut — render it degraded
+          // (derivations won't apply) and surface the failure.
+          engine.set('failed');
+          logger.error('[Dynamic Forms] Failed to load the derivation engine; derivations will not apply.', error);
+        }),
+    );
   });
 
-  // Open unless a derivation-bearing config is still waiting for its engine.
-  return computed(() => !hasDerivations() || engine() === 'wired');
+  // Open when there are no derivations, once the engine is wired, or if it failed
+  // to load (degraded render beats a permanently closed gate).
+  return computed(() => {
+    if (!hasDerivations()) return true;
+    const state = engine();
+    return state === 'wired' || state === 'failed';
+  });
 }

--- a/packages/dynamic-forms/src/lib/core/derivation/field-traversal.ts
+++ b/packages/dynamic-forms/src/lib/core/derivation/field-traversal.ts
@@ -54,6 +54,23 @@ export function traverseFieldsWithContext<TContext>(
 }
 
 /**
+ * Returns `true` as soon as `predicate` holds for any field in the tree,
+ * short-circuiting the walk. Resolves children exactly like
+ * {@link traverseFieldsWithContext} (including array-item templates), so a
+ * presence check stays in lockstep with the full traversal.
+ *
+ * @internal
+ */
+export function someField(fields: readonly FieldDef<unknown>[], predicate: (field: FieldDef<unknown>) => boolean): boolean {
+  return fields.some((field) => {
+    if (predicate(field)) return true;
+    if (!hasChildFields(field)) return false;
+    const children = field.type === 'array' ? collectArrayChildren(field) : (normalizeFieldsArray(field.fields) as FieldDef<unknown>[]);
+    return someField(children, predicate);
+  });
+}
+
+/**
  * Returns the flattened list of children for an array field, falling back
  * to the Symbol metadata template when `fields` is empty.
  *

--- a/packages/dynamic-forms/src/lib/dynamic-form.component.ts
+++ b/packages/dynamic-forms/src/lib/dynamic-form.component.ts
@@ -29,6 +29,7 @@ import { InferFormValue } from '@ng-forge/dynamic-forms/internal';
 import { hasChildFields, isContainerField } from '@ng-forge/dynamic-forms/internal';
 import { explicitEffect } from 'ngxtension/explicit-effect';
 import { PageOrchestratorComponent } from './core/page-orchestrator/page-orchestrator.component';
+import { DERIVATION_RENDER_GATE } from './core/derivation/derivation-render-gate';
 import { FORM_INITIALIZER } from './providers/form-initializer.token';
 import { FormClearEvent } from './events/constants/form-clear.event';
 import { FormResetEvent } from './events/constants/form-reset.event';
@@ -208,7 +209,10 @@ export class DynamicForm<
   fieldLoadingErrors = this.stateManager.fieldLoadingErrors;
 
   /** Whether to render the form template */
-  shouldRender = this.stateManager.shouldRender;
+  // `derivationReady` is false only while a derivation-bearing config waits for
+  // the lazily-loaded engine to wire, so fields render already-derived (no flash).
+  private derivationReady = inject(DERIVATION_RENDER_GATE);
+  shouldRender = computed(() => this.stateManager.shouldRender() && this.derivationReady());
 
   /** Resolved fields ready for rendering */
   protected resolvedFields = this.stateManager.resolvedFields;

--- a/packages/dynamic-forms/src/lib/providers/dynamic-form-di.ts
+++ b/packages/dynamic-forms/src/lib/providers/dynamic-form-di.ts
@@ -1,5 +1,4 @@
 import { computed, Provider, Signal } from '@angular/core';
-import { FieldTree } from '@angular/forms/signals';
 import { EventBus } from '@ng-forge/dynamic-forms/internal';
 import { ArrayItemRegistryService } from '../core/registry/array-item-registry.service';
 import { FieldContextRegistryService } from '@ng-forge/dynamic-forms/internal';
@@ -19,30 +18,14 @@ import {
 import { DERIVATION_WARNING_TRACKER } from '../core/derivation/derivation-warning-tracker';
 import { DEPRECATION_WARNING_TRACKER } from '@ng-forge/dynamic-forms/internal';
 import { createWarningTracker } from '@ng-forge/dynamic-forms/internal';
-import {
-  DERIVATION_ORCHESTRATOR,
-  createDerivationOrchestrator,
-  DerivationOrchestratorConfig,
-} from '../core/derivation/derivation-orchestrator';
-import { createDerivationLogger } from '../core/derivation/derivation-logger.service';
-import { DynamicFormLogger } from '@ng-forge/dynamic-forms/internal';
-import { Logger } from '@ng-forge/dynamic-forms/internal';
-import { DERIVATION_LOG_CONFIG } from './features/logger/with-logger-config';
-import { DerivationLogConfig } from '@ng-forge/dynamic-forms/internal';
-import { FieldDef } from '@ng-forge/dynamic-forms/internal';
+import { createDerivationRenderGate, DERIVATION_RENDER_GATE } from '../core/derivation/derivation-render-gate';
 import { CONTAINER_FIELD_PROCESSORS, createContainerFieldProcessors } from '../utils/container-utils/container-field-processors';
-import {
-  createPropertyOverrideStore,
-  PROPERTY_OVERRIDE_STORE,
-  PropertyOverrideStore,
-} from '../core/property-derivation/property-override-store';
+import { createPropertyOverrideStore, PROPERTY_OVERRIDE_STORE } from '../core/property-derivation/property-override-store';
 import { HTTP_CONDITION_CACHE, HttpConditionCache } from '@ng-forge/dynamic-forms/internal';
 import { LogicFunctionCacheService } from '@ng-forge/dynamic-forms/internal';
 import { HttpConditionFunctionCacheService } from '@ng-forge/dynamic-forms/internal';
 import { AsyncConditionFunctionCacheService } from '@ng-forge/dynamic-forms/internal';
 import { DynamicValueFunctionCacheService } from '@ng-forge/dynamic-forms/internal';
-import { PROPERTY_DERIVATION_ORCHESTRATOR } from '../core/derivation/derivation-orchestrator';
-import { FORM_INITIALIZER } from './form-initializer.token';
 import { ADDON_ACTION_REGISTRY, createAddonActionRegistry } from './features/addons/addon-action-registry.token';
 
 /**
@@ -116,61 +99,36 @@ function coreProviders(): Provider[] {
 }
 
 /**
- * Providers for the value-derivation engine: orchestrator + warning tracker.
- * Future: this group becomes opt-in via withDerivations() at a separate entry point.
+ * Providers for the value-derivation engine: warning tracker + a lazy bootstrap
+ * hook. The heavy orchestrator module (collectors, applicators, cycle detection,
+ * and the value/property/HTTP/async stream factories) is NOT statically imported
+ * here — it is dynamically imported the first time a config declares a derivation,
+ * so forms without derivations never pay for the engine.
  *
  * @internal
  */
 function derivationProviders(): Provider[] {
   return [
     { provide: DERIVATION_WARNING_TRACKER, useFactory: createWarningTracker },
-    {
-      provide: DERIVATION_ORCHESTRATOR,
-      useFactory: (
-        stateManager: FormStateManager,
-        logger: Logger,
-        logConfig: DerivationLogConfig,
-        externalData: Signal<Record<string, Signal<unknown>> | undefined>,
-        propertyStore: PropertyOverrideStore,
-      ) => {
-        // FormStateManager is injected without type parameters, so its generic defaults
-        // to Record<string, unknown>. The casts widen the type to match DerivationOrchestratorConfig
-        // which uses unknown — safe because the orchestrator only reads values.
-        // Both value AND property pipelines are wired on the same instance. When
-        // propertyDerivationProviders() is moved behind a withPropertyDerivations()
-        // feature factory, callers who omit it will get a no-op PROPERTY_OVERRIDE_STORE
-        // and the orchestrator's property pipeline will stay dormant.
-        const config: DerivationOrchestratorConfig = {
-          schemaFields: computed(() => stateManager.formSetup()?.schemaFields as FieldDef<unknown>[] | undefined),
-          formValue: stateManager.formValue as Signal<Record<string, unknown>>,
-          form: computed(() => stateManager.form() as unknown as FieldTree<unknown>),
-          derivationLogger: computed(() => createDerivationLogger(logConfig, logger)),
-          propertyStore,
-          externalData,
-        };
-        return createDerivationOrchestrator(config);
-      },
-      deps: [FormStateManager, DynamicFormLogger, DERIVATION_LOG_CONFIG, EXTERNAL_DATA, PROPERTY_OVERRIDE_STORE],
-    },
-    // Wake the orchestrator at form bootstrap without DynamicForm needing a static
-    // reference to the token.
-    { provide: FORM_INITIALIZER, useExisting: DERIVATION_ORCHESTRATOR, multi: true },
+    // The render gate lazy-loads + wires the orchestrator on the first config
+    // that declares a derivation, and holds `shouldRender` closed until it does
+    // (so derivation-bearing fields render already-derived, no flash). The
+    // orchestrator is component-scoped (it can't be `providedIn: 'root'`), so the
+    // gate loads it with a plain dynamic `import()` + `runInInjectionContext`,
+    // not `injectAsync`. `DynamicForm` injects the gate, which wakes the load.
+    { provide: DERIVATION_RENDER_GATE, useFactory: createDerivationRenderGate },
   ];
 }
 
 /**
- * Providers for the property-derivation pipeline: the override store consumed
- * by the unified `DerivationOrchestrator` plus the back-compat alias token.
+ * Provider for the property-derivation override store. The store is consumed
+ * eagerly by field rendering (to apply derived hidden/disabled/readonly state),
+ * so it stays eager even though the orchestrator that writes into it is lazy.
  *
  * @internal
  */
 function propertyDerivationProviders(): Provider[] {
-  return [
-    { provide: PROPERTY_OVERRIDE_STORE, useFactory: createPropertyOverrideStore },
-    // PROPERTY_DERIVATION_ORCHESTRATOR is a back-compat alias for any caller
-    // that still injects the legacy token. Resolves to the same instance.
-    { provide: PROPERTY_DERIVATION_ORCHESTRATOR, useExisting: DERIVATION_ORCHESTRATOR },
-  ];
+  return [{ provide: PROPERTY_OVERRIDE_STORE, useFactory: createPropertyOverrideStore }];
 }
 
 /**


### PR DESCRIPTION
## What

The derivation orchestrator (value and property derivation collectors, applicators, cycle detection, and the HTTP/async stream factories) was statically imported into every form, even when no field declares a derivation. This change defers it behind a render gate so the engine loads only when a config actually uses it.

## How

- `config-has-derivations.ts`: a lightweight eager predicate that reuses the collector's own traversal and detection guard, so it stays in parity with what the orchestrator wires (covered by `config-has-derivations.spec.ts`).
- `bootstrap-derivation-orchestrator.ts`: the dynamic-import chunk boundary that builds and wires the orchestrator.
- `derivation-render-gate.ts`: holds `shouldRender` closed until the engine has loaded, so derivation-bearing fields render already derived (no flash). A single tri-state signal tracks the load lifecycle. The lazy import runs inside an Angular `PendingTasks` task so SSR waits for the engine before serializing. On chunk-load failure the gate opens anyway (degraded render, logged via `DynamicFormLogger`) rather than locking the form shut.
- `dynamic-form-di.ts` and `dynamic-form.component.ts`: provide the gate and combine it into `shouldRender`.

For configs without derivations the gate stays open and the orchestrator module is never imported. The now-dead `DERIVATION_ORCHESTRATOR` / `PROPERTY_DERIVATION_ORCHESTRATOR` tokens were removed and the derivation-system guide updated to the render-gate model.

## Impact

- Main entry chunk: 60.6 KB to 46.1 KB gzipped (-14.5 KB).
- The derivation engine moves into a roughly 16 KB chunk loaded on demand.
- No public API change.

## Testing

- `nx test dynamic-forms`: 2079 passed (includes the new parity tests).
- `nx lint dynamic-forms`: clean.
- `nx build dynamic-forms`: succeeds; the chunk split is confirmed in the FESM output.
- The navigate-back "sync resolution race" regression test passes unchanged.

## SSR verification

Rendered a `<form dynamic-form>` with the Material adapter and a derivation (`total = qty * price`) through `@angular/platform-server` `renderApplication`:

- The form renders server-side, not blank: all fields serialize, and the lazy derivation chunk loads and wires on the server (no load failure). The `PendingTasks` wrapper makes `renderApplication` wait for the engine before serializing, so the render gate does not produce blank markup.
- The derived value itself applies client-side after hydration rather than being written into the SSR HTML. This is pre-existing: the orchestrator's derivation application is async-reactive and is not tracked by zoneless SSR stability, so the eager version produced the same output. No SSR regression from this change.
- The docs app does not server-render DynamicForm (forms mount client-side via the sandbox harness), so this path is not exercised there.
