### PR TITLE
feat(dynamic-forms): export HiddenField type and isHiddenField guard

### DIFF
--- a/etc/dynamic-forms.api.md
+++ b/etc/dynamic-forms.api.md
@@ -728,6 +728,18 @@ export function hasFormValue<T extends FormEvent>(event: T): event is T & {
 };
 
 // @public
+export interface HiddenField<TValue extends HiddenValue = HiddenValue> extends FieldDef<never> {
+    type: 'hidden';
+    value: TValue;
+}
+
+// @public
+export type HiddenScalar = string | number | boolean;
+
+// @public
+export type HiddenValue = HiddenScalar | HiddenScalar[];
+
+// @public
 export interface HttpCondition {
     cacheDurationMs?: number;
     debounceMs?: number;
@@ -808,6 +820,9 @@ export function isFormStateCondition(condition: StateLogicConfig['condition'] | 
 
 // @public
 export function isGroupField(field: FieldDef<any>): field is GroupField;
+
+// @public
+export function isHiddenField(field: FieldDef<unknown>): field is HiddenField;
 
 // @public
 export function isLeafField(field: RegisteredFieldTypes): field is LeafFieldTypes;

--- a/packages/dynamic-forms/src/lib/index.ts
+++ b/packages/dynamic-forms/src/lib/index.ts
@@ -150,6 +150,9 @@ export type {
 } from '@ng-forge/dynamic-forms/internal';
 export { isRowField, isSimplifiedArrayField } from '@ng-forge/dynamic-forms/internal';
 
+// Hidden Field (display-only, value pass-through)
+export type { HiddenField, HiddenValue, HiddenScalar } from '@ng-forge/dynamic-forms/internal';
+
 // Validation Config Types
 export type {
   AsyncValidatorConfig,
@@ -220,6 +223,7 @@ export {
   isContainerField,
   isDisplayOnlyField,
   isGroupField,
+  isHiddenField,
   isLeafField,
   isPageField,
   isValueBearingField,


### PR DESCRIPTION
## What

Promotes the hidden-field public types and guard from `/internal` to the main entrypoint:

- `HiddenField<TValue>` (and its value types `HiddenValue`, `HiddenScalar`)
- `isHiddenField()` type guard

## Why

The prebuilt hidden-fields documentation imports both from `@ng-forge/dynamic-forms`:

```ts
import { HiddenField } from '@ng-forge/dynamic-forms';
const idField: HiddenField<string> = { ... };

import { isHiddenField } from '@ng-forge/dynamic-forms';
if (isHiddenField(field)) { ... }
```

Neither was actually exported, so the documented examples did not compile. Every other built-in field type already exposes both its type and its `is*Field` guard; hidden fields were the lone gap. This rounds out the field-type/guard surface ahead of the 1.0 lock and makes the docs correct as written.

## Changes

- Re-export `HiddenField`, `HiddenValue`, `HiddenScalar` (types) and `isHiddenField` (guard) from the public `index.ts`.
- Regenerate the API Extractor report (`etc/dynamic-forms.api.md`).

## Verification

- `nx build dynamic-forms` passes.
- `api-extractor run` (check mode) passes against the regenerated report.
- The `prebuilt/hidden-fields.md` import sites now resolve against the public API.