### PR TITLE
perf(docs): client-render API reference and add legacy URL redirects

### DIFF
--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -6,7 +6,7 @@ import { defineConfig, type Plugin } from 'vite';
 import analog from '@analogjs/platform';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import * as sass from 'sass';
-import { apiDocsPlugin, getApiPackages } from './plugins/vite-plugin-api-docs';
+import { apiDocsPlugin } from './plugins/vite-plugin-api-docs';
 import { searchIndexPlugin } from './plugins/vite-plugin-search-index';
 import { ogImagePlugin } from './plugins/vite-plugin-og-images';
 import { docsMetaPlugin } from './plugins/vite-plugin-docs-meta';
@@ -250,29 +250,15 @@ const PRERENDER_ADAPTERS = ['material', 'bootstrap', 'primeng', 'ionic', 'custom
 const contentSlugs = collectContentSlugs(resolve(__dirname, 'public/content'));
 
 /**
- * API reference symbols are crawler-friendly only when prerendered. We render the
- * canonical version under /material/api-reference/{symbol} for each symbol that
- * appears in core or any adapter package — DocPageComponent emits a canonical link
- * pointing to material, so non-material adapter URLs stay as SPA-resolved without
- * SEO penalty. Per-adapter prerendering would multiply route count by 5x.
+ * Individual API-reference symbol pages are intentionally NOT prerendered. Search
+ * Console shows Google crawls them (via the prerendered api-reference index) but
+ * leaves them "Crawled - currently not indexed" — they're auto-generated, thin, and
+ * low-value, so prerendering ~400 of them was the bulk of the build's time and
+ * memory for zero indexation. They resolve client-side via the SPA fallback and stay
+ * discoverable through the index pages, which ARE still prerendered below.
  */
-function collectApiSymbols(): string[] {
-  try {
-    const packages = getApiPackages();
-    const names = new Set<string>();
-    for (const pkg of packages.values()) {
-      for (const decl of pkg.declarations) names.add(decl.name);
-    }
-    return [...names].sort();
-  } catch (err) {
-    console.warn('[prerender] Failed to extract API symbols, skipping api-reference prerender:', err);
-    return [];
-  }
-}
-
 function generatePrerenderRoutes(): string[] {
   const routes: string[] = ['/'];
-  const apiSymbols = collectApiSymbols();
   for (const adapter of PRERENDER_ADAPTERS) {
     routes.push(`/${adapter}/getting-started`);
     routes.push(`/${adapter}/examples`);
@@ -281,10 +267,7 @@ function generatePrerenderRoutes(): string[] {
       routes.push(`/${adapter}/${slug}`);
     }
   }
-  for (const symbol of apiSymbols) {
-    routes.push(`/material/api-reference/${symbol}`);
-  }
-  console.log(`[prerender] Generated ${routes.length} routes (${apiSymbols.length} API symbols on /material)`);
+  console.log(`[prerender] Generated ${routes.length} routes`);
   return routes;
 }
 

--- a/vercel.json
+++ b/vercel.json
@@ -54,6 +54,10 @@
     { "source": "/forgot-password", "destination": "/dynamic-forms/", "permanent": true },
     { "source": "/path/to/form.config.ts", "destination": "/dynamic-forms/", "permanent": true },
     { "source": "/examples", "destination": "/dynamic-forms/material/examples", "permanent": true },
+    { "source": "/configuration", "destination": "/dynamic-forms/material/configuration", "permanent": true },
+    { "source": "/feature-overview", "destination": "/dynamic-forms/material/feature-overview", "permanent": true },
+    { "source": "/api-driven-forms", "destination": "/dynamic-forms/material/api-driven-forms", "permanent": true },
+    { "source": "/migrating-from-ngx-formly", "destination": "/dynamic-forms/material/migrating-from-ngx-formly", "permanent": true },
 
     { "source": "/api/:kind/core/:symbol", "destination": "/dynamic-forms/material/api-reference/:symbol", "permanent": true },
     { "source": "/api/:kind/material/:symbol", "destination": "/dynamic-forms/material/api-reference/:symbol", "permanent": true },
@@ -89,7 +93,12 @@
     { "source": "/material/:path*", "destination": "/dynamic-forms/material/:path*", "permanent": true },
     { "source": "/prebuilt/:path*", "destination": "/dynamic-forms/material/prebuilt/:path*", "permanent": true },
     { "source": "/wrappers/:path*", "destination": "/dynamic-forms/material/wrappers/:path*", "permanent": true },
-    { "source": "/dynamic-behavior/:path*", "destination": "/dynamic-forms/material/dynamic-behavior/:path*", "permanent": true }
+    { "source": "/dynamic-behavior/:path*", "destination": "/dynamic-forms/material/dynamic-behavior/:path*", "permanent": true },
+    { "source": "/examples/:path*", "destination": "/dynamic-forms/material/examples/:path*", "permanent": true },
+    { "source": "/recipes/:path*", "destination": "/dynamic-forms/material/recipes/:path*", "permanent": true },
+    { "source": "/addons/:path*", "destination": "/dynamic-forms/material/addons/:path*", "permanent": true },
+    { "source": "/schema-validation/:path*", "destination": "/dynamic-forms/material/schema-validation/:path*", "permanent": true },
+    { "source": "/field-types/:path*", "destination": "/dynamic-forms/material/field-types/:path*", "permanent": true }
   ],
   "rewrites": [
     {


### PR DESCRIPTION
Follow-up to #468, driven by the Search Console exports. Two independent docs improvements.

## 1. Client-render the API-reference symbol pages (perf)

Search Console's "Crawled - currently not indexed" report shows Google fetches the prerendered `/material/api-reference/{symbol}` pages and **declines to index them** — they're thin, auto-generated, and not even in the sitemap. So prerendering ~400 of them bought zero indexation while dominating the docs build's time and memory.

Drop them from the prerender set; keep the per-adapter api-reference **index** pages as hubs. Individual symbols resolve client-side via the SPA fallback and stay discoverable through the index pages (same model the non-material adapter API pages already use).

- Prerendered routes: **733 → 321** (−56%)
- Builds lighter and faster, well under the 8 GB / 2-core container

## 2. Redirect legacy URLs reported as 404 (fix)

Search Console's "Not found (404)" report lists old flat doc URLs predating the `/dynamic-forms/material/` structure. Their targets all resolve 200 — they were just missing redirect rules. Added:

- Section prefixes: `/examples/*`, `/recipes/*`, `/addons/*`, `/schema-validation/*`, `/field-types/*`
- Flat slugs: `/configuration`, `/feature-overview`, `/api-driven-forms`, `/migrating-from-ngx-formly`

The bulk of the 404 report (~450 old `/api/*` URLs) already redirects correctly and self-heals on re-crawl — no change needed.

## Not included (need a decision, not guessing)

- **Bare section-parent URLs** (`/material/addons`, `/dynamic-forms/material/field-types`, etc.) 404 because those sections have child pages but no landing page. Fix is either a redirect to a chosen first child/overview or an actual index page — a content/IA call.
- **Removed API symbols** (`HttpValidatorConfig`, `isPropertyDerivationLogicConfig`) — leave to 404 or 410.
- **www duplicates** in the crawled-not-indexed report — benign legacy; sitemap is already apex-only; they age out.