### PR TITLE
refactor(dynamic-forms): drop deprecated InputTypeToValueType and tidy adapter testing exports

### DIFF
--- a/etc/dynamic-forms-integration.api.md
+++ b/etc/dynamic-forms-integration.api.md
@@ -577,9 +577,6 @@ export interface InputProps<T extends HtmlInputType = InputType> {
 // @public
 export type InputType = Extract<HtmlInputType, 'text' | 'email' | 'password' | 'number' | 'tel' | 'url' | 'search'>;
 
-// @public @deprecated (undocumented)
-export type InputTypeToValueType<T extends InputType> = InferInputValue<T>;
-
 // @public
 export function insertArrayItemButtonMapper<TProps>(fieldDef: BaseInsertArrayItemButtonField<TProps>): Signal<Record<string, unknown>>;
 

--- a/packages/dynamic-forms-ionic/src/lib/testing/index.ts
+++ b/packages/dynamic-forms-ionic/src/lib/testing/index.ts
@@ -6,4 +6,5 @@ export {
   createTestTranslationService,
 } from '@ng-forge/utils';
 export { waitForDFInit } from './wait-for-df';
-export { IonicFormTestUtils, IonicFormConfigBuilder, IonicFormTestConfig, IonicFormTestResult } from './ionic-test-utils';
+export { IonicFormTestUtils, IonicFormConfigBuilder } from './ionic-test-utils';
+export type { IonicFormTestConfig, IonicFormTestResult } from './ionic-test-utils';

--- a/packages/dynamic-forms-material/src/lib/testing/index.ts
+++ b/packages/dynamic-forms-material/src/lib/testing/index.ts
@@ -6,4 +6,5 @@ export {
   createTestTranslationService,
 } from '@ng-forge/utils';
 export { waitForDFInit } from './wait-for-df';
-export { MaterialFormTestUtils, MaterialFormConfigBuilder, MaterialFormTestConfig, MaterialFormTestResult } from './material-test-utils';
+export { MaterialFormTestUtils, MaterialFormConfigBuilder } from './material-test-utils';
+export type { MaterialFormTestConfig, MaterialFormTestResult } from './material-test-utils';

--- a/packages/dynamic-forms/integration/src/definitions/index.ts
+++ b/packages/dynamic-forms/integration/src/definitions/index.ts
@@ -2,16 +2,7 @@
 export type { ButtonField, EventArgs } from './button-field';
 export type { CheckboxField } from './checkbox-field';
 export type { DatepickerField, DatepickerProps } from './datepicker-field';
-export type {
-  InputField,
-  InputProps,
-  InputType,
-  InputTypeToValueType,
-  InferInputValue,
-  NumericInputType,
-  StringInputType,
-  HtmlInputType,
-} from './input-field';
+export type { InputField, InputProps, InputType, InferInputValue, NumericInputType, StringInputType, HtmlInputType } from './input-field';
 export type { InputMeta, AutocompleteValue, InputMode, EnterKeyHint, Autocapitalize } from './input-meta';
 export type { MultiCheckboxField } from './multi-checkbox-field';
 export type { RadioField } from './radio-field';

--- a/packages/dynamic-forms/integration/src/definitions/input-field.ts
+++ b/packages/dynamic-forms/integration/src/definitions/input-field.ts
@@ -45,11 +45,6 @@ export type InputType = Extract<HtmlInputType, 'text' | 'email' | 'password' | '
 export type InferInputValue<T extends HtmlInputType> = T extends 'number' ? number : string;
 
 /**
- * @deprecated Use `InferInputValue` instead. Will be removed in v1.0.0.
- */
-export type InputTypeToValueType<T extends InputType> = InferInputValue<T>;
-
-/**
  * Props for input fields with optional type specification.
  * Generic parameter allows extending InputType with additional HtmlInputType values.
  */

--- a/packages/dynamic-forms/integration/src/public_api.ts
+++ b/packages/dynamic-forms/integration/src/public_api.ts
@@ -23,7 +23,6 @@ export type {
   InputField,
   InputProps,
   InputType,
-  InputTypeToValueType,
   InferInputValue,
   NumericInputType,
   StringInputType,


### PR DESCRIPTION
## What

Two small public-surface hygiene fixes ahead of the 1.0 lock.

### 1. Remove the deprecated `InputTypeToValueType`

The alias was already marked `@deprecated ... Will be removed in v1.0.0` (use `InferInputValue`). It is removed from the `/integration` definitions and `public_api`. No references remain anywhere in the repo.

### 2. Tidy Material/Ionic testing barrels

The Material and Ionic `testing/index.ts` barrels exported their `FormTestConfig` / `FormTestResult` interfaces as runtime values. Split them into `export type` so they match the Bootstrap and PrimeNG barrels and are correct under `verbatimModuleSyntax` / `isolatedModules`.

## Changes

- `integration/src/definitions/input-field.ts`, `definitions/index.ts`, `public_api.ts`: drop `InputTypeToValueType`.
- `dynamic-forms-material` / `dynamic-forms-ionic` `testing/index.ts`: `export type` for the config/result interfaces.
- Regenerate `etc/dynamic-forms-integration.api.md`.

## Verification

- `nx build dynamic-forms` passes.
- `api-extractor run` (check mode) passes for both core and integration reports.
- `nx lint` passes for dynamic-forms-material and dynamic-forms-ionic.