### PR TITLE
test(dynamic-forms): enforce internal and integration definition type-tests in CI

### DIFF
--- a/packages/dynamic-forms/integration/src/definitions/datepicker-field.type-test.ts
+++ b/packages/dynamic-forms/integration/src/definitions/datepicker-field.type-test.ts
@@ -56,6 +56,13 @@ describe('DatepickerField - Exhaustive Whitelist', () => {
     | 'logic'
     | 'derivation'
     | 'schemas'
+    // Wrappers and addons
+    | 'wrappers'
+    | 'skipAutoWrappers'
+    | 'skipDefaultWrappers'
+    | 'addons'
+    // Nullable opt-in
+    | 'nullable'
     // DatepickerField-specific
     | 'minDate'
     | 'maxDate'
@@ -71,8 +78,10 @@ describe('DatepickerField - Exhaustive Whitelist', () => {
     expectTypeOf<DatepickerField<DatepickerProps>['type']>().toEqualTypeOf<'datepicker'>();
   });
 
-  it('value type is Date | string', () => {
-    expectTypeOf<DatepickerField<DatepickerProps>['value']>().toEqualTypeOf<Date | string | undefined>();
+  it('value type is Date | string (default TNullable = boolean distributes to | null)', () => {
+    expectTypeOf<DatepickerField<DatepickerProps>['value']>().toEqualTypeOf<Date | string | null | undefined>();
+    // Pinning nullable: false removes null from the value union.
+    expectTypeOf<DatepickerField<DatepickerProps, false>['value']>().toEqualTypeOf<Date | string | undefined>();
   });
 
   it('minDate accepts Date | string | null', () => {

--- a/packages/dynamic-forms/integration/src/definitions/input-field.type-test.ts
+++ b/packages/dynamic-forms/integration/src/definitions/input-field.type-test.ts
@@ -172,7 +172,14 @@ describe('InputField - Keys Whitelist', () => {
     | 'validationMessages'
     | 'logic'
     | 'derivation'
-    | 'schemas';
+    | 'schemas'
+    // Wrappers and addons
+    | 'wrappers'
+    | 'skipAutoWrappers'
+    | 'skipDefaultWrappers'
+    | 'addons'
+    // Nullable opt-in
+    | 'nullable';
 
   // For a union, keyof gives intersection of keys (common keys)
   type ActualKeys = keyof InputField;
@@ -232,9 +239,9 @@ describe('NumberInputField variant', () => {
       value: 100,
     };
 
-    // value on the union is number | string | undefined
+    // value on the union is number | string | null | undefined (default TNullable = boolean)
     // but when narrowed via props.type = 'number', it is number
-    expectTypeOf(field.value).toMatchTypeOf<number | string | undefined>();
+    expectTypeOf(field.value).toMatchTypeOf<number | string | null | undefined>();
   });
 });
 
@@ -272,7 +279,7 @@ describe('StringInputField variant', () => {
       value: 'test',
     };
 
-    expectTypeOf(field.value).toMatchTypeOf<number | string | undefined>();
+    expectTypeOf(field.value).toMatchTypeOf<number | string | null | undefined>();
   });
 });
 
@@ -445,12 +452,14 @@ describe('InputField - Nullable widening', () => {
     type NonNullableField = InputField<import('./input-field').InputProps, false>;
     expectTypeOf<null>().not.toMatchTypeOf<NonNullableField['value']>();
 
-    // Literal assignment must be rejected at compile time.
-    // @ts-expect-error - null is not assignable to value when nullable: false
+    // Literal assignment must be rejected at compile time. The directive sits on
+    // the offending property: TS reports the mismatch on the `value` line, not the
+    // declaration line.
     const field: InputField<import('./input-field').InputProps, false> = {
       type: 'input',
       key: 'name',
       props: { type: 'text' },
+      // @ts-expect-error - null is not assignable to value when nullable: false
       value: null,
     };
     expectTypeOf(field).not.toBeAny();

--- a/packages/dynamic-forms/integration/src/definitions/select-field.type-test.ts
+++ b/packages/dynamic-forms/integration/src/definitions/select-field.type-test.ts
@@ -44,6 +44,13 @@ describe('SelectField - Exhaustive Whitelist', () => {
     | 'logic'
     | 'derivation'
     | 'schemas'
+    // Wrappers and addons
+    | 'wrappers'
+    | 'skipAutoWrappers'
+    | 'skipDefaultWrappers'
+    | 'addons'
+    // Nullable opt-in
+    | 'nullable'
     // SelectField-specific
     | 'options';
 
@@ -67,8 +74,10 @@ describe('SelectField<string>', () => {
     expectTypeOf<SelectField<string>['options']>().toEqualTypeOf<readonly FieldOption<string>[]>();
   });
 
-  it('value is string', () => {
-    expectTypeOf<SelectField<string>['value']>().toEqualTypeOf<string | undefined>();
+  it('value is string (default TNullable = boolean distributes to | null)', () => {
+    expectTypeOf<SelectField<string>['value']>().toEqualTypeOf<string | null | undefined>();
+    // Pinning nullable: false removes null from the value union.
+    expectTypeOf<SelectField<string, SelectProps, false>['value']>().toEqualTypeOf<string | undefined>();
   });
 });
 
@@ -77,8 +86,8 @@ describe('SelectField<string>', () => {
 // ============================================================================
 
 describe('SelectField<number>', () => {
-  it('value is number', () => {
-    expectTypeOf<SelectField<number>['value']>().toEqualTypeOf<number | undefined>();
+  it('value is number (default TNullable = boolean distributes to | null)', () => {
+    expectTypeOf<SelectField<number>['value']>().toEqualTypeOf<number | null | undefined>();
   });
 
   it('options are FieldOption<number>', () => {
@@ -97,8 +106,8 @@ describe('SelectField<{ id: string; name: string }>', () => {
     expectTypeOf<SelectField<Obj>['options']>().toEqualTypeOf<readonly FieldOption<Obj>[]>();
   });
 
-  it('value is the object type', () => {
-    expectTypeOf<SelectField<Obj>['value']>().toEqualTypeOf<Obj | undefined>();
+  it('value is the object type (default TNullable = boolean distributes to | null)', () => {
+    expectTypeOf<SelectField<Obj>['value']>().toEqualTypeOf<Obj | null | undefined>();
   });
 });
 

--- a/packages/dynamic-forms/project.json
+++ b/packages/dynamic-forms/project.json
@@ -115,7 +115,7 @@
     },
     "type-test": {
       "executor": "@nx/vitest:test",
-      "dependsOn": ["type-test-inference"],
+      "dependsOn": ["type-test-inference", "type-test-definitions"],
       "options": {
         "configFile": "packages/dynamic-forms/vite.config.typecheck.ts"
       }
@@ -124,6 +124,12 @@
       "executor": "@nx/vitest:test",
       "options": {
         "configFile": "packages/dynamic-forms/vite.config.typecheck-inference.ts"
+      }
+    },
+    "type-test-definitions": {
+      "executor": "@nx/vitest:test",
+      "options": {
+        "configFile": "packages/dynamic-forms/vite.config.typecheck-definitions.ts"
       }
     },
     "lint": {

--- a/packages/dynamic-forms/tsconfig.typecheck-definitions.json
+++ b/packages/dynamic-forms/tsconfig.typecheck-definitions.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.typecheck-base.json",
+  "include": ["internal/src/**/*.type-test.ts", "integration/src/**/*.type-test.ts"]
+}

--- a/packages/dynamic-forms/vite.config.typecheck-definitions.ts
+++ b/packages/dynamic-forms/vite.config.typecheck-definitions.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vitest/config';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+
+// Isolated program for the internal/ and integration/ field-definition type-tests.
+// These assert base-registry facts (e.g. `AvailableFieldTypes` is exactly the core
+// container/leaf set), so they must typecheck against a CLEAN registry: the general
+// program augments value-field leaves for the DynamicForm test, and the inference
+// program registers a broad leaf set — either would falsify the whitelists here.
+//
+// Run as a `dependsOn` of the `type-test` target (see project.json), so it shares
+// the same CI enforcement with nothing extra to wire.
+const DEFINITIONS = ['internal/src/**/*.type-test.ts', 'integration/src/**/*.type-test.ts'];
+
+export default defineConfig({
+  plugins: [nxViteTsPaths()],
+  test: {
+    globals: true,
+    include: DEFINITIONS,
+    reporters: ['verbose'],
+    passWithNoTests: false,
+    typecheck: {
+      enabled: true,
+      only: true,
+      include: DEFINITIONS,
+      tsconfig: './tsconfig.typecheck-definitions.json',
+    },
+  },
+});


### PR DESCRIPTION
## Problem

The 20 `.type-test.ts` files under `internal/src` and `integration/src` were not part of any typecheck program. The `type-test` target only globbed `src/**`, so their 572 type-level assertions were never validated in CI. Three files had silently rotted against the current field definitions (10 failing assertions once enforced).

Follow-up to #480, which enforced the form-value inference type-tests; this closes the loop on the field-definition shapes.

## Change

**New isolated typecheck program** (`vite.config.typecheck-definitions.ts` + `tsconfig.typecheck-definitions.json`) covering `internal/src/**` and `integration/src/**` type-tests, wired as a `dependsOn` of the existing `type-test` target. CI workflows need no edits: `nx run-many -t type-test` and `nx affected -t type-test` pick it up through the dependency. A separate program is required because these tests assert base-registry facts (e.g. `AvailableFieldTypes` is exactly the core container/leaf set), which the value-leaf augmentations in the `src/lib` type-test programs would falsify.

**Rot fixes** (10 failures across 3 files):
- `ExpectedKeys` whitelists in datepicker/input/select tests were missing `wrappers`, `skipAutoWrappers`, `skipDefaultWrappers`, `addons`, and `nullable`
- value-type assertions predated the nullable feature: the default `TNullable extends boolean = boolean` distributes to `TValue | null`, so value unions include `null` unless `nullable: false` is pinned. Tests now assert both the default and the pinned form
- a `@ts-expect-error` directive sat on the declaration line while TS reports the null-assignment error on the `value` property line; moved onto the property

## Verification

- `nx run dynamic-forms:type-test` runs all three programs: 24 (inference) + 572 (definitions) + 34 (general), 0 type errors
- Mutation check: removing `startAt` from `DatepickerField` fails 4 definition tests; restored
- `/internal` public_api drift check up to date; eslint clean on changed files

## Notes

Two `field-registry.type-test.ts` failures observed during investigation turned out to be phantom (stale tsc incremental state), not real; they pass against a clean build and no change was needed there.