### PR TITLE
ci: support an rc prerelease channel in the release pipeline

### DIFF
--- a/.github/workflows/discord-release-notify.yml
+++ b/.github/workflows/discord-release-notify.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag to post (e.g. v0.8.0 or next/0.8.1-next.5). Fired automatically by release.yml on successful publish; can also be invoked manually to re-post.'
+        description: 'Release tag to post (e.g. v0.8.0, next/0.8.1-next.5, v1.0.0-rc.1, or rc/1.0.0-rc.2). Fired automatically by release.yml on successful publish; can also be invoked manually to re-post.'
         required: true
         type: string
 
@@ -57,6 +57,14 @@ jobs:
           RELEASE_NAME=$(echo "$META" | jq -r '.name // .tagName')
           RELEASE_URL=$(echo "$META" | jq -r '.url')
           IS_PRERELEASE=$(echo "$META" | jq -r '.isPrerelease')
+
+          # Install dist-tag inferred from the tag name: rc releases (vX.Y.Z-rc.N or
+          # rc/X.Y.Z-rc.N) install via @rc; nightly releases via @next.
+          case "$(echo "$META" | jq -r '.tagName')" in
+            *-rc.*) INSTALL_TAG="rc" ;;
+            *)      INSTALL_TAG="next" ;;
+          esac
+
           BODY=$(echo "$META" | jq -r '.body // empty')
           BODY="${BODY:-_No release notes provided._}"
 
@@ -72,6 +80,7 @@ jobs:
               --arg title "🌙 ${RELEASE_NAME}" \
               --arg url "$RELEASE_URL" \
               --arg description "$BODY" \
+              --arg install "$INSTALL_TAG" \
               '{
                 embeds: [{
                   title: $title,
@@ -80,7 +89,7 @@ jobs:
                   color: 15844367,
                   fields: [{
                     name: "Install",
-                    value: "```bash\npnpm add @ng-forge/dynamic-forms@next\n```"
+                    value: ("```bash\npnpm add @ng-forge/dynamic-forms@" + $install + "\n```")
                   }],
                   timestamp: now | todateiso8601
                 }]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,16 @@ on:
           - dry-run # stable path, no npm publish (dry-run only)
           - publish # stable path, real publish to @latest + tag + GH release
           - next # manual invocation of the @next path — same code as the scheduled run
+      target:
+        # Starts (or re-targets) an rc cycle as a prerelease CHANNEL off main — no release
+        # branch. One dispatch with mode=next + target=1.0.0 publishes 1.0.0-rc.1 to @rc;
+        # every nightly after that auto-continues (rc.2, rc.3, …) by detecting the rc tag,
+        # with no input needed. The cycle closes when the stable v1.0.0 ships. Ignored
+        # unless mode=next; leave empty for ordinary @next nightlies.
+        description: 'rc target version, e.g. 1.0.0 (mode=next only; leave empty for normal nightlies)'
+        required: false
+        type: string
+        default: ''
   schedule:
     - cron: '27 1 * * *' # 01:27 UTC daily (~04:27 EEST) — after the late-night commit window, off the hour to avoid GH Actions cron stampede
 
@@ -138,6 +148,9 @@ jobs:
       - name: Detect relevant changes & compute version
         id: gate
         shell: bash
+        env:
+          # Explicit rc target from a `mode=next` dispatch; empty on scheduled runs.
+          RC_TARGET_INPUT: ${{ inputs.target }}
         run: |
           set -euo pipefail
 
@@ -151,23 +164,29 @@ jobs:
             exit 0
           fi
 
-          # Detect an active RC cycle. An RC is "active" once vX.Y.Z-rc.N has been cut
-          # (human release via the stable path) and the final vX.Y.Z hasn't shipped yet.
-          # During an active RC, nightlies follow the rc format (X.Y.Z-rc.{N+1}) under the
-          # @rc dist-tag instead of the usual {nextMinor}.0-next.N under @next.
-          LAST_RC_TAG=$(git tag --list 'v[0-9]*-rc.*' --sort=-v:refname | head -1 || true)
-          RC_ACTIVE=""
-          if [ -n "$LAST_RC_TAG" ]; then
-            RC_BASE=${LAST_RC_TAG#v}; RC_BASE=${RC_BASE%%-rc.*}   # v1.0.0-rc.1 -> 1.0.0
-            if git rev-parse -q --verify "refs/tags/v${RC_BASE}^{}" >/dev/null 2>&1; then
-              echo "Final v${RC_BASE} already tagged — RC cycle is closed"
+          # RC cycle = a prerelease CHANNEL off main, no release branch. It is "active"
+          # either because this run explicitly bootstraps/re-targets it (mode=next with
+          # target=X.Y.Z) or because a prior rc tag exists whose final vX.Y.Z hasn't
+          # shipped — letting scheduled nightlies auto-continue rc.2, rc.3, … with no input.
+          # All rc versions we've ever tagged (manual v…-rc.N OR nightly rc/…), normalized
+          # to bare versions and version-sorted; the last is the most recent rc.
+          LATEST_RC=$(git tag --list 'v[0-9]*-rc.*' 'rc/[0-9]*-rc.*' \
+            | sed -e 's#^rc/##' -e 's#^v##' | sort -V | tail -1 || true)
+
+          RC_TARGET=""
+          if [ -n "${RC_TARGET_INPUT:-}" ]; then
+            RC_TARGET="$RC_TARGET_INPUT"               # explicit bootstrap / re-target
+          elif [ -n "$LATEST_RC" ]; then
+            CAND=${LATEST_RC%%-rc.*}                    # 1.0.0-rc.2 -> 1.0.0
+            if git rev-parse -q --verify "refs/tags/v${CAND}^{}" >/dev/null 2>&1; then
+              echo "Final v${CAND} already tagged — RC cycle is closed"
             else
-              RC_ACTIVE=1
+              RC_TARGET="$CAND"                         # auto-continue the open rc cycle
             fi
           fi
 
-          if [ -n "$RC_ACTIVE" ]; then
-            TARGET="$RC_BASE"; LABEL="rc"; DIST_TAG="rc"; TAG_NS="rc"
+          if [ -n "$RC_TARGET" ]; then
+            TARGET="$RC_TARGET"; LABEL="rc"; DIST_TAG="rc"; TAG_NS="rc"
           else
             LAST_VERSION=${LAST_STABLE#v}
             # @next always signals the upcoming minor, regardless of whether the next
@@ -191,7 +210,7 @@ jobs:
                      'refs/tags/v[0-9]*' 'refs/tags/next/*' 'refs/tags/rc/*')
           [ -z "$BASE" ] && BASE="$LAST_STABLE"
 
-          echo "Last stable: ${LAST_STABLE:-none}; last rc: ${LAST_RC_TAG:-none} (active: ${RC_ACTIVE:-no}); target: ${TARGET}-${LABEL}; gate base: $BASE"
+          echo "Last stable: ${LAST_STABLE:-none}; latest rc: ${LATEST_RC:-none}; target: ${TARGET}-${LABEL} (dist-tag: ${DIST_TAG}); gate base: $BASE"
 
           # Bump-worthy commit types per nx.json release.conventionalCommits:
           # feat, fix, perf, revert. Everything else (docs/ci/chore/test/build/style/refactor)
@@ -219,7 +238,11 @@ jobs:
 
           echo "Bump-worthy commits touching packages/ since $BASE: $RELEVANT"
 
-          if [ "$RELEVANT" -eq 0 ]; then
+          # An explicit rc bootstrap (mode=next + target=…) publishes rc.1 on demand even
+          # with no new commits — the human decision to enter the rc channel is the trigger.
+          # Auto-continue crons (no input) still require bump-worthy commits, so an idle
+          # rc cycle doesn't churn out empty rc.N every night.
+          if [ "$RELEVANT" -eq 0 ] && [ -z "${RC_TARGET_INPUT:-}" ]; then
             echo "No bump-worthy commits since last release — skipping next release"
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -232,8 +255,8 @@ jobs:
 
           # Monotonic counter per (target, label): TARGET.0-next.N normally, or
           # TARGET-rc.N during an active RC cycle (where TARGET already carries the rc's
-          # M.m.p, e.g. 1.0.0). The RC counter naturally continues past the human-cut
-          # rc.1 because that version is on npm too.
+          # M.m.p, e.g. 1.0.0). The bootstrap run finds no rc on npm yet → rc.1; every
+          # nightly after reads the published rc.N and continues rc.{N+1}.
           # Query *every* library package and take the max — if one package failed to
           # publish on a prior run the others advanced, and we must not collide with the
           # highest existing counter anywhere. Commit traceability stays recoverable via

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,6 +175,13 @@ jobs:
 
           RC_TARGET=""
           if [ -n "${RC_TARGET_INPUT:-}" ]; then
+            # Must be a bare M.m.p (no leading v, no suffix) — it becomes the rc base.
+            # A bootstrap bypasses the commit gate and goes straight to publish, so reject
+            # a typo here rather than failing opaquely later at `nx release version`.
+            if ! [[ "$RC_TARGET_INPUT" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Invalid rc target '$RC_TARGET_INPUT' — expected bare M.m.p (e.g. 1.0.0)"
+              exit 1
+            fi
             RC_TARGET="$RC_TARGET_INPUT"               # explicit bootstrap / re-target
           elif [ -n "$LATEST_RC" ]; then
             CAND=${LATEST_RC%%-rc.*}                    # 1.0.0-rc.2 -> 1.0.0
@@ -494,7 +501,10 @@ jobs:
         # runner, so ordering before publish is fine. Earlier placement also means
         # `RELEASE_NOTES.md` is ready when the GitHub Release step runs below.
         run: |
-          PREV_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*next*' --exclude '*nightly*' 2>/dev/null || echo "")
+          # `*-*` excludes every prerelease (matches the gate's LAST_STABLE), so a stable
+          # changelog spans since the last STABLE — never truncated to since-last-rc even
+          # if a v…-rc.… tag was ever cut via the prerelease safety-net path.
+          PREV_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*-*' 2>/dev/null || echo "")
 
           if [ -z "$PREV_TAG" ]; then
             CHANGELOG=$(git log --pretty=format:"- %s (%h)" --no-merges -50)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,10 @@ jobs:
       version: ${{ steps.gate.outputs.version }}
       sha: ${{ steps.gate.outputs.sha }}
       base: ${{ steps.gate.outputs.base }}
+      # 'next' normally, 'rc' during an active RC cycle. Drives the npm dist-tag and the
+      # git tag namespace (next/… vs rc/…) for the nightly publish.
+      dist_tag: ${{ steps.gate.outputs.dist_tag }}
+      tag_ns: ${{ steps.gate.outputs.tag_ns }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -137,7 +141,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          LAST_STABLE=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*next*' --exclude '*nightly*' 2>/dev/null || echo "")
+          # True stable only: `*-*` excludes every prerelease (-next, -nightly, -rc, …),
+          # so an in-flight RC tag (v1.0.0-rc.1) is NOT mistaken for the last stable.
+          LAST_STABLE=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*-*' 2>/dev/null || echo "")
 
           if [ -z "$LAST_STABLE" ]; then
             echo "::warning::No prior stable tag found — skipping next release"
@@ -145,22 +151,47 @@ jobs:
             exit 0
           fi
 
-          # Most recent next/* tag by commit date (empty if no nightlies have shipped yet).
-          LAST_NEXT=$(git for-each-ref --sort=-creatordate --format='%(refname:short)' 'refs/tags/next/*' | head -1 || true)
-
-          # Gate base: whichever of {last stable, last next} sits later in history.
-          # If LAST_STABLE is an ancestor of LAST_NEXT, the nightly is fresher (BASE = nightly).
-          # Otherwise the stable was tagged on a later commit (BASE = stable — typical right
-          # after a release cut). This single check replaces both the prior "commits since
-          # stable" gate and the SHA-idempotency lookup: when nothing relevant has landed
-          # since the most recent release, RELEVANT=0 and we skip.
-          if [ -n "$LAST_NEXT" ] && git merge-base --is-ancestor "$LAST_STABLE" "$LAST_NEXT"; then
-            BASE="$LAST_NEXT"
-          else
-            BASE="$LAST_STABLE"
+          # Detect an active RC cycle. An RC is "active" once vX.Y.Z-rc.N has been cut
+          # (human release via the stable path) and the final vX.Y.Z hasn't shipped yet.
+          # During an active RC, nightlies follow the rc format (X.Y.Z-rc.{N+1}) under the
+          # @rc dist-tag instead of the usual {nextMinor}.0-next.N under @next.
+          LAST_RC_TAG=$(git tag --list 'v[0-9]*-rc.*' --sort=-v:refname | head -1 || true)
+          RC_ACTIVE=""
+          if [ -n "$LAST_RC_TAG" ]; then
+            RC_BASE=${LAST_RC_TAG#v}; RC_BASE=${RC_BASE%%-rc.*}   # v1.0.0-rc.1 -> 1.0.0
+            if git rev-parse -q --verify "refs/tags/v${RC_BASE}^{}" >/dev/null 2>&1; then
+              echo "Final v${RC_BASE} already tagged — RC cycle is closed"
+            else
+              RC_ACTIVE=1
+            fi
           fi
 
-          echo "Last stable: $LAST_STABLE; last next: ${LAST_NEXT:-none}; gate base: $BASE"
+          if [ -n "$RC_ACTIVE" ]; then
+            TARGET="$RC_BASE"; LABEL="rc"; DIST_TAG="rc"; TAG_NS="rc"
+          else
+            LAST_VERSION=${LAST_STABLE#v}
+            # @next always signals the upcoming minor, regardless of whether the next
+            # stable ends up a patch or minor — keeps 0.10.0-next.1, 0.10.0-next.2, …
+            # stable across a cycle; the base rolls forward when the real release ships.
+            TARGET=$(node -e "const [M,m]='${LAST_VERSION}'.split('.').map(Number); console.log(\`\${M}.\${m+1}.0\`)")
+            LABEL="next"; DIST_TAG="next"; TAG_NS="next"
+          fi
+
+          # Gate base: the most recent release marker of ANY kind reachable from HEAD —
+          # last stable (vX.Y.Z), last RC (vX.Y.Z-rc.N or rc/…), or last nightly (next/…).
+          # Tags are scanned newest-first; the first that is an ancestor of HEAD wins, so
+          # the relevant-commit window below spans only what landed since the last release.
+          # Replaces the prior commits-since-stable + SHA-idempotency checks: when nothing
+          # relevant landed since the most recent release, RELEVANT=0 and we skip.
+          BASE=""
+          while read -r t; do
+            [ -z "$t" ] && continue
+            if git merge-base --is-ancestor "$t" HEAD 2>/dev/null; then BASE="$t"; break; fi
+          done < <(git for-each-ref --sort=-creatordate --format='%(refname:short)' \
+                     'refs/tags/v[0-9]*' 'refs/tags/next/*' 'refs/tags/rc/*')
+          [ -z "$BASE" ] && BASE="$LAST_STABLE"
+
+          echo "Last stable: ${LAST_STABLE:-none}; last rc: ${LAST_RC_TAG:-none} (active: ${RC_ACTIVE:-no}); target: ${TARGET}-${LABEL}; gate base: $BASE"
 
           # Bump-worthy commit types per nx.json release.conventionalCommits:
           # feat, fix, perf, revert. Everything else (docs/ci/chore/test/build/style/refactor)
@@ -199,22 +230,16 @@ jobs:
           # version doesn't embed the SHA, so pinning the ref is our only defense.)
           FULL_SHA=$(git rev-parse HEAD)
 
-          LAST_VERSION=${LAST_STABLE#v}
-          # Bump minor: @next always signals "the upcoming minor release", regardless
-          # of whether the next stable ends up being a patch or a minor. This keeps
-          # versions like 0.8.0-next.1, 0.8.0-next.2, … stable across a release cycle.
-          # When the real 0.8.0 (or 0.9.0) ships, the base rolls forward and the
-          # counter resets.
-          NEXT_MINOR=$(node -e "const [M,m,p]='${LAST_VERSION}'.split('.').map(Number); console.log(\`\${M}.\${m+1}.0\`)")
-
-          # Monotonic counter per base version: 0.8.0-next.1, 0.8.0-next.2, ...
-          # Query *every* library package and take the max — if one package failed
-          # to publish on a prior run the others advanced, and we must not collide
-          # with the highest existing counter anywhere. Commit traceability is still
-          # recoverable via the publish timestamp + the npm provenance attestation
-          # (records exact SHA).
-          # We MUST succeed at every package lookup — fail loud rather than default
-          # to counter=1, which could clobber a real previous publish on a transient error.
+          # Monotonic counter per (target, label): TARGET.0-next.N normally, or
+          # TARGET-rc.N during an active RC cycle (where TARGET already carries the rc's
+          # M.m.p, e.g. 1.0.0). The RC counter naturally continues past the human-cut
+          # rc.1 because that version is on npm too.
+          # Query *every* library package and take the max — if one package failed to
+          # publish on a prior run the others advanced, and we must not collide with the
+          # highest existing counter anywhere. Commit traceability stays recoverable via
+          # the publish timestamp + the npm provenance attestation (records exact SHA).
+          # We MUST succeed at every package lookup — fail loud rather than default to
+          # counter=1, which could clobber a real previous publish on a transient error.
           MAX_COUNTER=0
           for pkg in ${{ env.LIBRARY_PACKAGES }}; do
             if ! VERSIONS_JSON=$(npm view "@ng-forge/${pkg}" versions --json); then
@@ -222,12 +247,12 @@ jobs:
               exit 1
             fi
             # Regex-escape the base via env var inside Node — avoids leaving
-            # literal dots as wildcards in the pattern (0x8x0 would otherwise match).
+            # literal dots as wildcards in the pattern (1x0x0 would otherwise match).
             PKG_MAX=$(echo "$VERSIONS_JSON" \
-              | NEXT_MINOR="$NEXT_MINOR" node -e "
+              | TARGET="$TARGET" LABEL="$LABEL" node -e "
                 const v=JSON.parse(require('fs').readFileSync(0,'utf8'));
-                const base=process.env.NEXT_MINOR.replace(/\\./g, '\\\\.');
-                const re=new RegExp('^'+base+'-next\\\\.(\\\\d+)\$');
+                const base=process.env.TARGET.replace(/\\./g, '\\\\.');
+                const re=new RegExp('^'+base+'-'+process.env.LABEL+'\\\\.(\\\\d+)\$');
                 const nums=(Array.isArray(v)?v:[v]).map(x=>{const m=re.exec(x);return m?+m[1]:-1}).filter(n=>n>=0);
                 console.log(nums.length?Math.max(...nums):0);
               ")
@@ -236,14 +261,16 @@ jobs:
             fi
           done
           COUNTER=$((MAX_COUNTER + 1))
-          NEXT_VERSION="${NEXT_MINOR}-next.${COUNTER}"
+          NEXT_VERSION="${TARGET}-${LABEL}.${COUNTER}"
 
-          echo "Proposed next version: $NEXT_VERSION"
+          echo "Proposed next version: $NEXT_VERSION (dist-tag: $DIST_TAG)"
 
           echo "should_publish=true" >> "$GITHUB_OUTPUT"
           echo "version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
           echo "sha=${FULL_SHA}" >> "$GITHUB_OUTPUT"
           echo "base=${BASE}" >> "$GITHUB_OUTPUT"
+          echo "dist_tag=${DIST_TAG}" >> "$GITHUB_OUTPUT"
+          echo "tag_ns=${TAG_NS}" >> "$GITHUB_OUTPUT"
 
       - name: Verify CI passed on the candidate commit
         # Skip @next publishes when main's CI is red. The stable path already has this
@@ -338,21 +365,35 @@ jobs:
         id: resolve
         env:
           GATE_VERSION: ${{ needs.next-gate.outputs.version }}
+          GATE_DIST_TAG: ${{ needs.next-gate.outputs.dist_tag }}
+          GATE_TAG_NS: ${{ needs.next-gate.outputs.tag_ns }}
           # Single source of truth for "are we on the @next path?"
           IS_NEXT_PATH: ${{ github.event_name == 'schedule' || inputs.mode == 'next' }}
         run: |
           if [ "$IS_NEXT_PATH" = "true" ]; then
             VERSION="$GATE_VERSION"
-            DIST_TAG="next"
+            DIST_TAG="$GATE_DIST_TAG"          # 'next', or 'rc' during an active RC cycle
+            PRERELEASE=true
+            RELEASE_TAG="${GATE_TAG_NS}/${VERSION}"   # next/… or rc/…
           else
             # Stable dispatch (dry-run or publish): sources were already bumped by /release PR.
+            # A prerelease version (e.g. 1.0.0-rc.1) must NOT land on @latest — route rc
+            # versions to @rc, any other prerelease id to @next, and flag the GitHub
+            # release as a prerelease. Only a clean M.m.p goes to @latest.
             VERSION=$(node -p "require('./packages/dynamic-forms/package.json').version")
-            DIST_TAG="latest"
+            case "$VERSION" in
+              *-rc.*) DIST_TAG="rc";     PRERELEASE=true  ;;
+              *-*)    DIST_TAG="next";   PRERELEASE=true  ;;
+              *)      DIST_TAG="latest"; PRERELEASE=false ;;
+            esac
+            RELEASE_TAG="v${VERSION}"
           fi
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "DIST_TAG=$DIST_TAG" >> "$GITHUB_ENV"
+          echo "PRERELEASE=$PRERELEASE" >> "$GITHUB_ENV"
+          echo "RELEASE_TAG=$RELEASE_TAG" >> "$GITHUB_ENV"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "📦 Releasing $VERSION (dist-tag: $DIST_TAG)"
+          echo "📦 Releasing $VERSION (dist-tag: $DIST_TAG, prerelease: $PRERELEASE, tag: $RELEASE_TAG)"
 
       - name: Generate GitHub App Token
         # Generated up-front so the job fails before any irreversible action if App config
@@ -486,7 +527,7 @@ jobs:
           name: Release v${{ env.VERSION }}
           body_path: RELEASE_NOTES.md
           draft: false
-          prerelease: false
+          prerelease: ${{ env.PRERELEASE }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
@@ -504,7 +545,7 @@ jobs:
           CHANGELOG=$(git log "${BASE}..${NEXT_SHA}" --pretty=format:"- %s (%h)" --no-merges)
 
           cat > NEXT_RELEASE_NOTES.md <<EOF
-          Nightly @next prerelease — published from \`main\`.
+          Nightly @${DIST_TAG} prerelease — published from \`main\`.
 
           ## Changes since ${BASE}
 
@@ -513,8 +554,9 @@ jobs:
 
       - name: Create GitHub Prerelease (@next)
         # Replaces the prior manual `git tag` step. action-gh-release creates the
-        # `next/<version>` tag at the gate SHA via the GitHub API — same idempotency
-        # marker that next-gate looks up, so re-runs on the same commit still become no-ops.
+        # `next/<version>` (or `rc/<version>` during an RC cycle) tag at the gate SHA via
+        # the GitHub API — the same kind of marker next-gate's BASE scan looks up, so
+        # re-runs on the same commit still become no-ops.
         # Tag-after-publish (not before): if this fails, worst case is one duplicate
         # publish on the next run — strictly better than the tag-first failure mode where
         # a phantom tag could permanently block future publishes.
@@ -530,7 +572,7 @@ jobs:
         continue-on-error: true
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: next/${{ env.VERSION }}
+          tag_name: ${{ env.RELEASE_TAG }}
           target_commitish: ${{ needs.next-gate.outputs.sha }}
           name: Nightly v${{ env.VERSION }}
           body_path: NEXT_RELEASE_NOTES.md
@@ -557,13 +599,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "$DIST_TAG" = "next" ]; then
-            TAG="next/${VERSION}"
-          else
-            TAG="v${VERSION}"
-          fi
-          echo "Dispatching discord-release-notify.yml for tag: $TAG"
-          gh workflow run discord-release-notify.yml -f tag="$TAG"
+          # RELEASE_TAG already carries the correct namespace for every path:
+          # v<ver> (stable + rc cut), next/<ver> (nightly), rc/<ver> (rc nightly).
+          echo "Dispatching discord-release-notify.yml for tag: $RELEASE_TAG"
+          gh workflow run discord-release-notify.yml -f tag="$RELEASE_TAG"
 
       - name: Summary
         run: |


### PR DESCRIPTION
## What

Adds a 1.0.0-rc prerelease **channel** to the release pipeline. RCs flow off `main` via the existing nightly path under a dedicated `@rc` dist-tag — no release branch.

## Why

Today the nightly gate treats any `v[0-9]*` tag as the last stable, so a `v1.0.0-rc.1` tag would be read as stable and nightlies would jump to `1.1.0-next.N`, skipping the 1.0.0 rc cycle. The stable publish path also hardcodes `@latest`.

A release branch for rc was considered and dropped: rc.1-from-branch + rc.2+-from-main is an incoherent hybrid, and a frozen stabilization branch isn't worth the cherry-pick overhead at this stage. main is the candidate; the rc window is a feature freeze by convention.

## How it works

- **Start:** dispatch `Release -> mode=next` with `target=1.0.0`. Publishes `1.0.0-rc.1` to `@rc`, tags `rc/1.0.0-rc.1`, posts to Discord with the `@rc` install hint.
- **Continue:** every scheduled nightly detects the open `rc/*` tag (final `v1.0.0` not shipped) and auto-publishes `rc.2`, `rc.3`, … off main. No input needed. Auto-continue still requires bump-worthy commits, so an idle cycle doesn't churn empty rc.N.
- **Finish:** cut the stable `v1.0.0` the normal way (release branch -> mode=publish). The final tag closes the rc cycle; nightlies roll to `1.1.0-next.1` on `@next`.

## Changes

`release.yml`:
- `LAST_STABLE` excludes all prereleases so an rc tag isn't mistaken for stable.
- New optional `target` dispatch input bootstraps / re-targets an rc cycle (mode=next only).
- Gate enters rc mode from the input or from an open `rc/*` (or `v…-rc.…`) tag; otherwise unchanged `{nextMinor}.0-next.N` on `@next`.
- An explicit `target` bootstrap publishes rc.1 even with no new commits; auto-continue crons still gate on commits.
- npm counter parameterized by (target, label); gate base generalized to the most recent marker of any kind; unified `RELEASE_TAG` drives the GitHub release + Discord dispatch.
- Stable path routes any prerelease `package.json` version off `@latest` as a safety net (`*-rc.*` -> @rc, other `-*` -> @next).

`discord-release-notify.yml`:
- Prerelease embed install hint infers `@rc` vs `@next` from the tag name.

## Verified

Simulated the gate against real repo tags:

| State | Version | dist-tag | tag |
|---|---|---|---|
| Today (no input, no rc) | `0.10.0-next.N` | `@next` | `next/…` |
| Bootstrap (`target=1.0.0`) | `1.0.0-rc.N` | `@rc` | `rc/…` |
| Auto-continue (`rc/*` open) | `1.0.0-rc.N` | `@rc` | `rc/…` |
| After `v1.0.0` ships | `1.1.0-next.N` | `@next` | `next/…` |

Both workflows parse as valid YAML. No publish was triggered. This PR is CI config only.