### PR TITLE
fix(openapi-generator): extract multipart and urlencoded request body schemas

### DIFF
--- a/apps/docs/public/content/openapi-generator.md
+++ b/apps/docs/public/content/openapi-generator.md
@@ -217,6 +217,12 @@ OpenAPI schema constraints map directly to `@ng-forge/dynamic-forms` validators:
 | `additionalProperties`    | Skipped      | Warning logged                                      |
 | `$ref`                    | Dereferenced | Resolved at parse time via swagger-parser           |
 
+## Request Body Content Types
+
+Request body schemas are read from `application/json`, `multipart/form-data`, or `application/x-www-form-urlencoded`, in that preference order when an endpoint declares more than one.
+
+Binary file properties (`type: string` with `format: binary`, including arrays of them) are skipped with a warning since no file upload field type exists yet. An endpoint whose body contains only binary properties produces no form and is skipped entirely.
+
 ## Config File
 
 The generator persists your choices in `.ng-forge-generator.json`:

--- a/packages/openapi-generator/README.md
+++ b/packages/openapi-generator/README.md
@@ -404,6 +404,12 @@ GET endpoints with top-level array responses are always skipped since they don't
 
 To make GET endpoint fields read-only, use `--read-only`.
 
+### Which request body content types are supported?
+
+`application/json`, `multipart/form-data`, and `application/x-www-form-urlencoded`, in that preference order when an endpoint declares more than one.
+
+Binary file properties (`type: string, format: binary`, including arrays of them) are skipped with a warning since there is no file upload field type yet. An endpoint whose body contains only binary properties produces no form and is skipped entirely.
+
 ### Why does the generator say "Swagger 2.0" is not supported?
 
 Only OpenAPI 3.x specs are supported. Convert Swagger 2.0 specs using [converter.swagger.io](https://converter.swagger.io) or the `swagger2openapi` npm package.

--- a/packages/openapi-generator/src/__tests__/integration/__fixtures__/media-service.yaml
+++ b/packages/openapi-generator/src/__tests__/integration/__fixtures__/media-service.yaml
@@ -1,0 +1,159 @@
+openapi: '3.0.3'
+info:
+  title: API Documentation of the media service
+  version: '1.0'
+paths:
+  /api/media/videos:
+    get:
+      operationId: VideoController_findAll
+      responses:
+        '200':
+          description: The videos have been received successfully.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/VideoResponseDto'
+  /api/media/videos/{videoId}:
+    get:
+      operationId: VideoController_findById
+      parameters:
+        - name: videoId
+          required: true
+          in: path
+          schema: {}
+      responses:
+        '200':
+          description: The video has been found successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VideoResponseDto'
+    put:
+      operationId: VideoController_editById
+      parameters:
+        - name: videoId
+          required: true
+          in: path
+          schema: {}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EditVideoDto'
+      responses:
+        '200':
+          description: The video has been updated successfully.
+    delete:
+      operationId: VideoController_deleteById
+      parameters:
+        - name: videoId
+          required: true
+          in: path
+          schema: {}
+      responses:
+        '200':
+          description: The video has been deleted successfully.
+  /api/media/videos/{category}/upload:
+    post:
+      operationId: VideoController_upload
+      parameters:
+        - name: category
+          required: true
+          in: path
+          description: The category name
+          schema:
+            enum:
+              - trailer
+              - episode
+              - clip
+            type: string
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                clips:
+                  items:
+                    format: binary
+                    type: string
+                  type: array
+              type: object
+      responses:
+        '200':
+          description: The videos have been uploaded successfully.
+  /api/media/videos/{videoId}/captions:
+    post:
+      operationId: VideoController_uploadCaptions
+      parameters:
+        - name: videoId
+          required: true
+          in: path
+          schema: {}
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [language]
+              properties:
+                language:
+                  type: string
+                  enum:
+                    - en
+                    - de
+                    - fr
+                subtitleFile:
+                  type: string
+                  format: binary
+      responses:
+        '200':
+          description: The captions have been uploaded successfully.
+components:
+  schemas:
+    VideoResponseDto:
+      type: object
+      properties:
+        id:
+          type: string
+          description: A primary generated column in `uuid` format.
+          nullable: false
+        title:
+          type: string
+          description: The title of the video.
+          nullable: false
+        description:
+          type: string
+          description: The description of the video.
+          nullable: true
+          default: null
+        durationSeconds:
+          type: number
+          description: The duration of the video in seconds.
+          nullable: true
+          default: null
+      required:
+        - id
+        - title
+    EditVideoDto:
+      type: object
+      properties:
+        title:
+          type: string
+          description: The title of the video.
+          nullable: true
+          default: null
+        description:
+          type: string
+          description: The description of the video.
+          nullable: true
+          default: null
+        durationSeconds:
+          type: number
+          description: The duration of the video in seconds.
+          nullable: true
+          default: null

--- a/packages/openapi-generator/src/__tests__/integration/__fixtures__/multipart-upload.yaml
+++ b/packages/openapi-generator/src/__tests__/integration/__fixtures__/multipart-upload.yaml
@@ -1,0 +1,43 @@
+openapi: '3.0.3'
+info:
+  title: Test
+  version: '1.0.0'
+paths:
+  /images/{bucket}/upload:
+    post:
+      operationId: uploadImages
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                files:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+      responses:
+        '200':
+          description: Uploaded
+  /documents:
+    post:
+      operationId: createDocument
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [title]
+              properties:
+                title:
+                  type: string
+                  maxLength: 100
+                attachment:
+                  type: string
+                  format: binary
+      responses:
+        '201':
+          description: Created

--- a/packages/openapi-generator/src/__tests__/integration/generate-pipeline.integration.spec.ts
+++ b/packages/openapi-generator/src/__tests__/integration/generate-pipeline.integration.spec.ts
@@ -519,6 +519,79 @@ describe('Edge Cases', () => {
   });
 });
 
+// ─── Multipart Request Bodies (issue #485) ───────────────────────────
+
+describe('Multipart request bodies', () => {
+  it('should generate a form from a multipart/form-data body, skipping binary fields', async () => {
+    await generate('multipart-upload.yaml');
+
+    const form = await readGenerated(outputDir, 'forms', 'create-document.form.ts');
+    expect(form).toContain("key: 'title'");
+    expect(form).not.toContain("key: 'attachment'");
+  });
+
+  it('should skip endpoints whose multipart body contains only binary fields', async () => {
+    await generate('multipart-upload.yaml');
+
+    const uploadForm = await fileExists(join(outputDir, 'forms', 'upload-images.form.ts'));
+    expect(uploadForm).toBe(false);
+
+    const config = await readConfigFile(outputDir);
+    expect(config['endpoints']).toEqual(['POST:/documents']);
+  });
+});
+
+// ─── Storage-like service spec (issue #485 shape) ────────────────────
+
+describe('Storage-like service spec (issue #485 shape)', () => {
+  it('should generate forms for every endpoint that maps to one', async () => {
+    await generate('media-service.yaml');
+
+    const findById = await fileExists(join(outputDir, 'forms', 'video-controller-find-by-id.form.ts'));
+    const editById = await fileExists(join(outputDir, 'forms', 'video-controller-edit-by-id.form.ts'));
+    const uploadCaptions = await fileExists(join(outputDir, 'forms', 'video-controller-upload-captions.form.ts'));
+
+    expect(findById).toBe(true);
+    expect(editById).toBe(true);
+    expect(uploadCaptions).toBe(true);
+
+    const config = await readConfigFile(outputDir);
+    expect(config['endpoints']).toEqual([
+      'GET:/api/media/videos/{videoId}',
+      'PUT:/api/media/videos/{videoId}',
+      'POST:/api/media/videos/{videoId}/captions',
+    ]);
+  });
+
+  it('should skip the array-response list endpoint and the binary-only upload endpoint', async () => {
+    await generate('media-service.yaml');
+
+    const findAll = await fileExists(join(outputDir, 'forms', 'video-controller-find-all.form.ts'));
+    const upload = await fileExists(join(outputDir, 'forms', 'video-controller-upload.form.ts'));
+
+    expect(findAll).toBe(false);
+    expect(upload).toBe(false);
+  });
+
+  it('should keep non-binary multipart fields and drop the binary one', async () => {
+    await generate('media-service.yaml');
+
+    const form = await readGenerated(outputDir, 'forms', 'video-controller-upload-captions.form.ts');
+    expect(form).toContain("key: 'language'");
+    expect(form).toContain("type: 'select'");
+    expect(form).not.toContain('subtitleFile');
+  });
+
+  it('should map the dereferenced edit DTO with nullable fields', async () => {
+    await generate('media-service.yaml');
+
+    const form = await readGenerated(outputDir, 'forms', 'video-controller-edit-by-id.form.ts');
+    expect(form).toContain("key: 'title'");
+    expect(form).toContain("key: 'durationSeconds'");
+    expect(form).toContain('nullable: true');
+  });
+});
+
 // ─── N. Nullable Values (issue #341) ─────────────────────────────────
 
 describe('Nullable values', () => {

--- a/packages/openapi-generator/src/__tests__/integration/generate-pipeline.integration.spec.ts
+++ b/packages/openapi-generator/src/__tests__/integration/generate-pipeline.integration.spec.ts
@@ -530,6 +530,14 @@ describe('Multipart request bodies', () => {
     expect(form).not.toContain("key: 'attachment'");
   });
 
+  it('should omit skipped binary properties from the generated types so the interface matches the form', async () => {
+    await generate('multipart-upload.yaml');
+
+    const types = await readGenerated(outputDir, 'types', 'create-document.types.ts');
+    expect(types).toContain('title: string;');
+    expect(types).not.toContain('attachment');
+  });
+
   it('should skip endpoints whose multipart body contains only binary fields', async () => {
     await generate('multipart-upload.yaml');
 
@@ -580,6 +588,10 @@ describe('Storage-like service spec (issue #485 shape)', () => {
     expect(form).toContain("key: 'language'");
     expect(form).toContain("type: 'select'");
     expect(form).not.toContain('subtitleFile');
+
+    const types = await readGenerated(outputDir, 'types', 'video-controller-upload-captions.types.ts');
+    expect(types).toContain("language: 'en' | 'de' | 'fr';");
+    expect(types).not.toContain('subtitleFile');
   });
 
   it('should map the dereferenced edit DTO with nullable fields', async () => {

--- a/packages/openapi-generator/src/cli/commands/generate.command.ts
+++ b/packages/openapi-generator/src/cli/commands/generate.command.ts
@@ -225,6 +225,11 @@ async function runGenerate(options: GenerateOptions): Promise<void> {
       });
     }
 
+    if (result.fields.length === 0) {
+      logger.warn(`${endpoint.method} ${endpoint.path}: No mappable fields (all properties were skipped), skipping`);
+      continue;
+    }
+
     const formFileName = toFormFileName(endpoint.method, endpoint.path, endpoint.operationId);
 
     logger.verbose(`${endpoint.method} ${endpoint.path} → forms/${formFileName}`);

--- a/packages/openapi-generator/src/generator/interface-generator.spec.ts
+++ b/packages/openapi-generator/src/generator/interface-generator.spec.ts
@@ -518,6 +518,60 @@ describe('generateInterface', () => {
     expect(result).not.toContain('ref');
   });
 
+  // Issue #485: binary properties are skipped by the field mapper, so the
+  // FormValue interface must skip them too — otherwise it describes a property
+  // the form can never produce.
+  it('should skip binary file properties so the interface matches the generated form', () => {
+    const schema: OpenAPIV3.SchemaObject = {
+      type: 'object',
+      required: ['name', 'avatar'],
+      properties: {
+        name: { type: 'string' },
+        avatar: { type: 'string', format: 'binary' },
+      },
+    };
+
+    const result = generateInterface(schema, defaultOptions);
+
+    expect(result).toContain('  name: string;');
+    expect(result).not.toContain('avatar');
+  });
+
+  it('should skip arrays of binary files', () => {
+    const schema: OpenAPIV3.SchemaObject = {
+      type: 'object',
+      properties: {
+        title: { type: 'string' },
+        files: { type: 'array', items: { type: 'string', format: 'binary' } },
+      },
+    };
+
+    const result = generateInterface(schema, defaultOptions);
+
+    expect(result).toContain('  title?: string;');
+    expect(result).not.toContain('files');
+  });
+
+  it('should skip binary properties inside nested object interfaces', () => {
+    const schema: OpenAPIV3.SchemaObject = {
+      type: 'object',
+      properties: {
+        meta: {
+          type: 'object',
+          properties: {
+            label: { type: 'string' },
+            blob: { type: 'string', format: 'binary' },
+          },
+        },
+      },
+    };
+
+    const result = generateInterface(schema, defaultOptions);
+
+    expect(result).toContain('  label?: string;');
+    expect(result).not.toContain('blob');
+  });
+
   it('should include @generated header', () => {
     const schema: OpenAPIV3.SchemaObject = {
       type: 'object',

--- a/packages/openapi-generator/src/generator/interface-generator.ts
+++ b/packages/openapi-generator/src/generator/interface-generator.ts
@@ -1,8 +1,15 @@
 import type { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types';
 import { toInterfaceName, toPascalCase } from '../utils/naming.js';
-import { isReferenceObject } from '../utils/openapi-utils.js';
+import { isBinarySchema, isReferenceObject } from '../utils/openapi-utils.js';
 
 type SchemaObject = OpenAPIV3.SchemaObject | OpenAPIV3_1.SchemaObject;
+
+// Binary file properties (format: binary, including arrays of binary items) are
+// skipped by the field mapper (issue #485), so the FormValue interface must skip
+// them too — otherwise it would describe a property the form can never produce.
+function isSkippedBinaryProperty(schema: SchemaObject): boolean {
+  return isBinarySchema(schema) || isBinarySchema((schema as Record<string, unknown>)['items']);
+}
 
 export interface InterfaceGeneratorOptions {
   method: string;
@@ -155,6 +162,7 @@ function resolveSchemaProperties(
 
   for (const [name, propSchema] of Object.entries(schema.properties ?? {})) {
     if (isReferenceObject(propSchema)) continue;
+    if (isSkippedBinaryProperty(propSchema)) continue;
     properties.push([name, propSchema]);
   }
 
@@ -296,6 +304,7 @@ function generateNestedInterface(name: string, schema: SchemaObject, seen: WeakS
 
   for (const [propName, propSchema] of Object.entries(schema.properties ?? {})) {
     if (isReferenceObject(propSchema)) continue;
+    if (isSkippedBinaryProperty(propSchema)) continue;
     const optional = required.has(propName) ? '' : '?';
     const tsType = schemaToTsType(propName, propSchema, name, nestedInterfaces, seen);
     lines.push(`  ${propName}${optional}: ${tsType};`);

--- a/packages/openapi-generator/src/mapper/schema-to-fields.spec.ts
+++ b/packages/openapi-generator/src/mapper/schema-to-fields.spec.ts
@@ -555,7 +555,7 @@ describe('mapSchemaToFields', () => {
     expect(result.fields).toHaveLength(1);
     expect(result.fields[0].key).toBe('name');
     expect(result.warnings).toContain(
-      "Property 'avatar' is a file upload (format: binary) and was skipped — no file field type is available yet",
+      "Property 'avatar' is a file upload (format: binary) and was skipped; no file field type is available yet",
     );
   });
 
@@ -570,7 +570,7 @@ describe('mapSchemaToFields', () => {
     const result = mapSchemaToFields(schema, []);
     expect(result.fields).toHaveLength(0);
     expect(result.warnings).toContain(
-      "Property 'files' is a file upload (format: binary) and was skipped — no file field type is available yet",
+      "Property 'files' is a file upload (format: binary) and was skipped; no file field type is available yet",
     );
   });
 

--- a/packages/openapi-generator/src/mapper/schema-to-fields.spec.ts
+++ b/packages/openapi-generator/src/mapper/schema-to-fields.spec.ts
@@ -542,6 +542,38 @@ describe('mapSchemaToFields', () => {
     expect(result.warnings).toContain("Property 'oldField' is deprecated and was skipped");
   });
 
+  it('should skip binary file properties and add warning', () => {
+    const schema: SchemaObject = {
+      type: 'object',
+      properties: {
+        avatar: { type: 'string', format: 'binary' },
+        name: { type: 'string' },
+      },
+    };
+
+    const result = mapSchemaToFields(schema, []);
+    expect(result.fields).toHaveLength(1);
+    expect(result.fields[0].key).toBe('name');
+    expect(result.warnings).toContain(
+      "Property 'avatar' is a file upload (format: binary) and was skipped — no file field type is available yet",
+    );
+  });
+
+  it('should skip arrays of binary files and add warning', () => {
+    const schema: SchemaObject = {
+      type: 'object',
+      properties: {
+        files: { type: 'array', items: { type: 'string', format: 'binary' } },
+      },
+    };
+
+    const result = mapSchemaToFields(schema, []);
+    expect(result.fields).toHaveLength(0);
+    expect(result.warnings).toContain(
+      "Property 'files' is a file upload (format: binary) and was skipped — no file field type is available yet",
+    );
+  });
+
   it('should humanize enum labels with toEnumLabel', () => {
     const schema: SchemaObject = {
       type: 'object',

--- a/packages/openapi-generator/src/mapper/schema-to-fields.ts
+++ b/packages/openapi-generator/src/mapper/schema-to-fields.ts
@@ -33,6 +33,10 @@ const NULLABLE_SUPPORTED_FIELD_TYPES = new Set([
  */
 const CONTAINER_FIELD_TYPES = new Set(['group', 'array', 'row', 'page', 'container']);
 
+function isBinarySchema(schema: SchemaObject | undefined): boolean {
+  return !!schema && (schema as Record<string, unknown>)['format'] === 'binary';
+}
+
 function singularize(label: string): string {
   // Only strip trailing 's' if word is 4+ chars and doesn't end in 'ss'
   if (label.length >= 4 && label.endsWith('s') && !label.endsWith('ss')) {
@@ -192,6 +196,13 @@ function mapPropertyToField(
   // Skip deprecated properties
   if ((prop.schema as Record<string, unknown>)['deprecated']) {
     warnings.push(`Property '${prop.name}' is deprecated and was skipped`);
+    return undefined;
+  }
+
+  // Skip binary file properties — no file upload field type exists in this release (issue #485)
+  const propItems = (prop.schema as Record<string, unknown>)['items'] as SchemaObject | undefined;
+  if (isBinarySchema(prop.schema) || isBinarySchema(propItems)) {
+    warnings.push(`Property '${prop.name}' is a file upload (format: binary) and was skipped — no file field type is available yet`);
     return undefined;
   }
 

--- a/packages/openapi-generator/src/mapper/schema-to-fields.ts
+++ b/packages/openapi-generator/src/mapper/schema-to-fields.ts
@@ -5,6 +5,7 @@ import type { ValidatorConfig } from './validator-mapping.js';
 import { mapSchemaToValidators } from './validator-mapping.js';
 import { mapDiscriminator } from './discriminator-mapping.js';
 import { toLabel, toEnumLabel } from '../utils/naming.js';
+import { isBinarySchema } from '../utils/openapi-utils.js';
 import { logger } from '../utils/logger.js';
 
 /**
@@ -32,10 +33,6 @@ const NULLABLE_SUPPORTED_FIELD_TYPES = new Set([
  * a label on these types causes TS2322 in consumers (issue #348).
  */
 const CONTAINER_FIELD_TYPES = new Set(['group', 'array', 'row', 'page', 'container']);
-
-function isBinarySchema(schema: SchemaObject | undefined): boolean {
-  return !!schema && (schema as Record<string, unknown>)['format'] === 'binary';
-}
 
 function singularize(label: string): string {
   // Only strip trailing 's' if word is 4+ chars and doesn't end in 'ss'
@@ -202,7 +199,7 @@ function mapPropertyToField(
   // Skip binary file properties — no file upload field type exists in this release (issue #485)
   const propItems = (prop.schema as Record<string, unknown>)['items'] as SchemaObject | undefined;
   if (isBinarySchema(prop.schema) || isBinarySchema(propItems)) {
-    warnings.push(`Property '${prop.name}' is a file upload (format: binary) and was skipped — no file field type is available yet`);
+    warnings.push(`Property '${prop.name}' is a file upload (format: binary) and was skipped; no file field type is available yet`);
     return undefined;
   }
 

--- a/packages/openapi-generator/src/parser/endpoint-extractor.spec.ts
+++ b/packages/openapi-generator/src/parser/endpoint-extractor.spec.ts
@@ -116,6 +116,85 @@ describe('extractEndpoints', () => {
     expect(endpoints.map((e) => e.method)).toEqual(['PUT', 'PATCH']);
   });
 
+  it('should extract multipart/form-data request body schema', () => {
+    const spec = createSpec({
+      '/images/{bucket}/upload': {
+        post: {
+          operationId: 'uploadImages',
+          requestBody: {
+            required: true,
+            content: {
+              'multipart/form-data': {
+                schema: {
+                  type: 'object',
+                  required: ['files'],
+                  properties: {
+                    files: { type: 'array', items: { type: 'string', format: 'binary' } },
+                    description: { type: 'string' },
+                  },
+                },
+              },
+            },
+          },
+          responses: { '200': { description: 'Uploaded' } },
+        },
+      },
+    });
+
+    const endpoints = extractEndpoints(spec);
+
+    expect(endpoints).toHaveLength(1);
+    expect(endpoints[0].requestBodySchema).toBeDefined();
+    expect(endpoints[0].requestBodySchema?.properties).toHaveProperty('files');
+    expect(endpoints[0].requiredFields).toEqual(['files']);
+  });
+
+  it('should extract application/x-www-form-urlencoded request body schema', () => {
+    const spec = createSpec({
+      '/login': {
+        post: {
+          requestBody: {
+            content: {
+              'application/x-www-form-urlencoded': {
+                schema: { type: 'object', properties: { username: { type: 'string' } } },
+              },
+            },
+          },
+          responses: { '200': { description: 'OK' } },
+        },
+      },
+    });
+
+    const endpoints = extractEndpoints(spec);
+
+    expect(endpoints[0].requestBodySchema?.properties).toHaveProperty('username');
+  });
+
+  it('should prefer application/json when multiple content types are declared', () => {
+    const spec = createSpec({
+      '/pets': {
+        post: {
+          requestBody: {
+            content: {
+              'multipart/form-data': {
+                schema: { type: 'object', properties: { photo: { type: 'string', format: 'binary' } } },
+              },
+              'application/json': {
+                schema: { type: 'object', properties: { name: { type: 'string' } } },
+              },
+            },
+          },
+          responses: { '201': { description: 'Created' } },
+        },
+      },
+    });
+
+    const endpoints = extractEndpoints(spec);
+
+    expect(endpoints[0].requestBodySchema?.properties).toHaveProperty('name');
+    expect(endpoints[0].requestBodySchema?.properties).not.toHaveProperty('photo');
+  });
+
   it('should skip DELETE and other unsupported methods', () => {
     const spec = createSpec({
       '/pets/{id}': {

--- a/packages/openapi-generator/src/parser/endpoint-extractor.ts
+++ b/packages/openapi-generator/src/parser/endpoint-extractor.ts
@@ -14,6 +14,10 @@ export interface EndpointInfo {
 
 const SUPPORTED_METHODS = ['get', 'post', 'put', 'patch'] as const;
 
+// Request body content types in preference order. JSON wins when both are
+// declared; multipart/urlencoded bodies map to forms the same way (issue #485).
+const REQUEST_BODY_CONTENT_TYPES = ['application/json', 'multipart/form-data', 'application/x-www-form-urlencoded'] as const;
+
 export function extractEndpoints(spec: OpenAPISpec): EndpointInfo[] {
   const endpoints: EndpointInfo[] = [];
 
@@ -35,10 +39,13 @@ export function extractEndpoints(spec: OpenAPISpec): EndpointInfo[] {
       // Extract request body schema (for POST/PUT/PATCH)
       if (operation.requestBody && 'content' in operation.requestBody) {
         const content = operation.requestBody.content;
-        const jsonContent = content['application/json'];
-        if (jsonContent?.schema && !isReferenceObject(jsonContent.schema)) {
-          endpoint.requestBodySchema = jsonContent.schema;
-          endpoint.requiredFields = jsonContent.schema.required ?? [];
+        for (const contentType of REQUEST_BODY_CONTENT_TYPES) {
+          const mediaContent = content[contentType];
+          if (mediaContent?.schema && !isReferenceObject(mediaContent.schema)) {
+            endpoint.requestBodySchema = mediaContent.schema;
+            endpoint.requiredFields = mediaContent.schema.required ?? [];
+            break;
+          }
         }
       }
 

--- a/packages/openapi-generator/src/utils/openapi-utils.ts
+++ b/packages/openapi-generator/src/utils/openapi-utils.ts
@@ -3,3 +3,8 @@ import type { OpenAPIV3 } from 'openapi-types';
 export function isReferenceObject(obj: unknown): obj is OpenAPIV3.ReferenceObject {
   return typeof obj === 'object' && obj !== null && '$ref' in obj;
 }
+
+/** Binary file content (`format: binary`) has no field type in this release (issue #485). */
+export function isBinarySchema(schema: unknown): boolean {
+  return typeof schema === 'object' && schema !== null && (schema as Record<string, unknown>)['format'] === 'binary';
+}


### PR DESCRIPTION
## Summary

Fixes #485.

The endpoint extractor only read request body schemas from `application/json`, so endpoints with `multipart/form-data` bodies were silently dropped with a misleading "No schema found" warning.

- Request body schemas are now read from `application/json`, `multipart/form-data`, or `application/x-www-form-urlencoded`, preferring JSON when an endpoint declares more than one.
- Binary file properties (`type: string` with `format: binary`, including arrays of them) are skipped with an explicit warning, since no file upload field type exists yet. Mixed multipart bodies still generate a form from their remaining fields.
- Endpoints whose mapping produces zero fields (for example a body containing only binary properties) are skipped with a clear warning instead of emitting an empty form file.

A file upload field type is the proper long-term answer for binary properties and is out of scope here.

## Testing

- 3 new extractor unit tests (multipart extraction, urlencoded extraction, JSON preference)
- 2 new mapper unit tests (binary property skip, array-of-binary skip)
- 2 new integration fixtures, including `media-service.yaml` modeled on the spec shape reported in #485, with 6 new integration tests
- `nx test openapi-generator`: 392 passed
- `nx run-many -t build,lint -p openapi-generator`: clean
- Ran the built CLI against a repro of the reported spec and confirmed the new warnings and generated output

## Docs

- Added a "Request Body Content Types" section to the package README FAQ and the docs site page