### PR TITLE
refactor(dynamic-forms)!: trim and re-tier public API surface for 1.0

### DIFF
--- a/apps/docs/public/content/dynamic-behavior/submission.md
+++ b/apps/docs/public/content/dynamic-behavior/submission.md
@@ -135,7 +135,7 @@ Override form-level defaults on individual buttons using the `logic` array:
 }
 ```
 
-**Note:** `type: 'submit'` is a UI-integration convenience type that pre-configures the button with `SubmitEvent`. Use `type: 'button'` with `event: SubmitEvent` for the core API.
+**Note:** `type: 'submit'` is a UI-integration convenience type that pre-configures the button with `FormSubmitEvent`. Use `type: 'button'` with `event: FormSubmitEvent` for the core API.
 
 ### FormStateCondition
 

--- a/apps/docs/public/content/recipes/custom-fields.md
+++ b/apps/docs/public/content/recipes/custom-fields.md
@@ -149,19 +149,19 @@ For action / button components there's a sibling `createNgForgeActionFixture`:
 
 ```typescript
 import { createNgForgeActionFixture } from '@ng-forge/dynamic-forms/integration';
-import { SubmitEvent } from '@ng-forge/dynamic-forms';
+import { FormSubmitEvent } from '@ng-forge/dynamic-forms';
 import SubmitButtonComponent from './my-submit-button.component';
 
-it('dispatches SubmitEvent through EventBus on click', () => {
+it('dispatches FormSubmitEvent through EventBus on click', () => {
   const { fixture, eventBus } = createNgForgeActionFixture(SubmitButtonComponent, {
     key: 'submit',
     label: 'Save',
-    event: SubmitEvent,
+    event: FormSubmitEvent,
   });
   const spy = vi.spyOn(eventBus, 'dispatch');
   fixture.detectChanges();
   fixture.nativeElement.querySelector('button').click();
-  expect(spy).toHaveBeenCalledWith(SubmitEvent);
+  expect(spy).toHaveBeenCalledWith(FormSubmitEvent);
 });
 ```
 

--- a/apps/docs/public/content/recipes/events.md
+++ b/apps/docs/public/content/recipes/events.md
@@ -88,7 +88,7 @@ For observing events from a host component, use the output bindings exposed dire
 | Output                          | Emits                                                     |
 | ------------------------------- | --------------------------------------------------------- |
 | `(events)`                      | Every form event (full stream)                            |
-| `(submitted)`                   | Form value when submitted **and valid** (SubmitEvent)     |
+| `(submitted)`                   | Form value when submitted **and valid** (FormSubmitEvent) |
 | `(reset)`                       | When the form is reset to default values                  |
 | `(cleared)`                     | When the form is cleared to empty state                   |
 | `(onPageChange)`                | PageChangeEvent on each wizard page navigation            |
@@ -153,7 +153,7 @@ export class MyFormComponent {
 
 ```typescript
 import { Component, inject } from '@angular/core';
-import { SubmitEvent } from '@ng-forge/dynamic-forms';
+import { FormSubmitEvent } from '@ng-forge/dynamic-forms';
 import { EventBus } from '@ng-forge/dynamic-forms/integration';
 
 @Component({
@@ -164,7 +164,7 @@ export class CustomSubmitButton {
   private readonly eventBus = inject(EventBus);
 
   submit() {
-    this.eventBus.dispatch(SubmitEvent);
+    this.eventBus.dispatch(FormSubmitEvent);
   }
 }
 ```
@@ -187,12 +187,12 @@ export class CustomFieldComponent {
 
 ## Built-in Events
 
-### SubmitEvent
+### FormSubmitEvent
 
 Fired when form is submitted.
 
 ```typescript
-eventBus.on<SubmitEvent>('submit').subscribe(() => {
+eventBus.on<FormSubmitEvent>('submit').subscribe(() => {
   console.log('Form submitted');
 });
 ```
@@ -364,7 +364,7 @@ eventBus.dispatch(AddContactEvent);
 Subscribe to multiple event types by passing an array of type strings:
 
 ```typescript
-eventBus.on<SubmitEvent | PageChangeEvent | NextPageEvent>(['submit', 'page-change', 'next-page']).subscribe((event) => {
+eventBus.on<FormSubmitEvent | PageChangeEvent | NextPageEvent>(['submit', 'page-change', 'next-page']).subscribe((event) => {
   switch (event.type) {
     case 'submit':
       handleSubmit();
@@ -465,7 +465,7 @@ Use the `hasFormValue()` type guard to safely access the attached value:
 ```typescript
 import { hasFormValue } from '@ng-forge/dynamic-forms';
 
-eventBus.on<SubmitEvent>('submit').subscribe((event) => {
+eventBus.on<FormSubmitEvent>('submit').subscribe((event) => {
   if (hasFormValue(event)) {
     // TypeScript knows event.formValue exists
     console.log('Form value at submission:', event.formValue);

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/button/bs-button.type.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/button/bs-button.type.ts
@@ -3,6 +3,7 @@ import {
   ArrayAllowedChildren,
   FieldComponent,
   FormEvent,
+  FormSubmitEvent,
   InsertArrayItemEvent,
   NextPageEvent,
   PopArrayItemEvent,
@@ -29,7 +30,7 @@ export type BsButtonComponent<TEvent extends FormEvent> = FieldComponent<BsButto
 /** Specific button field types with preconfigured events */
 
 /** Submit button field - automatically disabled when form is invalid */
-export type BsSubmitButtonField = Omit<BsButtonField<SubmitEvent>, 'event' | 'type' | 'eventArgs'> & {
+export type BsSubmitButtonField = Omit<BsButtonField<FormSubmitEvent>, 'event' | 'type' | 'eventArgs'> & {
   type: 'submit';
 };
 

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/input/bs-input.component.spec.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/input/bs-input.component.spec.ts
@@ -1,11 +1,6 @@
 import { Type } from '@angular/core';
-import {
-  ADDON_ACTION_REGISTRY,
-  ADDON_KIND_COMPONENT_CACHE,
-  ADDON_KIND_REGISTRY,
-  type AddonKindDefinition,
-  DynamicFormLogger,
-} from '@ng-forge/dynamic-forms';
+import { type AddonKindDefinition, DynamicFormLogger } from '@ng-forge/dynamic-forms';
+import { ADDON_ACTION_REGISTRY, ADDON_KIND_COMPONENT_CACHE, ADDON_KIND_REGISTRY } from '@ng-forge/dynamic-forms/integration';
 import { createNgForgeFieldFixture, provideTestValidationMessages } from '@ng-forge/dynamic-forms/integration';
 import { describe, expect, it, vi } from 'vitest';
 import BsInputFieldComponent from './bs-input.component';

--- a/packages/dynamic-forms-ionic/src/lib/fields/button/ionic-button.type.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/button/ionic-button.type.ts
@@ -3,6 +3,7 @@ import {
   ArrayAllowedChildren,
   FieldComponent,
   FormEvent,
+  FormSubmitEvent,
   InsertArrayItemEvent,
   NextPageEvent,
   PopArrayItemEvent,
@@ -30,7 +31,7 @@ export type IonicButtonComponent<TEvent extends FormEvent> = FieldComponent<Ioni
 /** Specific button field types with preconfigured events */
 
 /** Submit button field - automatically disabled when form is invalid */
-export type IonicSubmitButtonField = Omit<IonicButtonField<SubmitEvent>, 'event' | 'type' | 'eventArgs'> & {
+export type IonicSubmitButtonField = Omit<IonicButtonField<FormSubmitEvent>, 'event' | 'type' | 'eventArgs'> & {
   type: 'submit';
 };
 

--- a/packages/dynamic-forms-ionic/src/lib/fields/input/ionic-input.component.spec.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/input/ionic-input.component.spec.ts
@@ -1,5 +1,6 @@
 import type { Type } from '@angular/core';
-import { ADDON_ACTION_REGISTRY, ADDON_KIND_COMPONENT_CACHE, ADDON_KIND_REGISTRY, type AddonKindDefinition } from '@ng-forge/dynamic-forms';
+import { type AddonKindDefinition } from '@ng-forge/dynamic-forms';
+import { ADDON_ACTION_REGISTRY, ADDON_KIND_COMPONENT_CACHE, ADDON_KIND_REGISTRY } from '@ng-forge/dynamic-forms/integration';
 import { createNgForgeFieldFixture } from '@ng-forge/dynamic-forms/integration';
 import { describe, expect, it } from 'vitest';
 import IonicInputFieldComponent from './ionic-input.component';

--- a/packages/dynamic-forms-material/src/lib/fields/button/mat-button.type.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/button/mat-button.type.ts
@@ -3,6 +3,7 @@ import {
   ArrayAllowedChildren,
   FieldComponent,
   FormEvent,
+  FormSubmitEvent,
   InsertArrayItemEvent,
   NextPageEvent,
   PopArrayItemEvent,
@@ -25,7 +26,7 @@ export type MatButtonComponent<TEvent extends FormEvent> = FieldComponent<MatBut
 /** Specific button field types with preconfigured events */
 
 /** Submit button field - automatically disabled when form is invalid */
-export type MatSubmitButtonField = Omit<MatButtonField<SubmitEvent>, 'event' | 'type' | 'eventArgs'> & {
+export type MatSubmitButtonField = Omit<MatButtonField<FormSubmitEvent>, 'event' | 'type' | 'eventArgs'> & {
   type: 'submit';
 };
 

--- a/packages/dynamic-forms-material/src/lib/fields/input/mat-input.component.spec.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/input/mat-input.component.spec.ts
@@ -1,12 +1,7 @@
 import { Injector, signal, type Type } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
-import {
-  ADDON_ACTION_REGISTRY,
-  ADDON_KIND_COMPONENT_CACHE,
-  ADDON_KIND_REGISTRY,
-  type AddonKindDefinition,
-  DynamicFormLogger,
-} from '@ng-forge/dynamic-forms';
+import { type AddonKindDefinition, DynamicFormLogger } from '@ng-forge/dynamic-forms';
+import { ADDON_ACTION_REGISTRY, ADDON_KIND_COMPONENT_CACHE, ADDON_KIND_REGISTRY } from '@ng-forge/dynamic-forms/integration';
 import {
   FIELD_SIGNAL_CONTEXT,
   type FieldSignalContext,

--- a/packages/dynamic-forms-primeng/src/lib/fields/button/prime-button.type.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/button/prime-button.type.ts
@@ -3,6 +3,7 @@ import {
   ArrayAllowedChildren,
   FieldComponent,
   FormEvent,
+  FormSubmitEvent,
   InsertArrayItemEvent,
   NextPageEvent,
   PopArrayItemEvent,
@@ -31,7 +32,7 @@ export type PrimeButtonComponent<TEvent extends FormEvent = FormEvent> = FieldCo
 /** Specific button field types with preconfigured events */
 
 /** Submit button field - automatically disabled when form is invalid */
-export type PrimeSubmitButtonField = Omit<PrimeButtonField<SubmitEvent>, 'event' | 'type' | 'eventArgs'> & {
+export type PrimeSubmitButtonField = Omit<PrimeButtonField<FormSubmitEvent>, 'event' | 'type' | 'eventArgs'> & {
   type: 'submit';
 };
 

--- a/packages/dynamic-forms-primeng/src/lib/fields/input/prime-input.component.spec.ts
+++ b/packages/dynamic-forms-primeng/src/lib/fields/input/prime-input.component.spec.ts
@@ -1,11 +1,6 @@
 import type { Type } from '@angular/core';
-import {
-  ADDON_ACTION_REGISTRY,
-  ADDON_KIND_COMPONENT_CACHE,
-  ADDON_KIND_REGISTRY,
-  type AddonKindDefinition,
-  DynamicFormLogger,
-} from '@ng-forge/dynamic-forms';
+import { type AddonKindDefinition, DynamicFormLogger } from '@ng-forge/dynamic-forms';
+import { ADDON_ACTION_REGISTRY, ADDON_KIND_COMPONENT_CACHE, ADDON_KIND_REGISTRY } from '@ng-forge/dynamic-forms/integration';
 import { createNgForgeFieldFixture, provideTestValidationMessages } from '@ng-forge/dynamic-forms/integration';
 import { describe, expect, it, vi } from 'vitest';
 import PrimeInputFieldComponent from './prime-input.component';

--- a/packages/dynamic-forms/integration/src/directives/ng-forge-addon-action.directive.spec.ts
+++ b/packages/dynamic-forms/integration/src/directives/ng-forge-addon-action.directive.spec.ts
@@ -1,8 +1,8 @@
 import { ChangeDetectionStrategy, Component, signal, WritableSignal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { describe, expect, it, vi } from 'vitest';
-import { ADDON_ACTION_REGISTRY, DynamicFormLogger } from '@ng-forge/dynamic-forms';
-import { type WrapperFieldInputs } from '@ng-forge/dynamic-forms/internal';
+import { DynamicFormLogger } from '@ng-forge/dynamic-forms';
+import { ADDON_ACTION_REGISTRY, type WrapperFieldInputs } from '@ng-forge/dynamic-forms/internal';
 import { ADDON_PRESET_HANDLER, type AddonPresetHandler } from './addon-preset-handler.token';
 import { injectNgForgeAddonAction, NgForgeAddonAction, NgForgeAddonActionBase } from './ng-forge-addon-action.directive';
 

--- a/packages/dynamic-forms/integration/src/directives/ng-forge-addon-action.directive.ts
+++ b/packages/dynamic-forms/integration/src/directives/ng-forge-addon-action.directive.ts
@@ -1,7 +1,7 @@
 import { computed, Directive, inject, Injector, input, Signal, signal } from '@angular/core';
 import { explicitEffect } from 'ngxtension/explicit-effect';
-import { ADDON_ACTION_REGISTRY, AddonActionHandler, BaseAddon, DynamicFormLogger, DynamicValue } from '@ng-forge/dynamic-forms';
-import { WrapperFieldInputs } from '@ng-forge/dynamic-forms/internal';
+import { BaseAddon, DynamicFormLogger, DynamicValue } from '@ng-forge/dynamic-forms';
+import { ADDON_ACTION_REGISTRY, AddonActionHandler, WrapperFieldInputs } from '@ng-forge/dynamic-forms/internal';
 import { AddonActionContext, resolveDynamicValue, writeToFieldValue } from '@ng-forge/dynamic-forms/internal';
 import { ADDON_PRESET_HANDLER } from './addon-preset-handler.token';
 import type { AssertTupleLockstep } from './assert-input-lockstep';

--- a/packages/dynamic-forms/integration/src/mappers/button/navigation-button.mapper.ts
+++ b/packages/dynamic-forms/integration/src/mappers/button/navigation-button.mapper.ts
@@ -1,17 +1,13 @@
 import { computed, inject, Signal } from '@angular/core';
-import {
-  FieldWithValidation,
-  NextPageEvent,
-  PreviousPageEvent,
-  resolveNextButtonDisabled,
-  resolveSubmitButtonDisabled,
-} from '@ng-forge/dynamic-forms';
+import { FieldWithValidation, FormSubmitEvent, NextPageEvent, PreviousPageEvent } from '@ng-forge/dynamic-forms';
 import {
   buildBaseInputs,
   DEFAULT_PROPS,
   FieldDef,
   injectFieldSignalContext,
   FORM_OPTIONS,
+  resolveNextButtonDisabled,
+  resolveSubmitButtonDisabled,
   RootFormRegistryService,
 } from '@ng-forge/dynamic-forms/internal';
 import { ButtonField } from '../../definitions';
@@ -22,7 +18,7 @@ import { resolveHiddenValue } from './non-field-logic.utils';
 // =============================================================================
 
 /** Base interface for navigation button fields (submit, next, previous). */
-export type BaseNavigationButtonField<TProps = unknown> = ButtonField<TProps, SubmitEvent | NextPageEvent | PreviousPageEvent> & {
+export type BaseNavigationButtonField<TProps = unknown> = ButtonField<TProps, FormSubmitEvent | NextPageEvent | PreviousPageEvent> & {
   type: string;
   /** Logic rules for dynamic disabled state */
   logic?: FieldWithValidation['logic'];

--- a/packages/dynamic-forms/integration/src/mappers/button/non-field-logic.utils.ts
+++ b/packages/dynamic-forms/integration/src/mappers/button/non-field-logic.utils.ts
@@ -1,5 +1,10 @@
-import { LogicConfig, resolveNonFieldDisabled, resolveNonFieldHidden } from '@ng-forge/dynamic-forms';
-import { NonFieldLogicConfig, RootFormRegistryService } from '@ng-forge/dynamic-forms/internal';
+import {
+  LogicConfig,
+  NonFieldLogicConfig,
+  resolveNonFieldDisabled,
+  resolveNonFieldHidden,
+  RootFormRegistryService,
+} from '@ng-forge/dynamic-forms/internal';
 import { FieldTree } from '@angular/forms/signals';
 
 /**

--- a/packages/dynamic-forms/integration/src/public_api.ts
+++ b/packages/dynamic-forms/integration/src/public_api.ts
@@ -134,8 +134,8 @@ export { NgForgeFieldHost, NgForgeActionHost } from './directives';
 // Non-Field Logic Resolvers (re-exported from @ng-forge/dynamic-forms)
 // =============================================================================
 
-export { resolveNonFieldHidden, resolveNonFieldDisabled } from '@ng-forge/dynamic-forms';
-export type { NonFieldLogicContext, NonFieldLogicType, NonFieldLogicConfig } from '@ng-forge/dynamic-forms';
+export { resolveNonFieldHidden, resolveNonFieldDisabled } from '@ng-forge/dynamic-forms/internal';
+export type { NonFieldLogicContext, NonFieldLogicType, NonFieldLogicConfig } from '@ng-forge/dynamic-forms/internal';
 
 // =============================================================================
 // Wrapper Authoring (re-exported from @ng-forge/dynamic-forms)
@@ -185,6 +185,7 @@ export { FIELD_REGISTRY } from '@ng-forge/dynamic-forms/internal';
 
 // Base field component contracts
 export type { ValueFieldComponent, CheckedFieldComponent } from '@ng-forge/dynamic-forms/internal';
+export { isValueField, isCheckedField } from '@ng-forge/dynamic-forms/internal';
 
 // Signal-context injection tokens
 export {
@@ -232,9 +233,10 @@ export { withPreviousValue } from '@ng-forge/dynamic-forms/internal';
 export { BUILT_IN_FIELDS } from '@ng-forge/dynamic-forms';
 export { runPresetAction } from '@ng-forge/dynamic-forms';
 export type { PresetCollaborators } from '@ng-forge/dynamic-forms';
-export { ADDON_ACTION_REGISTRY, ADDON_ACTION_HANDLERS } from '@ng-forge/dynamic-forms';
-export type { AddonActionHandler } from '@ng-forge/dynamic-forms';
+export { ADDON_ACTION_REGISTRY, ADDON_ACTION_HANDLERS } from '@ng-forge/dynamic-forms/internal';
+export type { AddonActionHandler } from '@ng-forge/dynamic-forms/internal';
 export { ADDON_KIND_DEFINITIONS } from '@ng-forge/dynamic-forms';
-export { ADDON_KIND_REGISTRY, ADDON_KIND_COMPONENT_CACHE, injectAddonKindRegistry } from '@ng-forge/dynamic-forms';
+export { ADDON_KIND_REGISTRY, ADDON_KIND_COMPONENT_CACHE } from '@ng-forge/dynamic-forms/internal';
+export { injectAddonKindRegistry } from '@ng-forge/dynamic-forms';
 export { injectFieldsSupportingAddons } from '@ng-forge/dynamic-forms';
 export type { FieldAddonSupportEntry } from '@ng-forge/dynamic-forms';

--- a/packages/dynamic-forms/internal/src/lib/definitions/default/container-field.ts
+++ b/packages/dynamic-forms/internal/src/lib/definitions/default/container-field.ts
@@ -36,7 +36,7 @@ export interface ContainerField<
 
 /** Type guard for ContainerField with proper type narrowing. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Type guard must accept any field type
-export function isContainerTypedField(field: FieldDef<any>): field is ContainerField {
+export function isGenericContainerField(field: FieldDef<any>): field is ContainerField {
   return (
     field.type === 'container' &&
     'wrappers' in field &&

--- a/packages/dynamic-forms/internal/src/lib/definitions/default/index.ts
+++ b/packages/dynamic-forms/internal/src/lib/definitions/default/index.ts
@@ -5,7 +5,7 @@ export { isSimplifiedArrayField } from './array-field';
 export type { PageField } from './page-field';
 export type { TextField, TextElementType, TextProps } from './text-field';
 export type { HiddenField, HiddenValue, HiddenScalar } from './hidden-field';
-export { type ContainerField, isContainerTypedField } from './container-field';
+export { type ContainerField, isGenericContainerField } from './container-field';
 export type { WrapperConfig } from '../../models/wrapper-type';
 export type { CssWrapper } from '../../wrappers/css/css-wrapper.type';
 export type { RowWrapper } from '../../wrappers/row/row-wrapper.type';

--- a/packages/dynamic-forms/internal/src/lib/definitions/default/page-field.ts
+++ b/packages/dynamic-forms/internal/src/lib/definitions/default/page-field.ts
@@ -2,7 +2,7 @@ import { FieldDef } from '../base/field-def';
 import { PageAllowedChildren } from '../../models/types/nesting-constraints';
 import { isRowField } from './row-field';
 import { isGroupField } from './group-field';
-import { isContainerTypedField } from './container-field';
+import { isGenericContainerField } from './container-field';
 import { ContainerLogicConfig } from '../base/container-logic-config';
 
 /**
@@ -49,7 +49,7 @@ export function validatePageNesting(pageField: PageField): boolean {
 /** Type guard to check if a field is a container with fields property */
 function isContainerWithFields(field: FieldDef<unknown>): field is FieldDef<unknown> & { readonly fields: readonly FieldDef<unknown>[] } {
   return (
-    (isRowField(field) || isGroupField(field) || isContainerTypedField(field)) &&
+    (isRowField(field) || isGroupField(field) || isGenericContainerField(field)) &&
     'fields' in field &&
     Array.isArray((field as { fields: unknown }).fields)
   );

--- a/packages/dynamic-forms/internal/src/lib/models/addon/addon-action-registry.ts
+++ b/packages/dynamic-forms/internal/src/lib/models/addon/addon-action-registry.ts
@@ -1,5 +1,5 @@
 import { inject, InjectionToken } from '@angular/core';
-import { AddonActionContext } from '@ng-forge/dynamic-forms/internal';
+import { AddonActionContext } from './addon-action';
 
 /** Handler signature for user-registered addon actions. */
 export type AddonActionHandler<TValue = unknown> = (ctx: AddonActionContext<TValue>) => void;

--- a/packages/dynamic-forms/internal/src/lib/models/addon/addon-kind.ts
+++ b/packages/dynamic-forms/internal/src/lib/models/addon/addon-kind.ts
@@ -1,4 +1,4 @@
-import { InjectionToken } from '@angular/core';
+import { InjectionToken, Type } from '@angular/core';
 import { LazyComponentLoader } from '../wrapper-type';
 import { BaseAddon } from './addon-def';
 import { AddonSlot } from './addon-slot';
@@ -87,3 +87,11 @@ export const ADDON_KIND_REGISTRY = new InjectionToken<Map<string, AddonKindDefin
   providedIn: 'root',
   factory: () => new Map<string, AddonKindDefinition>(),
 });
+
+/**
+ * Cache for resolved addon-kind components. Provided at form scope by
+ * `provideDynamicForm`.
+ *
+ * @internal
+ */
+export const ADDON_KIND_COMPONENT_CACHE = new InjectionToken<Map<string, Type<unknown>>>('ADDON_KIND_COMPONENT_CACHE');

--- a/packages/dynamic-forms/internal/src/lib/models/index.ts
+++ b/packages/dynamic-forms/internal/src/lib/models/index.ts
@@ -112,7 +112,7 @@ export {
   isPagedForm,
   isPageField,
   isRowField,
-  isContainerTypedField,
+  isGenericContainerField,
   isValidNonPagedForm,
   isValidPagedForm,
   isValueBearingField,

--- a/packages/dynamic-forms/internal/src/lib/models/types/index.ts
+++ b/packages/dynamic-forms/internal/src/lib/models/types/index.ts
@@ -9,7 +9,7 @@ export type {
   RowAllowedChildren,
 } from './nesting-constraints';
 export { isContainerField, isDisplayOnlyField, isLeafField, isValueBearingField } from './type-guards';
-export { isArrayField, isGroupField, isPageField, isRowField, isContainerTypedField } from './type-guards';
+export { isArrayField, isGroupField, isPageField, isRowField, isGenericContainerField } from './type-guards';
 export type { FieldPathAccess } from './field-helpers';
 export type { AvailableFieldTypes, ContainerFieldTypes, LeafFieldTypes, RegisteredFieldTypes } from '../registry';
 export type { DynamicText } from './dynamic-text';

--- a/packages/dynamic-forms/internal/src/lib/models/types/type-guards.ts
+++ b/packages/dynamic-forms/internal/src/lib/models/types/type-guards.ts
@@ -3,7 +3,7 @@ import { isPageField } from '../../definitions/default/page-field';
 import { isRowField } from '../../definitions/default/row-field';
 import { isGroupField } from '../../definitions/default/group-field';
 import { isArrayField } from '../../definitions/default/array-field';
-import { isContainerTypedField } from '../../definitions/default/container-field';
+import { isGenericContainerField } from '../../definitions/default/container-field';
 import { ContainerFieldTypes, LeafFieldTypes, RegisteredFieldTypes } from '../registry/field-registry';
 
 /**
@@ -60,4 +60,4 @@ export function isDisplayOnlyField(field: RegisteredFieldTypes): boolean {
 }
 
 // Re-export the specific type guards for convenience
-export { isPageField, isRowField, isGroupField, isArrayField, isContainerTypedField };
+export { isPageField, isRowField, isGroupField, isArrayField, isGenericContainerField };

--- a/packages/dynamic-forms/internal/src/public_api.ts
+++ b/packages/dynamic-forms/internal/src/public_api.ts
@@ -76,6 +76,7 @@ export * from './lib/mappers/row/row-field-mapper';
 export * from './lib/mappers/text/text-field-mapper';
 export * from './lib/mappers/types';
 export * from './lib/models/addon/addon-action';
+export * from './lib/models/addon/addon-action-registry';
 export * from './lib/models/addon/addon-def';
 export * from './lib/models/addon/addon-kind';
 export * from './lib/models/addon/addon-slot';

--- a/packages/dynamic-forms/src/lib/components/df-addon-slot.component.spec.ts
+++ b/packages/dynamic-forms/src/lib/components/df-addon-slot.component.spec.ts
@@ -5,7 +5,7 @@ import { DynamicFormError } from '@ng-forge/dynamic-forms/internal';
 import { ADDON_KIND_REGISTRY, AddonKindDefinition } from '@ng-forge/dynamic-forms/internal';
 import { AnyAddon, TextAddon } from '@ng-forge/dynamic-forms/internal';
 import { DynamicFormLogger } from '@ng-forge/dynamic-forms/internal';
-import { ADDON_KIND_COMPONENT_CACHE } from '../utils/inject-addon-kind-registry/inject-addon-kind-registry';
+import { ADDON_KIND_COMPONENT_CACHE } from '@ng-forge/dynamic-forms/internal';
 import { DfAddonSlot } from './df-addon-slot.component';
 
 @Component({ template: 'icon-rendered' })

--- a/packages/dynamic-forms/src/lib/core/form-mapping.ts
+++ b/packages/dynamic-forms/src/lib/core/form-mapping.ts
@@ -23,7 +23,7 @@ import { isGroupField } from '@ng-forge/dynamic-forms/internal';
 import { isArrayField } from '@ng-forge/dynamic-forms/internal';
 import { isPageField } from '@ng-forge/dynamic-forms/internal';
 import { isRowField } from '@ng-forge/dynamic-forms/internal';
-import { isContainerTypedField } from '@ng-forge/dynamic-forms/internal';
+import { isGenericContainerField } from '@ng-forge/dynamic-forms/internal';
 import { getNormalizedArrayMetadata } from '../utils/array-field/normalized-array-metadata';
 import { DynamicFormError } from '@ng-forge/dynamic-forms/internal';
 import { isStateLogicConfig, LogicConfig } from '@ng-forge/dynamic-forms/internal';
@@ -156,7 +156,7 @@ export function mapFieldToForm(
   // Layout containers (page, row, container) - flatten children to current level.
   // Layout containers have no schema path of their own, so any hidden state on them
   // must be propagated to descendants through the cascade.
-  if (isPageField(fieldDef) || isRowField(fieldDef) || isContainerTypedField(fieldDef)) {
+  if (isPageField(fieldDef) || isRowField(fieldDef) || isGenericContainerField(fieldDef)) {
     const descendantContext = resolveDescendantContext(fieldDef, ownContext);
     mapContainerChildren(fieldDef.fields as FieldDef<unknown>[] | undefined, fieldPath, descendantContext);
     return;
@@ -196,7 +196,7 @@ function mapContainerChildren(
   const pathRecord = parentPath as Record<string, AnySchemaPath>;
 
   for (const field of fields) {
-    if (isPageField(field) || isRowField(field) || isContainerTypedField(field)) {
+    if (isPageField(field) || isRowField(field) || isGenericContainerField(field)) {
       // Layout containers can still carry their own cascading overrides that flow
       // down to their flattened descendants.
       const layoutOwn = resolveFieldOwnContext(field, inheritedContext);
@@ -389,7 +389,7 @@ function mapArrayFieldToForm(arrayField: FieldDef<unknown>, fieldPath: AnySchema
     } else if (
       isPageField(itemDef as FieldDef<unknown>) ||
       isRowField(itemDef as FieldDef<unknown>) ||
-      isContainerTypedField(itemDef as FieldDef<unknown>)
+      isGenericContainerField(itemDef as FieldDef<unknown>)
     ) {
       // Layout container as a single-template item: its descendants describe
       // the item's object shape. Hand it to the object-item collector wrapped
@@ -417,7 +417,7 @@ function mapArrayFieldToForm(arrayField: FieldDef<unknown>, fieldPath: AnySchema
 
     // Map ALL unique template fields from all object items
     for (const templateField of allObjectFields) {
-      if (isRowField(templateField) || isPageField(templateField) || isContainerTypedField(templateField)) {
+      if (isRowField(templateField) || isPageField(templateField) || isGenericContainerField(templateField)) {
         // Row/page/container templates flatten their children
         const layoutOwn = resolveFieldOwnContext(templateField, context);
         const layoutDescendant = resolveDescendantContext(templateField, layoutOwn);
@@ -462,7 +462,7 @@ function collectFieldsFromObjectItem(itemFields: readonly FieldDef<unknown>[], a
 
   for (const field of itemFields) {
     // For row/page/container fields, we need to collect their children's keys
-    if (isRowField(field) || isPageField(field) || isContainerTypedField(field)) {
+    if (isRowField(field) || isPageField(field) || isGenericContainerField(field)) {
       // Use a synthetic key for container fields to dedupe them
       const containerKey = `__container_${field.type}_${JSON.stringify(field.fields?.map((f) => f.key))}`;
       if (!seenKeys.has(containerKey)) {

--- a/packages/dynamic-forms/src/lib/dynamic-form.component.ts
+++ b/packages/dynamic-forms/src/lib/dynamic-form.component.ts
@@ -22,7 +22,7 @@ import { createSubmissionHandler } from './utils/submission-handler/submission-h
 import { FormConfig, FormOptions } from '@ng-forge/dynamic-forms/internal';
 import { RegisteredFieldTypes } from '@ng-forge/dynamic-forms/internal';
 import { EventBus } from '@ng-forge/dynamic-forms/internal';
-import { SubmitEvent } from './events/constants/submit.event';
+import { FormSubmitEvent } from './events/constants/submit.event';
 import { ComponentInitializedEvent } from '@ng-forge/dynamic-forms/internal';
 import { setupInitializationTracking } from '@ng-forge/dynamic-forms/internal';
 import { InferFormValue } from '@ng-forge/dynamic-forms/internal';
@@ -251,7 +251,7 @@ export class DynamicForm<
   /** Emits when form dirty state changes. */
   dirtyChange = outputFromObservable(toObservable(this.dirty));
 
-  /** Emits form values when submitted (via SubmitEvent) and form is valid. */
+  /** Emits form values when submitted (via FormSubmitEvent) and form is valid. */
   submitted = outputFromObservable(this.stateManager.submitted$);
 
   /** Emits when form is reset to default values. */
@@ -305,7 +305,7 @@ export class DynamicForm<
    */
   protected onNativeSubmit(event: Event): void {
     event.preventDefault();
-    this.eventBus.dispatch(SubmitEvent);
+    this.eventBus.dispatch(FormSubmitEvent);
   }
 
   // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/dynamic-forms/src/lib/events/constants/index.ts
+++ b/packages/dynamic-forms/src/lib/events/constants/index.ts
@@ -1,4 +1,4 @@
-export { SubmitEvent } from './submit.event';
+export { FormSubmitEvent } from './submit.event';
 export { NextPageEvent } from './next-page.event';
 export { PageChangeEvent } from './page-change.event';
 export { PreviousPageEvent } from './previous-page.event';

--- a/packages/dynamic-forms/src/lib/events/constants/submit.event.spec.ts
+++ b/packages/dynamic-forms/src/lib/events/constants/submit.event.spec.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect } from 'vitest';
-import { SubmitEvent } from './submit.event';
+import { FormSubmitEvent } from './submit.event';
 import { FormEvent } from '@ng-forge/dynamic-forms/internal';
 
-describe('SubmitEvent', () => {
+describe('FormSubmitEvent', () => {
   it('should create event with correct type', () => {
-    const event = new SubmitEvent();
+    const event = new FormSubmitEvent();
 
-    expect(event).toBeInstanceOf(SubmitEvent);
+    expect(event).toBeInstanceOf(FormSubmitEvent);
     expect(event.type).toBe('submit');
   });
 
   it('should implement FormEvent interface', () => {
-    const event = new SubmitEvent();
+    const event = new FormSubmitEvent();
     const formEvent: FormEvent = event;
 
     expect(formEvent.type).toBe('submit');

--- a/packages/dynamic-forms/src/lib/events/constants/submit.event.ts
+++ b/packages/dynamic-forms/src/lib/events/constants/submit.event.ts
@@ -1,5 +1,5 @@
 import { FormEvent } from '@ng-forge/dynamic-forms/internal';
 
-export class SubmitEvent implements FormEvent {
+export class FormSubmitEvent implements FormEvent {
   readonly type = 'submit' as const;
 }

--- a/packages/dynamic-forms/src/lib/events/index.ts
+++ b/packages/dynamic-forms/src/lib/events/index.ts
@@ -12,7 +12,7 @@ export {
   PreviousPageEvent,
   RemoveAtIndexEvent,
   ShiftArrayItemEvent,
-  SubmitEvent,
+  FormSubmitEvent,
 } from './constants';
 export type { ArrayItemTemplate, ArrayItemDefinitionTemplate } from './constants';
 

--- a/packages/dynamic-forms/src/lib/fields/group/group-field.component.ts
+++ b/packages/dynamic-forms/src/lib/fields/group/group-field.component.ts
@@ -28,7 +28,7 @@ import { FieldSignalContext, GroupContext } from '@ng-forge/dynamic-forms/intern
 import { FIELD_SIGNAL_CONTEXT, GROUP_CONTEXT, injectFieldSignalContext } from '@ng-forge/dynamic-forms/internal';
 import { createSchemaFromFields } from '../../core/schema-builder';
 import { EventBus } from '@ng-forge/dynamic-forms/internal';
-import { SubmitEvent } from '../../events/constants/submit.event';
+import { FormSubmitEvent } from '../../events/constants/submit.event';
 
 /** Container component for rendering nested form groups. */
 @Component({
@@ -213,7 +213,7 @@ export default class GroupFieldComponent<TModel extends Record<string, unknown> 
 
   readonly validityChange = outputFromObservable(toObservable(this.valid));
   readonly dirtyChange = outputFromObservable(toObservable(this.dirty));
-  readonly submitted = outputFromObservable(this.eventBus.on<SubmitEvent>('submit'));
+  readonly submitted = outputFromObservable(this.eventBus.on<FormSubmitEvent>('submit'));
 
   // ─────────────────────────────────────────────────────────────────────────────
   // Field Resolution

--- a/packages/dynamic-forms/src/lib/helpers/create-field.spec.ts
+++ b/packages/dynamic-forms/src/lib/helpers/create-field.spec.ts
@@ -1,4 +1,4 @@
-import { createField, field } from './create-field';
+import { createField } from './create-field';
 import { DynamicFormError } from '@ng-forge/dynamic-forms/internal';
 
 describe('createField', () => {
@@ -184,12 +184,6 @@ describe('createField', () => {
           template: [{ type: 'input', key: 'name' }],
         } as unknown as Parameters<typeof createField>[1]),
       ).toThrow("Use 'fields' (NOT 'template')");
-    });
-  });
-
-  describe('field alias', () => {
-    it('should be an alias for createField', () => {
-      expect(field).toBe(createField);
     });
   });
 });

--- a/packages/dynamic-forms/src/lib/helpers/create-field.ts
+++ b/packages/dynamic-forms/src/lib/helpers/create-field.ts
@@ -139,6 +139,3 @@ export function createField<T extends AvailableFieldTypes>(type: T, config: Omit
 
   return { type, ...config } as ExtractField<T>;
 }
-
-/** Shorthand alias for createField */
-export const field = createField;

--- a/packages/dynamic-forms/src/lib/helpers/index.ts
+++ b/packages/dynamic-forms/src/lib/helpers/index.ts
@@ -1,2 +1,2 @@
 export { formConfig } from './form-config';
-export { createField, field } from './create-field';
+export { createField } from './create-field';

--- a/packages/dynamic-forms/src/lib/index.ts
+++ b/packages/dynamic-forms/src/lib/index.ts
@@ -7,7 +7,7 @@
  * - DynamicForm component
  * - provideDynamicForm() for configuration
  * - FormConfig and field definition types
- * - Event classes (SubmitEvent, PageChangeEvent, etc.)
+ * - Event classes (FormSubmitEvent, PageChangeEvent, etc.)
  *
  * ## Integration API (for UI library authors)
  * Import from '@ng-forge/dynamic-forms/integration' for:
@@ -56,7 +56,7 @@ export { withLegacyStatusClasses } from './providers/features/legacy-status-clas
 
 // Wrapper Types
 export type { WrapperTypeDefinition, FieldWrapper } from '@ng-forge/dynamic-forms/internal';
-export { isWrapperTypeDefinition, WRAPPER_REGISTRY } from '@ng-forge/dynamic-forms/internal';
+export { isWrapperTypeDefinition } from '@ng-forge/dynamic-forms/internal';
 
 // Wrapper Registration DX
 export { wrapperProps } from './wrappers/wrapper-props';
@@ -89,7 +89,7 @@ export type {
   OrphanAddonActionContext,
   RegisteredActionRef,
 } from '@ng-forge/dynamic-forms/internal';
-export { ADDON_KIND_REGISTRY, DF_FIELD_TEMPLATES, isFieldBoundContext } from '@ng-forge/dynamic-forms/internal';
+export { DF_FIELD_TEMPLATES, isFieldBoundContext } from '@ng-forge/dynamic-forms/internal';
 export type { DynamicValue } from '@ng-forge/dynamic-forms/internal';
 
 // Addon Components & Directives
@@ -102,7 +102,7 @@ export { runPresetAction } from './addons/run-preset-action';
 export type { PresetCollaborators } from './addons/run-preset-action';
 
 // Addon Registry helpers (for adapter authors)
-export { ADDON_KIND_COMPONENT_CACHE, injectAddonKindRegistry } from './utils/inject-addon-kind-registry/inject-addon-kind-registry';
+export { injectAddonKindRegistry } from './utils/inject-addon-kind-registry/inject-addon-kind-registry';
 export { injectFieldsSupportingAddons } from './utils/inject-addon-kind-registry/inject-fields-supporting-addons';
 export type { FieldAddonSupportEntry } from './utils/inject-addon-kind-registry/inject-fields-supporting-addons';
 export { resolveDynamicValue } from '@ng-forge/dynamic-forms/internal';
@@ -112,18 +112,9 @@ export { withCustomAddon } from './providers/features/addons/with-custom-addon';
 export { provideAddonActions } from './providers/features/addons/provide-addon-actions';
 export type { AddonActionsFeature } from './providers/features/addons/provide-addon-actions';
 export { ADDON_KIND_DEFINITIONS } from './providers/features/addons/addon-kind-definitions.token';
-export { ADDON_ACTION_HANDLERS, ADDON_ACTION_REGISTRY } from './providers/features/addons/addon-action-registry.token';
-export type { AddonActionHandler } from './providers/features/addons/addon-action-registry.token';
 
 // Addon Validation
-export {
-  formatAddonWarning,
-  logAddonWarnings,
-  sanitizeFormConfig,
-  sanitizeFormConfigPure,
-  validateFieldAddons,
-  walkAndValidateAddons,
-} from './utils/validate-form-config/validate-form-config';
+export { sanitizeFormConfig } from './utils/validate-form-config/validate-form-config';
 export type { AddonWarning, SanitizedFormConfig, SanitizeFormConfigOptions } from './utils/validate-form-config/validate-form-config';
 
 // Configuration Types
@@ -137,17 +128,6 @@ export type { SubmissionConfig, SubmissionActionResult, SubmitButtonOptions, Nex
 export type { FormStateCondition } from '@ng-forge/dynamic-forms/internal';
 export { isFormStateCondition } from '@ng-forge/dynamic-forms/internal';
 
-// Logic Resolvers
-export {
-  resolveSubmitButtonDisabled,
-  resolveNextButtonDisabled,
-  resolveNonFieldHidden,
-  resolveNonFieldDisabled,
-  evaluateNonFieldHidden,
-  evaluateNonFieldDisabled,
-} from './core/logic';
-export type { ButtonLogicContext, NonFieldLogicContext, NonFieldLogicType, NonFieldLogicConfig } from './core/logic';
-
 // Abstract Base Field Types (for extension by UI libraries)
 export type {
   BaseCheckedField,
@@ -160,7 +140,6 @@ export type {
   ValueFieldComponent,
   ValueType,
 } from '@ng-forge/dynamic-forms/internal';
-export { isCheckedField, isValueField } from '@ng-forge/dynamic-forms/internal';
 
 // Built-in Container Field Types
 export type {
@@ -177,7 +156,7 @@ export type {
   WrapperConfig,
   CssWrapper,
 } from '@ng-forge/dynamic-forms/internal';
-export { isRowField, isSimplifiedArrayField, isContainerTypedField } from '@ng-forge/dynamic-forms/internal';
+export { isRowField, isSimplifiedArrayField } from '@ng-forge/dynamic-forms/internal';
 
 // Validation Config Types
 export type {
@@ -239,7 +218,6 @@ export type {
   GroupAllowedChildren,
   InferFormValue,
   PageAllowedChildren,
-  Prettify,
   RowAllowedChildren,
   WithInputSignals,
 } from '@ng-forge/dynamic-forms/internal';
@@ -269,7 +247,7 @@ export {
   PreviousPageEvent,
   RemoveAtIndexEvent,
   ShiftArrayItemEvent,
-  SubmitEvent,
+  FormSubmitEvent,
 } from './events';
 
 // Array event builder (recommended public API)
@@ -279,7 +257,7 @@ export type { ArrayItemTemplate, ArrayItemDefinitionTemplate } from './events';
 export type { FormEvent, FormEventConstructor, TokenContext, ArrayItemContext } from './events';
 
 // Helpers
-export { createField, field, formConfig } from './helpers';
+export { createField, formConfig } from './helpers';
 
 // Errors
 export { DynamicFormError } from '@ng-forge/dynamic-forms/internal';

--- a/packages/dynamic-forms/src/lib/providers/dynamic-form-di.ts
+++ b/packages/dynamic-forms/src/lib/providers/dynamic-form-di.ts
@@ -26,7 +26,7 @@ import { LogicFunctionCacheService } from '@ng-forge/dynamic-forms/internal';
 import { HttpConditionFunctionCacheService } from '@ng-forge/dynamic-forms/internal';
 import { AsyncConditionFunctionCacheService } from '@ng-forge/dynamic-forms/internal';
 import { DynamicValueFunctionCacheService } from '@ng-forge/dynamic-forms/internal';
-import { ADDON_ACTION_REGISTRY, createAddonActionRegistry } from './features/addons/addon-action-registry.token';
+import { ADDON_ACTION_REGISTRY, createAddonActionRegistry } from '@ng-forge/dynamic-forms/internal';
 
 /**
  * Always-on providers for any DynamicForm: state machine, registries, signal-context tokens.

--- a/packages/dynamic-forms/src/lib/providers/dynamic-form-providers.ts
+++ b/packages/dynamic-forms/src/lib/providers/dynamic-form-providers.ts
@@ -1,7 +1,6 @@
 import { EnvironmentProviders, inject, makeEnvironmentProviders, Provider, Type } from '@angular/core';
-import { ADDON_KIND_REGISTRY, AddonKindDefinition } from '@ng-forge/dynamic-forms/internal';
+import { ADDON_KIND_COMPONENT_CACHE, ADDON_KIND_REGISTRY, AddonKindDefinition } from '@ng-forge/dynamic-forms/internal';
 import { FIELD_REGISTRY, FieldTypeDefinition } from '@ng-forge/dynamic-forms/internal';
-import { ADDON_KIND_COMPONENT_CACHE } from '../utils/inject-addon-kind-registry/inject-addon-kind-registry';
 import { BUILT_IN_ADDON_KINDS } from './built-in-addons';
 import { BUILT_IN_FIELDS, BUILT_IN_WRAPPERS } from './built-in-fields';
 import { FieldDef } from '@ng-forge/dynamic-forms/internal';

--- a/packages/dynamic-forms/src/lib/providers/features/addons/provide-addon-actions.ts
+++ b/packages/dynamic-forms/src/lib/providers/features/addons/provide-addon-actions.ts
@@ -1,5 +1,5 @@
 import { createFeature, DynamicFormFeature } from '../dynamic-form-feature';
-import { AddonActionHandler, ADDON_ACTION_HANDLERS } from './addon-action-registry.token';
+import { AddonActionHandler, ADDON_ACTION_HANDLERS } from '@ng-forge/dynamic-forms/internal';
 
 /**
  * Typed feature returned by {@link provideAddonActions}. Carries the

--- a/packages/dynamic-forms/src/lib/state/form-state-manager.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-manager.ts
@@ -26,7 +26,7 @@ import { isPageField, PageField } from '@ng-forge/dynamic-forms/internal';
 import { EventBus } from '@ng-forge/dynamic-forms/internal';
 import { FormClearEvent } from '../events/constants/form-clear.event';
 import { FormResetEvent } from '../events/constants/form-reset.event';
-import { SubmitEvent } from '../events/constants/submit.event';
+import { FormSubmitEvent } from '../events/constants/submit.event';
 import { FieldSignalContext } from '@ng-forge/dynamic-forms/internal';
 import { FIELD_SIGNAL_CONTEXT } from '@ng-forge/dynamic-forms/internal';
 import { FieldTypeDefinition } from '@ng-forge/dynamic-forms/internal';
@@ -780,7 +780,7 @@ export class FormStateManager<
       return this.fieldsSource().length === this.resolvedFields().length;
     });
 
-    this.submitted$ = this.eventBus.on<SubmitEvent>('submit').pipe(
+    this.submitted$ = this.eventBus.on<FormSubmitEvent>('submit').pipe(
       filter(() => {
         if (!this.valid()) {
           this.logger.debug('Form submitted while invalid, not emitting to (submitted) output');
@@ -896,7 +896,7 @@ export class FormStateManager<
 
   /** Triggers form submission. */
   submit(): void {
-    this.eventBus.dispatch(SubmitEvent);
+    this.eventBus.dispatch(FormSubmitEvent);
   }
 
   // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/dynamic-forms/src/lib/utils/flattener/field-flattener.ts
+++ b/packages/dynamic-forms/src/lib/utils/flattener/field-flattener.ts
@@ -2,7 +2,7 @@ import { FieldDef } from '@ng-forge/dynamic-forms/internal';
 import { isRowField } from '@ng-forge/dynamic-forms/internal';
 import { isGroupField } from '@ng-forge/dynamic-forms/internal';
 import { isArrayField } from '@ng-forge/dynamic-forms/internal';
-import { isContainerTypedField } from '@ng-forge/dynamic-forms/internal';
+import { isGenericContainerField } from '@ng-forge/dynamic-forms/internal';
 import { FieldTypeDefinition, getFieldValueHandling } from '@ng-forge/dynamic-forms/internal';
 import { normalizeFieldsArray } from '@ng-forge/dynamic-forms/internal';
 
@@ -95,7 +95,7 @@ export function flattenFields(
     // Step 2: Check if this is a row or container field that should be preserved for DOM rendering
     // Row fields need to render their container element for grid layouts to work
     // Container fields need to render their container for the wrapper chain
-    if (options.preserveRows && (isRowField(field) || isContainerTypedField(field))) {
+    if (options.preserveRows && (isRowField(field) || isGenericContainerField(field))) {
       if (field.fields) {
         // Recursively flatten children while preserving row structure
         const flattenedChildren = flattenFields(normalizeFieldsArray(field.fields as FieldDef<unknown>[]), registry, options);

--- a/packages/dynamic-forms/src/lib/utils/inject-addon-kind-registry/inject-addon-kind-registry.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/inject-addon-kind-registry/inject-addon-kind-registry.spec.ts
@@ -3,7 +3,8 @@ import { TestBed } from '@angular/core/testing';
 import { describe, expect, it } from 'vitest';
 import { DynamicFormError } from '@ng-forge/dynamic-forms/internal';
 import { ADDON_KIND_REGISTRY, AddonKindDefinition } from '@ng-forge/dynamic-forms/internal';
-import { ADDON_KIND_COMPONENT_CACHE, injectAddonKindRegistry } from './inject-addon-kind-registry';
+import { ADDON_KIND_COMPONENT_CACHE } from '@ng-forge/dynamic-forms/internal';
+import { injectAddonKindRegistry } from './inject-addon-kind-registry';
 
 @Component({ template: '' })
 class IconKindComponent {}

--- a/packages/dynamic-forms/src/lib/utils/inject-addon-kind-registry/inject-addon-kind-registry.ts
+++ b/packages/dynamic-forms/src/lib/utils/inject-addon-kind-registry/inject-addon-kind-registry.ts
@@ -1,14 +1,7 @@
-import { inject, InjectionToken, Type } from '@angular/core';
+import { inject, Type } from '@angular/core';
 import { DynamicFormError } from '@ng-forge/dynamic-forms/internal';
-import { ADDON_KIND_REGISTRY, AddonKindDefinition } from '@ng-forge/dynamic-forms/internal';
+import { ADDON_KIND_COMPONENT_CACHE, ADDON_KIND_REGISTRY, AddonKindDefinition } from '@ng-forge/dynamic-forms/internal';
 import { resolveDefaultExport } from '../wrapper-chain/wrapper-chain';
-
-/**
- * Cache for resolved addon-kind components.
- *
- * @internal
- */
-export const ADDON_KIND_COMPONENT_CACHE = new InjectionToken<Map<string, Type<unknown>>>('ADDON_KIND_COMPONENT_CACHE');
 
 /**
  * Public shape returned by {@link injectAddonKindRegistry}. Pinned explicitly

--- a/packages/dynamic-forms/src/lib/utils/submission-handler/submission-handler.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/submission-handler/submission-handler.spec.ts
@@ -4,7 +4,7 @@ import { form, type FieldTree } from '@angular/forms/signals';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Subscription } from 'rxjs';
 import { EventBus } from '@ng-forge/dynamic-forms/internal';
-import { SubmitEvent } from '../../events/constants/submit.event';
+import { FormSubmitEvent } from '../../events/constants/submit.event';
 import type { FormConfig } from '@ng-forge/dynamic-forms/internal';
 import type { Logger } from '@ng-forge/dynamic-forms/internal';
 import { createSubmissionHandler } from './submission-handler';
@@ -44,7 +44,7 @@ describe('createSubmissionHandler', () => {
     });
   }
 
-  const dispatchSubmit = () => runInInjectionContext(injector, () => eventBus.dispatch(new SubmitEvent()));
+  const dispatchSubmit = () => runInInjectionContext(injector, () => eventBus.dispatch(new FormSubmitEvent()));
 
   it('skips the submission action when the form is not valid (invalid OR pending async validators)', async () => {
     const action = vi.fn().mockResolvedValue(undefined);
@@ -77,8 +77,8 @@ describe('createSubmissionHandler', () => {
     const action = vi.fn().mockReturnValue(gate);
     const sub = start(true, action);
     runInInjectionContext(injector, () => {
-      eventBus.dispatch(new SubmitEvent());
-      eventBus.dispatch(new SubmitEvent());
+      eventBus.dispatch(new FormSubmitEvent());
+      eventBus.dispatch(new FormSubmitEvent());
     });
     await tick(15);
     expect(action).toHaveBeenCalledTimes(1);

--- a/packages/dynamic-forms/src/lib/utils/submission-handler/submission-handler.ts
+++ b/packages/dynamic-forms/src/lib/utils/submission-handler/submission-handler.ts
@@ -2,7 +2,7 @@ import { Signal } from '@angular/core';
 import { FieldTree, submit } from '@angular/forms/signals';
 import { catchError, EMPTY, exhaustMap, firstValueFrom, from, isObservable, Observable } from 'rxjs';
 import { EventBus } from '@ng-forge/dynamic-forms/internal';
-import { SubmitEvent } from '../../events/constants/submit.event';
+import { FormSubmitEvent } from '../../events/constants/submit.event';
 import { FormConfig } from '@ng-forge/dynamic-forms/internal';
 import { RegisteredFieldTypes } from '@ng-forge/dynamic-forms/internal';
 import type { InferFormValue } from '@ng-forge/dynamic-forms/internal';
@@ -67,7 +67,7 @@ export function createSubmissionHandler<
   // is in-flight is silently dropped rather than cancelling the running Promise.
   // switchMap would unsubscribe the Observable wrapper but cannot cancel the
   // underlying Promise, causing both side effects to execute.
-  return eventBus.on<SubmitEvent>('submit').pipe(
+  return eventBus.on<FormSubmitEvent>('submit').pipe(
     exhaustMap(() => {
       const submissionConfig = configSignal().submission;
 


### PR DESCRIPTION
## What

Trims duplicate, ambiguous, and internal exports off the end-user `.` entrypoint ahead of 1.0, and re-tiers adapter-only symbols onto `/integration` (sourced from `/internal`). Verified against source; the breakdown maps to a 9-point API review.

| # | Change |
| - | ------ |
| 1 | Drop `field` alias. `createField` is the sole name. |
| 2 | Rename `SubmitEvent` to `FormSubmitEvent`. This also fixes a latent bug: all four adapters and the integration navigation mapper referenced `SubmitEvent` without importing it, so they were silently binding the DOM `SubmitEvent` global instead of the library event. |
| 3 | Re-tier guards. Move base guards `isValueField` / `isCheckedField` to `/integration`. Drop `isContainerTypedField` from the surface (renamed `isGenericContainerField`, internal-only, since it guards only the `container` field type, not a category). The remaining end-user guards are now unambiguous without renaming. |
| 4 | Drop addon-validation internals (`formatAddonWarning`, `logAddonWarnings`, `sanitizeFormConfigPure`, `validateFieldAddons`, `walkAndValidateAddons`) from `.`. Keep `sanitizeFormConfig`. |
| 5 | Drop the six non-field / button logic resolvers from `.`. They already live in `/internal`; `/integration` and its mappers now import them directly from `/internal` instead of routing through the main entrypoint. |
| 6 | Drop raw DI tokens from `.` (`WRAPPER_REGISTRY`, `ADDON_KIND_REGISTRY`, `ADDON_KIND_COMPONENT_CACHE`, `ADDON_ACTION_REGISTRY`, `ADDON_ACTION_HANDLERS`). Relocate the `ADDON_ACTION_*` and `ADDON_KIND_COMPONENT_CACHE` tokens into `/internal` and re-expose the adapter-tier ones via `/integration`. `WRAPPER_REGISTRY` and `isGenericContainerField` had no adapter consumers, so they stay internal-only. |
| 7 | Drop `Prettify` (a build-time TS helper) from `.`. |

The `/internal` blanket-export concern from the review is intentionally left for a separate PR.

## Verification

- `nx build` green for `dynamic-forms` (all entrypoints), the four adapters, and `docs`
- `nx test` green: core/integration 113 files, four adapters all pass
- `nx lint` green across the five touched projects
- MCP registry unaffected (no references to the renamed symbols)

## Breaking changes

Pre-1.0 surface change with no deprecation aliases (clean break). Consumers importing the removed symbols from `@ng-forge/dynamic-forms` should switch to `createField`, `FormSubmitEvent`, or `@ng-forge/dynamic-forms/integration` as applicable.