### PR TITLE
docs(dynamic-forms): document /internal as unsupported (no semver guarantee)

### DIFF
--- a/packages/dynamic-forms/README.md
+++ b/packages/dynamic-forms/README.md
@@ -31,6 +31,19 @@ Core library for building type-safe, dynamic Angular forms with signal forms int
 | 0.1.1+                  | 21.0.2-21.0.5 |
 | 0.1.0                   | 21.0.0-21.0.1 |
 
+## Supported entrypoints
+
+| Entrypoint                            | Audience            | Stability                        |
+| ------------------------------------- | ------------------- | -------------------------------- |
+| `@ng-forge/dynamic-forms`             | Form consumers      | Public API, governed by semver   |
+| `@ng-forge/dynamic-forms/integration` | UI adapter authors  | Public API, governed by semver   |
+| `@ng-forge/dynamic-forms/internal`    | None (build-time)   | Unsupported, no semver guarantee |
+| `@ng-forge/dynamic-forms/testing`     | None (test helpers) | Unsupported, no semver guarantee |
+
+The `/internal` and `/testing` entrypoints are unsupported build and test surfaces with no semver guarantee. They are published only because shared DI tokens, services, and config types must keep a single compiled identity across the public bundles. Their contents may change or be removed in any release, including patch releases.
+
+Import only from `@ng-forge/dynamic-forms` (form consumers) or `@ng-forge/dynamic-forms/integration` (UI adapter authors).
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## What

Adds a **Supported entrypoints** section to the `@ng-forge/dynamic-forms` package README documenting that `/internal` and `/testing` are unsupported build/test surfaces with no semver guarantee.

## Why

`/internal` is a published, consumer-resolvable secondary entrypoint. It exists so DI tokens, services, and config types keep a single compiled identity across the `.` (form consumers) and `/integration` (adapter authors) bundles, which both re-export from it at runtime. It cannot be un-published or hidden via the package `exports` map without breaking that re-export chain and token identity (same constraint as `rxjs/internal/*`). The only viable guard is a documented social contract, which until now lived only in the generator's code-comment header. This surfaces it where consumers actually look.

## Scope

- Documentation only. No runtime changes.
- Does not touch `src/lib/index.ts`, the adapter barrels, the generator, or the `export *` surface, so it will not conflict with #465/#469.
- Wording mirrors the existing `gen-public-api.mjs` header so the two stay consistent.

## Verification

- `node scripts/refactor/gen-public-api.mjs --check` passes (generated `internal/src/public_api.ts` still in sync, 125 export lines).
- Pre-commit format and commitlint passed.