### PR TITLE
docs(docs): add /integration to the API-reference generator

### DIFF
--- a/apps/docs/plugins/vite-plugin-api-docs.ts
+++ b/apps/docs/plugins/vite-plugin-api-docs.ts
@@ -76,6 +76,7 @@ interface PackageDef {
 
 const PACKAGES: PackageDef[] = [
   { name: '@ng-forge/dynamic-forms', slug: 'core', entryPoints: ['packages/dynamic-forms/src/index.ts'] },
+  { name: '@ng-forge/dynamic-forms/integration', slug: 'integration', entryPoints: ['packages/dynamic-forms/integration/index.ts'] },
   { name: '@ng-forge/dynamic-forms/schema', slug: 'schema', entryPoints: ['packages/dynamic-forms/schema/index.ts'] },
   { name: '@ng-forge/dynamic-forms-material', slug: 'material', entryPoints: ['packages/dynamic-forms-material/src/index.ts'] },
   { name: '@ng-forge/dynamic-forms-bootstrap', slug: 'bootstrap', entryPoints: ['packages/dynamic-forms-bootstrap/src/index.ts'] },


### PR DESCRIPTION
## What

Adds `@ng-forge/dynamic-forms/integration` to the docs API-reference generator (`apps/docs/plugins/vite-plugin-api-docs.ts` `PACKAGES`), so it gets a generated reference page like the core, schema, and adapter entrypoints.

## Why

Follow-up to #478. `/integration` is a public, semver-governed surface for UI adapter authors, but it had no generated API-reference page. Its exports (`EventBus`, `NgForgeField`, the field mappers, `FieldTypeDefinition`, etc.) were only discoverable through hand-written guides. It is already locked by an API Extractor golden (`etc/dynamic-forms-integration.api.md`); this closes the docs-site discoverability gap.

## Changes

- One entry added to `PACKAGES` (slug `integration`), mirroring the existing `core` and `schema` entries (same `export * from './src/public_api'` resolution path).

## Verification

- Entry mirrors the proven `core`/`schema` entries exactly; the docs build (Vercel preview) exercises the generator and renders the page.