### PR TITLE
docs: fix API inaccuracies and tighten prose across the docs site

### DIFF
--- a/apps/docs/plugins/vite-plugin-docs-meta.spec.ts
+++ b/apps/docs/plugins/vite-plugin-docs-meta.spec.ts
@@ -8,6 +8,11 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { Plugin, PluginContext, ViteDevServer } from 'vite';
 import { docsMetaPlugin } from './vite-plugin-docs-meta';
 
+// The sitemap middleware generates the sitemap on demand, which shells out to
+// `git log` once per content file. Give this file headroom over the 5s default
+// so the git-backed paths do not flake under parallel test load.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 type Hook<K extends keyof Plugin> = Plugin[K];
 
 // vite types `hook` as `T | ObjectHook<T>`; resolveId/load are the function form here.

--- a/apps/docs/public/content/addons/custom-types.md
+++ b/apps/docs/public/content/addons/custom-types.md
@@ -1,10 +1,10 @@
 ---
 title: Custom Types
 slug: addons/custom-types
-description: 'Register a custom addon type component with withCustomAddon() and make it type-safe per field via the InputAddonExtensions module-augmentation seam. Covers runtime validation, ARIA defaults, and dropping into per-adapter input fields.'
+description: 'Register a custom addon type component with withCustomAddon() and make it type-safe per field via the per-adapter module-augmentation seams (MatAddonExtensions, BsAddonExtensions, PrimeAddonExtensions, IonAddonExtensions). Covers runtime validation, ARIA defaults, and dropping into per-adapter input fields.'
 ---
 
-When the shipped types — universal `text`, `template`, `component` plus the per-adapter icon and button types (`mat-icon` / `mat-button` for Material, `bs-icon` / `bs-button` for Bootstrap, `prime-icon` / `prime-button` for PrimeNG, `ion-icon` / `ion-button` for Ionic) — don't cover your case (a rating widget in the prefix, a status pill in the suffix, a copy-to-clipboard component with bespoke styling), register a custom type. Two independent steps: a runtime registration (`withCustomAddon`) and an optional type-level augmentation.
+The shipped types are the universal `text`, `template`, and `component` types plus the per-adapter icon and button types (`mat-icon` / `mat-button` for Material, `bs-icon` / `bs-button` for Bootstrap, `prime-icon` / `prime-button` for PrimeNG, `ion-icon` / `ion-button` for Ionic). When they don't cover your case (a rating widget in the prefix, a status pill in the suffix, a copy-to-clipboard component with bespoke styling), register a custom type. Two independent steps: a runtime registration (`withCustomAddon`) and an optional type-level augmentation.
 
 ## 1. Define the addon shape
 
@@ -20,7 +20,7 @@ export interface RatingAddon extends BaseAddon {
 }
 ```
 
-`BaseAddon` carries the universal axes — `slot`, optional `hidden`, optional `className`, optional `disabled` — so you only declare the type-specific fields.
+`BaseAddon` carries the universal axes (`slot`, optional `hidden`, optional `className`, optional `disabled`) so you only declare the type-specific fields.
 
 ## 2. Build the type component
 
@@ -46,7 +46,7 @@ export class RatingAddonComponent {
 }
 ```
 
-The contract: declare `addon: input.required<TAddon>()`. The dispatcher (`<df-addon-slot>`) wires the addon object via `[addon]` and forwards the `slot` HTML attribute on the host element. ARIA defaults are owned by your component — decorative types typically set `aria-hidden="true"`; interactive types handle their own labelling.
+The contract: declare `addon: input.required<TAddon>()`. The dispatcher (`<df-addon-slot>`) wires the addon object via `[addon]` and forwards the `slot` HTML attribute on the host element. ARIA defaults are owned by your component: decorative types typically set `aria-hidden="true"`; interactive types handle their own labelling.
 
 ## 3. Register at the provider level
 
@@ -67,27 +67,27 @@ export const RATING_KIND: AddonTypeDefinition<RatingAddon> = {
 };
 ```
 
-Then pass it through `withCustomAddon(...)` to `provideDynamicForm` alongside your adapter s field bundle:
+Then pass it through `withCustomAddon(...)` to `provideDynamicForm` alongside your adapter's field bundle:
 
 <docs-addon-info field="custom-type-invocation"></docs-addon-info>
 
-`loadComponent` returns a Promise — the type component is loaded lazily on first render and cached.
+`loadComponent` returns a Promise; the type component is loaded lazily on first render and cached.
 
-`validate` is optional; when provided, the runtime addon validator calls it at config init. Throwing `DynamicFormError` drops the addon with an actionable warning and the form keeps rendering — `validate` is a sanitisation hook, not a hard fail.
+`validate` is optional; when provided, the runtime addon validator calls it at config init. Throwing `DynamicFormError` drops the addon with an actionable warning and the form keeps rendering; `validate` is a sanitisation hook, not a hard fail.
 
 ## 4. Type-level augmentation (optional but recommended)
 
-To make `type: 'rating'` autocomplete inside the field s `addons` array, augment the active adapter s addon-extension seam:
+To make `type: 'rating'` autocomplete inside the field's `addons` array, augment the active adapter's addon-extension seam (`MatAddonExtensions`, `BsAddonExtensions`, `PrimeAddonExtensions`, or `IonAddonExtensions`):
 
 <docs-addon-info field="custom-extension-name"></docs-addon-info>
 
-The runtime registration and the type-level augmentation are independent — use either or both. Without augmentation, custom types still work at runtime; you lose IDE narrowing on the `addons` array.
+The runtime registration and the type-level augmentation are independent; use either or both. Without augmentation, custom types still work at runtime; you lose IDE narrowing on the `addons` array.
 
 ## When _not_ to use a custom type
 
-- **Static decoration** — pure CSS / text → `type: 'text'` covers it.
-- **An entirely new field control** (file picker, rich-text editor, color picker) → register a custom **field type**, not an addon type. Addons decorate; field types render the primary control. See [Adding custom fields](/recipes/custom-fields).
-- **One-off behavior** for a specific button — use `action` (code-only) or `actionRef` (registered handler) on a built-in button type.
+- **Static decoration** (pure CSS or text): `type: 'text'` covers it.
+- **An entirely new field control** (file picker, rich-text editor, color picker): register a custom **field type**, not an addon type. Addons decorate; field types render the primary control. See [Adding custom fields](/recipes/custom-fields).
+- **One-off behavior** for a specific button: use `action` (code-only) or `actionRef` (registered handler) on a built-in button type.
 
 ## Verification checklist
 
@@ -97,9 +97,9 @@ When you ship a custom type:
 2. `withCustomAddon(...)` is passed to `provideDynamicForm` after the field-type bundle.
 3. The runtime `validate` function rejects malformed configs with `DynamicFormError`.
 4. The type-level augmentation lives in the same file as the runtime registration so the two stay in sync.
-5. ARIA defaults are explicit — `aria-hidden="true"` for decorative types; `aria-label` for types that convey meaning.
+5. ARIA defaults are explicit: `aria-hidden="true"` for decorative types; `aria-label` for types that convey meaning.
 
 ## Where to next
 
-- **[Building an Adapter](/building-an-adapter)** — adapter authors registering bundled types.
-- **[Custom field types](/recipes/custom-fields)** — when the "addon" you re building is really a new field control.
+- **[Building an Adapter](/building-an-adapter)**: adapter authors registering bundled types.
+- **[Custom field types](/recipes/custom-fields)**: when the "addon" you're building is really a new field control.

--- a/apps/docs/public/content/addons/overview.md
+++ b/apps/docs/public/content/addons/overview.md
@@ -1,12 +1,12 @@
 ---
 title: Addons
 slug: addons/overview
-description: 'Render icons, buttons, or text inside a fields prefix and suffix slots. Addons are typed, JSON-safe, with built-in presets for clear, reset, paste, copy, and password toggle.'
+description: "Render icons, buttons, or text inside a field's prefix and suffix slots. Addons are typed, JSON-safe, with built-in presets for clear, reset, paste, copy, and password toggle."
 ---
 
-Addons decorate a field with inline content — a search icon, a clear button, a currency symbol, a password-visibility toggle — placed in the field s `prefix` or `suffix` slot. They re typed, JSON-safe, and ship as a first-class feature of every UI adapter.
+Addons decorate a field with inline content (a search icon, a clear button, a currency symbol, a password-visibility toggle) placed in the field's `prefix` or `suffix` slot. They're typed, JSON-safe, and ship as a first-class feature of every UI adapter.
 
-> **Prerequisites.** Addons attach to a field, not the form. You need a working ng-forge setup first: `provideDynamicForm(...with{Adapter}Fields())` at the application config and a `[dynamic-form]`-bearing form using a field type that supports addons (today: every adapter's `input`). See [Getting Started](/getting-started) if you re new to ng-forge.
+> **Prerequisites.** Addons attach to a field, not the form. You need a working ng-forge setup first: `provideDynamicForm(...with{Adapter}Fields())` at the application config and a `[dynamic-form]`-bearing form using a field type that supports addons (today: every adapter's `input`). See [Getting Started](/getting-started) if you're new to ng-forge.
 
 ## Quickstart
 
@@ -28,7 +28,7 @@ A universal addon (works the same in every adapter, no per-type branching):
 
 <docs-addon-info field="rendering-mechanism"></docs-addon-info>
 
-The wrapper is dropped entirely when every addon is reactively hidden — no empty group element.
+The wrapper is dropped entirely when every addon is reactively hidden: no empty group element.
 
 ## Provider setup
 
@@ -36,7 +36,7 @@ The wrapper is dropped entirely when every addon is reactively hidden — no emp
 
 ## Reactive `hidden` and `disabled`
 
-Both axes accept `DynamicValue<boolean>` — any of `boolean`, `Signal<boolean>`, or `Observable<boolean>`. Four equivalent shapes for the same toggle:
+Both axes accept `DynamicValue<boolean>`: any of `boolean`, `Signal<boolean>`, or `Observable<boolean>`. Four equivalent shapes for the same toggle:
 
 ```typescript
 { ..., hidden: true }                              // Static — JSON-safe.
@@ -49,23 +49,23 @@ The classic "show clear button only when input has value" pattern, in your activ
 
 <docs-addon-info field="reactive-hidden-snippet"></docs-addon-info>
 
-When `hidden` resolves to `true` the addon stays in DOM but is `display: none` — cheaper than tearing down the component, and the reactive transition is instant.
+When `hidden` resolves to `true` the addon is filtered out of the rendered slot entirely, and it reappears reactively as soon as `hidden` turns falsy again.
 
-Authoring forms in JSON? Reactive values can't survive serialization — see [Reactive addons from JSON](/addons/presets-and-actions#reactive-from-json).
+Authoring forms in JSON? Reactive values can't survive serialization; see [Reactive addons from JSON](/addons/presets-and-actions#reactive-addons-from-json).
 
 ## Accessibility
 
-Icon types emit `aria-hidden="true"` by default. When the icon conveys meaning (status, action), set `ariaLabel`. Icon-only button types (no `label`) require `ariaLabel` — TypeScript and the runtime validator both enforce this.
+Icon types emit `aria-hidden="true"` by default. When the icon conveys meaning (status, action), set `ariaLabel`. Icon-only button types (no `label`) require `ariaLabel`; TypeScript and the runtime validator both enforce this.
 
 ## Troubleshooting
 
-- **Addon doesn t render at all.** Check the console for `[Dynamic Forms]` warnings. Common causes: the active adapter s `with*Fields()` helper isn t in `provideDynamicForm`; the `type` string belongs to a different adapter (e.g. `prime-button` in a Material form); the host field type doesn t support addons.
-- **Icon-only button has no `ariaLabel`.** TypeScript and the runtime validator both refuse this — set `ariaLabel`. For genuinely decorative icons, prefer `type: 'text'` or the adapter s `*-icon` type.
-- **`actionRef` warning at click time.** The handler name isn t registered. Did you call `withAddonActions({ runSearch: ... })` for that name?
-- **Inline function silently dropped.** Configs with `source: 'json'` strip functions on `action`, `hidden`, `disabled`, `loading` at validation time — they cant round-trip through JSON. See [Reactive addons from JSON](/addons/presets-and-actions#reactive-from-json).
-- **Material `MatFormFieldControl` ContentChild missing.** Caused by wrapping the input in a template that breaks Material s content-projection query. Render `<input matInput>` directly inside `<mat-form-field>`.
+- **Addon doesn't render at all.** Check the console for `[Dynamic Forms]` warnings. Common causes: the active adapter's `with*Fields()` helper isn't in `provideDynamicForm`; the `type` string belongs to a different adapter (e.g. `prime-button` in a Material form); the host field type doesn't support addons.
+- **Icon-only button has no `ariaLabel`.** TypeScript and the runtime validator both refuse this; set `ariaLabel`. For genuinely decorative icons, prefer `type: 'text'` or the adapter's `*-icon` type.
+- **`actionRef` warning at click time.** The handler name isn't registered. Did you call `withAddonActions({ runSearch: ... })` for that name?
+- **Inline function silently dropped.** Configs with `source: 'json'` strip functions on `action`, `hidden`, `disabled`, `loading` at validation time; they can't round-trip through JSON. See [Reactive addons from JSON](/addons/presets-and-actions#reactive-addons-from-json).
+- **Material `MatFormFieldControl` ContentChild missing.** Caused by wrapping the input in a template that breaks Material's content-projection query. Render `<input matInput>` directly inside `<mat-form-field>`.
 
 ## Where to next
 
-1. **[Presets and Actions](/addons/presets-and-actions)** — built-in click presets (`clear`, `reset`, `paste`, `copy`, `toggle-password-visibility`), `actionRef` for registered handlers, and inline `action` for code-only behaviour.
-2. **[Custom Types](/addons/custom-types)** — register your own addon type (rating widget, status pill, anything) with `withCustomAddon(...)` and augment the type-level extensions seam.
+1. **[Presets and Actions](/addons/presets-and-actions)**: built-in click presets (`clear`, `reset`, `paste`, `copy`, `toggle-password-visibility`), `actionRef` for registered handlers, and inline `action` for code-only behaviour.
+2. **[Custom Types](/addons/custom-types)**: register your own addon type (rating widget, status pill, anything) with `withCustomAddon(...)` and augment the type-level extensions seam.

--- a/apps/docs/public/content/addons/overview.md
+++ b/apps/docs/public/content/addons/overview.md
@@ -55,7 +55,7 @@ Authoring forms in JSON? Reactive values can't survive serialization; see [React
 
 ## Accessibility
 
-Icon types emit `aria-hidden="true"` by default. When the icon conveys meaning (status, action), set `ariaLabel`. Icon-only button types (no `label`) require `ariaLabel`; TypeScript and the runtime validator both enforce this.
+Icon types emit `aria-hidden="true"` by default. When the icon conveys meaning (status, action), set `ariaLabel`. Icon-only button types (no `label`) require `ariaLabel`. TypeScript flags it at compile time; at runtime an icon-only addon missing `ariaLabel` is dropped with a `[Dynamic Forms]` warning rather than rendered, and the rest of the form is unaffected.
 
 ## Troubleshooting
 

--- a/apps/docs/public/content/addons/presets-and-actions.md
+++ b/apps/docs/public/content/addons/presets-and-actions.md
@@ -4,7 +4,7 @@ slug: addons/presets-and-actions
 description: 'Wire button addons to behavior. Five built-in presets cover the common patterns (clear, reset, paste, copy, toggle-password-visibility). For custom behavior, register named handlers with withAddonActions and reference them by string, or pass an inline action for code-only configs.'
 ---
 
-Button addons accept exactly one click variant: `preset`, `actionRef`, or `action`. The variants are mutually exclusive at the type level — setting two is a compile error.
+Button addons accept exactly one click variant: `preset`, `actionRef`, or `action`. The variants are mutually exclusive at the type level; setting two is a compile error.
 
 ## The three variants
 
@@ -19,12 +19,12 @@ Five presets ship with the library, available in every adapter:
 | Preset                         | Behaviour                                                                                                                                                                                       |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `'clear'`                      | Empties the field value. Writes `''` for string fields and `undefined` for non-string fields (numeric, date, object) so the field's declared type is preserved.                                 |
-| `'reset'`                      | Restores the field s configured default value from the form s `defaultValues` map (resolved at click time). Falls back to `''` / `undefined` (matching `'clear'`) when no default is reachable. |
+| `'reset'`                      | Restores the field's configured default value from the form's `defaultValues` map (resolved at click time). Falls back to `''` / `undefined` (matching `'clear'`) when no default is reachable. |
 | `'paste'`                      | Reads from the system clipboard (`navigator.clipboard.readText()`) and writes the result to the field.                                                                                          |
-| `'copy'`                       | Writes the field s current value to the system clipboard (`navigator.clipboard.writeText`).                                                                                                     |
-| `'toggle-password-visibility'` | Flips the host input s `type` between `'password'` and `'text'`. No-op (warning logged) when used outside an input-style field that exposes a type-override token.                              |
+| `'copy'`                       | Writes the field's current value to the system clipboard (`navigator.clipboard.writeText`).                                                                                                     |
+| `'toggle-password-visibility'` | Flips the host input's `type` between `'password'` and `'text'`. No-op (warning logged) when used outside an input-style field that exposes a type-override token.                              |
 
-All presets are JSON-safe. For form submission, use the dedicated `'submit'` field type — it is intentionally not exposed as a preset.
+All presets are JSON-safe. For form submission, use the dedicated `'submit'` field type; it is intentionally not exposed as a preset.
 
 ### Password toggle live demo
 
@@ -54,12 +54,12 @@ Wire the feature into `provideDynamicForm`:
 The backend can now ship configs like:
 
 ```json
-{ "type": "<adapter-button-kind>", "icon": "send", "ariaLabel": "Send", "actionRef": "submitDraft" }
+{ "slot": "suffix", "type": "<adapter-button-kind>", "icon": "send", "ariaLabel": "Send", "actionRef": "submitDraft" }
 ```
 
 ### Type narrowing
 
-`withAddonActions(...)` returns a feature whose `__handlerKeys` phantom field captures the registered names — derive the global `DynamicFormActionRegistry` augmentation from it in one line so `actionRef` autocompletes everywhere:
+`withAddonActions(...)` returns a feature whose `__handlerKeys` phantom field captures the registered names; derive the global `DynamicFormActionRegistry` augmentation from it in one line so `actionRef` autocompletes everywhere:
 
 ```typescript
 export const appActions = withAddonActions({
@@ -91,7 +91,7 @@ interface FieldBoundAddonActionContext<TValue = unknown> {
 }
 ```
 
-Narrow with the `isFieldBoundContext` guard so write-back handlers don t need `ctx.setValue?.(…)` everywhere:
+Narrow with the `isFieldBoundContext` guard so write-back handlers don't need `ctx.setValue?.(…)` everywhere:
 
 ```typescript
 import { isFieldBoundContext, withAddonActions } from '@ng-forge/dynamic-forms';
@@ -104,7 +104,7 @@ withAddonActions({
 });
 ```
 
-For broader field state, use the form-tree projection ng-forge already supplies to wrappers — `field.key` is intentionally the only stable identity surface across the addon contract.
+For broader field state, use the form-tree projection ng-forge already supplies to wrappers; `field.key` is intentionally the only stable identity surface across the addon contract.
 
 ## JSON-safety quick reference
 
@@ -114,11 +114,11 @@ For broader field state, use the form-tree projection ng-forge already supplies 
 | `actionRef`   | yes        | Custom behaviour registered once via `withAddonActions`.                        |
 | `action`      | code-only  | Prototypes / scenarios where the config is hand-authored and never round-trips. |
 
-Reactive axes are similarly tiered: `boolean` values are JSON-safe, `Signal<boolean>` / `Observable<boolean>` / function values are stripped from JSON-source configs by the validator (with a warning). See [Reactive addons from JSON](#reactive-from-json) below.
+Reactive axes are similarly tiered: `boolean` values are JSON-safe. On JSON-source configs the validator strips any function value (signals are functions, so they are stripped too) with a warning; Observables cannot appear in parsed JSON in the first place. See [Reactive addons from JSON](#reactive-addons-from-json) below.
 
 ## Inline `action` (code-only)
 
-For prototypes or scenarios where the handler can t live in JSON, pass a function directly:
+For prototypes or scenarios where the handler can't live in JSON, pass a function directly:
 
 ```typescript
 {
@@ -134,14 +134,14 @@ For prototypes or scenarios where the handler can t live in JSON, pass a functio
 }
 ```
 
-The validator drops `action` from JSON-source configs (it can t serialise a function), so reach for `actionRef` if the config might round-trip through a backend.
+The validator drops `action` from JSON-source configs (it can't serialise a function), so reach for `actionRef` if the config might round-trip through a backend.
 
 ## Reactive `loading` and `disabled`
 
 Button types expose both:
 
-- `loading?: DynamicValue<boolean>` — when truthy, the button shows the adapter s spinner state. Implies disabled.
-- `disabled?: DynamicValue<boolean>` — independent of loading; click is a no-op.
+- `loading?: DynamicValue<boolean>`: when truthy, the button shows the adapter's spinner state. Implies disabled.
+- `disabled?: DynamicValue<boolean>`: independent of loading; click is a no-op.
 
 ```typescript
 const submitting = signal(false);
@@ -159,9 +159,9 @@ const submitting = signal(false);
 
 ## Multi-set rule
 
-Exactly one of `preset` / `actionRef` / `action` may be set. The TypeScript types enforce this via an XOR union; the runtime validator additionally drops any addon that smuggles multiple values past the type checker (with an actionable warning). Decorative buttons that simply look like buttons but do nothing are valid — omit all three.
+Exactly one of `preset` / `actionRef` / `action` may be set. The TypeScript types enforce this via an XOR union; when an addon smuggles multiple variants past the type checker, the runtime validator keeps the highest-precedence one (`preset`, then `actionRef`, then `action`), strips the rest, and logs a warning. Decorative buttons that simply look like buttons but do nothing are valid; omit all three.
 
-## Reactive addons from JSON {#reactive-from-json}
+## Reactive addons from JSON
 
 JSON cannot carry `Signal` / `Observable` / function values, so two questions come up when you ship configs from a backend:
 
@@ -170,7 +170,7 @@ JSON cannot carry `Signal` / `Observable` / function values, so two questions co
 
 Three patterns, in order of preference:
 
-1. **Pre-process the JSON in app code.** Before passing the parsed config to `DynamicForm`, walk the parsed tree and replace reactive axes with `computed(...)` against your app's signals. This keeps the wire format JSON-safe and the runtime reactive — your bridge code is the only place that needs to know app state.
+1. **Pre-process the JSON in app code.** Before passing the parsed config to `DynamicForm`, walk the parsed tree and replace reactive axes with `computed(...)` against your app's signals. This keeps the wire format JSON-safe and the runtime reactive; your bridge code is the only place that needs to know app state.
 
    ```typescript
    const config = JSON.parse(jsonFromApi) as FormConfig;
@@ -186,9 +186,9 @@ Three patterns, in order of preference:
 
 3. **Skip reactivity at the addon layer.** If the addon's visibility is purely a function of static form metadata, render it unconditionally and let the field's own validation/state hide the value semantically. Reach for this when (1) and (2) feel heavy.
 
-Functions on `hidden` / `disabled` / `loading` / `action` are stripped from JSON-source configs at validation time with a logged warning — you'll see them in the console if a config carries an inline function. `preset` and `actionRef` are the JSON-safe escape hatches for behaviour; `computed`/`Observable` are the code-side escape hatches for reactivity.
+Functions on `hidden` / `disabled` / `loading` / `action` are stripped from JSON-source configs at validation time with a logged warning; you'll see them in the console if a config carries an inline function. `preset` and `actionRef` are the JSON-safe escape hatches for behaviour; `computed`/`Observable` are the code-side escape hatches for reactivity.
 
 ## Where to next
 
-- **[Custom Types](/addons/custom-types)** — when none of the built-in types fit, register your own type component and augment the type registry.
-- **[Migrating from ngx-formly](/migrating-from-ngx-formly#addons)** — concept mapping for users coming from formly s per-adapter addon shapes.
+- **[Custom Types](/addons/custom-types)**: when none of the built-in types fit, register your own type component and augment the type registry.
+- **[Migrating from ngx-formly](/migrating-from-ngx-formly#addons-prefix-suffix-slots)**: concept mapping for users coming from formly's per-adapter addon shapes.

--- a/apps/docs/public/content/ai-integration.md
+++ b/apps/docs/public/content/ai-integration.md
@@ -10,7 +10,7 @@ The `@ng-forge/dynamic-form-mcp` package provides a [Model Context Protocol (MCP
 
 ## Available Tools
 
-The MCP server provides 4 focused tools:
+The MCP server provides 5 focused tools:
 
 | Tool               | Description                                                 | Read-only |
 | ------------------ | ----------------------------------------------------------- | --------- |
@@ -18,6 +18,7 @@ The MCP server provides 4 focused tools:
 | `ngforge_examples` | Get working code examples for common form patterns          | ✅        |
 | `ngforge_validate` | Validate FormConfig and get detailed error feedback         | ✅        |
 | `ngforge_scaffold` | Generate valid FormConfig skeletons                         | ✅        |
+| `ngforge_search`   | Keyword search across all documentation topics and examples | ✅        |
 
 ## Get Started
 
@@ -90,12 +91,16 @@ Get documentation about any ng-forge topic.
 
 **Available Topics:**
 
-| Category    | Topics                                                                                                                                                                                                                                                     |
-| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Field Types | `input`, `select`, `radio`, `checkbox`, `textarea`, `datepicker`, `slider`, `toggle`, `hidden`, `text`, `button`, `submit`, `next`, `previous`, `addArrayItem`, `prependArrayItem`, `insertArrayItem`, `removeArrayItem`, `popArrayItem`, `shiftArrayItem` |
-| Containers  | `group`, `row`, `array`, `page`                                                                                                                                                                                                                            |
-| Concepts    | `validation`, `conditional`, `derivation`, `options-format`, `expression-variables`, `async-validators`, `validation-messages`                                                                                                                             |
-| Patterns    | `golden-path`, `multi-page-gotchas`, `pitfalls`, `workflow`                                                                                                                                                                                                |
+| Category    | Topics                                                                                                                                                                                                                  |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Field Types | `input`, `select`, `slider`, `radio`, `checkbox`, `multi-checkbox`, `textarea`, `datepicker`, `toggle`, `text`, `hidden`, `button`, `submit`, `next`, `previous`, `addArrayItem`, `removeArrayItem`                     |
+| Containers  | `group`, `row`, `array`, `simplified-array`, `page`                                                                                                                                                                     |
+| Wrappers    | `wrappers`, `css`, `arraySection`, `section`                                                                                                                                                                            |
+| Addons      | `addons`, `template`, `component`, `mat-icon`, `mat-button`, `bs-icon`, `bs-button`, `prime-icon`, `prime-button`, `ion-icon`, `ion-button`                                                                             |
+| Concepts    | `validation`, `validation-messages`, `conditional`, `derivation`, `property-derivation`, `options-format`, `expression-variables`, `async-validators`, `buttons`, `external-data`                                       |
+| Patterns    | `golden-path`, `multi-page-gotchas`, `pitfalls`, `field-placement`, `logic-matrix`, `context-api`, `containers`, `array-buttons`, `custom-validators`, `conditions`, `common-expressions`, `type-narrowing`, `workflow` |
+
+Wrapper and addon topics are read from the registry at runtime, so use `topic="list"` to get the complete, current set with descriptions.
 
 **Examples:**
 
@@ -111,26 +116,28 @@ ngforge_lookup topic="input" depth="schema" uiIntegration="material"
 
 Get working code examples for common patterns.
 
-| Parameter | Type                                                  | Default    | Description     |
-| --------- | ----------------------------------------------------- | ---------- | --------------- |
-| `pattern` | string                                                | (required) | Pattern name    |
-| `depth`   | `"minimal"` \| `"brief"` \| `"full"` \| `"explained"` | `"full"`   | Level of detail |
+| Parameter | Type                                                  | Default    | Description                                                   |
+| --------- | ----------------------------------------------------- | ---------- | ------------------------------------------------------------- |
+| `pattern` | string                                                | (optional) | Pattern name; omit it (or pass `"list"`) to list all patterns |
+| `depth`   | `"minimal"` \| `"brief"` \| `"full"` \| `"explained"` | `"full"`   | Level of detail                                               |
 
 **Available Patterns:**
 
-| Pattern               | Description                              | Lines |
-| --------------------- | ---------------------------------------- | ----- |
-| `minimal-multipage`   | Simplest 2-page wizard form              | ~50   |
-| `minimal-array`       | Array with add/remove buttons            | ~30   |
-| `minimal-conditional` | Show/hide field based on condition       | ~25   |
-| `minimal-validation`  | Password confirmation validation         | ~20   |
-| `minimal-hidden`      | Hidden fields in multi-page form         | ~15   |
-| `derivation`          | Value derivation (computed fields)       | -     |
-| `conditional`         | Conditional visibility patterns          | -     |
-| `multi-page`          | Multi-step wizard forms                  | -     |
-| `validation`          | Form validation patterns                 | -     |
-| `complete`            | Full form with all major features        | -     |
-| `mega`                | Kitchen sink demonstrating every feature | -     |
+| Pattern                    | Description                                        | Lines |
+| -------------------------- | -------------------------------------------------- | ----- |
+| `minimal-multipage`        | Simplest 2-page wizard form                        | ~50   |
+| `minimal-array`            | Array with add/remove buttons                      | ~30   |
+| `minimal-conditional`      | Show/hide field based on condition                 | ~25   |
+| `minimal-validation`       | Password confirmation validation                   | ~20   |
+| `minimal-hidden`           | Hidden fields in multi-page form                   | ~15   |
+| `minimal-simplified-array` | Simplified array with template and value           | -     |
+| `derivation`               | Value derivation (computed fields)                 | -     |
+| `property-derivation`      | Dynamic field properties (label, options, min/max) | -     |
+| `conditional`              | Conditional visibility patterns                    | -     |
+| `multi-page`               | Multi-step wizard forms                            | -     |
+| `validation`               | Form validation patterns                           | -     |
+| `complete`                 | Full form with all major features                  | -     |
+| `mega`                     | Kitchen sink demonstrating every feature           | -     |
 
 **Examples:**
 
@@ -162,7 +169,7 @@ Validate FormConfig and get detailed error feedback.
 
 - "Hidden field missing REQUIRED value property"
 - "options MUST be at FIELD level, NOT inside props"
-- "row containers do NOT support logic blocks"
+- "Containers (group, row, array) only support 'hidden' logic type"
 
 **Examples:**
 
@@ -204,15 +211,24 @@ ngforge_scaffold hidden=["userId:abc123","source:web"]
 
 In addition to tools, the server exposes resources that AI can read:
 
-| Resource URI               | Description                                    |
-| -------------------------- | ---------------------------------------------- |
-| `ng-forge://instructions`  | Best practices guide for generating FormConfig |
-| `ng-forge://examples`      | Curated FormConfig examples                    |
-| `ng-forge://examples/{id}` | Specific example by ID                         |
-| `ng-forge://field-types`   | Field type reference                           |
-| `ng-forge://validators`    | Validator reference                            |
-| `ng-forge://ui-adapters`   | UI library configurations                      |
-| `ng-forge://docs`          | Full documentation index                       |
+| Resource URI                       | Description                                                    |
+| ---------------------------------- | -------------------------------------------------------------- |
+| `ng-forge://instructions`          | Best practices guide for generating FormConfig                 |
+| `ng-forge://schemas`               | Schema reference (UI integrations, field types, tool overview) |
+| `ng-forge://examples`              | Curated FormConfig examples                                    |
+| `ng-forge://examples/{id}`         | Specific example by ID                                         |
+| `ng-forge://field-types`           | Field type reference                                           |
+| `ng-forge://field-types/{type}`    | Details for a specific field type                              |
+| `ng-forge://validators`            | Validator reference                                            |
+| `ng-forge://validators/{type}`     | Details for a specific validator                               |
+| `ng-forge://wrappers`              | Wrapper reference                                              |
+| `ng-forge://wrappers/{type}`       | Details for a specific wrapper                                 |
+| `ng-forge://ui-adapters`           | UI library configurations                                      |
+| `ng-forge://ui-adapters/{library}` | Details for a specific UI library                              |
+| `ng-forge://docs`                  | Full documentation index                                       |
+| `ng-forge://docs/{topic}`          | Documentation for a specific topic                             |
+
+Category-filtered URIs also exist for field types, validators, and wrappers (`ng-forge://field-types/category/{category}`, and the equivalents for validators and wrappers).
 
 ---
 

--- a/apps/docs/public/content/api-driven-forms.md
+++ b/apps/docs/public/content/api-driven-forms.md
@@ -4,7 +4,7 @@ slug: api-driven-forms
 description: 'Render Angular forms from API responses or backend JSON. Fetch form configs at runtime, type form values, and hydrate client-side features like submission handlers and validation.'
 ---
 
-Build dynamic forms from JSON returned by your backend or CMS. When your form configuration is fetched at runtime instead of defined statically, you don't need `as const satisfies FormConfig` — the plain `FormConfig` type works out of the box.
+Build dynamic forms from JSON returned by your backend or CMS. When your form configuration is fetched at runtime instead of defined statically, you don't need `as const satisfies FormConfig`: the plain `FormConfig` type works out of the box.
 
 This is the recommended pattern for server-driven forms, JSON-based form builders, and any scenario where the form structure isn't known at compile time.
 
@@ -44,27 +44,28 @@ export class MyPageComponent {
 }
 ```
 
-No `as const`, no `satisfies` — the `FormConfig` interface accepts any valid field configuration at its default generic parameters.
+No `as const`, no `satisfies`: the `FormConfig` interface accepts any valid field configuration at its default generic parameters.
 
 ## What's Serializable
 
 Not every `FormConfig` property can come from a JSON API. Some require runtime code:
 
-| Property                    | Serializable | Notes                                                                       |
-| --------------------------- | ------------ | --------------------------------------------------------------------------- |
-| `fields`                    | Yes          | Core form structure — field types, keys, values, options, validators, logic |
-| `options`                   | Yes          | Disabled state, button behavior, value exclusion                            |
-| `schemas`                   | Yes          | Reusable validation schemas                                                 |
-| `defaultValidationMessages` | Yes          | Fallback error messages                                                     |
-| `defaultProps`              | Yes          | Default UI props (appearance, sizing)                                       |
-| `submission`                | No           | Requires an `action` function                                               |
-| `customFnConfig`            | No           | Custom validators, derivation functions, condition functions                |
-| `externalData`              | No           | Angular `Signal` instances                                                  |
-| `schema`                    | No           | Standard Schema objects (Zod, Valibot, etc.)                                |
+| Property                    | Serializable | Notes                                                                      |
+| --------------------------- | ------------ | -------------------------------------------------------------------------- |
+| `fields`                    | Yes          | Core form structure: field types, keys, values, options, validators, logic |
+| `options`                   | Yes          | Disabled state, button behavior, value exclusion                           |
+| `schemas`                   | Yes          | Reusable validation schemas                                                |
+| `defaultValidationMessages` | Yes          | Fallback error messages                                                    |
+| `defaultProps`              | Yes          | Default UI props (appearance, sizing)                                      |
+| `defaultWrappers`           | Yes          | Form-wide default wrapper configs                                          |
+| `submission`                | No           | Requires an `action` function                                              |
+| `customFnConfig`            | No           | Custom validators, derivation functions, condition functions               |
+| `externalData`              | No           | Angular `Signal` instances                                                 |
+| `schema`                    | No           | Standard Schema objects (Zod, Valibot, etc.)                               |
 
 The serializable properties cover the vast majority of form configuration. The non-serializable ones are for advanced features that inherently require client-side code.
 
-Fields accept a [`nullable: true`](/configuration#nullable-values) flag to preserve `null` through defaults and submission — useful when mirroring OpenAPI schemas that distinguish null from empty.
+Fields accept a [`nullable: true`](/configuration#nullable-values) flag to preserve `null` through defaults and submission, useful when mirroring OpenAPI schemas that distinguish null from empty.
 
 ## Hydrating Runtime Features
 
@@ -161,6 +162,6 @@ function onSubmit(value: unknown) {
 
 ## Related
 
-- **[Configuration](/configuration)** — Global form setup and provider options
-- **[Type Safety](/recipes/type-safety)** — Compile-time type inference with `as const satisfies`
-- **[Form Submission](/dynamic-behavior/submission)** — Submission handlers and server error mapping
+- **[Configuration](/configuration)**: Global form setup and provider options
+- **[Type Safety](/recipes/type-safety)**: Compile-time type inference with `as const satisfies`
+- **[Form Submission](/dynamic-behavior/submission)**: Submission handlers and server error mapping

--- a/apps/docs/public/content/building-an-adapter.md
+++ b/apps/docs/public/content/building-an-adapter.md
@@ -6,7 +6,7 @@ description: 'Build a custom UI adapter for ng-forge dynamic forms. Compose the 
 
 Build a custom integration so ng-forge field types render with your own component library or design system.
 
-> **Just need one extra field on top of an existing adapter** (Material/Bootstrap/PrimeNG/Ionic)? See the shorter [Custom Fields](/recipes/custom-fields) recipe — same primitive, scoped to a single field type.
+> **Just need one extra field on top of an existing adapter** (Material/Bootstrap/PrimeNG/Ionic)? See the shorter [Custom Fields](/recipes/custom-fields) recipe: same primitive, scoped to a single field type.
 
 ## Overview
 
@@ -16,7 +16,7 @@ An ng-forge adapter provides:
 2. A **provider function** (`withMyAdapterFields()`) that registers all those types with `provideDynamicForm()`.
 3. Optional **adapter-level configuration** that cascades into individual fields (size, appearance, theme color).
 
-Every field component composes the `NgForgeField` directive via `hostDirectives`. That directive owns the standard contract — the 10 forwarded inputs every field accepts, eight derived signals (errors, ARIA helpers, ID derivation), and four universal host bindings — so you only write the parts that are actually adapter-specific: the template and any UI-library quirks.
+Every field component composes the `NgForgeField` directive via `hostDirectives`. That directive owns the standard contract: the nine forwarded inputs every field accepts, eight derived signals (errors, ARIA helpers, ID derivation), and five universal host bindings. You only write the parts that are actually adapter-specific: the template and any UI-library quirks.
 
 Package entrypoints you'll import from:
 
@@ -31,24 +31,24 @@ ng-forge ships three layered directives + two **wrapper** directives that bundle
 
 **Layers:**
 
-- **`NgForgeFieldShell`** — the universal base. Owns the `key` + `className` inputs and the identity host bindings (`[id]`, `[attr.data-testid]`, `[class]`). Every ng-forge component uses this.
-- **`NgForgeField`** — the **value** add-on. Injects Shell. Owns `field`/`label`/`placeholder`/`tabIndex`/`props`/`meta`/`validationMessages`, the error/aria derived signals, meta-tracking, and the `[attr.hidden]`/`[attr.aria-disabled]` host bindings driven by `field()()`.
-- **`NgForgeAction`** — the **action** add-on. Injects Shell. Owns `label`/`disabled`/`hidden`/`tabIndex`/`event`/`eventArgs`/`eventContext`/`props`, the `[attr.hidden]`/`[attr.aria-disabled]` host bindings driven by its own inputs, and a `dispatch()` method that resolves event-arg tokens and dispatches through `EventBus`.
+- **`NgForgeFieldShell`**: the universal base. Owns the `key` + `className` inputs and the identity host bindings (`[id]`, `[attr.data-testid]`, `[class]`). Every ng-forge component uses this.
+- **`NgForgeField`**: the **value** add-on. Injects Shell. Owns `field`/`label`/`placeholder`/`tabIndex`/`props`/`meta`/`validationMessages`, the error/aria derived signals, meta-tracking, and the `[attr.hidden]`/`[attr.aria-disabled]` host bindings driven by `field()()`.
+- **`NgForgeAction`**: the **action** add-on. Injects Shell. Owns `label`/`disabled`/`hidden`/`tabIndex`/`event`/`eventArgs`/`eventContext`/`props`, the `[attr.hidden]`/`[attr.aria-disabled]` host bindings driven by its own inputs, and a `dispatch()` method that resolves event-arg tokens and dispatches through `EventBus`.
 
 **Wrappers:**
 
-- **`NgForgeFieldHost`** — composes `NgForgeFieldShell` + `NgForgeField`. Use for value-bearing components.
-- **`NgForgeActionHost`** — composes `NgForgeFieldShell` + `NgForgeAction`. Use for button / action components.
+- **`NgForgeFieldHost`**: composes `NgForgeFieldShell` + `NgForgeField`. Use for value-bearing components.
+- **`NgForgeActionHost`**: composes `NgForgeFieldShell` + `NgForgeAction`. Use for button / action components.
 
-The wrappers exist because Angular's library partial-compilation can't resolve cross-package const references inside `hostDirectives:` — a wrapper directive's own `hostDirectives` IS resolvable at the integration package's compile time, so consumers compose a single class instead of writing the two-entry literal in every component.
+The wrappers exist because Angular's library partial-compilation can't resolve cross-package const references inside `hostDirectives:`. A wrapper directive's own `hostDirectives` IS resolvable at the integration package's compile time, so consumers compose a single class instead of writing the two-entry literal in every component.
 
 **Forwarded inputs** (per directive):
 
 | Directive           | Input names array (re-export)                                                                                       |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `NgForgeFieldShell` | `NG_FORGE_FIELD_SHELL_INPUTS` → `key`, `className`                                                                  |
-| `NgForgeField`      | `NG_FORGE_VALUE_FIELD_INPUTS` → `field`, `label`, `placeholder`, `tabIndex`, `props`, `meta`, `validationMessages`  |
-| `NgForgeAction`     | `NG_FORGE_ACTION_INPUTS` → `label`, `disabled`, `hidden`, `tabIndex`, `event`, `eventArgs`, `eventContext`, `props` |
+| `NgForgeFieldShell` | `NG_FORGE_FIELD_SHELL_INPUTS` (`key`, `className`)                                                                  |
+| `NgForgeField`      | `NG_FORGE_VALUE_FIELD_INPUTS` (`field`, `label`, `placeholder`, `tabIndex`, `props`, `meta`, `validationMessages`)  |
+| `NgForgeAction`     | `NG_FORGE_ACTION_INPUTS` (`label`, `disabled`, `hidden`, `tabIndex`, `event`, `eventArgs`, `eventContext`, `props`) |
 
 **Derived signals available via `injectNgForgeField<T>()`:**
 
@@ -122,9 +122,9 @@ export default class CustomInputComponent {
 
 What the component does **not** declare:
 
-- Standard inputs (`field`, `key`, `label`, etc.) — those come from `NgForgeField` via `hostDirectives`. The component reads them through `ngf.X()`.
-- Host bindings for `id`/`data-testid`/`class`/`hidden` — `NgForgeField` owns those.
-- Error / ARIA / hint plumbing — derived signals come from the directive.
+- Standard inputs (`field`, `key`, `label`, etc.): those come from `NgForgeField` via `hostDirectives`. The component reads them through `ngf.X()`.
+- Host bindings for `id`/`data-testid`/`class`/`hidden`: `NgForgeField` owns those.
+- Error / ARIA / hint plumbing: derived signals come from the directive.
 
 What the component **does** declare:
 
@@ -135,13 +135,13 @@ What the component **does** declare:
 
 ### Typed access via injectNgForgeField
 
-`injectNgForgeField<T>()` returns the `NgForgeField` instance with `field` narrowed to `Signal<FieldTree<T>>`. The cast is unchecked — the runtime contract is that the field-type registration matches the value type — but it lets `[formField]="ngf.field()"` type-check inside templates that need a strict generic.
+`injectNgForgeField<T>()` returns the `NgForgeField` instance with `field` narrowed to `Signal<FieldTree<T>>`. The cast is unchecked (the runtime contract is that the field-type registration matches the value type), but it lets `[formField]="ngf.field()"` type-check inside templates that need a strict generic.
 
 For boolean fields you'd write `injectNgForgeField<boolean>()`, for `Date | null` datepickers `injectNgForgeField<Date | null>()`, and so on.
 
 ## Anatomy of an action component
 
-Buttons, submits, navigation buttons, and array-mutation buttons all compose `NgForgeFieldShell` + `NgForgeAction` instead of `NgForgeField`. The Action directive owns event dispatch — your component's click handler calls `action.dispatch()` and the directive resolves any `eventArgs` tokens via the ambient `ARRAY_CONTEXT` and dispatches through `EventBus`.
+Buttons, submits, navigation buttons, and array-mutation buttons all compose `NgForgeFieldShell` + `NgForgeAction` instead of `NgForgeField`. The Action directive owns event dispatch: your component's click handler calls `action.dispatch()` and the directive resolves any `eventArgs` tokens via the ambient `ARRAY_CONTEXT` and dispatches through `EventBus`.
 
 ```typescript
 // custom-button.component.ts
@@ -186,13 +186,13 @@ The corresponding `FieldTypeDefinition` opts out of value handling and explicit 
 }
 ```
 
-`buttonFieldMapper` (or `submitButtonFieldMapper` / `nextButtonFieldMapper` / `addArrayItemButtonMapper` / …) emits exactly the keys `NgForgeFieldShell` + `NgForgeAction` accept — same lockstep guarantee as value fields.
+`buttonFieldMapper` (or `submitButtonFieldMapper` / `nextButtonFieldMapper` / `addArrayItemButtonMapper` / …) emits exactly the keys `NgForgeFieldShell` + `NgForgeAction` accept, the same lockstep guarantee as value fields.
 
 ## Meta forwarding
 
-Field meta — the `meta` input on every field — carries native HTML attributes (`data-*`, `autocomplete`, `inputmode`, etc.). Markers also forward the directive's derived aria signals (`aria-invalid`, `aria-required`, `aria-describedby`) onto the same target, so authors don't bind those manually. ng-forge ships two marker directives plus an ambient injection path for sub-components.
+Field meta (the `meta` input on every field) carries native HTML attributes (`data-*`, `autocomplete`, `inputmode`, etc.). Markers also forward the directive's derived aria signals (`aria-invalid`, `aria-required`, `aria-describedby`) onto the same target, so authors don't bind those manually. ng-forge ships two marker directives plus an ambient injection path for sub-components.
 
-### NgForgeControl — the common case
+### NgForgeControl: the common case
 
 A template attribute directive. Place it on the canonical control element in your template:
 
@@ -214,9 +214,9 @@ For dynamic option lists (radio buttons, multi-checkbox), put `ngForgeControl` i
 }
 ```
 
-Each iteration spawns its own directive instance. Adding/removing options via Angular's structural lifecycle creates and destroys those instances naturally — no manual subscription, no `dependents` array.
+Each iteration spawns its own directive instance. Adding/removing options via Angular's structural lifecycle creates and destroys those instances naturally: no manual subscription, no `dependents` array.
 
-### NgForgeHostControl — for shadow-DOM wrappers
+### NgForgeHostControl: for shadow-DOM wrappers
 
 Some component libraries (Ionic web components, certain PrimeNG controls) wrap a native input inside shadow DOM that you can't reach with a template selector. In those cases the wrapper element itself is the canonical control from the user's perspective. Add `NgForgeHostControl` to your component's `hostDirectives` so meta + aria land on the host:
 
@@ -242,19 +242,19 @@ export default class IonicToggleField {
 }
 ```
 
-`NgForgeHostControl` is selectorless — it's only used via `hostDirectives`, never as a template attribute. Reversing the order (`[NgForgeHostControl, NgForgeFieldHost]`) causes `inject(NgForgeField)` inside the marker's constructor to fail with NG0203 because the parent isn't on the element injector yet.
+`NgForgeHostControl` is selectorless: it's only used via `hostDirectives`, never as a template attribute. Reversing the order (`[NgForgeHostControl, NgForgeFieldHost]`) causes `inject(NgForgeField)` inside the marker's constructor to fail with NG0203 because the parent isn't on the element injector yet.
 
 ### Quick decision rule
 
-- The control element is rendered in **your template** (an `input`, `select`, or any custom element) → `[ngForgeControl]` on that element.
-- The control element is the **component's host** (no inner element to mark, e.g. shadow-DOM wrapper) → `NgForgeHostControl` in `hostDirectives`.
-- Meta should not be applied at all → omit both.
+- The control element is rendered in **your template** (an `input`, `select`, or any custom element): use `[ngForgeControl]` on that element.
+- The control element is the **component's host** (no inner element to mark, e.g. shadow-DOM wrapper): use `NgForgeHostControl` in `hostDirectives`.
+- Meta should not be applied at all: omit both.
 
 If you set `meta()` on a field but no marker / ambient consumer claims it, ng-forge logs a dev-mode warning so the wiring gap surfaces immediately instead of failing silently.
 
 ### Forwarding to a sub-component
 
-If your field component delegates rendering to a sub-component (e.g. `df-bs-radio-group` inside `df-bs-radio`), put `ngForgeControl` on the canonical control element in the sub-component's template — the marker walks the element-injector tree to find the parent's `NgForgeField` and absorbs meta + aria automatically. For per-iteration shapes (radio buttons, multi-checkbox options), one marker instance per `@for` iteration:
+If your field component delegates rendering to a sub-component (e.g. `df-bs-radio-group` inside `df-bs-radio`), put `ngForgeControl` on the canonical control element in the sub-component's template. The marker walks the element-injector tree to find the parent's `NgForgeField` and absorbs meta + aria automatically. For per-iteration shapes (radio buttons, multi-checkbox options), one marker instance per `@for` iteration:
 
 ```typescript
 @Component({
@@ -280,9 +280,9 @@ export class BsRadioGroupComponent {
 }
 ```
 
-No `[meta]="ngf.meta()"` binding on the parent side is needed and no `setupMetaTracking` call inside the sub-component — each marker instance claims the ambient field on construction. The dev-mode unclaimed-meta warning fires if `meta()` is non-empty and no marker / ambient consumer registered.
+No `[meta]="ngf.meta()"` binding on the parent side is needed and no `setupMetaTracking` call inside the sub-component: each marker instance claims the ambient field on construction. The dev-mode unclaimed-meta warning fires if `meta()` is non-empty and no marker / ambient consumer registered.
 
-> **Warning-race note.** In a normal template-driven render, sub-components construct during the parent's template instantiation (so `markClaimed()` runs before `NgForgeField`'s `afterRenderEffect.write` fires). For programmatic late mounts (Storybook stories, mid-tree manual instantiation) the warning can fire once before the late claim lands — the latch ensures it doesn't repeat.
+> **Warning-race note.** In a normal template-driven render, sub-components construct during the parent's template instantiation (so `markClaimed()` runs before `NgForgeField`'s `afterRenderEffect.write` fires). For programmatic late mounts (Storybook stories, mid-tree manual instantiation) the warning can fire once before the late claim lands; the latch ensures it doesn't repeat.
 
 ## Mappers
 
@@ -292,28 +292,28 @@ A mapper translates a field definition (`FieldDef<...>`) into the inputs that fl
 type MapperFn<T extends FieldDef<unknown>> = (input: T) => Signal<Record<string, unknown>>;
 ```
 
-The signal emits a record of input-name → value. The form engine reads each entry and calls `ref.setInput(name, value)` on the rendered component.
+The signal emits a record mapping input names to values. The form engine reads each entry and calls `ref.setInput(name, value)` on the rendered component.
 
 ng-forge ships mappers for the standard field categories. You'll register field types against these, not write your own most of the time:
 
-| Mapper                  | For                                     | What it emits                                                                                                                                                                                                                                                                                                                                                                                                               |
-| ----------------------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `valueFieldMapper`      | input, textarea, datepicker, slider, …  | `field`, `key`, `label`, `placeholder`, `className`, `tabIndex`, `props`, `meta`, `validationMessages`. Note: the mapper no longer emits `defaultValidationMessages` as a per-component input — `NgForgeField` reads `DEFAULT_VALIDATION_MESSAGES` from DI directly. The form-level `defaultValidationMessages` config option in `provideDynamicForm` / `FormConfig` is unaffected: it still flows in through the DI token. |
-| `checkboxFieldMapper`   | checkbox, toggle                        | same as `valueFieldMapper`                                                                                                                                                                                                                                                                                                                                                                                                  |
-| `optionsFieldMapper`    | select, radio, multi-checkbox           | adds `options`                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `datepickerFieldMapper` | datepicker                              | adds `minDate`, `maxDate`, `startAt` (string→Date conversion)                                                                                                                                                                                                                                                                                                                                                               |
-| `buttonFieldMapper`     | plain buttons                           | `key`, `label`, `disabled`, `event`, `props`, `className`                                                                                                                                                                                                                                                                                                                                                                   |
-| Array button mappers    | `addArrayItem`, `removeArrayItem`, etc. | event + event-args wiring for array mutations                                                                                                                                                                                                                                                                                                                                                                               |
+| Mapper                  | For                                     | What it emits                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| ----------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `valueFieldMapper`      | input, textarea, datepicker, slider, …  | `field`, `key`, `label`, `placeholder`, `className`, `tabIndex`, `props`, `meta`, `validationMessages`, plus `addons` when the field declares addons. Note: the mapper no longer emits `defaultValidationMessages` as a per-component input; `NgForgeField` reads `DEFAULT_VALIDATION_MESSAGES` from DI directly. The form-level `defaultValidationMessages` config option in `provideDynamicForm` / `FormConfig` is unaffected: it still flows in through the DI token. |
+| `checkboxFieldMapper`   | checkbox, toggle                        | same as `valueFieldMapper`                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `optionsFieldMapper`    | select, radio, multi-checkbox           | adds `options`                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `datepickerFieldMapper` | datepicker                              | adds `minDate`, `maxDate`, `startAt` (string to Date conversion)                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `buttonFieldMapper`     | plain buttons                           | `key`, `label`, `disabled`, `event`, `props`, `className`                                                                                                                                                                                                                                                                                                                                                                                                                |
+| Array button mappers    | `addArrayItem`, `removeArrayItem`, etc. | event + event-args wiring for array mutations                                                                                                                                                                                                                                                                                                                                                                                                                            |
 
 ### Mapper-as-contract
 
-Every key a mapper emits must match a declared input on the component or one of its host directives. If your component exposes the standard 10 inputs (via `NgForgeField` `hostDirectives`) and accepts `props`, every key the built-in mappers emit lines up automatically.
+Every key a mapper emits must match a declared input on the component or one of its host directives. If your component exposes the standard nine inputs (via `NgForgeField` `hostDirectives`) and accepts `props`, every key the built-in mappers emit lines up automatically.
 
-`ComponentRef.setInput` (used by the field outlet to push mapper output onto the rendered component) is **lenient** on unknown input names in Angular 21 — extra keys are silently dropped rather than throwing NG0303. So if a custom mapper emits a key the component doesn't declare, the input is lost without a runtime error. Composing `NgForgeFieldHost` registers all the standard input names on the component (Shell's `key`/`className` + Field's `field`/`label`/`placeholder`/`tabIndex`/`props`/`meta`/`validationMessages`) so built-in mapper output always lines up — that's the recommended authoring shape for third-party adapters.
+`ComponentRef.setInput` (used by the field outlet to push mapper output onto the rendered component) is **lenient** on unknown input names in Angular 22: extra keys are silently dropped rather than throwing NG0303. So if a custom mapper emits a key the component doesn't declare, the input is lost without a runtime error. Composing `NgForgeFieldHost` registers all the standard input names on the component (Shell's `key`/`className` + Field's `field`/`label`/`placeholder`/`tabIndex`/`props`/`meta`/`validationMessages`) so built-in mapper output always lines up. That's the recommended authoring shape for third-party adapters.
 
 ### Writing a custom mapper
 
-Most adapter authors never need this — the built-in mappers handle every standard category. You'd write a custom mapper when your field type doesn't fit any standard category (e.g. a multi-select with grouped options, a tree-picker with a custom data shape).
+Most adapter authors never need this: the built-in mappers handle every standard category. You'd write a custom mapper when your field type doesn't fit any standard category (e.g. a multi-select with grouped options, a tree-picker with a custom data shape).
 
 Example: a hypothetical "weighted choice" field where each option has an associated number:
 
@@ -341,13 +341,13 @@ export function weightedChoiceFieldMapper(fieldDef: WeightedChoiceField): Signal
 }
 ```
 
-Reuse `buildValueFieldInputs` (exported from `/integration`) to get the standard 10 keys without rewriting them, then layer your extra keys on top.
+Reuse `buildValueFieldInputs` (exported from `/integration`) to get the standard value-field keys without rewriting them, then layer your extra keys on top.
 
 ### Writing a custom action / button mapper
 
 Action fields (buttons, submits, array-mutation buttons) compose `NgForgeActionHost` instead of `NgForgeFieldHost`. Their mapper emits a different key set: `key`, `className`, `label`, `disabled`, `hidden`, `tabIndex`, `event`, `eventArgs`, `eventContext`, `props`. `NgForgeAction.dispatch()` reads `event` + `eventArgs` and resolves any tokens (`$key`, `$index`, `$arrayKey`, `formValue`) against the ambient `ARRAY_CONTEXT` injection token, falling back to the static `eventContext` input.
 
-The built-in `buttonFieldMapper` covers the generic case. For preconfigured events (submit, next/previous-page, array mutations) ng-forge ships `submitButtonFieldMapper`, `nextButtonFieldMapper`, `previousButtonFieldMapper`, `addArrayItemButtonMapper`, `prependArrayItemButtonMapper`, `insertArrayItemButtonMapper`, `removeArrayItemButtonMapper`, `popArrayItemButtonMapper`, `shiftArrayItemButtonMapper` — each one wires the `event` class internally so the field definition doesn't have to.
+The built-in `buttonFieldMapper` covers the generic case. For preconfigured events (submit, next/previous-page, array mutations) ng-forge ships `submitButtonFieldMapper`, `nextButtonFieldMapper`, `previousButtonFieldMapper`, `addArrayItemButtonMapper`, `prependArrayItemButtonMapper`, `insertArrayItemButtonMapper`, `removeArrayItemButtonMapper`, `popArrayItemButtonMapper`, `shiftArrayItemButtonMapper`. Each one wires the `event` class internally so the field definition doesn't have to.
 
 You'd write a custom action mapper for a button that dispatches a custom `FormEvent` subclass with a non-standard payload shape, or for a button whose event-arg resolution differs from the built-in tokens.
 
@@ -402,12 +402,12 @@ Register with `valueHandling: 'exclude'` and `renderReadyWhen: []` since action 
 
 ## Required-input forwarding & renderReadyWhen
 
-`NgForgeField` declares `field` and `key` as `input.required()`. The form engine guarantees both are bound before the component renders, but the contract is enforced via the `renderReadyWhen` mechanism on the `FieldTypeDefinition`.
+`NgForgeField` declares `field` as `input.required()`, and `NgForgeFieldShell` declares `key` the same way. The form engine guarantees both are bound before the component renders, but the contract is enforced via the `renderReadyWhen` mechanism on the `FieldTypeDefinition`.
 
 The renderer resolves the effective `renderReadyWhen` per registration in this order:
 
-1. `FieldTypeDefinition.renderReadyWhen` — explicit on the registration. Always wins (escape hatch).
-2. `valueHandling: 'exclude'` — short-circuits to `[]`. Display / action / layout fields don't bind to a form value, so they never wait.
+1. `FieldTypeDefinition.renderReadyWhen`: explicit on the registration. Always wins (escape hatch).
+2. `valueHandling: 'exclude'`: short-circuits to `[]`. Display / action / layout fields don't bind to a form value, so they never wait.
 3. Default `['field']`. In dev mode the renderer also emits a one-time warning via `DynamicFormLogger` so adapter authors learn to declare the contract explicitly.
 
 Every registration in your adapter should declare `renderReadyWhen` (directly or via a shared base constant) so the contract is visible at the registration site. The convention the built-in adapters follow:
@@ -519,7 +519,7 @@ After this declaration, IDE autocomplete on `FormConfig.fields[].type` resolves 
 
 ## Adapter-level configuration
 
-Most design systems have settings that should cascade across every field — appearance variant, size, theme color. The pattern is:
+Most design systems have settings that should cascade across every field: appearance variant, size, theme color. The pattern is:
 
 1. Define an injection token with the config shape.
 2. Make the config optional in your provider function.
@@ -564,7 +564,7 @@ Templates bind the resolved computeds rather than reading `props` directly:
 
 ### propsToMeta
 
-Some "props" are actually native HTML attributes — `type` on inputs, `rows`/`cols` on textareas, `autocomplete`. Listing them in `propsToMeta` on the field type definition causes the form engine to merge those values into `meta` before passing them to your component, which means they flow through `[ngForgeControl]` onto the actual control element automatically.
+Some "props" are actually native HTML attributes: `type` on inputs, `rows`/`cols` on textareas, `autocomplete`. Listing them in `propsToMeta` on the field type definition causes the form engine to merge those values into `meta` before passing them to your component, which means they flow through `[ngForgeControl]` onto the actual control element automatically.
 
 ```typescript
 {
@@ -579,11 +579,11 @@ If `meta` and `props` both carry the same key, `meta` wins.
 
 ## Custom wrappers
 
-Wrappers are "chrome" around a field — sections, accordions, tooltips, badges. ng-forge ships a wrapper-chain registry separate from the field-type registry, so adapters can register custom wrappers alongside field types from the same provider entry point.
+Wrappers are "chrome" around a field: sections, accordions, tooltips, badges. ng-forge ships a wrapper-chain registry separate from the field-type registry, so adapters can register custom wrappers alongside field types from the same provider entry point.
 
 The complete wrapper-authoring guide lives in **[Writing a Wrapper](/wrappers/writing-a-wrapper)** (component shape, slot semantics, `WrapperFieldInputs`, error patterns) and **[Registering and Applying](/wrappers/registering-and-applying)** (the `createWrappers` bundle + module augmentation).
 
-For adapter library packaging, import the wrapper-authoring API from `@ng-forge/dynamic-forms/integration` rather than the root entry point — keeps a single import path across your field components and wrapper components:
+For adapter library packaging, import the wrapper-authoring API from `@ng-forge/dynamic-forms/integration` rather than the root entry point. This keeps a single import path across your field components and wrapper components:
 
 ```typescript
 import {
@@ -595,20 +595,20 @@ import {
 } from '@ng-forge/dynamic-forms/integration';
 ```
 
-Functionally identical to the root entry — same symbols, same `declare module '@ng-forge/dynamic-forms'` augmentation. The integration re-export exists so adapter packages have one import path.
+Functionally identical to the root entry: same symbols, same `declare module '@ng-forge/dynamic-forms'` augmentation. The integration re-export exists so adapter packages have one import path.
 
 ## Reference adapters
 
 The four in-tree adapters are the canonical reference implementations. Each ships ~10 field components, all built on `NgForgeField`. Read them as full working examples:
 
-- [`packages/dynamic-forms-bootstrap`](https://github.com/ng-forge/ng-forge/tree/main/packages/dynamic-forms-bootstrap) — the smallest surface, often the easiest to copy from.
-- [`packages/dynamic-forms-material`](https://github.com/ng-forge/ng-forge/tree/main/packages/dynamic-forms-material) — wraps Angular Material's existing form-field primitives.
-- [`packages/dynamic-forms-primeng`](https://github.com/ng-forge/ng-forge/tree/main/packages/dynamic-forms-primeng) — examples of inner control components for opaque PrimeNG widgets.
-- [`packages/dynamic-forms-ionic`](https://github.com/ng-forge/ng-forge/tree/main/packages/dynamic-forms-ionic) — shadow-DOM wrappers using `NgForgeHostControl`.
+- [`packages/dynamic-forms-bootstrap`](https://github.com/ng-forge/ng-forge/tree/main/packages/dynamic-forms-bootstrap): the smallest surface, often the easiest to copy from.
+- [`packages/dynamic-forms-material`](https://github.com/ng-forge/ng-forge/tree/main/packages/dynamic-forms-material): wraps Angular Material's existing form-field primitives.
+- [`packages/dynamic-forms-primeng`](https://github.com/ng-forge/ng-forge/tree/main/packages/dynamic-forms-primeng): examples of inner control components for opaque PrimeNG widgets.
+- [`packages/dynamic-forms-ionic`](https://github.com/ng-forge/ng-forge/tree/main/packages/dynamic-forms-ionic): shadow-DOM wrappers using `NgForgeHostControl`.
 
 ## Related
 
-- **[Custom Fields](/recipes/custom-fields)** — single-field recipe alongside an existing adapter.
-- **[Field Types](/field-types/text-inputs)** — what the standard field types provide.
-- **[Type Safety](/recipes/type-safety)** — module augmentation patterns.
-- **[Validation](/validation/basics)** — how validation surfaces through `ngf.errorsToDisplay()`.
+- **[Custom Fields](/recipes/custom-fields)**: single-field recipe alongside an existing adapter.
+- **[Field Types](/field-types/text-inputs)**: what the standard field types provide.
+- **[Type Safety](/recipes/type-safety)**: module augmentation patterns.
+- **[Validation](/validation/basics)**: how validation surfaces through `ngf.errorsToDisplay()`.

--- a/apps/docs/public/content/building-an-adapter.md
+++ b/apps/docs/public/content/building-an-adapter.md
@@ -16,7 +16,7 @@ An ng-forge adapter provides:
 2. A **provider function** (`withMyAdapterFields()`) that registers all those types with `provideDynamicForm()`.
 3. Optional **adapter-level configuration** that cascades into individual fields (size, appearance, theme color).
 
-Every field component composes the `NgForgeField` directive via `hostDirectives`. That directive owns the standard contract: the nine forwarded inputs every field accepts, eight derived signals (errors, ARIA helpers, ID derivation), and five universal host bindings. You only write the parts that are actually adapter-specific: the template and any UI-library quirks.
+Every field component composes the `NgForgeField` directive via `hostDirectives`. That directive owns the standard contract: the nine forwarded inputs every field accepts, eight derived signals (errors, ARIA helpers, ID derivation) on top of the re-exported `key` and `className`, and five universal host bindings. You only write the parts that are actually adapter-specific: the template and any UI-library quirks.
 
 Package entrypoints you'll import from:
 

--- a/apps/docs/public/content/configuration.md
+++ b/apps/docs/public/content/configuration.md
@@ -11,7 +11,7 @@ Configure global defaults for all forms at provider level, or per-form via `defa
 
 ## The Cascade
 
-ng-forge applies props in priority order — more specific always wins:
+ng-forge applies props in priority order: more specific always wins.
 
 <docs-cascade-visual></docs-cascade-visual>
 
@@ -31,7 +31,7 @@ Value fields accept an optional `nullable?: boolean` flag. When `true`:
 
 - `value` accepts `null` in addition to the field's normal type (e.g. `string | null`).
 - An omitted `value` resolves to `null` instead of the type-specific empty default (`''`, `NaN`, `[]`, …).
-- `nullable` stays orthogonal to `required` — they describe different layers. `nullable` declares that the **model** accepts `null` (data shape). `required` is a **validation** constraint. Angular's `Validators.required` treats `null` as invalid, so a field that is both `nullable` and `required` will fail required-validation when the value is `null`. The flags are independent OpenAPI concepts; combine them if that matches your schema, but understand the runtime interaction.
+- `nullable` stays orthogonal to `required`: they describe different layers. `nullable` declares that the **model** accepts `null` (data shape). `required` is a **validation** constraint. ng-forge maps `{ type: 'required' }` to the Signal Forms `required()` validator, which treats `null` as invalid, so a field that is both `nullable` and `required` will fail required-validation when the value is `null`. The flags are independent OpenAPI concepts; combine them if that matches your schema, but understand the runtime interaction.
 
 ```typescript
 {
@@ -43,16 +43,16 @@ Value fields accept an optional `nullable?: boolean` flag. When `true`:
 }
 ```
 
-**Read-side caveat.** A user clearing a text input reads back as `""`, not `null` — this is a DOM/Web IDL contract, identical to classic Reactive Forms. `nullable` is a contract for _accepted_ values, not a guarantee of _emitted_ ones. If your backend distinguishes null from empty string, handle the coercion at submission.
+**Read-side caveat.** A user clearing a text input reads back as `""`, not `null`. This is a DOM/Web IDL contract, identical to classic Reactive Forms. `nullable` is a contract for _accepted_ values, not a guarantee of _emitted_ ones. If your backend distinguishes null from empty string, handle the coercion at submission.
 
 ## Multiple forms on one page
 
-Each field renders a DOM `id` derived from its key (`id="email"`, `id="email-input"`), and that id is reused for the `<label for>`, `aria-describedby`, and error/hint targets. Render **two forms built from the same config** on one page and those ids collide — clicking the second form's label focuses the first form's input, and duplicate ids are invalid HTML that also break `getByLabelText`-style queries.
+Each field renders a DOM `id` derived from its key (`id="email"`, `id="email-input"`), and that id is reused for the `<label for>`, `aria-describedby`, and error/hint targets. Render **two forms built from the same config** on one page and those ids collide: clicking the second form's label focuses the first form's input, and duplicate ids are invalid HTML that also break `getByLabelText`-style queries.
 
 ng-forge scopes ids to a form instance to prevent this:
 
-- **One form on the page** → ids stay clean and unprefixed (`email-input`). Nothing changes, so existing selectors and `data-testid`s are untouched.
-- **Two or more forms visible at once** → each form automatically gets a generated prefix (`df-1`, `df-2`, …), so its ids become `df-2_email-input`. Detection tracks the forms currently rendered, so a form reverts to clean, unprefixed ids once it's the only one left (and hidden/cached pages — e.g. a previous route still in the DOM — don't count).
+- **One form on the page**: ids stay clean and unprefixed (`email-input`). Nothing changes, so existing selectors and `data-testid`s are untouched.
+- **Two or more forms visible at once**: each form automatically gets a generated prefix (`df-1`, `df-2`, …), so its ids become `df-2_email-input`. Detection tracks the forms currently rendered, so a form reverts to clean, unprefixed ids once it's the only one left (and hidden/cached pages, such as a previous route still in the DOM, don't count).
 
 Set `options.idPrefix` when you want **stable, human-readable** ids regardless of how many forms are on the page (recommended when you control both forms). An explicit prefix always wins over auto-detection:
 
@@ -70,13 +70,13 @@ The prefix is the **outermost** id segment, composing with group and array scopi
 {idPrefix}_{group}_{key}_{index}   e.g.  billing_address_street_0
 ```
 
-Use a valid id token — letters, digits, `-`, `_`. Whitespace or punctuation is replaced with `_` (with a dev-mode warning), since a space would break the `aria-describedby` token list and `for`/`id` matching.
+Use a valid id token: letters, digits, `-`, `_`. Whitespace or punctuation is replaced with `_` (with a dev-mode warning), since a space would break the `aria-describedby` token list and `for`/`id` matching.
 
 > [!TIP]
 > Writing E2E selectors or `aria-*` references against a form that shares the page with another form? Set an explicit `idPrefix` so the ids you target are deterministic, then select `#billing_email-input` rather than the auto-generated `#df-2_email-input`.
 
 ## Next Steps
 
-- **[Examples](/examples)** — Browse complete form examples
-- **[Field Types](/field-types/text-inputs)** — Per-field adapter props reference
-- **[Building an Adapter](/building-an-adapter)** — Build your own adapter
+- **[Examples](/examples)**: Browse complete form examples
+- **[Field Types](/field-types/text-inputs)**: Per-field adapter props reference
+- **[Building an Adapter](/building-an-adapter)**: Build your own adapter

--- a/apps/docs/public/content/dynamic-behavior/conditional-logic.md
+++ b/apps/docs/public/content/dynamic-behavior/conditional-logic.md
@@ -11,7 +11,7 @@ Control field behavior dynamically based on form state. Dynamic forms provides a
 The library integrates with Angular's signal forms logic functions:
 
 ```typescript
-import { hidden, readonly, required } from '@angular/forms/signals';
+import { disabled, hidden, readonly, required } from '@angular/forms/signals';
 ```
 
 All conditional logic configuration is applied using these functions, providing:
@@ -39,7 +39,7 @@ Hide a field from view (field still participates in form state):
 }
 ```
 
-The field is hidden from the UI but still included in the form value.
+The field is hidden from the UI but still included in the form value. Note that hidden field values are excluded from the submitted output by default; see [Value Exclusion](/recipes/value-exclusion).
 
 ### disabled
 
@@ -55,7 +55,7 @@ Disable user interaction:
 }
 ```
 
-**Note:** The `disabled` property is handled at the component level and does not use signal forms logic functions. It's a static UI property that prevents user interaction.
+**Note:** The static `disabled: true` property is handled at the component level and does not use signal forms logic functions. Dynamic disabled state configured via the `logic` array does use the `disabled` logic function.
 
 ### readonly
 
@@ -73,17 +73,25 @@ Make a field read-only (displays value but prevents modification):
 
 ## Dynamic Conditional Logic
 
-For conditional behavior based on form state, use the `logic` array with `LogicConfig` objects.
+For conditional behavior based on form state, use the `logic` array with `LogicConfig` objects. State logic entries use `StateLogicConfig`:
 
 ```typescript
-interface LogicConfig {
+type StateLogicConfig = {
   /** Logic type */
   type: 'hidden' | 'readonly' | 'disabled' | 'required';
 
   /** Boolean expression, static value, or form state condition */
   condition: ConditionalExpression | boolean | FormStateCondition;
-}
+
+  /** When to evaluate: 'onChange' (default) or 'debounced' */
+  trigger?: 'onChange' | 'debounced';
+
+  /** Debounce duration in ms when trigger is 'debounced' (default: 500) */
+  debounceMs?: number;
+};
 ```
+
+`LogicConfig` is the union `StateLogicConfig | DerivationLogicConfig`; derivation entries are covered in [Value Derivation](/dynamic-behavior/derivation).
 
 `FormStateCondition` values (`'formInvalid'`, `'formSubmitting'`, `'pageInvalid'`) are primarily used for button disabled logic.
 
@@ -293,22 +301,6 @@ Check a specific field's value - the most common expression type.
 }
 ```
 
-### formValue
-
-Compare the entire form value object against a specific value using operators.
-
-```typescript
-{
-  type: 'formValue',
-  operator: 'equals',
-  value: { status: 'active', role: 'admin' },
-}
-```
-
-**Use when:** Checking if the entire form matches a specific state
-
-**Note:** This type is rarely useful in practice — deep equality on an entire form object is an unusual requirement. For conditions that involve multiple specific fields, use `javascript` or `custom` expressions instead (e.g. `formValue.status === 'active' && formValue.role === 'admin'`).
-
 ### javascript
 
 JavaScript expressions with access to `fieldValue` (current field) and `formValue` (entire form).
@@ -339,7 +331,7 @@ JavaScript expressions with access to `fieldValue` (current field) and `formValu
   }],
 }
 
-// Check multiple form fields (replaces old formValue expression pattern)
+// Check multiple form fields
 {
   key: 'stateProvince',
   type: 'select',
@@ -366,31 +358,30 @@ JavaScript expressions with access to `fieldValue` (current field) and `formValu
 
 ### custom
 
-Advanced custom expressions with access to both field and form values.
+Custom condition functions with access to the full evaluation context. Reference a registered function by name (`functionName`) or pass an inline function (`fn`):
 
 ```typescript
+// Registered function (JSON-serializable config)
 {
   type: 'custom',
-  expression: 'fieldValue > formValue.minAge && fieldValue < formValue.maxAge',
+  functionName: 'isBusinessAccount',
+}
+
+// Inline function (code-only)
+{
+  type: 'custom',
+  fn: (ctx) => ctx.formValue.accountType === 'business' && ctx.formValue.hasTeam === true,
 }
 ```
 
-**Safe member access:** Like `formValue` expressions, nested property access is safe:
-
-```typescript
-{
-  type: 'custom',
-  // Safe even when nested values are null/undefined
-  expression: 'fieldValue !== formValue.user.profile.firstName',
-}
-```
+For expression-string conditions, use the [javascript](#javascript) type instead.
 
 #### Function-based forms (registered vs inline)
 
-For logic that doesn't fit cleanly into an expression — Angular service calls, complex predicates, closures over TS enums/constants — use the function form. Two mutually exclusive variants:
+For logic that doesn't fit cleanly into an expression (Angular service calls, complex predicates, closures over TS enums/constants), use the function form. Two mutually exclusive variants:
 
-- **Registered (`functionName`)** — JSON-serializable; references a function in `customFnConfig.customFunctions`. Use for configs loaded from APIs, OpenAPI, or databases.
-- **Inline (`fn`)** — code-only, type-safe; the function reference is captured directly with no registry indirection. NOT JSON-serializable.
+- **Registered (`functionName`)**: JSON-serializable; references a function in `customFnConfig.customFunctions`. Use for configs loaded from APIs, OpenAPI, or databases.
+- **Inline (`fn`)**: code-only, type-safe; the function reference is captured directly with no registry indirection. NOT JSON-serializable.
 
 ```typescript
 // Registered — config can travel over the wire
@@ -412,8 +403,8 @@ TypeScript rejects setting both `fn` and `functionName` at compile time (`?: nev
 
 `javascript` and `custom` expressions have access to two additional variables for querying field interaction state:
 
-- **`fieldState`** — the current field's own state
-- **`formFieldState`** — state of any field in the form, by key
+- **`fieldState`**: the current field's own state
+- **`formFieldState`**: state of any field in the form, by key
 
 #### fieldState
 
@@ -469,7 +460,7 @@ Use `formFieldState` to react to another field's state. Access by field key:
 
 `formFieldState` has the same properties as `fieldState`, keyed by field name.
 
-**Example — show a confirmation field only after the primary field is dirty:**
+**Example (show a confirmation field only after the primary field is dirty):**
 
 ```typescript
 {
@@ -506,7 +497,7 @@ Evaluate a condition by sending an HTTP request and inspecting the response. The
 
 **Use when:** Field visibility or state must be determined server-side (permissions, feature flags, country-specific rules).
 
-**Full example — hide an admin panel based on server permissions:**
+**Full example (hide an admin panel based on server permissions):**
 
 ```typescript
 {
@@ -534,8 +525,8 @@ Evaluate a condition by sending an HTTP request and inspecting the response. The
 
 | Property             | Type                | Required | Default      | Description                                                              |
 | -------------------- | ------------------- | -------- | ------------ | ------------------------------------------------------------------------ |
-| `type`               | `'http'`            | Yes      | —            | Identifies this as an HTTP condition                                     |
-| `http`               | `HttpRequestConfig` | Yes      | —            | Request configuration (see below)                                        |
+| `type`               | `'http'`            | Yes      | (none)       | Identifies this as an HTTP condition                                     |
+| `http`               | `HttpRequestConfig` | Yes      | (none)       | Request configuration (see below)                                        |
 | `responseExpression` | `string`            | No       | `!!response` | Expression evaluated with `{ response }` in scope. Must return a boolean |
 | `pendingValue`       | `boolean`           | No       | `false`      | Value returned while the request is in-flight                            |
 | `cacheDurationMs`    | `number`            | No       | `30000`      | How long to cache responses (ms)                                         |
@@ -553,7 +544,7 @@ Evaluate a condition by sending an HTTP request and inspecting the response. The
 | `evaluateBodyExpressions` | When `true`, top-level `body` string values are evaluated as expressions            |
 | `headers`                 | Request headers                                                                     |
 
-**HTTP condition on `required` — server-driven required fields:**
+**HTTP condition on `required` (server-driven required fields):**
 
 ```typescript
 {
@@ -588,7 +579,7 @@ Evaluate a condition using a custom async function registered in `customFnConfig
 
 **Use when:** Condition logic involves Angular service injection, complex async operations, or anything that `http` conditions cannot express directly.
 
-> **Why `inject()` works here:** `customFnConfig` functions are called within an Angular injection context, so Angular's `inject()` API is available — the same way it works in a constructor or field initializer. Import `inject` from `@angular/core` as usual.
+> **Why `inject()` works here:** `customFnConfig` functions are called within an Angular injection context, so Angular's `inject()` API is available, the same way it works in a constructor or field initializer. Import `inject` from `@angular/core` as usual.
 
 **Registration and usage:**
 
@@ -626,13 +617,13 @@ const formConfig = {
 
 **Async condition properties:**
 
-| Property            | Type                     | Required | Default | Description                                               |
-| ------------------- | ------------------------ | -------- | ------- | --------------------------------------------------------- |
-| `type`              | `'async'`                | Yes      | —       | Identifies this as an async condition                     |
-| `asyncFunctionName` | `string`                 | XOR\*    | —       | Name registered in `customFnConfig.asyncConditions`       |
-| `asyncFn`           | `AsyncConditionFunction` | XOR\*    | —       | Inline async function (code-only — not JSON-serializable) |
-| `pendingValue`      | `boolean`                | No       | `false` | Value returned while the function is resolving            |
-| `debounceMs`        | `number`                 | No       | `300`   | Debounce delay before re-evaluating (ms)                  |
+| Property            | Type                     | Required | Default | Description                                              |
+| ------------------- | ------------------------ | -------- | ------- | -------------------------------------------------------- |
+| `type`              | `'async'`                | Yes      | (none)  | Identifies this as an async condition                    |
+| `asyncFunctionName` | `string`                 | XOR\*    | (none)  | Name registered in `customFnConfig.asyncConditions`      |
+| `asyncFn`           | `AsyncConditionFunction` | XOR\*    | (none)  | Inline async function (code-only, not JSON-serializable) |
+| `pendingValue`      | `boolean`                | No       | `false` | Value returned while the function is resolving           |
+| `debounceMs`        | `number`                 | No       | `300`   | Debounce delay before re-evaluating (ms)                 |
 
 \* Exactly one of `asyncFunctionName` or `asyncFn` must be set. The two are mutually exclusive at the type level; if both keys appear at runtime (e.g. a JSON config that hand-edited both in), the library logs a warning and the inline `asyncFn` wins.
 
@@ -804,6 +795,8 @@ Regular expression match.
 
 ## Combining Conditions
 
+**Note:** `and`/`or` composites accept only synchronous sub-conditions. Nesting `http` or `async` conditions inside them throws an error; declare async conditions as separate `logic` entries on the field.
+
 ### AND Logic
 
 All conditions must be true.
@@ -888,7 +881,7 @@ At least one condition must be true.
 }
 ```
 
-**Use case:** Show field for multiple roles — hide unless role is `admin` or `owner`.
+**Use case:** Show field for multiple roles. Hide unless role is `admin` or `owner`.
 
 ```typescript
 // Hide the panel when role is neither 'admin' nor 'owner'
@@ -1092,7 +1085,7 @@ Order items become read-only once order is shipped, delivered, or cancelled.
 
 // ❌ Avoid - Hard to maintain
 {
-  type: 'formValue',
+  type: 'javascript',
   expression: 'formValue.accountType === "business" && formValue.country !== null && formValue.hasTeam',
 }
 ```
@@ -1105,9 +1098,9 @@ Order items become read-only once order is shipped, delivered, or cancelled.
 // Sync expressions
 type ConditionalExpression =
   | { type: 'fieldValue'; fieldPath: string; operator: Operator; value: unknown }
-  | { type: 'formValue'; operator: Operator; value: unknown }
   | { type: 'javascript'; expression: string }
-  | { type: 'custom'; expression: string }
+  | { type: 'custom'; functionName: string } // Registered (XOR with fn)
+  | { type: 'custom'; fn: CustomFunction } // Inline (XOR with functionName)
   | { type: 'and'; conditions: ConditionalExpression[] }
   | { type: 'or'; conditions: ConditionalExpression[] }
   // Async expressions
@@ -1156,7 +1149,6 @@ type AsyncCondition =
 | Type         | Sync/Async | Key properties                         | Purpose                                                               |
 | ------------ | ---------- | -------------------------------------- | --------------------------------------------------------------------- |
 | `fieldValue` | Sync       | `fieldPath`, `operator`, `value`       | Compare a specific field's value                                      |
-| `formValue`  | Sync       | `operator`, `value`                    | Compare entire form object                                            |
 | `javascript` | Sync       | `expression`                           | Custom JS with `fieldValue`/`formValue`/`fieldState`/`formFieldState` |
 | `custom`     | Sync       | `functionName` \| `fn` (XOR)           | Registered or inline custom function                                  |
 | `and`/`or`   | Sync       | `conditions`                           | Combine multiple conditions                                           |
@@ -1271,9 +1263,9 @@ const config = {
 
 ## Related
 
-- **[Value Derivation](/dynamic-behavior/derivation)** — Computed field values
-- **[Async Derivation](/dynamic-behavior/derivation/async)** — HTTP and async function derivations, stopOnUserOverride
-- **[Validation](/validation/basics)** — Conditional validation
-- **[Custom Validators](/validation/custom-validators)** — Async and HTTP validators
-- **[Type Safety](/recipes/type-safety)** — TypeScript integration
-- **[Examples](/examples)** — Real-world form patterns
+- **[Value Derivation](/dynamic-behavior/derivation)**: Computed field values
+- **[Async Derivation](/dynamic-behavior/derivation/async)**: HTTP and async function derivations, stopOnUserOverride
+- **[Validation](/validation/basics)**: Conditional validation
+- **[Custom Validators](/validation/custom-validators)**: Async and HTTP validators
+- **[Type Safety](/recipes/type-safety)**: TypeScript integration
+- **[Examples](/examples)**: Real-world form patterns

--- a/apps/docs/public/content/dynamic-behavior/derivation/async.md
+++ b/apps/docs/public/content/dynamic-behavior/derivation/async.md
@@ -1,7 +1,7 @@
 ---
 title: Async
 route: async
-description: 'Derive field values from HTTP endpoints or custom async functions with automatic debouncing, cancellation, and loading state management.'
+description: 'Derive field values from HTTP endpoints or custom async functions with automatic debouncing and in-flight request cancellation.'
 ---
 
 Derive field values from HTTP responses or custom async functions. Async derivations are ideal for server-driven computed values, address/zip lookups, exchange rates, and any value that requires a network call.
@@ -110,12 +110,12 @@ responseExpression: 'response.items[0].value'; // Array access
 
 `source: 'http'` enforces two fields at the TypeScript level:
 
-- **`dependsOn: string[]`** — Explicit field dependencies. The request only re-fires when these fields change.
-- **`responseExpression: string`** — Expression to extract the derived value from the response body.
+- **`dependsOn: string[]`**: Explicit field dependencies. The request only re-fires when these fields change.
+- **`responseExpression: string`**: Expression to extract the derived value from the response body.
 
 ### Controlling Request Timing
 
-Use `trigger` and `debounceMs` to control when requests fire:
+HTTP and async function derivations are always debounced, regardless of `trigger`. Requests wait for dependencies to stop changing (default: 300ms). Use `debounceMs` to adjust the delay:
 
 ```typescript
 {
@@ -127,7 +127,6 @@ Use `trigger` and `debounceMs` to control when requests fire:
   },
   responseExpression: 'response.suggestion',
   dependsOn: ['companyName'],
-  trigger: 'debounced',
   debounceMs: 400,
 }
 ```
@@ -164,7 +163,7 @@ Add a `condition` to only send the request when certain criteria are met:
 
 ## Async Function Derivations
 
-Use `source: 'asyncFunction'` when you need custom logic — Angular service injection, complex transformations, or any async computation not expressible as a plain HTTP config. Functions receive the full evaluation context and can return a `Promise` or `Observable`.
+Use `source: 'asyncFunction'` when you need custom logic: Angular service injection, complex transformations, or any async computation not expressible as a plain HTTP config. Functions receive the full evaluation context and can return a `Promise` or `Observable`.
 
 ### Basic Example
 
@@ -259,8 +258,8 @@ The async function is only called when `enableLookup === true`.
 
 `source: 'asyncFunction'` requires:
 
-- **One of `asyncFunctionName: string` or `asyncFn: AsyncDerivationFunction`** — see [Inline alternative](#inline-alternative-asyncfn) below. The two are mutually exclusive.
-- **`dependsOn: string[]`** — Explicit field dependencies. Without this, the function would re-run on every form change.
+- **One of `asyncFunctionName: string` or `asyncFn: AsyncDerivationFunction`**: see [Inline alternative](#inline-alternative-asyncfn) below. The two are mutually exclusive.
+- **`dependsOn: string[]`**: Explicit field dependencies. Without this, the function would re-run on every form change.
 
 ### Inline alternative (`asyncFn`)
 
@@ -295,7 +294,7 @@ const formConfig = {
 } as const satisfies FormConfig;
 ```
 
-Inject Angular services inside `asyncFn` the same way you would inside a registered function — both run in the form's injection context.
+Inject Angular services inside `asyncFn` the same way you would inside a registered function. Both run in the form's injection context.
 
 Use `asyncFunctionName` for configs loaded over the wire (APIs, OpenAPI, MCP); use `asyncFn` for code-only configs. TypeScript rejects setting both keys, and the runtime warns + prefers `asyncFn` if a JSON config sneaks both through.
 
@@ -303,7 +302,7 @@ Use `asyncFunctionName` for configs loaded over the wire (APIs, OpenAPI, MCP); u
 
 ## Stop On User Override
 
-`stopOnUserOverride` turns a derivation into a "smart default" — the field is auto-filled initially, but derivation stops once the user manually edits it.
+`stopOnUserOverride` turns a derivation into a "smart default": the field is auto-filled initially, but derivation stops once the user manually edits it.
 
 ### Basic Example
 
@@ -352,7 +351,7 @@ Use `reEngageOnDependencyChange: true` to clear the user override when a depende
 }
 ```
 
-When the user changes the country, the phone prefix is auto-filled again — overriding any previous manual edit.
+When the user changes the country, the phone prefix is auto-filled again, overriding any previous manual edit.
 
 **Without** `reEngageOnDependencyChange`: once the user edits the field, the derivation never runs again for that field instance.
 
@@ -401,8 +400,8 @@ When the user changes the country, the phone prefix is auto-filled again — ove
   responseExpression: string; // Required — expression to extract value from response
 
   // Shared optional fields
-  trigger?: 'onChange' | 'debounced'; // Default: 'onChange'
-  debounceMs?: number;                // Default: 500 (when trigger: 'debounced')
+  trigger?: 'onChange' | 'debounced'; // No effect here: HTTP requests are always debounced
+  debounceMs?: number;                // Default: 300
   condition?: ConditionalExpression | boolean;
   stopOnUserOverride?: boolean;
   reEngageOnDependencyChange?: boolean;
@@ -427,8 +426,8 @@ When the user changes the country, the phone prefix is auto-filled again — ove
   dependsOn: string[];       // Required — explicit field dependencies
 
   // Shared optional fields
-  trigger?: 'onChange' | 'debounced';
-  debounceMs?: number;
+  trigger?: 'onChange' | 'debounced'; // No effect here: async functions are always debounced
+  debounceMs?: number;                // Default: 300
   condition?: ConditionalExpression | boolean;
   stopOnUserOverride?: boolean;
   reEngageOnDependencyChange?: boolean;
@@ -438,7 +437,7 @@ When the user changes the country, the phone prefix is auto-filled again — ove
 
 ## Related
 
-- **[Values](/dynamic-behavior/derivation/values)** — Expression, static value, and function-based derivations
-- **[Properties](/dynamic-behavior/derivation/property)** — Derive component properties from form values
-- **[HTTP Conditions](/dynamic-behavior/conditional-logic)** — HTTP-driven field visibility and state
-- **[Custom Validators](/validation/custom-validators)** — Async and HTTP validation
+- **[Values](/dynamic-behavior/derivation/values)**: Expression, static value, and function-based derivations
+- **[Properties](/dynamic-behavior/derivation/property)**: Derive component properties from form values
+- **[HTTP Conditions](/dynamic-behavior/conditional-logic)**: HTTP-driven field visibility and state
+- **[Custom Validators](/validation/custom-validators)**: Async and HTTP validation

--- a/apps/docs/public/content/dynamic-behavior/derivation/property.md
+++ b/apps/docs/public/content/dynamic-behavior/derivation/property.md
@@ -109,7 +109,7 @@ fields: [
 
 ### HTTP
 
-Use `source: 'http'` to derive a property from an HTTP response — typically used to populate a select's `options` from a backend search endpoint. The request fires when any `dependsOn` field changes, with automatic in-flight cancellation when dependencies change again.
+Use `source: 'http'` to derive a property from an HTTP response, typically used to populate a select's `options` from a backend search endpoint. The request fires when any `dependsOn` field changes, with automatic in-flight cancellation when dependencies change again.
 
 ```typescript
 {
@@ -128,23 +128,22 @@ Use `source: 'http'` to derive a property from an HTTP response — typically us
     },
     responseExpression: 'response.map(d => ({ value: d.id, label: d.streetNameShort }))',
     dependsOn: ['street'],
-    trigger: 'debounced',
     debounceMs: 300,
   }],
 }
 ```
 
 - `source: 'http'` is required.
-- `dependsOn` is required and must be non-empty — wildcards (`'*'`) are rejected.
+- `dependsOn` is required and must be non-empty; wildcards (`'*'`) are rejected.
 - `responseExpression` is evaluated against `{ response }`. Object literals and arrow functions are supported, so you can map response rows into the `FieldOption` shape inline.
-- `trigger: 'debounced'` with a `debounceMs` is strongly recommended for autocomplete-style inputs to avoid spamming the server on every keystroke.
+- HTTP property derivations are always debounced (300ms default); `trigger` has no effect on them. Set `debounceMs` to tune the delay for autocomplete-style inputs.
 - Requires `provideHttpClient()` in your application providers.
 
-See [Async Derivations → HTTP](/dynamic-behavior/derivation/async#http-derivations) for the full request configuration (path params, headers, POST bodies, conditional firing).
+See [Async Derivations: HTTP](/dynamic-behavior/derivation/async#http-derivations) for the full request configuration (path params, headers, POST bodies, conditional firing).
 
 ### Async Function
 
-Use `source: 'asyncFunction'` when you need custom client-side logic — Angular service injection, complex transformations, or any async computation that's not a plain HTTP call. The function receives the full `EvaluationContext` and can return a `Promise` or `Observable`.
+Use `source: 'asyncFunction'` when you need custom client-side logic: Angular service injection, complex transformations, or any async computation that's not a plain HTTP call. The function receives the full `EvaluationContext` and can return a `Promise` or `Observable`.
 
 ```typescript
 import { inject } from '@angular/core';
@@ -506,23 +505,47 @@ interface DerivationLogicConfig {
   /** When to evaluate: 'onChange' (default) or 'debounced' */
   trigger?: 'onChange' | 'debounced';
 
-  /** Debounce duration in ms (default: 500) */
+  /** Debounce duration in ms (default: 500 for synchronous derivations) */
   debounceMs?: number;
 
-  /** Static value to set (mutually exclusive) */
+  /** Async source discriminator. Omit for synchronous derivations */
+  source?: 'http' | 'asyncFunction';
+
+  /** Static value to set (sync; mutually exclusive with other sources) */
   value?: unknown;
 
-  /** JavaScript expression (mutually exclusive) */
+  /** JavaScript expression (sync; mutually exclusive with other sources) */
   expression?: string;
 
-  /** Name of registered custom function (mutually exclusive) */
+  /** Name of registered custom function (sync; XOR with fn) */
   functionName?: string;
 
-  /** Explicit field dependencies */
+  /** Inline custom function, code-only (sync; XOR with functionName) */
+  fn?: CustomFunction;
+
+  /** HTTP request configuration (required when source: 'http') */
+  http?: HttpRequestConfig;
+
+  /** Expression extracting the derived value from the HTTP response (required when source: 'http') */
+  responseExpression?: string;
+
+  /** Name of registered async function (source: 'asyncFunction'; XOR with asyncFn) */
+  asyncFunctionName?: string;
+
+  /** Inline async function, code-only (source: 'asyncFunction'; XOR with asyncFunctionName) */
+  asyncFn?: AsyncDerivationFunction;
+
+  /** Explicit field dependencies (required for http and asyncFunction sources) */
   dependsOn?: string[];
 
   /** Condition for when derivation applies (default: true) */
   condition?: ConditionalExpression | boolean;
+
+  /** Stop running after the user manually edits the target field */
+  stopOnUserOverride?: boolean;
+
+  /** With stopOnUserOverride, clear the override when a declared dependency changes */
+  reEngageOnDependencyChange?: boolean;
 }
 ```
 
@@ -575,5 +598,5 @@ External data values are reactively tracked - when signals change, property deri
 ## Related
 
 - **Value Derivation** (see tab above) - Compute field form values
-- **[Conditional Logic](/dynamic-behavior/overview)** - Control field visibility and state
+- **[Conditional Logic](/dynamic-behavior/conditional-logic)** - Control field visibility and state
 - **[Array Fields](/prebuilt/form-arrays/simplified)** - Working with array fields

--- a/apps/docs/public/content/dynamic-behavior/derivation/values.md
+++ b/apps/docs/public/content/dynamic-behavior/derivation/values.md
@@ -109,7 +109,7 @@ fields: [
 
 #### Inline alternative (`fn`)
 
-For code-only configs you can attach the function directly via `fn` and skip the `customFnConfig.derivations` registration. `fn` is mutually exclusive with `functionName` — TypeScript rejects setting both, and the runtime logs a warning + prefers `fn` if a JSON config sets both keys.
+For code-only configs you can attach the function directly via `fn` and skip the `customFnConfig.derivations` registration. `fn` is mutually exclusive with `functionName`: TypeScript rejects setting both, and the runtime logs a warning and prefers `fn` if a JSON config sets both keys.
 
 ```typescript
 import type { CustomFunction } from '@ng-forge/dynamic-forms';
@@ -138,7 +138,7 @@ const config = {
 
 **Default dependencies for function derivations:** if you omit `dependsOn`, both `functionName` and `fn` derivations default to a wildcard (`'*'`), meaning the derivation re-runs on every form change. In development, the library logs a one-time `Derivation: custom functions without explicit dependsOn detected` warning so you can narrow it down. Specify `dependsOn` whenever you know the exact inputs to avoid this.
 
-Use `functionName` when the config must survive JSON serialization (APIs, OpenAPI, databases, MCP). Use `fn` for code-only authoring where you'd rather not maintain a separate registry — especially when the function closes over TS enums, constants, or class-scoped helpers that don't round-trip through a string registry.
+Use `functionName` when the config must survive JSON serialization (APIs, OpenAPI, databases, MCP). Use `fn` for code-only authoring where you'd rather not maintain a separate registry, especially when the function closes over TS enums, constants, or class-scoped helpers that don't round-trip through a string registry.
 
 **See also:** the same XOR pattern applies to [async derivations (`asyncFn`)](/dynamic-behavior/derivation/async#inline-alternative-asyncfn), [conditions (`fn` / `asyncFn`)](/dynamic-behavior/conditional-logic#function-based-forms-registered-vs-inline), and [validators](/validation/custom-validators#inline-functions-vs-registered-names). See [Configuration](/configuration) for setting up `customFnConfig`.
 
@@ -417,8 +417,9 @@ Create two-way bindings between fields:
 The system automatically detects derivation cycles and warns during development:
 
 ```
-Bidirectional derivation detected: celsius <-> fahrenheit
-Bidirectional derivations stabilize via equality check.
+Derivation: bidirectional derivation patterns detected. These patterns stabilize via equality checks,
+but may oscillate with floating-point values (e.g., currency conversions with rounding).
+Consider adding tolerance-based comparisons for numeric values. ['celsius↔fahrenheit']
 ```
 
 ### Floating-Point Precision
@@ -514,13 +515,13 @@ External data values are reactively tracked - when signals change, derivations a
 
 ## Next Steps
 
-- **[Conditional Logic](/dynamic-behavior/overview)** — Control field visibility, required state, and disabled state dynamically
-- **[i18n](/dynamic-behavior/i18n)** — Translate labels and messages with Observables and Signals
-- **[Expression Parser](/recipes/expression-parser)** — Understand the security model behind derivation expressions
+- **[Conditional Logic](/dynamic-behavior/conditional-logic)**: Control field visibility, required state, and disabled state dynamically
+- **[i18n](/dynamic-behavior/i18n)**: Translate labels and messages with Observables and Signals
+- **[Expression Parser](/recipes/expression-parser)**: Understand the security model behind derivation expressions
 
 ## Related
 
-- **Property Derivation** (see tab above) — Derive component properties (minDate, options, label) from form values
-- **Async Derivation** (see tab above) — HTTP and async function derivations, stopOnUserOverride
-- **[Array Fields](/prebuilt/form-arrays/simplified)** — Working with array fields
-- **[Examples](/examples)** — Real-world form patterns
+- **Property Derivation** (see tab above): Derive component properties (minDate, options, label) from form values
+- **Async Derivation** (see tab above): HTTP and async function derivations, stopOnUserOverride
+- **[Array Fields](/prebuilt/form-arrays/simplified)**: Working with array fields
+- **[Examples](/examples)**: Real-world form patterns

--- a/apps/docs/public/content/dynamic-behavior/i18n.md
+++ b/apps/docs/public/content/dynamic-behavior/i18n.md
@@ -114,7 +114,8 @@ The message resolution priority is:
 
 1. **Field-level** `validationMessages` (highest priority)
 2. **Form-level** `defaultValidationMessages` (fallback)
-3. **No message** - If neither is provided, the error is not displayed and a warning is logged to the console
+3. **Error message** - The error's own `message`, as set by schema validators
+4. **No message** - If all three are absent, the error is not displayed and a warning is logged to the console
 
 This approach is especially useful when you have many fields with the same validation rules - define the translations once instead of repeating them for each field.
 
@@ -255,7 +256,7 @@ export class MyFormComponent {
 
 ## Translated Select Options
 
-Options also support `DynamicText`:
+Each option's `label` supports `DynamicText`. The `options` array itself is static; make the individual labels reactive:
 
 ```typescript
 {
@@ -263,12 +264,10 @@ Options also support `DynamicText`:
   type: 'select',
   label: translationService.translate('form.country'),
   value: '',
-  options: translationService.translate('countries').pipe(
-    map(countries => [
-      { value: 'us', label: countries.us },
-      { value: 'es', label: countries.es },
-    ])
-  ),
+  options: [
+    { value: 'us', label: translationService.translate('countries.us') },
+    { value: 'es', label: translationService.translate('countries.es') },
+  ],
 }
 ```
 
@@ -292,6 +291,6 @@ The key is that your translation method returns `Observable<string>` or `Signal<
 
 ## Next Steps
 
-- **[Form Submission](/dynamic-behavior/submission)** — Configure async submission with loading states and server error handling
-- **[Conditional Logic](/dynamic-behavior/overview)** — Show, hide, and disable fields based on form state
-- **[Value Derivation](/dynamic-behavior/derivation)** — Automatically compute field values from other fields
+- **[Form Submission](/dynamic-behavior/submission)**: Configure async submission with loading states
+- **[Conditional Logic](/dynamic-behavior/conditional-logic)**: Show, hide, and disable fields based on form state
+- **[Value Derivation](/dynamic-behavior/derivation)**: Automatically compute field values from other fields

--- a/apps/docs/public/content/dynamic-behavior/submission.md
+++ b/apps/docs/public/content/dynamic-behavior/submission.md
@@ -1,17 +1,17 @@
 ---
 title: Submission
 slug: dynamic-behavior/submission
-description: 'Handle form submission with automatic loading states, submit button disabling, and server-side validation error mapping.'
+description: 'Handle form submission with automatic loading states and submit button disabling.'
 ---
 
-Form submission in dynamic forms integrates with Angular Signal Forms' native `submit()` function, providing automatic button disabling, loading states, and server error handling.
+Form submission in dynamic forms integrates with Angular Signal Forms' native `submit()` function, providing automatic button disabling and loading states.
 
 ## Overview
 
 The submission system provides:
 
 - Async form submission with automatic loading state
-- Server-side validation error handling
+- Thrown action errors caught and logged
 - Automatic submit button disabling during submission
 - Configurable button disabled behavior
 - Custom disabled logic via `FormStateCondition`
@@ -25,6 +25,7 @@ Configure form submission with the `submission` property:
 ```typescript
 import { Component, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { FieldTree } from '@angular/forms/signals';
 import { FormConfig, InferFormValue } from '@ng-forge/dynamic-forms';
 
 const formFields = {
@@ -44,7 +45,7 @@ export class LoginFormComponent {
   config = {
     ...formFields,
     submission: {
-      action: (form: LoginForm) => this.http.post('/api/login', form),
+      action: (form: FieldTree<LoginForm>) => this.http.post('/api/login', form().value()),
     },
   };
 }
@@ -52,34 +53,27 @@ export class LoginFormComponent {
 
 ## SubmissionConfig
 
-The `submission.action` function receives the typed form value and can return an Observable or Promise:
+The `submission.action` function receives the form's `FieldTree` instance and can return an Observable or Promise. Read the current value with `form().value()`.
 
-| Return Value           | Meaning                                    |
-| ---------------------- | ------------------------------------------ |
-| Completes successfully | Successful submission                      |
-| `TreeValidationResult` | Server validation errors (single or array) |
+While the action is executing, the form is in a submitting state, enabling automatic button disabling and loading states. Errors thrown by the action are caught and logged by the library, and the form exits the submitting state.
 
-**Note:** `TreeValidationResult` from Angular Signal Forms supports both single errors and arrays. You can return a single error object or an array of errors.
-
-While the action is executing, the form is in a submitting state, enabling automatic button disabling and loading states.
+**Note:** The action's resolved value is discarded. Returned validation results (such as `TreeValidationResult`) are not currently applied to form fields.
 
 ### Server Error Handling
 
-Return validation errors to apply them to specific fields using `catchError`:
+Returned validation results are not applied to fields, so handle server errors inside your action for now, for example by mapping them to your own notification or error state:
 
 ```typescript
-import { catchError, of } from 'rxjs';
+import { catchError, EMPTY } from 'rxjs';
 
 submission: {
-  action: (form: FormValue) => this.http.post('/api/register', form).pipe(
+  action: (form) => this.http.post('/api/register', form().value()).pipe(
     catchError((error) => {
       if (error.error?.code === 'EMAIL_EXISTS') {
-        return of([{
-          field: 'email',
-          error: { kind: 'server', message: 'Email already exists' },
-        }]);
+        this.notifications.error('Email already exists');
+        return EMPTY;
       }
-      throw error; // Re-throw unexpected errors
+      throw error; // Unexpected errors are caught and logged by the library
     }),
   ),
 }
@@ -187,7 +181,7 @@ Combine form state conditions with custom expressions:
 
 By default, field values are excluded from the `(submitted)` output when the field is hidden, disabled, or readonly. This prevents stale or irrelevant data from being submitted.
 
-Value exclusion supports a 3-tier configuration hierarchy: **Global > Form > Field**, where the most specific level wins. Internal form state and two-way binding are unaffected.
+Value exclusion supports a 3-tier configuration hierarchy: **Field > Form > Global** (the most specific level wins). Internal form state and two-way binding are unaffected.
 
 ```typescript
 // Disable hidden value exclusion for this form
@@ -218,6 +212,6 @@ export class MyFormComponent {
 
 ## Next Steps
 
-- **[Events](/recipes/events)** — Dispatch and subscribe to form events from inside or outside the form
-- **[Schema Validation](/schema-validation/overview)** — Add cross-field validation rules with Angular schemas or Zod
-- **[Value Exclusion](/recipes/value-exclusion)** — Control which field values are included in submission output
+- **[Events](/recipes/events)**: Dispatch and subscribe to form events from inside or outside the form
+- **[Schema Validation](/schema-validation/overview)**: Add cross-field validation rules with Angular schemas or Zod
+- **[Value Exclusion](/recipes/value-exclusion)**: Control which field values are included in submission output

--- a/apps/docs/public/content/examples/addon-clear-button.md
+++ b/apps/docs/public/content/examples/addon-clear-button.md
@@ -1,10 +1,10 @@
 ---
 title: Addon Clear Button
 slug: examples/addon-clear-button
-description: 'Canonical addon pattern — an icon in the prefix slot and a clear-preset button in the suffix slot. JSON-safe and works the same on every adapter.'
+description: 'Canonical addon pattern: an icon in the prefix slot and a clear-preset button in the suffix slot. JSON-safe and works the same on every adapter.'
 ---
 
-The canonical addon pattern: a search icon in the prefix slot, a clear button in the suffix slot. The button uses the built-in `'clear'` preset — no handler code required.
+The canonical addon pattern: a search icon in the prefix slot, a clear button in the suffix slot. The button uses the built-in `'clear'` preset, so no handler code is required.
 
 ## Live Demo
 
@@ -16,5 +16,5 @@ The canonical addon pattern: a search icon in the prefix slot, a clear button in
 
 ## What to read next
 
-- **[Addons / Overview](/addons/overview)** — kinds, slots, reactive `hidden` / `disabled`.
-- **[Presets and Actions](/addons/presets-and-actions)** — the five built-in presets and how to register your own via `actionRef`.
+- **[Addons / Overview](/addons/overview)**: kinds, slots, reactive `hidden` / `disabled`.
+- **[Presets and Actions](/addons/presets-and-actions)**: the five built-in presets and how to register your own via `actionRef`.

--- a/apps/docs/public/content/examples/addon-currency.md
+++ b/apps/docs/public/content/examples/addon-currency.md
@@ -1,10 +1,10 @@
 ---
 title: Addon Currency
 slug: examples/addon-currency
-description: 'Universal text addons — a dollar sign in the prefix slot and a USD label in the suffix slot. Single config, no per-adapter branching.'
+description: 'Universal text addons: a dollar sign in the prefix slot and a USD label in the suffix slot. Single config, no per-adapter branching.'
 ---
 
-When the addon content is just text, use `type: 'text'` — it works the same in every adapter without any per-adapter branching. The config object below is byte-identical regardless of which UI library renders it.
+When the addon content is just text, use `type: 'text'`. It works the same in every adapter without any per-adapter branching. The config object below is byte-identical regardless of which UI library renders it.
 
 ## Live Demo
 
@@ -20,7 +20,6 @@ When the addon content is just text, use `type: 'text'` — it works the same in
       type: 'input',
       label: 'Amount',
       value: '99.00',
-      props: { type: 'number' },
       addons: [
         { slot: 'prefix', type: 'text', text: '$' },
         { slot: 'suffix', type: 'text', text: 'USD' },
@@ -30,9 +29,9 @@ When the addon content is just text, use `type: 'text'` — it works the same in
 }
 ```
 
-`text` is one of three universal types (alongside `template` and `component`) registered by core. The icon and button types — `mat-icon` / `prime-button` / etc. — are per-adapter, but for simple labels and currency markers the universal `text` type is the lowest-friction choice.
+`text` is one of three universal types (alongside `template` and `component`) registered by core. The icon and button types (`mat-icon`, `prime-button`, and so on) are per-adapter, but for simple labels and currency markers the universal `text` type is the lowest-friction choice.
 
 ## What to read next
 
-- **[Addons / Overview](/addons/overview)** — types catalog, slots, reactive `hidden`.
-- **[Addon Clear Button](/examples/addon-clear-button)** — the adapter-specific icon + button pattern.
+- **[Addons / Overview](/addons/overview)**: types catalog, slots, reactive `hidden`.
+- **[Addon Clear Button](/examples/addon-clear-button)**: the adapter-specific icon + button pattern.

--- a/apps/docs/public/content/examples/addon-password-toggle.md
+++ b/apps/docs/public/content/examples/addon-password-toggle.md
@@ -4,7 +4,7 @@ slug: examples/addon-password-toggle
 description: 'The toggle-password-visibility preset flips a password input between hidden and visible. Ships in every adapter with no handler code.'
 ---
 
-The `'toggle-password-visibility'` preset flips the input s `type` attribute between `'password'` and `'text'`. The button addon writes to a per-field type-override signal provided by the adapter; the input reads the override when computing its effective `type`. Click the eye icon below to see the value reveal — then click again to hide.
+The `'toggle-password-visibility'` preset flips the input's `type` attribute between `'password'` and `'text'`. The button addon writes to a per-field type-override signal provided by the adapter; the input reads the override when computing its effective `type`. Click the eye icon below to see the value reveal, then click again to hide.
 
 ## Live Demo
 
@@ -12,5 +12,5 @@ The `'toggle-password-visibility'` preset flips the input s `type` attribute bet
 
 ## What to read next
 
-- **[Presets and Actions](/addons/presets-and-actions)** — the full preset table and `actionRef` recipe for registered handlers.
-- **[Addons / Overview](/addons/overview)** — addon kinds and slots primer.
+- **[Presets and Actions](/addons/presets-and-actions)**: the full preset table and `actionRef` recipe for registered handlers.
+- **[Addons / Overview](/addons/overview)**: addon kinds and slots primer.

--- a/apps/docs/public/content/examples/age-conditional-form.md
+++ b/apps/docs/public/content/examples/age-conditional-form.md
@@ -33,6 +33,10 @@ export class AgeConditionalFormComponent {
   formValue = signal({});
 
   config = {
+    defaultValidationMessages: {
+      required: 'This field is required',
+      email: 'Please enter a valid email address',
+    },
     fields: [
       {
         key: 'name',
@@ -52,11 +56,15 @@ export class AgeConditionalFormComponent {
       {
         key: 'age',
         type: 'input',
-        value: null,
+        value: undefined,
         label: 'Age',
         required: true,
         min: 0,
         max: 120,
+        validationMessages: {
+          min: 'Age must be at least 0',
+          max: 'Age must be at most 120',
+        },
         props: {
           type: 'number',
           hint: 'Enter your age to see relevant options',
@@ -253,6 +261,6 @@ This example uses numeric comparison operators:
 
 ## Related Documentation
 
-- **[Conditional Logic](/dynamic-behavior/overview)** - Full conditional logic guide
+- **[Conditional Logic](/dynamic-behavior/conditional-logic)** - Full conditional logic guide
 - **[Validation](/validation/basics)** - Min/max validation
 - **[User Registration](/examples/user-registration)** - Basic registration example

--- a/apps/docs/public/content/examples/array-form.md
+++ b/apps/docs/public/content/examples/array-form.md
@@ -134,7 +134,6 @@ export class ArrayFormComponent {
         label: 'Add Tag',
         arrayKey: 'tags',
         template: [tagTemplate],
-        props: { color: 'primary' },
       },
 
       // Object array with multiple fields per item
@@ -181,16 +180,17 @@ export class ArrayFormComponent {
             label: 'Add Contact',
             arrayKey: 'contacts',
             template: contactTemplate,
-            props: { color: 'primary' },
           },
         ],
       },
 
-      { key: 'submit', type: 'submit', label: 'Save All', props: { color: 'primary' } },
+      { key: 'submit', type: 'submit', label: 'Save All' },
     ],
   } as const satisfies FormConfig;
 }
 ```
+
+The live demo config additionally contains section heading and description text fields, omitted here for brevity.
 
 ## Key Features
 

--- a/apps/docs/public/content/examples/business-account-form.md
+++ b/apps/docs/public/content/examples/business-account-form.md
@@ -33,6 +33,10 @@ export class BusinessAccountFormComponent {
   formValue = signal({});
 
   config = {
+    defaultValidationMessages: {
+      required: 'This field is required',
+      email: 'Please enter a valid email address',
+    },
     fields: [
       {
         key: 'accountType',
@@ -118,7 +122,7 @@ export class BusinessAccountFormComponent {
       {
         key: 'numberOfEmployees',
         type: 'input',
-        value: null,
+        value: undefined,
         label: 'Number of Employees',
         props: { type: 'number' },
         logic: [
@@ -216,6 +220,6 @@ Business fields are hidden when personal is selected:
 
 ## Related Documentation
 
-- **[Conditional Logic](/dynamic-behavior/overview)** - Full conditional logic guide
+- **[Conditional Logic](/dynamic-behavior/conditional-logic)** - Full conditional logic guide
 - **[User Registration](/examples/user-registration)** - Basic registration example
 - **[Radio Buttons](/field-types/selection)** - Field types reference

--- a/apps/docs/public/content/examples/contact-dynamic-fields.md
+++ b/apps/docs/public/content/examples/contact-dynamic-fields.md
@@ -33,6 +33,11 @@ export class ContactFormComponent {
   formValue = signal({});
 
   config = {
+    defaultValidationMessages: {
+      required: 'This field is required',
+      email: 'Please enter a valid email address',
+      minlength: 'Value is too short',
+    },
     fields: [
       {
         key: 'name',
@@ -143,6 +148,11 @@ export class ContactFormComponent {
         minLength: 10,
         props: { rows: 4 },
       },
+      {
+        key: 'submit',
+        type: 'submit',
+        label: 'Send Message',
+      },
     ],
   } as const satisfies FormConfig;
 }
@@ -199,6 +209,6 @@ This ensures that visible contact fields are required.
 
 ## Related Documentation
 
-- **[Conditional Logic](/dynamic-behavior/overview)** - Full conditional logic guide
+- **[Conditional Logic](/dynamic-behavior/conditional-logic)** - Full conditional logic guide
 - **[Validation](/validation/basics)** - Form validation
 - **[Contact Form](/examples/contact-form)** - Basic contact form example

--- a/apps/docs/public/content/examples/contact-form.md
+++ b/apps/docs/public/content/examples/contact-form.md
@@ -1,5 +1,5 @@
 ---
-description: 'Create a contact form with text inputs, textarea, date picker, and real-time validation feedback using ng-forge dynamic forms.'
+description: 'Create a contact form with text inputs, a subject select, a message textarea, and real-time validation feedback using ng-forge dynamic forms.'
 ---
 
 Simple contact form demonstrating basic form fields, validation, and user input.
@@ -13,8 +13,9 @@ Simple contact form demonstrating basic form fields, validation, and user input.
 This example shows a basic contact form with:
 
 - Text inputs (name, email, phone)
+- Subject select
 - Textarea for messages
-- Date selection
+- Newsletter checkbox
 - Basic validation (required, email format)
 - Real-time validation feedback
 
@@ -31,6 +32,10 @@ import { DynamicForm, FormConfig } from '@ng-forge/dynamic-forms';
 })
 export class ContactFormComponent {
   config = {
+    defaultValidationMessages: {
+      required: 'This field is required',
+      email: 'Please enter a valid email address',
+    },
     fields: [
       {
         key: 'firstName',
@@ -112,7 +117,6 @@ export class ContactFormComponent {
         type: 'submit',
         key: 'submit',
         label: 'Send Message',
-        props: { color: 'primary' },
       },
     ],
   } as const satisfies FormConfig;

--- a/apps/docs/public/content/examples/enterprise-features.md
+++ b/apps/docs/public/content/examples/enterprise-features.md
@@ -33,6 +33,9 @@ export class EnterpriseFeaturesFormComponent {
   formValue = signal({});
 
   config = {
+    defaultValidationMessages: {
+      required: 'This field is required',
+    },
     fields: [
       {
         key: 'accountType',
@@ -49,9 +52,12 @@ export class EnterpriseFeaturesFormComponent {
       {
         key: 'teamSize',
         type: 'input',
-        value: null,
+        value: undefined,
         label: 'Team Size',
         min: 1,
+        validationMessages: {
+          min: 'Team size must be at least 1',
+        },
         props: {
           type: 'number',
           hint: 'Number of team members',
@@ -308,6 +314,8 @@ Different tiers have different feature access:
 | Custom Branding   | ✗    | ✗   | ✓                |
 | Dedicated Support | ✗    | ✗   | ✓                |
 
+Note: Custom Branding depends only on the account type. It is hidden for Free and Pro accounts and shown for Enterprise regardless of team size. The team size threshold (10+) applies to SSO and Dedicated Support.
+
 ## Using AND Conditions
 
 For features that require ALL conditions to be met, use `type: 'and'`:
@@ -335,6 +343,6 @@ For features that require ALL conditions to be met, use `type: 'and'`:
 
 ## Related Documentation
 
-- **[Conditional Logic](/dynamic-behavior/overview)** - Full conditional logic guide
+- **[Conditional Logic](/dynamic-behavior/conditional-logic)** - Full conditional logic guide
 - **[Combining Conditions](/dynamic-behavior/conditional-logic)** - AND/OR logic
 - **[Form Groups](/prebuilt/form-groups)** - Organizing fields

--- a/apps/docs/public/content/examples/login-form.md
+++ b/apps/docs/public/content/examples/login-form.md
@@ -86,9 +86,6 @@ export class LoginFormComponent {
         type: 'submit',
         key: 'submit',
         label: 'Sign In',
-        props: {
-          color: 'primary',
-        },
       },
     ],
   } as const satisfies FormConfig;
@@ -139,15 +136,17 @@ Simple checkbox for persistent login:
 
 ## Common Enhancements
 
-### Add "Forgot Password" Link
+### Add "Forgot Password" Text
 
 ```typescript
 {
   type: 'text',
   key: 'forgotLink',
-  label: '<a href="/forgot-password">Forgot your password?</a>',
+  label: 'Forgot your password?',
 }
 ```
+
+Text-field labels render as plain text, so HTML in a label appears literally. Place actual links in the host component template around the form.
 
 ### Social Login Buttons
 
@@ -163,15 +162,17 @@ For social login buttons, you can use text fields with links or handle this outs
 
 **Note:** Social login typically involves OAuth flows handled outside the form. Consider placing social login buttons in your component template rather than in the form configuration.
 
-### Add Sign Up Link
+### Add Sign Up Text
 
 ```typescript
 {
   type: 'text',
   key: 'signupText',
-  label: "Don't have an account? <a href='/signup'>Sign up</a>",
+  label: "Don't have an account?",
 }
 ```
+
+As with the forgot-password text, the sign-up link itself belongs in the host component template.
 
 ## Use Cases
 

--- a/apps/docs/public/content/examples/paginated-form.md
+++ b/apps/docs/public/content/examples/paginated-form.md
@@ -20,14 +20,15 @@ This example showcases a 4-step registration form with:
 
 ## Implementation
 
+Field types come from your UI adapter, registered once in the application config with `provideDynamicForm(...withMaterialFields())`.
+
 ```typescript
 import { Component, signal } from '@angular/core';
 import { DynamicForm, FormConfig } from '@ng-forge/dynamic-forms';
-import '@ng-forge/dynamic-forms-material';
 
 @Component({
   selector: 'app-paginated-form',
-  imports: [DynamicForm, JsonPipe],
+  imports: [DynamicForm],
   template: ` <form [dynamic-form]="config" [(value)]="formValue"></form> `,
 })
 export class PaginatedFormComponent {
@@ -126,7 +127,7 @@ export class PaginatedFormComponent {
             key: 'step2Buttons',
             fields: [
               { type: 'previous', key: 'step2Previous', label: 'Back' },
-              { type: 'next', key: 'step2Next', label: 'Continue' },
+              { type: 'next', key: 'step2Next', label: 'Continue to Address' },
             ],
           },
         ],
@@ -169,6 +170,7 @@ export class PaginatedFormComponent {
                   { value: 'ny', label: 'New York' },
                   { value: 'ca', label: 'California' },
                   { value: 'tx', label: 'Texas' },
+                  { value: 'fl', label: 'Florida' },
                 ],
                 col: 6,
               },
@@ -187,7 +189,7 @@ export class PaginatedFormComponent {
             key: 'step3Buttons',
             fields: [
               { type: 'previous', key: 'step3Previous', label: 'Back' },
-              { type: 'next', key: 'step3Next', label: 'Continue' },
+              { type: 'next', key: 'step3Next', label: 'Continue to Preferences' },
             ],
           },
         ],
@@ -218,6 +220,8 @@ export class PaginatedFormComponent {
               { value: 'sports', label: 'Sports' },
               { value: 'music', label: 'Music' },
               { value: 'travel', label: 'Travel' },
+              { value: 'food', label: 'Food & Cooking' },
+              { value: 'art', label: 'Art & Design' },
             ],
           },
           {
@@ -225,6 +229,12 @@ export class PaginatedFormComponent {
             type: 'checkbox',
             label: 'Subscribe to newsletter',
             value: true,
+          },
+          {
+            key: 'notifications',
+            type: 'toggle',
+            label: 'Enable notifications',
+            value: false,
           },
           {
             key: 'terms',
@@ -265,6 +275,7 @@ Note that page fields use `valueHandling: 'flatten'`, meaning their children are
   "zipCode": "10001",
   "interests": ["technology", "sports"],
   "newsletter": true,
+  "notifications": false,
   "terms": true
 }
 ```
@@ -300,7 +311,7 @@ Each page validates independently. Users cannot proceed to the next page until a
 
 ## Performance & Lazy Loading
 
-Dynamic Forms uses Angular's `@defer` blocks with **smart prefetching** to achieve true lazy loading while maintaining flicker-free navigation.
+Dynamic Forms uses Angular's `@defer` blocks to render the current and adjacent pages immediately and defer distant pages until the browser is idle, so next/previous navigation does not flicker.
 
 ### How It Works
 
@@ -324,11 +335,8 @@ fields: [
 
 **Performance advantages:**
 
-- ⚡ **Zero flicker navigation** - Adjacent pages prefetched for instant next/previous
-- 🚀 **Faster initial load** - Only 3 pages load immediately, distant pages defer until idle
-- ⏱️ **Better Time to Interactive (TTI)** - Reduced initial JavaScript parsing/compilation
-- 📱 **Mobile-friendly** - Lower startup cost on slower devices
-- 🎯 **Optimized user experience** - Smooth page transitions without loading states
+- The current and adjacent pages render immediately, so next/previous navigation does not flicker
+- Distant pages defer until the browser is idle, which lowers the initial rendering cost
 
 ### Technical Details
 
@@ -439,15 +447,30 @@ Show/hide pages based on user choices:
 
 ### Progress Indicator
 
-Add a custom progress component:
+The form emits the `onPageChange` output with a `PageChangeEvent` carrying `currentPageIndex` (0-based), `totalPages`, and `previousPageIndex`. Track it in your component to render a progress indicator:
 
 ```typescript
-template: `
-  <div class="progress-bar">
-    Step {{ currentPage() + 1 }} of {{ totalPages }}
-  </div>
-  <form [dynamic-form]="config" [(value)]="formValue" />
-`;
+import { Component, signal } from '@angular/core';
+import { DynamicForm, FormConfig, PageChangeEvent } from '@ng-forge/dynamic-forms';
+
+@Component({
+  selector: 'app-paginated-form',
+  imports: [DynamicForm],
+  template: `
+    <div class="progress-bar">Step {{ currentPage() + 1 }} of {{ totalPages() }}</div>
+    <form [dynamic-form]="config" [(value)]="formValue" (onPageChange)="handlePageChange($event)"></form>
+  `,
+})
+export class PaginatedFormComponent {
+  formValue = signal({});
+  currentPage = signal(0);
+  totalPages = signal(1);
+
+  handlePageChange(event: PageChangeEvent) {
+    this.currentPage.set(event.currentPageIndex);
+    this.totalPages.set(event.totalPages);
+  }
+}
 ```
 
 ### Conditional Validation
@@ -488,6 +511,6 @@ Apply different validation rules per step:
 
 ## Related Documentation
 
-- [Conditional Logic](/dynamic-behavior/overview) - Show/hide pages dynamically
+- [Conditional Logic](/dynamic-behavior/conditional-logic) - Show/hide pages dynamically
 - [Validation](/validation/basics) - Per-page and cross-page validation
 - [Material Integration](/configuration) - Material Design styling

--- a/apps/docs/public/content/examples/shipping-billing-address.md
+++ b/apps/docs/public/content/examples/shipping-billing-address.md
@@ -1,5 +1,5 @@
 ---
-description: "Implement the 'same as billing' checkout pattern by toggling an entire shipping address group with a single checkbox condition."
+description: "Implement the 'same as billing' checkout pattern by hiding the shipping address fields with a checkbox-driven condition."
 ---
 
 Checkout form demonstrating the common "same as billing" pattern for shipping addresses.
@@ -10,11 +10,11 @@ Checkout form demonstrating the common "same as billing" pattern for shipping ad
 
 ## Overview
 
-This example shows how to toggle an entire group of fields based on a checkbox. When "Shipping same as billing" is checked, the shipping address fields are hidden.
+This example shows how to toggle a set of fields based on a checkbox. When "Shipping same as billing" is checked, every shipping address field is hidden.
 
 **Key patterns demonstrated:**
 
-- Entire group hidden/shown with single condition
+- Each shipping field hidden and required based on the same checkbox condition
 - Checkbox controls form complexity
 - Reduces user effort when addresses are the same
 
@@ -33,6 +33,9 @@ export class ShippingBillingFormComponent {
   formValue = signal({});
 
   config = {
+    defaultValidationMessages: {
+      required: 'This field is required',
+    },
     fields: [
       {
         key: 'billingTitle',
@@ -98,8 +101,10 @@ export class ShippingBillingFormComponent {
         ],
       },
       {
-        key: 'shippingAddress',
-        type: 'group',
+        key: 'shippingStreet',
+        type: 'input',
+        value: '',
+        label: 'Street Address',
         logic: [
           {
             type: 'hidden',
@@ -110,35 +115,92 @@ export class ShippingBillingFormComponent {
               value: true,
             },
           },
+          {
+            type: 'required',
+            condition: {
+              type: 'fieldValue',
+              fieldPath: 'sameAsBilling',
+              operator: 'notEquals',
+              value: true,
+            },
+          },
         ],
-        fields: [
+      },
+      {
+        key: 'shippingCity',
+        type: 'input',
+        value: '',
+        label: 'City',
+        logic: [
           {
-            key: 'street',
-            type: 'input',
-            value: '',
-            label: 'Street Address',
-            required: true,
+            type: 'hidden',
+            condition: {
+              type: 'fieldValue',
+              fieldPath: 'sameAsBilling',
+              operator: 'equals',
+              value: true,
+            },
           },
           {
-            key: 'city',
-            type: 'input',
-            value: '',
-            label: 'City',
-            required: true,
+            type: 'required',
+            condition: {
+              type: 'fieldValue',
+              fieldPath: 'sameAsBilling',
+              operator: 'notEquals',
+              value: true,
+            },
+          },
+        ],
+      },
+      {
+        key: 'shippingState',
+        type: 'input',
+        value: '',
+        label: 'State/Province',
+        logic: [
+          {
+            type: 'hidden',
+            condition: {
+              type: 'fieldValue',
+              fieldPath: 'sameAsBilling',
+              operator: 'equals',
+              value: true,
+            },
           },
           {
-            key: 'state',
-            type: 'input',
-            value: '',
-            label: 'State/Province',
-            required: true,
+            type: 'required',
+            condition: {
+              type: 'fieldValue',
+              fieldPath: 'sameAsBilling',
+              operator: 'notEquals',
+              value: true,
+            },
+          },
+        ],
+      },
+      {
+        key: 'shippingZipCode',
+        type: 'input',
+        value: '',
+        label: 'ZIP/Postal Code',
+        logic: [
+          {
+            type: 'hidden',
+            condition: {
+              type: 'fieldValue',
+              fieldPath: 'sameAsBilling',
+              operator: 'equals',
+              value: true,
+            },
           },
           {
-            key: 'zipCode',
-            type: 'input',
-            value: '',
-            label: 'ZIP/Postal Code',
-            required: true,
+            type: 'required',
+            condition: {
+              type: 'fieldValue',
+              fieldPath: 'sameAsBilling',
+              operator: 'notEquals',
+              value: true,
+            },
           },
         ],
       },
@@ -167,32 +229,44 @@ A simple checkbox controls whether shipping fields are visible:
 }
 ```
 
-### Group Visibility
+### Per-Field Visibility
 
-The entire shipping address group is hidden when the checkbox is checked:
+Each shipping field carries the same pair of rules: hidden when the checkbox is checked, required when it is not:
 
 ```typescript
 {
-  key: 'shippingAddress',
-  type: 'group',
-  logic: [{
-    type: 'hidden',
-    condition: {
-      type: 'fieldValue',
-      fieldPath: 'sameAsBilling',
-      operator: 'equals',
-      value: true,
+  key: 'shippingStreet',
+  type: 'input',
+  value: '',
+  label: 'Street Address',
+  logic: [
+    {
+      type: 'hidden',
+      condition: {
+        type: 'fieldValue',
+        fieldPath: 'sameAsBilling',
+        operator: 'equals',
+        value: true,
+      },
     },
-  }],
-  fields: [
-    // All shipping fields...
+    {
+      type: 'required',
+      condition: {
+        type: 'fieldValue',
+        fieldPath: 'sameAsBilling',
+        operator: 'notEquals',
+        value: true,
+      },
+    },
   ],
 }
 ```
 
+Because the shipping fields are flat (not nested in a group), the form value keeps them at the top level: `shippingStreet`, `shippingCity`, `shippingState`, and `shippingZipCode` sit alongside `billingAddress` and `sameAsBilling`. As an alternative, you can wrap the four fields in a `group` with a single `hidden` rule, which nests them under the group key in the form value.
+
 ### Section Titles
 
-The section title is also hidden along with the group:
+The section title is also hidden along with the shipping fields:
 
 ```typescript
 {
@@ -220,6 +294,6 @@ The section title is also hidden along with the group:
 
 ## Related Documentation
 
-- **[Conditional Logic](/dynamic-behavior/overview)** - Full conditional logic guide
+- **[Conditional Logic](/dynamic-behavior/conditional-logic)** - Full conditional logic guide
 - **[Form Groups](/prebuilt/form-groups)** - Working with groups
 - **[Checkbox Fields](/field-types/selection)** - Field types reference

--- a/apps/docs/public/content/examples/simplified-array-form.md
+++ b/apps/docs/public/content/examples/simplified-array-form.md
@@ -47,7 +47,7 @@ export class SimplifiedArrayFormComponent {
           placeholder: 'Enter a tag',
         },
         value: ['angular', 'typescript'],
-        addButton: { label: 'Add Tag', props: { color: 'primary' } },
+        addButton: { label: 'Add Tag' },
         removeButton: { label: 'Remove', props: { color: 'warn' } },
       },
 
@@ -76,7 +76,7 @@ export class SimplifiedArrayFormComponent {
           { name: 'Jane Smith', phone: '5551234567' },
           { name: 'John Doe', phone: '5559876543' },
         ],
-        addButton: { label: 'Add Contact', props: { color: 'primary' } },
+        addButton: { label: 'Add Contact' },
       },
 
       // Empty array — notes
@@ -102,11 +102,13 @@ export class SimplifiedArrayFormComponent {
         addButton: { label: 'Add Category' },
       },
 
-      { key: 'submit', type: 'submit', label: 'Save All', props: { color: 'primary' } },
+      { key: 'submit', type: 'submit', label: 'Save All' },
     ],
   } as const satisfies FormConfig;
 }
 ```
+
+The live demo config additionally contains section heading and description text fields, omitted here for brevity.
 
 ## Key Features
 

--- a/apps/docs/public/content/examples/user-registration.md
+++ b/apps/docs/public/content/examples/user-registration.md
@@ -26,6 +26,10 @@ import { Component } from '@angular/core';
 import { FormConfig, DynamicForm } from '@ng-forge/dynamic-forms';
 
 const registrationConfig = {
+  defaultValidationMessages: {
+    required: 'This field is required',
+    email: 'Please enter a valid email address',
+  },
   fields: [
     // Step 1: Account Information
     {
@@ -54,7 +58,6 @@ const registrationConfig = {
             pattern: 'Username can only contain letters, numbers, and underscores',
           },
           props: {
-            appearance: 'outline',
             hint: '3-20 characters, letters, numbers, and underscores only',
           },
         },
@@ -71,7 +74,6 @@ const registrationConfig = {
           },
           props: {
             type: 'email',
-            appearance: 'outline',
             hint: "We'll send a verification email",
           },
         },
@@ -90,7 +92,6 @@ const registrationConfig = {
           },
           props: {
             type: 'password',
-            appearance: 'outline',
             hint: 'At least 8 characters with uppercase, lowercase, number, and special character',
           },
         },
@@ -113,14 +114,12 @@ const registrationConfig = {
           },
           props: {
             type: 'password',
-            appearance: 'outline',
           },
         },
         {
           type: 'next',
           key: 'nextToProfile',
           label: 'Continue to Profile',
-          props: { color: 'primary' },
         },
       ],
     },
@@ -141,7 +140,6 @@ const registrationConfig = {
               label: 'First Name',
               required: true,
               col: 6,
-              props: { appearance: 'outline' },
             },
             {
               key: 'lastName',
@@ -150,25 +148,8 @@ const registrationConfig = {
               label: 'Last Name',
               required: true,
               col: 6,
-              props: { appearance: 'outline' },
             },
           ],
-        },
-        {
-          key: 'dateOfBirth',
-          type: 'datepicker',
-          value: null,
-          label: 'Date of Birth',
-          required: true,
-          maxDate: new Date(new Date().getFullYear() - 13, 0, 1),
-          validationMessages: {
-            required: 'Date of birth is required',
-            maxDate: 'You must be at least 13 years old',
-          },
-          props: {
-            appearance: 'outline',
-            hint: 'You must be at least 13 years old',
-          },
         },
         {
           key: 'accountType',
@@ -180,7 +161,6 @@ const registrationConfig = {
             { value: 'personal', label: 'Personal Account' },
             { value: 'business', label: 'Business Account' },
           ],
-          props: { color: 'primary' },
         },
         {
           key: 'companyName',
@@ -207,7 +187,6 @@ const registrationConfig = {
               },
             },
           ],
-          props: { appearance: 'outline' },
         },
         {
           key: 'industry',
@@ -243,9 +222,6 @@ const registrationConfig = {
             },
           ],
           placeholder: 'Select your industry',
-          props: {
-            appearance: 'outline',
-          },
         },
         {
           type: 'row',
@@ -260,7 +236,6 @@ const registrationConfig = {
               type: 'next',
               key: 'nextToPreferences',
               label: 'Continue',
-              props: { color: 'primary' },
             },
           ],
         },
@@ -284,21 +259,18 @@ const registrationConfig = {
             { value: 'marketing', label: 'Marketing & Sales' },
             { value: 'development', label: 'Software Development' },
           ],
-          props: { color: 'primary' },
         },
         {
           key: 'newsletter',
           type: 'checkbox',
           value: false,
           label: 'Subscribe to newsletter',
-          props: { color: 'primary' },
         },
         {
           key: 'notifications',
           type: 'toggle',
           value: true,
           label: 'Enable email notifications',
-          props: { color: 'primary' },
         },
         {
           key: 'terms',
@@ -309,7 +281,6 @@ const registrationConfig = {
           validationMessages: {
             required: 'You must accept the terms and conditions',
           },
-          props: { color: 'primary' },
         },
         {
           key: 'privacy',
@@ -320,7 +291,6 @@ const registrationConfig = {
           validationMessages: {
             required: 'You must accept the privacy policy',
           },
-          props: { color: 'primary' },
         },
         {
           type: 'row',
@@ -335,7 +305,6 @@ const registrationConfig = {
               type: 'submit',
               key: 'submitRegistration',
               label: 'Create Account',
-              props: { color: 'primary' },
             },
           ],
         },
@@ -361,7 +330,7 @@ export class UserRegistrationComponent {
 The form uses page fields to create a wizard-style registration process:
 
 1. **Account Information** - Username, email, password
-2. **Profile Information** - Name, DOB, account type
+2. **Profile Information** - Name, account type
 3. **Preferences & Terms** - Interests, notifications, agreements
 
 Navigation buttons (`next`, `previous`, `submit`) control flow between pages.
@@ -425,21 +394,6 @@ Company name and industry appear only for business accounts:
 }
 ```
 
-### Age Verification
-
-Uses datepicker `maxDate` to ensure users are at least 13 years old:
-
-```typescript
-{
-  key: 'dateOfBirth',
-  type: 'datepicker',
-  maxDate: new Date(new Date().getFullYear() - 13, 0, 1),
-  validationMessages: {
-    maxDate: 'You must be at least 13 years old',
-  },
-}
-```
-
 ### Type Safety
 
 Full type inference for form values:
@@ -455,7 +409,6 @@ type RegistrationValue = InferFormValue<typeof registrationConfig.fields>;
 //   confirmPassword: string;
 //   firstName: string;
 //   lastName: string;
-//   dateOfBirth: Date | null;
 //   accountType: string;
 //   companyName?: string;      // Conditional
 //   industry?: string;          // Conditional
@@ -504,5 +457,5 @@ Add social login buttons before the form:
 - **[Login Form](/examples/login-form)** - Simple authentication form
 - **[Paginated Form](/examples/paginated-form)** - Page field navigation patterns
 - **[Validation](/validation/basics)** - Validation guide
-- **[Conditional Logic](/dynamic-behavior/overview)** - Dynamic field behavior
+- **[Conditional Logic](/dynamic-behavior/conditional-logic)** - Dynamic field behavior
 - **[Material Integration](/configuration)** - Material Design styling

--- a/apps/docs/public/content/examples/user-registration.md
+++ b/apps/docs/public/content/examples/user-registration.md
@@ -330,7 +330,7 @@ export class UserRegistrationComponent {
 The form uses page fields to create a wizard-style registration process:
 
 1. **Account Information** - Username, email, password
-2. **Profile Information** - Name, account type
+2. **Profile Information** - Name, account type, plus company name and industry shown conditionally for business accounts
 3. **Preferences & Terms** - Interests, notifications, agreements
 
 Navigation buttons (`next`, `previous`, `submit`) control flow between pages.

--- a/apps/docs/public/content/examples/wrapper-array-actions.md
+++ b/apps/docs/public/content/examples/wrapper-array-actions.md
@@ -2,7 +2,7 @@
 description: 'Wrap an array field in a custom wrapper whose header hosts its own Add button. The wrapper dispatches arrayEvent(key).append(template), so the consumer config stays free of separate action fields.'
 ---
 
-Action buttons for an array (Add, Clear, etc.) don't have to be separate fields in the config — a wrapper can own the button and the behaviour. Here, `arraySection` renders a titled card whose header contains an Add button; clicking it dispatches `arrayEvent(key).append(itemTemplate)` against the array it wraps.
+Action buttons for an array (Add, Clear, etc.) don't have to be separate fields in the config; a wrapper can own the button and the behaviour. Here, `arraySection` renders a titled card whose header contains an Add button; clicking it dispatches `arrayEvent(key).append(itemTemplate)` against the array it wraps.
 
 ## Live Demo
 
@@ -70,11 +70,11 @@ export default class ArraySectionWrapper implements FieldWrapper {
 ## Why this pattern
 
 - **Config stays focused.** The array owns the data shape; the wrapper owns the chrome plus the add action.
-- **Reusable.** Apply the same wrapper to any array by changing the `itemTemplate` — no custom buttons to wire up.
+- **Reusable.** Apply the same wrapper to any array by changing the `itemTemplate`, with no custom buttons to wire up.
 - **Consistent placement.** Every array wrapped this way has the Add button in the same visual position.
 
 ## Related
 
-- **[Wrappers overview](/wrappers/overview)** — concept and built-ins
-- **[Writing a wrapper](/wrappers/writing-a-wrapper)** — the component contract
-- **[Complete Array API](/prebuilt/form-arrays/complete)** — alternative: add button as a separate field
+- **[Wrappers overview](/wrappers/overview)**: concept and built-ins
+- **[Writing a wrapper](/wrappers/writing-a-wrapper)**: the component contract
+- **[Complete Array API](/prebuilt/form-arrays/complete)**: alternative with the add button as a separate field

--- a/apps/docs/public/content/feature-overview.md
+++ b/apps/docs/public/content/feature-overview.md
@@ -1,7 +1,7 @@
 ---
 title: Feature Overview
 slug: feature-overview
-description: Task-oriented navigator into the ng-forge docs — pick what you're trying to do, plus a general FAQ and the most common pitfalls.
+description: Task-oriented navigator into the ng-forge docs. Pick what you're trying to do, plus a general FAQ and the most common pitfalls.
 ---
 
 > [!TIP]

--- a/apps/docs/public/content/field-types/advanced-controls.md
+++ b/apps/docs/public/content/field-types/advanced-controls.md
@@ -53,14 +53,10 @@ Date selection control.
 
 **Core Properties (all optional):**
 
-- `minDate`: Minimum selectable date — `Date | string | null`
-- `maxDate`: Maximum selectable date — `Date | string | null`
-- `startAt`: Initial calendar view date — `Date | null`
-
-**Core Props:**
-
-- `placeholder`: Placeholder text
-- `format`: Date format string (UI-integration specific)
+- `minDate`: Minimum selectable date (`Date | string | null`)
+- `maxDate`: Maximum selectable date (`Date | string | null`)
+- `startAt`: Initial calendar view date (`Date | null`)
+- `placeholder`: Placeholder text (at field level, not in props)
 
 #### Adapter Props
 

--- a/apps/docs/public/content/field-types/buttons.md
+++ b/apps/docs/public/content/field-types/buttons.md
@@ -23,10 +23,10 @@ Renders a submit button that triggers form submission. Automatically disabled wh
 }
 ```
 
-**Core Props:**
+**Core Properties:**
 
-- `label`: Button text (also set via top-level `label`)
-- `disabled`: Whether the button is disabled
+- `label`: Button text (a top-level field property, not in props)
+- `disabled`: Whether the button is disabled (a top-level field property, not in props)
 
 #### Adapter Props
 
@@ -36,7 +36,7 @@ Renders a submit button that triggers form submission. Automatically disabled wh
 
 ## button
 
-Generic action button. Dispatches a form `event` when clicked — subscribe to the event on the form to handle the click.
+Generic action button. Dispatches a form `event` when clicked; subscribe to the event on the form to handle the click.
 
 ```typescript
 import { FormResetEvent } from '@ng-forge/dynamic-forms';
@@ -54,7 +54,7 @@ import { FormResetEvent } from '@ng-forge/dynamic-forms';
 
 **Core Properties:**
 
-- `event`: Form event constructor dispatched on click (e.g. `FormResetEvent`, `FormClearEvent`, or a custom `FormEvent` subclass) — **required**
+- `event`: Form event constructor dispatched on click (e.g. `FormResetEvent`, `FormClearEvent`, or a custom `FormEvent` subclass). **Required**
 - `label`: Button text
 
 #### Adapter Props
@@ -63,7 +63,7 @@ import { FormResetEvent } from '@ng-forge/dynamic-forms';
 
 ## next
 
-Advances to the next page in a multi-step form. Only valid inside a `page` container. Validates the current page before advancing.
+Advances to the next page in a multi-step form. Only valid inside a `page` container. Automatically disabled while the current page is invalid, so users cannot advance until it is valid.
 
 ```typescript
 {
@@ -121,7 +121,7 @@ Appends a new item to the end of the target array.
 **Core Properties:**
 
 - `arrayKey`: Key of the target array field (required if placed outside the array)
-- `template`: Field definition(s) for the new item — single `FieldDef` for primitive items, array of `FieldDef` for object items (**required**)
+- `template`: Field definition(s) for the new item: a single `FieldDef` for primitive items, an array of `FieldDef` for object items (**required**)
 
 ### prependArrayItem
 
@@ -182,7 +182,7 @@ Removes the current item from the array. Typically placed inside each array item
 
 **Core Properties:**
 
-- `arrayKey`: Key of the target array field (optional when placed inside the array — automatically inferred)
+- `arrayKey`: Key of the target array field (optional when placed inside the array, where it is inferred automatically)
 
 ### popArrayItem
 

--- a/apps/docs/public/content/field-types/selection.md
+++ b/apps/docs/public/content/field-types/selection.md
@@ -27,11 +27,8 @@ Single or multi-select dropdown.
 
 **Core Properties:**
 
-- `options`: Array of `{ value: T, label: string }` objects (at field level, not in props)
-
-**Core Props:**
-
-- `placeholder`: Placeholder text when no value selected
+- `options`: Array of `{ label: DynamicText, value: T, disabled?: boolean }` objects (at field level, not in props). `label` accepts static strings, signals, or observables; `disabled` makes the option non-selectable
+- `placeholder`: Placeholder text when no value selected (at field level, not in props)
 
 #### Adapter Props
 
@@ -60,7 +57,7 @@ Single selection from multiple options.
 
 **Core Properties:**
 
-- `options`: Array of `{ value: string, label: string }` objects (at field level, not in props)
+- `options`: Array of `{ label: DynamicText, value: string, disabled?: boolean }` objects (at field level, not in props). `label` accepts static strings, signals, or observables; `disabled` makes the option non-selectable
 
 #### Adapter Props
 
@@ -126,7 +123,7 @@ Multiple selection from a list of checkboxes. Value is an array of selected valu
 
 **Core Properties:**
 
-- `options`: Array of `{ value: T, label: string }` objects (at field level, not in props)
+- `options`: Array of `{ label: DynamicText, value: T, disabled?: boolean }` objects (at field level, not in props). `label` accepts static strings, signals, or observables; `disabled` makes the option non-selectable
 
 #### Adapter Props
 

--- a/apps/docs/public/content/field-types/text-inputs.md
+++ b/apps/docs/public/content/field-types/text-inputs.md
@@ -25,10 +25,13 @@ Text-based input with HTML5 type support.
 }
 ```
 
+**Core Properties:**
+
+- `placeholder`: Input placeholder text (at field level, not in props)
+
 **Core Props:**
 
 - `type`: HTML input type (`'text'` | `'email'` | `'password'` | `'number'` | `'tel'` | `'url'`)
-- `placeholder`: Input placeholder text
 
 #### Adapter Props
 
@@ -54,9 +57,12 @@ Multi-line text input.
 }
 ```
 
+**Core Properties:**
+
+- `placeholder`: Placeholder text (at field level, not in props)
+
 **Core Props:**
 
-- `placeholder`: Placeholder text
 - `rows`: Number of visible text rows
 
 #### Adapter Props

--- a/apps/docs/public/content/field-types/utility.md
+++ b/apps/docs/public/content/field-types/utility.md
@@ -24,7 +24,7 @@ Renders static text content inside the form layout. Useful for instructions, sec
 
 **Core Properties:**
 
-- `label`: The text to render (DynamicText — string, signal, or observable)
+- `label`: The text to render (DynamicText: string, signal, or observable)
 - `className`: Optional CSS class applied to the rendered element
 
 **Props:**
@@ -47,4 +47,4 @@ Carries a fixed value through the form without rendering any UI. Useful for meta
 
 - `value`: The value to include in the form result (required)
 
-> Hidden fields always appear in the submitted form value regardless of visibility or conditional logic.
+> Hidden fields are included in the submitted form value by default; they have no reactive hidden state, so conditional logic does not exclude them.

--- a/apps/docs/public/content/getting-started.md
+++ b/apps/docs/public/content/getting-started.md
@@ -7,15 +7,15 @@ description: 'Install ng-forge, pick a UI adapter (Material, Bootstrap, PrimeNG,
 > [!TIP]
 > **Coming from ngx-formly?** The [migration guide](/migrating-from-ngx-formly) maps every concept side-by-side and includes a checklist for porting a non-trivial app.
 
-ng-forge generates fully working Angular forms from a single configuration object — validation, conditional logic, and multi-step wizards included. Here's how to set it up.
+ng-forge generates fully working Angular forms from a single configuration object: validation, conditional logic, and multi-step wizards included. Here's how to set it up.
 
 ## Quick setup
 
-In an existing Angular 21+ workspace:
+In an existing Angular 22 workspace:
 
 <docs-cli-command package="@ng-forge/dynamic-forms"></docs-cli-command>
 
-Pick an adapter when prompted. Works in Nx too — toggle the **Nx** tab.
+Pick an adapter when prompted. Works in Nx too; toggle the **Nx** tab.
 
 Prefer to wire things by hand? Manual setup is below.
 
@@ -29,7 +29,7 @@ Prefer to wire things by hand? Manual setup is below.
 
 ## 2. Your First Form
 
-Every adapter uses the same `FormConfig` schema — import `DynamicForm` and bind a config object:
+Every adapter uses the same `FormConfig` schema. Import `DynamicForm` and bind a config object:
 
 ```typescript
 @Component({
@@ -45,30 +45,30 @@ export class ContactComponent {
 }
 ```
 
-Try it out — select a contact method and watch fields appear. Switch to the "Config" tab to see the full schema:
+Try it out: select a contact method and watch fields appear. Switch to the "Config" tab to see the full schema:
 
 <docs-live-example scenario="examples/contact-dynamic-fields" hideForCustom></docs-live-example>
 
 ## Requirements
 
-- **Angular 21+** — required for signal support
-- **TypeScript 5.6+** — for best type inference
+- **Angular 22**: the published packages declare `@angular/*` peers of `~22.0.0`. Signal Forms, which ng-forge builds on, is stable in Angular 22
+- **TypeScript 6.0**: required by the Angular 22 toolchain
 
 ---
 
 ## Community & Support
 
-- **[Discord](https://discord.gg/qpzzvFagj3)** — Ask questions, share what you've built, and chat with the community
-- **[GitHub Issues](https://github.com/ng-forge/ng-forge/issues)** — Report bugs or request features
-- **[Contributing](https://github.com/ng-forge/ng-forge/blob/main/CONTRIBUTING.md)** — Learn how to contribute to ng-forge
+- **[Discord](https://discord.gg/qpzzvFagj3)**: Ask questions, share what you've built, and chat with the community
+- **[GitHub Issues](https://github.com/ng-forge/ng-forge/issues)**: Report bugs or request features
+- **[Contributing](https://github.com/ng-forge/ng-forge/blob/main/CONTRIBUTING.md)**: Learn how to contribute to ng-forge
 
 ---
 
 ## Next Steps
 
-- **[Feature overview](/feature-overview)** — Task-oriented map of the docs, plus a general FAQ and the most common pitfalls
-- **[Configuration](/configuration)** — Set global defaults with `withXxxFields({ ... })` and per-form `defaultProps`
-- **[Examples](/examples)** — Browse complete form examples
-- **[Field Types](/field-types/text-inputs)** — All available field types and their props
-- **[Building an Adapter](/building-an-adapter)** — Create your own adapter for any UI library
-- **[Migrating from ngx-formly](/migrating-from-ngx-formly)** — Side-by-side migration guide if you're coming from formly
+- **[Feature overview](/feature-overview)**: Task-oriented map of the docs, plus a general FAQ and the most common pitfalls
+- **[Configuration](/configuration)**: Set global defaults with `withXxxFields({ ... })` and per-form `defaultProps`
+- **[Examples](/examples)**: Browse complete form examples
+- **[Field Types](/field-types/text-inputs)**: All available field types and their props
+- **[Building an Adapter](/building-an-adapter)**: Create your own adapter for any UI library
+- **[Migrating from ngx-formly](/migrating-from-ngx-formly)**: Side-by-side migration guide if you're coming from formly

--- a/apps/docs/public/content/migrating-from-ngx-formly.md
+++ b/apps/docs/public/content/migrating-from-ngx-formly.md
@@ -6,24 +6,24 @@ description: Migrate an Angular dynamic-forms app from ngx-formly to ng-forge. C
 
 # Migrating from ngx-formly to ng-forge
 
-A migration reference for moving an Angular dynamic-forms app from **ngx-formly** to **ng-forge**. Angular **Signal Forms** (`@angular/forms/signals`) is the new built-in forms substrate as of Angular 21; ng-forge is built on it, ngx-formly is built on Reactive Forms. That substrate change is the load-bearing difference everything else here flows from. The surface shape is similar — a config object describes the form, the library renders it — so most concepts map directly.
+A migration reference for moving an Angular dynamic-forms app from **ngx-formly** to **ng-forge**. Angular **Signal Forms** (`@angular/forms/signals`) is Angular's built-in signal-based forms system, introduced in Angular 21 and stable since Angular 22; ng-forge is built on it, ngx-formly is built on Reactive Forms. That substrate change is the load-bearing difference everything else here flows from. The surface shape is similar (a config object describes the form, the library renders it), so most concepts map directly.
 
 ## Should you migrate?
 
 | Your situation                                                          | What to do                                                                  |
 | ----------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| Standardising on Angular Signal Forms as the form substrate             | Migrate — formly is Reactive Forms, ng-forge is Signal Forms                |
-| Want schema-validation-first design (Zod, Valibot, ArkType)             | Migrate — built in via Standard Schema                                      |
-| Hitting performance limits on large forms or array sections             | Migrate — see [Performance](#performance) below for the substrate reasons   |
-| Heavy reliance on community formly extensions or custom field types     | Evaluate — the porting cost may outweigh the substrate benefits             |
-| Need a stable, low-churn API today                                      | Stay — ng-forge is younger; formly is mature                                |
-| Use a UI library ng-forge does not ship (Kendo, NG-ZORRO, NativeScript) | Build an adapter — see [Building an Adapter](/building-an-adapter)          |
+| Standardising on Angular Signal Forms as the form substrate             | Migrate: formly is Reactive Forms, ng-forge is Signal Forms                |
+| Want schema-validation-first design (Zod, Valibot, ArkType)             | Migrate: built in via Standard Schema                                      |
+| Hitting performance limits on large forms or array sections             | Migrate: see [Performance](#performance) below for the substrate reasons   |
+| Heavy reliance on community formly extensions or custom field types     | Evaluate: the porting cost may outweigh the substrate benefits             |
+| Need a stable, low-churn API today                                      | Stay: ng-forge is younger; formly is mature                                |
+| Use a UI library ng-forge does not ship (Kendo, NG-ZORRO, NativeScript) | Build an adapter; see [Building an Adapter](/building-an-adapter)          |
 
 ## At a glance
 
 | ngx-formly                                | ng-forge                                                                |
 | ----------------------------------------- | ----------------------------------------------------------------------- |
-| `FormlyFieldConfig`                       | `FieldConfig` (registered field type)                                   |
+| `FormlyFieldConfig`                       | `FieldDef` (base interface; each registered field type narrows it)      |
 | `props` (was `templateOptions`)           | UI-adapter-specific keys live in `props`; validation and labelling (`label`, `required`, `email`, `min`, `max`, `minLength`, `maxLength`, `pattern`, `placeholder`) live at the top level |
 | `expressions: { hide: '!model.x' }`       | `logic: [{ type: 'hidden', condition: { … } }]` (structured)            |
 | `expressionProperties` (deprecated v6)    | `logic` array + `derivation` for values                                 |
@@ -33,7 +33,7 @@ A migration reference for moving an Angular dynamic-forms app from **ngx-formly*
 | `fieldGroup` (object)                     | `type: 'group'` with `fields: [...]`                                    |
 | `fieldArray` (custom `repeat` type)       | `type: 'array'` (built in; verbose form with explicit add/remove fields, or simplified form with `template` + auto-buttons) |
 | `hooks: { onInit, onChanges, … }`         | Angular component lifecycle inside custom field components, plus `EventBus` / `EventDispatcher` for cross-field events |
-| `FormlyJsonschema.toFieldConfig(schema)`  | `standardSchema(zodSchema)` (different paradigm — see below)            |
+| `FormlyJsonschema.toFieldConfig(schema)`  | `standardSchema(zodSchema)` (different paradigm; see below)            |
 | `[model]` two-way binding                 | `[(value)]` two-way binding (Angular `model()` signal)                   |
 
 The default shifts from **string-first** (formly's `expressions` DSL, template options) to **structured-config-first**. Strings still exist in ng-forge as shorthand (`derivation: 'formValue.x * formValue.y'`) and escape hatches (the `javascript` condition), but the typical condition or derivation is now a typed object the engine can analyse for dependencies, refactor safely, and run under strict CSP.
@@ -65,7 +65,7 @@ export const appConfig: ApplicationConfig = {
 };">
 </docs-code-compare>
 
-The package layout matches one-for-one: `@ngx-formly/material` ↔ `@ng-forge/dynamic-forms-material`, and so on for Bootstrap, PrimeNG, and Ionic.
+The package layout matches one-for-one: `@ngx-formly/material` maps to `@ng-forge/dynamic-forms-material`, and so on for Bootstrap, PrimeNG, and Ionic.
 
 ## Your first form
 
@@ -137,7 +137,7 @@ export class ContactComponent {
 Three things to internalise:
 
 - **`label` / `required` / `email` / `min` / `max` / `minLength` / `maxLength` / `pattern` / `placeholder` live at the top level of the field**, not under `props`. `props` carries the rendered control's attributes (`type: 'email'`, `rows`) and UI-adapter-specific options (`appearance`, `hint` for Material; equivalents elsewhere).
-- **`value` seeds the initial value and the inferred type** — `value: ''` makes the field a string, `value: 0` makes it a number. Optional; omit when the field is computed or hydrated from a backend.
+- **`value` seeds the initial value and the inferred type**: `value: ''` makes the field a string, `value: 0` makes it a number. Optional; omit when the field is computed or hydrated from a backend.
 - **`as const satisfies FormConfig` is how strong typing flows in.** No decorator-style generics; the literal field shapes infer the form value.
 
 Two-way binding is `[(value)]` (Angular `model()` signal); read-only access is `(submitted)`, `(events)`, or the `formValue` signal off a `viewChild` ref.
@@ -160,9 +160,9 @@ The names line up directly except for a few cases.
 | _none_              | `page`                  | Multi-step container                                               |
 | _none_              | `row`                   | Horizontal flex layout                                             |
 | _none_              | `text`                  | Display-only label / heading                                       |
-| _none_              | `submit` / `next` / `previous` / `addArrayItem` / `removeArrayItem` | Built-in action buttons; auto-disabled while the form is invalid  |
+| _none_              | `submit` / `next` / `previous` / `addArrayItem` / `removeArrayItem` | Built-in action buttons; `submit` auto-disables while the form is invalid, `next` while the current page is invalid |
 
-**Selects.** Formly takes `options` inside `props`; ng-forge takes `options` at the top level. The `FieldOption` shape is fixed at `{ value, label, disabled? }` — if your data has custom keys, remap once at the source (`data.map(d => ({ value: d.id, label: d.name }))`) or use a `targetProperty: 'options'` derivation (see [Async data](#async-data-and-dynamic-options)).
+**Selects.** Formly takes `options` inside `props`; ng-forge takes `options` at the top level. The `FieldOption` shape is fixed at `{ value, label, disabled? }`. If your data has custom keys, remap once at the source (`data.map(d => ({ value: d.id, label: d.name }))`) or use a `targetProperty: 'options'` derivation (see [Async data](#async-data-and-dynamic-options)).
 
 <docs-code-compare
   title="Select with static options"
@@ -197,7 +197,7 @@ Both libraries support shorthand validators (`required`, `min`, `max`, `minLengt
 
 <docs-validator-pillars></docs-validator-pillars>
 
-Validator functions return only `{ kind }` — the human-readable message is configured separately via `validationMessages` (per-field) or `defaultValidationMessages` (form-level), so the same `kind` can be localised consistently.
+Validator functions return only `{ kind }`; the human-readable message is configured separately via `validationMessages` (per-field) or `defaultValidationMessages` (form-level), so the same `kind` can be localised consistently.
 
 <docs-code-compare
   title="Custom validator"
@@ -245,7 +245,7 @@ For HTTP-driven and async (`resource()`-API) validators, see [Custom validators]
 
 ## Conditional fields and dynamic props
 
-Formly's `expressions` DSL — string-evaluated functions like `'!model.country'` — becomes ng-forge's structured `logic` array. More verbose, typed end-to-end, CSP-safe by default.
+Formly's `expressions` DSL (string-evaluated functions like `'!model.country'`) becomes ng-forge's structured `logic` array. More verbose, but typed end-to-end and CSP-safe by default.
 
 <docs-code-compare
   title="Hide a field based on another field's value"
@@ -287,13 +287,13 @@ Formly's `expressions` DSL — string-evaluated functions like `'!model.country'
 }">
 </docs-code-compare>
 
-For genuinely complex expressions, ng-forge has an opt-in `javascript` condition (a string evaluated against `formValue`) — see [Conditional logic](/dynamic-behavior/conditional-logic).
+For genuinely complex expressions, ng-forge has an opt-in `javascript` condition (a string evaluated against `formValue`); see [Conditional logic](/dynamic-behavior/conditional-logic).
 
-**Hidden field values work differently.** Formly defaults to actively *resetting* a field's value when it becomes hidden (via `resetOnHide`). ng-forge keeps the value live; the optional `excludeValueIfHidden` form option filters it out at submission time. If your code relied on the formly reset, port it as an explicit derivation that clears the value when the hide condition is true. See [Hidden fields](/prebuilt/hidden-fields) and the [common pitfalls](/feature-overview#common-pitfalls).
+**Hidden field values work differently.** Formly defaults to actively *resetting* a field's value when it becomes hidden (via `resetOnHide`). ng-forge keeps the value in form state but excludes it from the submitted output by default (`excludeValueIfHidden` defaults to true; override it per field, per form, or globally). If your code relied on the formly reset, port it as an explicit derivation that clears the value when the hide condition is true. See [Hidden fields](/prebuilt/hidden-fields) and the [common pitfalls](/feature-overview#common-pitfalls).
 
 ## Cross-field validation
 
-Formly puts cross-field validators on the parent `fieldGroup`. ng-forge does the same with a `group` field, but most users find Zod's `.refine()` / `.superRefine()` cleaner for this case:
+Formly puts cross-field validators on the parent `fieldGroup`. ng-forge group fields do not accept validators; the idiomatic port is Zod's `.refine()` / `.superRefine()` attached via `standardSchema`:
 
 ```typescript
 import { z } from 'zod';
@@ -320,7 +320,7 @@ const config = {
 
 ## Custom field types
 
-Both libraries register a Component against a name and let the field config reference it by name. ng-forge custom fields are **plain standalone components** with explicit `input` signals (no base class with magic getters); they receive Angular Signal Forms' `FieldTree<T>` and read/write via `f().value()` / `f().valueChange.set(...)`. The library bridges your component to its internal state via a `mapper` (`valueFieldMapper`, `optionsFieldMapper`, etc.) — for most field shapes you reuse a built-in mapper.
+Both libraries register a Component against a name and let the field config reference it by name. ng-forge custom fields are **plain standalone components** with explicit `input` signals (no base class with magic getters); they receive Angular Signal Forms' `FieldTree<T>` and read/write via `f().value()` / `f().value.set(...)`. The library bridges your component to its internal state via a `mapper` (`valueFieldMapper`, `optionsFieldMapper`, etc.); for most field shapes you reuse a built-in mapper.
 
 See [Adding custom fields](/recipes/custom-fields) for the full walkthrough.
 
@@ -332,13 +332,13 @@ See [Writing a wrapper](/wrappers/writing-a-wrapper) and [Registering and applyi
 
 ## Addons (prefix / suffix slots)
 
-Formly's addon story is **uneven across adapters** — Bootstrap ships first-class addons via `props.addonLeft` / `props.addonRight`; Material has a demo wrapper users copy into their app; PrimeNG and Ionic have nothing built-in.
+Formly's addon story is **uneven across adapters**: Bootstrap ships first-class addons via `props.addonLeft` / `props.addonRight`; Material has a demo wrapper users copy into their app; PrimeNG and Ionic have nothing built-in.
 
-ng-forge unifies all four adapters under one shape: `addons: [{ slot, type, ... }]`. The same `slot` vocabulary (`'prefix'` / `'suffix'`) works everywhere — adapters translate internally to their native projection mechanism. Buttons accept built-in `preset` actions (`clear`, `reset`, `paste`, `copy`, `toggle-password-visibility`) so common patterns require no handler code.
+ng-forge unifies all four adapters under one shape: `addons: [{ slot, type, ... }]`. The same `slot` vocabulary (`'prefix'` / `'suffix'`) works everywhere; adapters translate internally to their native projection mechanism. Buttons accept built-in `preset` actions (`clear`, `reset`, `paste`, `copy`, `toggle-password-visibility`) so common patterns require no handler code.
 
 <docs-code-compare
   title="Bootstrap addons"
-  formly="// ngx-formly (Bootstrap — first-class)
+  formly="// ngx-formly (Bootstrap: first-class)
 {
   key: 'amount',
   type: 'input',
@@ -355,7 +355,7 @@ ng-forge unifies all four adapters under one shape: `addons: [{ slot, type, ... 
   addons: [
     { slot: 'prefix', type: 'bs-icon', icon: 'currency-euro' },
     { slot: 'suffix', type: 'text', text: 'EUR' },
-    // 'save' must be registered once via withAddonActions({ save: (ctx) => ... }) — see /addons/presets-and-actions.
+    // 'save' must be registered once via withAddonActions({ save: (ctx) => ... }); see /addons/presets-and-actions.
     { slot: 'suffix', type: 'bs-button', icon: 'save', ariaLabel: 'Save', actionRef: 'save' },
   ],
 }">
@@ -363,7 +363,7 @@ ng-forge unifies all four adapters under one shape: `addons: [{ slot, type, ... 
 
 <docs-code-compare
   title="Material addons"
-  formly="// ngx-formly (Material — demo wrapper only; users copy into their app)
+  formly="// ngx-formly (Material: demo wrapper only; users copy into their app)
 {
   key: 'search',
   type: 'input',
@@ -386,10 +386,10 @@ ng-forge unifies all four adapters under one shape: `addons: [{ slot, type, ... 
 
 **What's different:**
 
-- **JSON-safe by default.** ngx-formly's addon clicks are inline `onClick(field, $event) => void` functions — they can't live in JSON or a database. ng-forge addons are plain data; behavior is wired via `actionRef: 'name'` resolved against a registered handler map (`withAddonActions({...})`), so configs round-trip through JSON.
-- **Typed `type` per adapter.** ngx-formly addon props are typed loosely (`{ icon?, text?, class?, onClick? }`) and differ per adapter — Bootstrap uses `class`, Material's demo uses `icon` / `text`. ng-forge uses a discriminated union (`mat-icon | mat-button | bs-icon | bs-button | prime-icon | prime-button | ion-icon | ion-button` plus universal `text | template | component`) so the compiler knows which fields are valid for each adapter.
+- **JSON-safe by default.** ngx-formly's addon clicks are inline `onClick(field, $event) => void` functions; they can't live in JSON or a database. ng-forge addons are plain data; behavior is wired via `actionRef: 'name'` resolved against a registered handler map (`withAddonActions({...})`), so configs round-trip through JSON.
+- **Typed `type` per adapter.** ngx-formly addon props are typed loosely (`{ icon?, text?, class?, onClick? }`) and differ per adapter: Bootstrap uses `class`, Material's demo uses `icon` / `text`. ng-forge uses a discriminated union (`mat-icon | mat-button | bs-icon | bs-button | prime-icon | prime-button | ion-icon | ion-button` plus universal `text | template | component`) so the compiler knows which fields are valid for each adapter.
 - **Universal slot vocabulary.** ngx-formly mixes `addonLeft` / `addonRight` (Bootstrap, Material demo) with adapter-native slot names. ng-forge uses universal `slot: 'prefix' | 'suffix'` everywhere; the adapter translates that internally.
-- **Preset actions.** ng-forge ships `clear`, `reset`, `paste`, `copy`, `toggle-password-visibility` as declarative `preset` values. ngx-formly has nothing equivalent — every action is a hand-written callback.
+- **Preset actions.** ng-forge ships `clear`, `reset`, `paste`, `copy`, `toggle-password-visibility` as declarative `preset` values. ngx-formly has nothing equivalent; every action is a hand-written callback.
 - **First-class on all 4 adapters.** ngx-formly only ships addons for Bootstrap; Material is demo-only, PrimeNG / Ionic have nothing. ng-forge ships first-class addons for all four with a single config shape.
 - **Reactive `hidden` / `disabled` / `loading`.** Each axis accepts `boolean | Signal<boolean> | Observable<boolean>` (`DynamicValue<boolean>`). Neither ngx-formly's addon types nor its Material demo wrapper expose reactive visibility.
 
@@ -397,7 +397,7 @@ See [Addons / Overview](/addons/overview) and [Presets and Actions](/addons/pres
 
 ## Repeating sections / arrays
 
-**Formly has no built-in `repeat` type** — apps register a custom `FieldArrayType` with `add()` / `remove()` handlers and a template. ng-forge ships `type: 'array'` directly.
+**Formly has no built-in `repeat` type**: apps register a custom `FieldArrayType` with `add()` / `remove()` handlers and a template. ng-forge ships `type: 'array'` directly.
 
 <docs-code-compare
   title="Repeating array of items"
@@ -430,7 +430,7 @@ provideFormlyCore({
     ],
   },
 }"
-  ngforge="// Simplified form — pass a template, ng-forge auto-generates buttons
+  ngforge="// Simplified form: pass a template, ng-forge auto-generates buttons
 {
   key: 'tags',
   type: 'array',
@@ -440,7 +440,7 @@ provideFormlyCore({
   removeButton: { label: 'Remove' },
 }
 
-// Verbose form — full control over per-item layout and button placement
+// Verbose form: full control over per-item layout and button placement
 {
   key: 'tasks',
   type: 'array',
@@ -459,11 +459,11 @@ provideFormlyCore({
 }">
 </docs-code-compare>
 
-The verbose form gives you placeable button fields (`addArrayItem`, `prependArrayItem`, `insertArrayItem`, `removeArrayItem`, `popArrayItem`, `shiftArrayItem`) — put the add button anywhere, including outside the array.
+The verbose form gives you placeable button fields (`addArrayItem`, `prependArrayItem`, `insertArrayItem`, `removeArrayItem`, `popArrayItem`, `shiftArrayItem`): put the add button anywhere, including outside the array.
 
 ## Multi-step wizards
 
-Formly does not ship a wizard primitive — the canonical "stepper" example is a custom `FieldType` wrapping `mat-stepper`. ng-forge has a built-in `page` field type and `next` / `previous` button types that handle navigation, per-page validation, and disabled-when-invalid state.
+Formly does not ship a wizard primitive; the canonical "stepper" example is a custom `FieldType` wrapping `mat-stepper`. ng-forge has a built-in `page` field type and `next` / `previous` button types that handle navigation, per-page validation, and disabled-when-invalid state.
 
 ```typescript
 {
@@ -495,11 +495,11 @@ Formly does not ship a wizard primitive — the canonical "stepper" example is a
 } as const satisfies FormConfig;
 ```
 
-The form value stays flat — pages are a layout / navigation concern, not a value-shape concern.
+The form value stays flat: pages are a layout and navigation concern, not a value-shape concern.
 
 ## Async data and dynamic options
 
-Reactive options loading — populate a select from an HTTP call, or one select from another's value — is canonical in formly via `hooks.onInit` subscribing to `valueChanges`. In ng-forge it's a `derivation` with a `targetProperty` of `options`:
+Reactive options loading (populate a select from an HTTP call, or one select from another's value) is canonical in formly via `hooks.onInit` subscribing to `valueChanges`. In ng-forge it's a `derivation` with a `targetProperty` of `options`:
 
 <docs-code-compare
   title="Cascade: load departments after a company is picked"
@@ -570,17 +570,17 @@ For non-trivial derivations (HTTP, multiple async sources, debounce), use the lo
 
 Two related concerns: **schema-driven validation** (a schema enforces correctness) and **JSON-driven form generation** (the form structure itself comes from a serialized document, often a backend payload). ng-forge handles both.
 
-**Schema-driven validation.** ngx-formly canonically uses **JSON Schema** for validation via `@ngx-formly/core/json-schema`'s `FormlyJsonschema.toFieldConfig(schema)`. ng-forge integrates with the **[Standard Schema](https://standardschema.dev) spec** — Zod, Valibot, ArkType, and any other library that implements it — via `standardSchema(yourSchema)`.
+**Schema-driven validation.** ngx-formly canonically uses **JSON Schema** for validation via `@ngx-formly/core/json-schema`'s `FormlyJsonschema.toFieldConfig(schema)`. ng-forge integrates with the **[Standard Schema](https://standardschema.dev) spec**: Zod, Valibot, ArkType, and any other library that implements it plug in via `standardSchema(yourSchema)`.
 
-**JSON-driven form generation.** ng-forge's `FormConfig` **is itself a JSON-serializable document** — you can author it as JSON, ship it from a backend, hydrate it on the client. There's no conversion step. If your backend currently emits JSON Schemas to drive formly, you have three options:
+**JSON-driven form generation.** ng-forge's `FormConfig` **is itself a JSON-serializable document**: you can author it as JSON, ship it from a backend, hydrate it on the client. There's no conversion step. If your backend currently emits JSON Schemas to drive formly, you have three options:
 
-1. **Have the backend emit `FormConfig` directly** — most ergonomic; your API now ships ng-forge schemas as JSON.
+1. **Have the backend emit `FormConfig` directly**: most ergonomic; your API now ships ng-forge schemas as JSON.
 2. **Generate `FormConfig` from your OpenAPI 3.x spec at build time** via `@ng-forge/openapi-generator`. Best when the spec is your source of truth.
-3. **Run a one-time `JSON Schema → FormConfig` conversion** during your migration. The two formats are structurally similar; a small adapter (~200 LOC) covers most apps.
+3. **Run a one-time JSON Schema to `FormConfig` conversion** during your migration. The two formats are structurally similar; a small adapter (~200 LOC) covers most apps.
 
 <docs-code-compare
   title="Schema-driven validation"
-  formly="// JSON Schema → FormlyFieldConfig
+  formly="// JSON Schema to FormlyFieldConfig
 import { FormlyJsonschema } from '@ngx-formly/core/json-schema';
 
 const schema = {
@@ -615,13 +615,13 @@ const config = {
 
 ## Things that work differently
 
-- **Strings → structured config.** `'model.foo === "bar"'` becomes a `fieldValue` condition object (or a `javascript` escape-hatch string for genuinely complex expressions).
-- **Hooks → Angular lifecycle + EventBus.** `hooks.onInit` / `onDestroy` map to `effect()` / `OnDestroy` inside a custom field. Cross-field coordination uses the [EventBus / EventDispatcher](/recipes/events).
-- **Dependency tracking.** `fieldValue` conditions and shorthand `derivation` strings auto-detect the field paths they read. Custom-function and HTTP variants need an explicit `dependsOn: [...]` because the engine can't introspect those bodies.
-- **`templateOptions` cascading.** Formly inherits `props` through `defaultOptions` and `extends` chains. ng-forge has form-level `defaultProps` and adapter-level defaults, but no per-type inheritance — type-level defaults become a wrapper or a custom field component instead.
+- **Strings become structured config.** `'model.foo === "bar"'` becomes a `fieldValue` condition object (or a `javascript` escape-hatch string for genuinely complex expressions).
+- **Hooks become Angular lifecycle + EventBus.** `hooks.onInit` / `onDestroy` map to `effect()` / `OnDestroy` inside a custom field. Cross-field coordination uses the [EventBus / EventDispatcher](/recipes/events).
+- **Dependency tracking.** `fieldValue` conditions and shorthand `derivation` strings auto-detect the field paths they read. HTTP and async variants require an explicit `dependsOn: [...]` (enforced at init); sync custom-function derivations accept it optionally and otherwise re-run on every form change.
+- **`templateOptions` cascading.** Formly inherits `props` through `defaultOptions` and `extends` chains. ng-forge has form-level `defaultProps` and adapter-level defaults, but no per-type inheritance; type-level defaults become a wrapper or a custom field component instead.
 - **Wrappers carry their own props.** Wrapper config objects own their props (`{ type: 'panel', title: 'Address' }`), so the wrapped field doesn't need to know it has a wrapper.
 - **`parsers`, `modelOptions.debounce`, `focus: true`.** No direct per-field knobs. Workarounds: a self-targeting `derivation` with `trigger: 'debounced'` covers `parsers`-style transforms; consumers (conditions, derivations) debounce via `debounceMs`; programmatic focus is a `viewChild` + `.nativeElement.focus()` in the host component.
-- **`modelOptions.updateOn: 'blur' | 'submit'`.** No equivalent today — `LogicTrigger` only exposes `'onChange' | 'debounced'`, and the Signal Forms substrate commits on every change. If formly's commit-on-blur was load-bearing for your form, debouncing the consumers (validators, derivations) is the closest workaround. This is a hard wall, not a knob.
+- **`modelOptions.updateOn: 'blur' | 'submit'`.** No equivalent today: `LogicTrigger` only exposes `'onChange' | 'debounced'`, and the Signal Forms substrate commits on every change. If formly's commit-on-blur was load-bearing for your form, debouncing the consumers (validators, derivations) is the closest workaround. This is a hard wall, not a knob.
 
 ## What ng-forge does NOT have an equivalent for
 
@@ -629,10 +629,10 @@ If any of these are blockers, decide upfront before starting the migration.
 
 - **`FormlyJsonschema.toFieldConfig(schema)` as a runtime converter.** No 1:1. See [Schema validation](#schema-validation-and-json-driven-forms) for the three migration paths.
 - **A community plugin / extension ecosystem.** Formly has a long tail of community-built field types and extensions; ng-forge currently has only the four official UI adapters and the OpenAPI / MCP packages.
-- **Two-or-more-dot prop paths in derivations.** Formly's `expressions: { 'props.config.foo': '…' }` lets you compute any nested prop. ng-forge supports up to one level (`options`, `label`, `disabled`, `props.minDate`, …) and **throws `DynamicFormError` at form-initialisation time** if the path goes deeper — restructure your prop shape so the dynamic value sits at the top of `props`, or move the dynamic computation into a custom field component.
+- **Two-or-more-dot prop paths in derivations.** Formly's `expressions: { 'props.config.foo': '…' }` lets you compute any nested prop. ng-forge supports up to one level (`options`, `label`, `disabled`, `props.minDate`, …) and **throws `DynamicFormError` at runtime, when the derived value is applied to the field,** if the path goes deeper. Restructure your prop shape so the dynamic value sits at the top of `props`, or move the dynamic computation into a custom field component.
 - **Custom `valueProp` / `labelProp` for selects.** ng-forge's `FieldOption` is fixed at `{ value, label, disabled? }`; remap source data with `.map()` or a `targetProperty: 'options'` derivation.
-- **`extensions` API for cross-cutting field-construction hooks.** Formly's extensions can mutate every field's config during construction. ng-forge has no public equivalent — those concerns become wrappers, custom field components, or build-time codegen.
-- **Maturity at scale.** ngx-formly has been in production for years; ng-forge is younger — fewer Stack Overflow answers, fewer copy-paste solutions on the long tail. The [MCP server](/ai-integration) and [Discord](https://discord.gg/qpzzvFagj3) help, but they don't replace years of community-tested patterns.
+- **`extensions` API for cross-cutting field-construction hooks.** Formly's extensions can mutate every field's config during construction. ng-forge has no public equivalent; those concerns become wrappers, custom field components, or build-time codegen.
+- **Maturity at scale.** ngx-formly has been in production for years; ng-forge is younger, with fewer Stack Overflow answers and fewer copy-paste solutions on the long tail. The [MCP server](/ai-integration) and [Discord](https://discord.gg/qpzzvFagj3) help, but they don't replace years of community-tested patterns.
 
 ## OpenAPI generator
 
@@ -640,20 +640,20 @@ If your formly forms are driven by an OpenAPI 3.x spec, `@ng-forge/openapi-gener
 
 ## Performance
 
-ng-forge is **built for zoneless** — every default component runs `ChangeDetectionStrategy.OnPush` and the value/validity/dirty-tracking layer is signal-driven, so there is no whole-tree change-detection cycle on every input event the way zone.js + Reactive Forms triggers one. The renderer also uses stable `track` keys on every `@for`, preserves field-instance identity across config updates so unchanged fields don't re-render, defers non-adjacent pages in multi-step forms via `@defer (on idle)`, and updates arrays differentially (appending an item only renders the new one).
+The state layer (value, validity, dirty tracking) is built on signals, and every shipped component uses `ChangeDetectionStrategy.OnPush`, so a value change re-renders only the components that read the affected state. Where formly re-evaluates its field expressions across the whole form on model changes, ng-forge re-runs only the conditions and derivations whose dependencies changed. OnPush and zoneless are complementary here: OnPush narrows how much work each change triggers, zoneless removes zone.js scheduling on top, and since nothing in ng-forge relies on zone.js it runs unchanged under `provideZonelessChangeDetection()`. The renderer also uses stable `track` keys on its `@for` loops, preserves field-instance identity across config updates so unchanged fields don't re-render, defers non-adjacent pages in multi-step forms via `@defer (on idle)`, and updates arrays differentially (appending an item only renders the new one).
 
 <docs-perf-pipeline></docs-perf-pipeline>
 
 ## FAQ
 
 **Can I run both libraries side by side during a migration?**
-Yes. They don't conflict — different package names, different injection tokens, different component selectors. Install ng-forge, port one form at a time, deprecate formly only when nothing imports `@ngx-formly/*`.
+Yes. They don't conflict: different package names, different injection tokens, different component selectors. Install ng-forge, port one form at a time, deprecate formly only when nothing imports `@ngx-formly/*`.
 
-**Does ng-forge support Angular 21?**
-Yes — ng-forge requires Angular 21+ as its baseline (signal-native APIs depend on it). If you're on Angular 20 or earlier, migrating to ng-forge implies an Angular upgrade first.
+**Which Angular versions does ng-forge support?**
+Angular 22. The published packages declare `@angular/*` peer dependencies of `~22.0.0` (Signal Forms became stable in Angular 22). If you're on Angular 21 or earlier, migrating to ng-forge implies an Angular upgrade first.
 
 **Does ng-forge use Reactive Forms (`FormGroup` / `FormControl`)?**
-No. ng-forge is built on Angular **Signal Forms** (`@angular/forms/signals`), a separate system with a different primitive — `FieldTree<T>` — that holds value, validity, dirty/touched state, and errors as signals. There is no `FormGroup` or `FormControl` involved. If your formly app exposes a `formGroup` to consumers (template parents, services, etc.), those touch-points have no direct equivalent and need to be rewritten against the Signal Forms surface.
+No. ng-forge is built on Angular **Signal Forms** (`@angular/forms/signals`), a separate system whose primitive, `FieldTree<T>`, holds value, validity, dirty/touched state, and errors as signals. There is no `FormGroup` or `FormControl` involved. If your formly app exposes a `formGroup` to consumers (template parents, services, etc.), those touch-points have no direct equivalent and need to be rewritten against the Signal Forms surface.
 
 **How do I report bugs / get help?**
 Open an issue at [github.com/ng-forge/ng-forge](https://github.com/ng-forge/ng-forge/issues) or join [Discord](https://discord.gg/qpzzvFagj3). For evaluation help, the [MCP server](/ai-integration) lets an LLM in your IDE scaffold configs for you.
@@ -664,17 +664,17 @@ An order that works for porting a non-trivial app:
 
 1. **Audit blockers** against [What ng-forge does NOT have an equivalent for](#what-ng-forge-does-not-have-an-equivalent-for). Decide upfront whether you'll work around or stay.
 2. **Install ng-forge** and the matching UI adapter (see [Setup](#setup)). Both libraries can coexist.
-3. **Port one read-only form first** — typically a settings page or a profile form. Fewer moving parts; easier sanity check.
+3. **Port one read-only form first**: typically a settings page or a profile form. Fewer moving parts; easier sanity check.
 4. **Translate validators next.** Centralise custom validators on a single `customFnConfig` object you can import everywhere.
 5. **Translate forms in dependency order.** Forms with no cross-form coupling first; complex multi-step / array-heavy ones last.
 6. **Remove formly when nothing imports `@ngx-formly/*`.** `pnpm uninstall @ngx-formly/core @ngx-formly/<theme>` and clean up `provideFormlyCore`.
 
-**Rough effort estimate.** Plan ~half a day per simple form (a login, a profile, a contact form), and ~1–2 days per non-trivial form (multi-step wizards, custom field types, schema-driven forms with non-trivial cross-field validators, anything with custom wrappers or extension hooks). Plus an extra pass for performance verification on array-heavy forms — this is one of the cases where you should see meaningful improvement coming from formly. There is no automated migration tool today; port manually.
+**Rough effort estimate.** Plan ~half a day per simple form (a login, a profile, a contact form), and ~1–2 days per non-trivial form (multi-step wizards, custom field types, schema-driven forms with non-trivial cross-field validators, anything with custom wrappers or extension hooks). Plus an extra pass for performance verification on array-heavy forms; this is one of the cases where you should see meaningful improvement coming from formly. There is no automated migration tool today; port manually.
 
 ## Next steps
 
-- **[Getting started](/getting-started)** — install ng-forge, pick an adapter, render a form.
-- **[Configuration](/configuration)** — `defaultProps`, global validators, schema integration.
-- **[Examples](/examples)** — complete working forms covering most patterns above.
-- **[OpenAPI generator](/openapi-generator)** — for backend-driven forms.
-- **[AI integration (MCP)](/ai-integration)** — scaffold configs from your IDE.
+- **[Getting started](/getting-started)**: install ng-forge, pick an adapter, render a form.
+- **[Configuration](/configuration)**: `defaultProps`, global validators, schema integration.
+- **[Examples](/examples)**: complete working forms covering most patterns above.
+- **[OpenAPI generator](/openapi-generator)**: for backend-driven forms.
+- **[AI integration (MCP)](/ai-integration)**: scaffold configs from your IDE.

--- a/apps/docs/public/content/openapi-generator.md
+++ b/apps/docs/public/content/openapi-generator.md
@@ -6,7 +6,7 @@ description: 'Generate @ng-forge/dynamic-forms FormConfig objects and TypeScript
 
 # OpenAPI Generator
 
-The `@ng-forge/openapi-generator` reads your OpenAPI 3.x spec and produces ready-to-use `FormConfig` objects and TypeScript interfaces. No manual field wiring — your API contract drives your forms.
+The `@ng-forge/openapi-generator` reads your OpenAPI 3.x spec and produces ready-to-use `FormConfig` objects and TypeScript interfaces. No manual field wiring: your API contract drives your forms.
 
 **Key features:**
 
@@ -134,19 +134,20 @@ Both directories include barrel `index.ts` files for convenient imports.
 ng-forge-generator [options]
 ```
 
-| Flag                   | Type                 | Default        | Description                                                             |
-| ---------------------- | -------------------- | -------------- | ----------------------------------------------------------------------- |
-| `--spec <path>`        | `string`             | **(required)** | Path to OpenAPI 3.x spec file (JSON or YAML)                            |
-| `--output <path>`      | `string`             | **(required)** | Output directory for generated files                                    |
-| `--interactive <mode>` | `'full'` \| `'none'` | `'full'`       | `'full'` prompts for ambiguous fields; `'none'` uses defaults           |
-| `--endpoints <list>`   | `string`             | —              | Comma-separated endpoints: `POST:/pets,GET:/pets/{id}`                  |
-| `--read-only`          | `boolean`            | `false`        | Generate GET endpoint forms with all fields disabled                    |
-| `--watch`              | `boolean`            | `false`        | Watch spec file and regenerate on changes                               |
-| `--config <path>`      | `string`             | `<output>`     | Directory containing `.ng-forge-generator.json`                         |
-| `--dry-run`            | `boolean`            | `false`        | List files that would be generated without writing them                 |
-| `--skip-existing`      | `boolean`            | `false`        | Skip files that already exist on disk                                   |
-| `--verbose`            | `boolean`            | `false`        | Show detailed output including field mapping decisions                  |
-| `--quiet`              | `boolean`            | `false`        | Suppress info output; still shows success summary, warnings, and errors |
+| Flag                       | Type                 | Default        | Description                                                                                      |
+| -------------------------- | -------------------- | -------------- | ------------------------------------------------------------------------------------------------ |
+| `--spec <path>`            | `string`             | **(required)** | Path to OpenAPI 3.x spec file (JSON or YAML)                                                     |
+| `--output <path>`          | `string`             | **(required)** | Output directory for generated files                                                             |
+| `--interactive <mode>`     | `'full'` \| `'none'` | `'full'`       | `'full'` prompts for ambiguous fields; `'none'` uses defaults                                    |
+| `--endpoints <list>`       | `string`             | _(none)_       | Comma-separated endpoints: `POST:/pets,GET:/pets/{id}`                                           |
+| `--read-only`              | `boolean`            | `false`        | Generate GET endpoint forms with all fields disabled                                             |
+| `--watch`                  | `boolean`            | `false`        | Watch spec file and regenerate on changes                                                        |
+| `--config <path>`          | `string`             | `<output>`     | Directory containing `.ng-forge-generator.json`                                                  |
+| `--dry-run`                | `boolean`            | `false`        | List files that would be generated without writing them                                          |
+| `--skip-existing`          | `boolean`            | `false`        | Skip files that already exist on disk                                                            |
+| `--barrel-extension <ext>` | `string`             | `""`           | Extension used in barrel file exports, e.g. `.js` for Node ESM; empty for bundler/Angular setups |
+| `--verbose`                | `boolean`            | `false`        | Show detailed output including field mapping decisions                                           |
+| `--quiet`                  | `boolean`            | `false`        | Suppress info output; still shows success summary, warnings, and errors                          |
 
 ## OpenAPI to Field Type Mapping
 
@@ -156,13 +157,13 @@ The generator maps OpenAPI schema types and formats to `@ng-forge/dynamic-forms`
 | -------------------- | -------------------- | ---------------- | ---------------------- |
 | `string`             | `email`              | `input`          | `{ type: 'email' }`    |
 | `string`             | `uri` / `url`        | `input`          | `{ type: 'url' }`      |
-| `string`             | `date` / `date-time` | `datepicker`     | —                      |
+| `string`             | `date` / `date-time` | `datepicker`     | _(none)_               |
 | `string`             | `password`           | `input`          | `{ type: 'password' }` |
 | `string`             | _(none)_             | `input`          | `{ type: 'text' }`     |
-| `string`             | + `enum`             | `select`         | —                      |
+| `string`             | + `enum`             | `select`         | _(none)_               |
 | `integer` / `number` | _(any)_              | `input`          | `{ type: 'number' }`   |
-| `boolean`            | _(any)_              | `checkbox`       | —                      |
-| `array`              | + enum items         | `multi-checkbox` | —                      |
+| `boolean`            | _(any)_              | `checkbox`       | _(none)_               |
+| `array`              | + enum items         | `multi-checkbox` | _(none)_               |
 | `array`              | + object items       | `array`          | _(container)_          |
 | `object`             | _(any)_              | `group`          | _(container)_          |
 
@@ -176,7 +177,7 @@ OpenAPI nullability is preserved end-to-end:
 | 3.1          | `{ type: ['string', 'null'] }`       | `nullable: true`              |
 | Either       | `{ nullable: true, default: null }`  | `nullable: true, value: null` |
 
-See [Configuration → Nullable values](/configuration#nullable-values) for runtime behavior and the read-side caveat.
+See [Nullable values in Configuration](/configuration#nullable-values) for runtime behavior and the read-side caveat.
 
 ### Ambiguous Field Types
 
@@ -197,13 +198,13 @@ OpenAPI schema constraints map directly to `@ng-forge/dynamic-forms` validators:
 
 | OpenAPI Property          | Validator   | Value        |
 | ------------------------- | ----------- | ------------ |
-| Field in `required` array | `required`  | —            |
+| Field in `required` array | `required`  | _(none)_     |
 | `minLength`               | `minLength` | number       |
 | `maxLength`               | `maxLength` | number       |
 | `minimum`                 | `min`       | number       |
 | `maximum`                 | `max`       | number       |
 | `pattern`                 | `pattern`   | regex string |
-| `format: 'email'`         | `email`     | —            |
+| `format: 'email'`         | `email`     | _(none)_     |
 
 ## Schema Support
 
@@ -240,13 +241,13 @@ The generator persists your choices in `.ng-forge-generator.json`:
 }
 ```
 
-On subsequent runs, persisted decisions are reused — so interactive prompts only appear for new or changed fields.
+On subsequent runs, persisted decisions are reused, so interactive prompts only appear for new or changed fields.
 
 ## Interactive vs Non-Interactive Mode
 
-**Interactive (`--interactive full`)** — the default:
+**Interactive (`--interactive full`)** is the default:
 
-1. Prompts you to select which endpoints to generate forms for (POST/PUT/PATCH are pre-selected, GET is unchecked)
+1. Prompts you to select which endpoints to generate forms for (all endpoints are pre-selected; uncheck the ones you don't want)
 2. Prompts for each ambiguous field type choice
 3. Saves decisions to the config file
 
@@ -254,7 +255,7 @@ On subsequent runs, persisted decisions are reused — so interactive prompts on
 
 - Uses all endpoints, or filters by `--endpoints` flag
 - Uses default field type choices for ambiguous fields
-- No prompts — suitable for CI/CD pipelines
+- No prompts, suitable for CI/CD pipelines
 
 ## Watch Mode
 
@@ -287,7 +288,7 @@ Generated files follow this layout:
     └── index.ts
 ```
 
-File names are derived from `operationId` if available, otherwise from the HTTP method and path (e.g. `POST /pets/{id}/tags` → `post-pets-by-id-tags`).
+File names are derived from `operationId` if available, otherwise from the HTTP method and path (e.g. `POST /pets/{id}/tags` becomes `post-pets-by-id-tags`).
 
 ## GET Endpoints
 

--- a/apps/docs/public/content/prebuilt/container-field.md
+++ b/apps/docs/public/content/prebuilt/container-field.md
@@ -1,15 +1,15 @@
 ---
 title: Container Fields
 slug: prebuilt/container-field
-description: 'Wrap a group of fields in a chain of wrapper components — titled sections, cards, collapsible panels — without adding nesting to your form values.'
+description: 'Wrap a group of fields in a chain of wrapper components (titled sections, cards, collapsible panels) without adding nesting to your form values.'
 ---
 
-A `container` is a layout-only field that chains [wrapper components](/wrappers/overview) around its children. It gives you a place to stack wrappers without the wrappers having to know about each other — no form nesting, no new form context, values flatten to the parent just like a [row](/prebuilt/form-rows).
+A `container` is a layout-only field that chains [wrapper components](/wrappers/overview) around its children. It gives you a place to stack wrappers without the wrappers having to know about each other: no form nesting, no new form context, values flatten to the parent just like a [row](/prebuilt/form-rows).
 
 ## When to reach for a container
 
 - You want one wrapper (or several stacked) around a **group of sibling fields**, not a single field.
-- You don't want a new form key or nested value shape — the fields should flatten.
+- You don't want a new form key or nested value shape; the fields should flatten.
 - You want a purely visual grouping: a section header, a card, a collapsible panel.
 
 If you need a nested value shape (e.g. `user.address.street`), use a [form group](/prebuilt/form-groups) instead. If you only need horizontal layout, use a [form row](/prebuilt/form-rows).
@@ -46,6 +46,8 @@ The `wrappers` array chains outermost-first: the first wrapper wraps everything 
 }
 ```
 
+> The `section` wrapper used in the examples on this page is a custom wrapper shown for illustration; it must be registered before use. Only the `css` and `row` wrappers ship built in.
+
 See [Writing a Wrapper](/wrappers/writing-a-wrapper) for how to build your own, and [Registering and Applying](/wrappers/registering-and-applying) for how to make a custom wrapper type available.
 
 ## Container vs row vs group
@@ -56,7 +58,7 @@ See [Writing a Wrapper](/wrappers/writing-a-wrapper) for how to build your own, 
 | [`group`](/prebuilt/form-groups)         | Yes (under `key`)  | No                 | No             |
 | [`container`](/prebuilt/container-field) | No (flat)          | No                 | Yes (explicit) |
 
-A `row` is itself a container-field under the hood — the `row` type resolves to the container renderer with an auto-injected `row` wrapper. Keep writing `type: 'row'` for horizontal layouts; use `type: 'container'` when the wrappers are the point.
+A `row` is itself a container-field under the hood: the `row` type resolves to the container renderer with an auto-injected `row` wrapper. Keep writing `type: 'row'` for horizontal layouts; use `type: 'container'` when the wrappers are the point.
 
 ## Value Structure
 
@@ -89,7 +91,7 @@ The `key` on the container itself is used for DOM id / test selectors only. It n
 
 ## Nesting Rules
 
-Containers follow the same rules as rows — they are layout-only.
+Containers follow the same rules as rows: they are layout-only.
 
 **Containers can appear inside:**
 
@@ -98,10 +100,7 @@ Containers follow the same rules as rows — they are layout-only.
 - Groups
 - Array items
 
-**Containers cannot appear inside:**
-
-- Rows
-- Other containers _(treat each container as a single wrapping layer — stack wrappers on one container instead)_
+The types also allow containers inside rows and inside other containers. Treat each container as a single wrapping layer; in most cases, stacking wrappers on one container is clearer than nesting containers.
 
 **Containers can contain:**
 
@@ -175,7 +174,7 @@ export class ProfileFormComponent {
 }
 ```
 
-The resulting form value is flat — containers contribute structure to the UI, not the data:
+The resulting form value is flat: containers contribute structure to the UI, not the data.
 
 ```typescript
 {
@@ -188,8 +187,8 @@ The resulting form value is flat — containers contribute structure to the UI, 
 
 ## Next Steps
 
-- **[Wrappers Overview](/wrappers/overview)** — what wrappers are and when to use them
-- **[Writing a Wrapper](/wrappers/writing-a-wrapper)** — build your own wrapper component
-- **[Registering and Applying](/wrappers/registering-and-applying)** — make a custom wrapper type available
-- **[Form Rows](/prebuilt/form-rows)** — horizontal layout without a wrapper chain
-- **[Form Groups](/prebuilt/form-groups)** — add a nested value shape instead of flattening
+- **[Wrappers Overview](/wrappers/overview)**: what wrappers are and when to use them
+- **[Writing a Wrapper](/wrappers/writing-a-wrapper)**: build your own wrapper component
+- **[Registering and Applying](/wrappers/registering-and-applying)**: make a custom wrapper type available
+- **[Form Rows](/prebuilt/form-rows)**: horizontal layout without a wrapper chain
+- **[Form Groups](/prebuilt/form-groups)**: add a nested value shape instead of flattening

--- a/apps/docs/public/content/prebuilt/form-arrays/complete.md
+++ b/apps/docs/public/content/prebuilt/form-arrays/complete.md
@@ -16,8 +16,8 @@ Arrays create dynamic collections of field values. Each item in the `fields` arr
 
 The `fields` property supports two item formats:
 
-- **Single FieldDef** (not wrapped in array) → **Primitive item** - extracts field value directly
-- **Array of FieldDefs** → **Object item** - merges fields into an object
+- **Single FieldDef** (not wrapped in an array) creates a **primitive item**: the field value is extracted directly
+- **Array of FieldDefs** creates an **object item**: the fields are merged into an object
 
 ```typescript
 // Primitive array: ['angular', 'typescript']
@@ -278,8 +278,8 @@ For more control, use the `arrayEvent` builder to dispatch array operations dire
 
 **Which API to use depends on where your code lives:**
 
-- **Inside a custom field component** → inject `EventBus` (it is scoped to the form's DI tree)
-- **From a host/parent component** → provide and inject `EventDispatcher` (see [Events](/recipes/events))
+- **Inside a custom field component**: inject `EventBus` (it is scoped to the form's DI tree)
+- **From a host/parent component**: provide and inject `EventDispatcher` (see [Events](/recipes/events))
 
 **From a host component (most common case):**
 
@@ -364,9 +364,9 @@ Arrays are ideal for:
 - Dynamic collections where items can be added/removed
 - Collection-based data structures where order matters
 
-## Complete Example: Primitive Array with Initial Values
+## Complete Example: Object Array with Row Items
 
-Here's a complete working example of a primitive array field (simple value list) with initial values and declarative add/remove buttons:
+Here's a complete working example of a tag list with initial values and declarative add/remove buttons. Each item is a row wrapping an input and a remove button; rows flatten, so each item produces an object like `{ value: 'featured' }`:
 
 ```typescript
 import { FormConfig } from '@ng-forge/dynamic-forms';
@@ -433,7 +433,7 @@ const formConfig = {
   ],
 } as const satisfies FormConfig;
 
-// Form value: { tags: [{ tag: { value: 'featured' } }, { tag: { value: 'popular' } }] }
+// Form value: { tags: [{ value: 'featured' }, { value: 'popular' }] }
 ```
 
 ## Complete Example: Object Array with Initial Values
@@ -566,9 +566,9 @@ Arrays **cannot** contain:
 
 Arrays can contain these field types:
 
-- Leaf fields (input, select, checkbox, etc.) -> creates flat or object arrays
-- Group fields with key -> creates nested object arrays `[{groupKey: {...}}, ...]`
-- Row fields -> creates flat object arrays `[{...}, {...}]` (rows don't add nesting)
+- Leaf fields (input, select, checkbox, etc.), which create flat or object arrays
+- Group fields with a key, which create nested object arrays `[{groupKey: {...}}, ...]`
+- Row fields, which create flat object arrays `[{...}, {...}]` (rows don't add nesting)
 - Button fields (for remove operations inside each item)
 
 See [Type Safety & Inference](/recipes/type-safety) for details on how arrays affect type inference.
@@ -596,7 +596,7 @@ Array containers support the `logic` property to conditionally show or hide the 
 
 When the array is hidden, all items and add/remove buttons are hidden with it. Only `'hidden'` is supported as a logic type on containers.
 
-For all available condition types and operators, see [Conditional Logic](/dynamic-behavior/overview).
+For all available condition types and operators, see [Conditional Logic](/dynamic-behavior/conditional-logic).
 
 ## When to Use the Complete API
 

--- a/apps/docs/public/content/prebuilt/form-arrays/simplified.md
+++ b/apps/docs/public/content/prebuilt/form-arrays/simplified.md
@@ -14,7 +14,7 @@ The simplified array API provides a concise way to define dynamic arrays. Instea
 
 ## Overview
 
-The simplified API uses two key properties:
+The simplified API is built around `template` and `value`, plus optional `minLength`/`maxLength`:
 
 | Property    | Description                                                                |
 | ----------- | -------------------------------------------------------------------------- |
@@ -177,7 +177,7 @@ Set `addButton: false` or `removeButton: false` to suppress the corresponding au
 }
 ```
 
-When `removeButton: false` is set for a primitive array, each item renders as a plain field without being wrapped in a row. When set for an object array, the remove button is simply omitted from the item's field list.
+Setting `removeButton: false` simply omits the auto-generated remove control. Primitive items always render as plain fields, never wrapped in a row; for object arrays, the remove button is omitted from the item's field list.
 
 ## Complete Example: Primitive Array
 
@@ -318,6 +318,5 @@ Simplified arrays support `logic` for conditional visibility, just like the comp
 | Custom button placement (buttons outside array) | Complete        |
 | Programmatic control via EventDispatcher        | Complete        |
 | Multiple add buttons (append, prepend, insert)  | Complete        |
-| Nested arrays inside item templates             | Complete        |
 
 As a rule of thumb: **start with the simplified API**. If you hit a limitation, switch to the [complete API](/prebuilt/form-arrays/complete).

--- a/apps/docs/public/content/prebuilt/form-groups.md
+++ b/apps/docs/public/content/prebuilt/form-groups.md
@@ -165,10 +165,10 @@ Group containers support the `logic` property to conditionally show or hide the 
 
 When the group is hidden, all its nested fields are hidden with it. Only `'hidden'` is supported as a logic type on containers (not `required`, `readonly`, or `disabled`).
 
-For all available condition types and operators, see [Conditional Logic](/dynamic-behavior/overview).
+For all available condition types and operators, see [Conditional Logic](/dynamic-behavior/conditional-logic).
 
 ## Next Steps
 
-- **[Form Rows](/prebuilt/form-rows)** — Arrange fields side-by-side in horizontal layouts
-- **[Form Pages](/prebuilt/form-pages)** — Build multi-step wizard forms with page navigation
-- **[Form Arrays](/prebuilt/form-arrays/simplified)** — Create repeating sections with dynamic add/remove
+- **[Form Rows](/prebuilt/form-rows)**: Arrange fields side-by-side in horizontal layouts
+- **[Form Pages](/prebuilt/form-pages)**: Build multi-step wizard forms with page navigation
+- **[Form Arrays](/prebuilt/form-arrays/simplified)**: Create repeating sections with dynamic add/remove

--- a/apps/docs/public/content/prebuilt/form-pages.md
+++ b/apps/docs/public/content/prebuilt/form-pages.md
@@ -4,7 +4,7 @@ slug: prebuilt/form-pages
 description: 'Build multi-step wizard forms with page fields. Automatically enables paged mode with navigation controls and per-page validation.'
 ---
 
-Create multi-step forms by using page fields. When your form contains page fields, it automatically enters "paged mode" and renders with navigation controls.
+Create multi-step forms by using page fields. When your form contains page fields, it automatically enters "paged mode" and shows one page at a time. Navigation is added as `next` and `previous` button fields inside each page.
 
 ## Basic Multi-Step Form
 
@@ -20,6 +20,7 @@ Create a multi-step form by adding multiple page fields to your form configurati
         { key: 'accountTitle', type: 'text', label: 'Account Information', props: { elementType: 'h3' } },
         { key: 'username', type: 'input', label: 'Username', value: '', required: true },
         { key: 'password', type: 'input', label: 'Password', value: '', props: { type: 'password' }, required: true },
+        { key: 'accountNext', type: 'next', label: 'Continue' },
       ],
     },
     {
@@ -29,6 +30,8 @@ Create a multi-step form by adding multiple page fields to your form configurati
         { key: 'profileTitle', type: 'text', label: 'Profile Details', props: { elementType: 'h3' } },
         { key: 'firstName', type: 'input', label: 'First Name', value: '' },
         { key: 'lastName', type: 'input', label: 'Last Name', value: '' },
+        { key: 'profilePrevious', type: 'previous', label: 'Back' },
+        { key: 'submit', type: 'submit', label: 'Create Account' },
       ],
     },
   ],
@@ -43,7 +46,7 @@ Each page field supports:
 - `type: 'page'` (required) - Field type identifier
 - `fields` (required) - Array of child fields to render on this page
 
-## Page with Description
+## Example: Preferences Page
 
 ```typescript
 {
@@ -61,13 +64,13 @@ Each page field supports:
 When your form contains page fields:
 
 - **Automatic Detection**: Form automatically enters "paged mode"
-- **Navigation Controls**: Previous/Next buttons are rendered automatically
+- **Navigation Controls**: Add `next` and `previous` button fields inside each page to move between pages
 - **Validation**: Users must complete required fields before advancing to the next page
 - **Single Page View**: Only one page is visible at a time
 
 ## Performance & Lazy Loading
 
-ng-forge uses Angular's `@defer` blocks with smart prefetching to optimize page rendering while maintaining flicker-free navigation.
+ng-forge renders the current and adjacent pages immediately and defers distant pages until the browser is idle, keeping navigation flicker free.
 
 ### How It Works
 
@@ -76,7 +79,7 @@ The page orchestrator uses a **2-tier loading strategy**:
 **Tier 1: Current + Adjacent Pages (±1)**
 
 - Render immediately using `@defer (on immediate)`
-- Initially, only 3 pages load (current + 2 adjacent)
+- Only the current page and its immediate neighbors render immediately (2 pages on load, up to 3 mid-form)
 - Adjacent pages are fully rendered but hidden with `display: none`
 - Ensures zero flicker when navigating forward/backward
 
@@ -102,10 +105,8 @@ fields: [
 
 **Performance advantages:**
 
-- ⚡ **Zero navigation flicker** - Adjacent pages already rendered
-- 🚀 **Faster initial load** - Only 3 pages render immediately, distant pages defer until idle
-- ⏱️ **Better Time to Interactive (TTI)** - Reduced initial JavaScript parsing/compilation
-- 📱 **Mobile-friendly** - Lower startup cost on slower devices
+- **No navigation flicker**: adjacent pages are already rendered
+- **Less initial rendering work**: distant pages defer until the browser is idle
 
 **Note:** Once loaded, pages remain in the DOM (hidden with CSS). The primary benefit is optimizing **initial load performance**, not ongoing memory usage.
 
@@ -161,6 +162,8 @@ Pages can contain:
 - Leaf fields (input, select, checkbox, etc.)
 - Row fields (for horizontal layouts)
 - Group fields (for nested data structures)
+- Array fields (for repeating sections)
+- Container fields (for wrapper chains)
 
 ## Conditional Visibility
 
@@ -170,7 +173,6 @@ Pages support the `logic` property to conditionally skip a page (hide it from th
 {
   key: 'businessDetails',
   type: 'page',
-  label: 'Business Details',
   logic: [{
     type: 'hidden',
     condition: {
@@ -187,21 +189,21 @@ Pages support the `logic` property to conditionally skip a page (hide it from th
 }
 ```
 
-When a page is hidden, it is excluded from the multi-step navigation — users skip directly past it. Only `'hidden'` is supported as a logic type on containers.
+When a page is hidden, it is excluded from the multi-step navigation; users skip directly past it. Only `'hidden'` is supported as a logic type on containers.
 
-For all available condition types and operators, see [Conditional Logic](/dynamic-behavior/overview).
+For all available condition types and operators, see [Conditional Logic](/dynamic-behavior/conditional-logic).
 
 ## CSS Classes
 
 Page fields use these classes for styling:
 
-- `.df-page` - Applied to the page container
+- `.df-page-orchestrator` - Applied to the host element that wraps all pages
+- `.df-page-field` - Applied to each page field component
 - `.df-page-visible` - Applied to the currently visible page
 - `.df-page-hidden` - Applied to hidden pages
-- `.df-page-field` - Applied to the page field component
 
 ## Next Steps
 
-- **[Form Arrays](/prebuilt/form-arrays/simplified)** — Create repeating sections with add/remove controls
-- **[Dynamic Behavior](/dynamic-behavior/overview)** — Conditional logic, value derivation, and form submission
-- **[Form Rows](/prebuilt/form-rows)** — Arrange fields side-by-side within pages
+- **[Form Arrays](/prebuilt/form-arrays/simplified)**: Create repeating sections with add/remove controls
+- **[Dynamic Behavior](/dynamic-behavior/conditional-logic)**: Conditional logic, value derivation, and form submission
+- **[Form Rows](/prebuilt/form-rows)**: Arrange fields side-by-side within pages

--- a/apps/docs/public/content/prebuilt/form-rows.md
+++ b/apps/docs/public/content/prebuilt/form-rows.md
@@ -14,6 +14,7 @@ Organize fields into horizontal rows for compact layouts. Rows display fields si
 
 ```typescript
 {
+  key: 'nameRow',
   type: 'row',
   fields: [
     { key: 'firstName', type: 'input', label: 'First Name', value: '', col: 6 },
@@ -30,6 +31,7 @@ Control field widths within rows using the `col` property:
 
 ```typescript
 {
+  key: 'addressRow',
   type: 'row',
   fields: [
     { key: 'city', type: 'input', label: 'City', value: '', col: 6 },
@@ -60,13 +62,13 @@ import { DynamicForm } from '@ng-forge/dynamic-forms';
 @Component({
   selector: 'app-address-form',
   imports: [DynamicForm],
-  template: `<form [dynamic-form]="formConfig"></form>
-    >`,
+  template: `<form [dynamic-form]="formConfig"></form>`,
 })
 export class AddressFormComponent {
   formConfig = {
     fields: [
       {
+        key: 'nameRow',
         type: 'row',
         fields: [
           {
@@ -96,6 +98,7 @@ export class AddressFormComponent {
         email: true,
       },
       {
+        key: 'addressRow',
         type: 'row',
         fields: [
           {
@@ -153,6 +156,7 @@ Rows are layout containers - they don't add nesting to your form values. Fields 
 {
   fields: [
     {
+      key: 'nameRow',
       type: 'row',
       fields: [
         { key: 'firstName', type: 'input', value: '', col: 6 },
@@ -178,9 +182,7 @@ Row fields can be used within:
 - Groups (for layouts within grouped data)
 - Arrays (for layouts within array items)
 
-Rows **cannot** be nested inside:
-
-- Other row fields
+Nesting rows inside other rows is allowed by the types, but it is usually a sign the layout should be flattened into a single row with `col` sizing.
 
 ## Allowed Children
 
@@ -214,10 +216,10 @@ Row containers support the `logic` property to conditionally show or hide the en
 }
 ```
 
-Only `'hidden'` is supported as a logic type on containers. For all available condition types and operators, see [Conditional Logic](/dynamic-behavior/overview).
+Only `'hidden'` is supported as a logic type on containers. For all available condition types and operators, see [Conditional Logic](/dynamic-behavior/conditional-logic).
 
 ## Next Steps
 
-- **[Form Groups](/prebuilt/form-groups)** — Nest fields under a single key for structured form data
-- **[Form Arrays](/prebuilt/form-arrays/simplified)** — Create repeating sections with add/remove controls
-- **[Form Pages](/prebuilt/form-pages)** — Build multi-step wizard forms with page navigation
+- **[Form Groups](/prebuilt/form-groups)**: Nest fields under a single key for structured form data
+- **[Form Arrays](/prebuilt/form-arrays/simplified)**: Create repeating sections with add/remove controls
+- **[Form Pages](/prebuilt/form-pages)**: Build multi-step wizard forms with page navigation

--- a/apps/docs/public/content/prebuilt/hidden-fields.md
+++ b/apps/docs/public/content/prebuilt/hidden-fields.md
@@ -135,7 +135,7 @@ Hidden fields can be placed:
 - Inside page fields
 - Inside group fields
 
-**Note:** Placing hidden fields inside row fields will generate a validation warning. Rows are meant for horizontal layouts, and since hidden fields don't render anything, placing them in rows serves no purpose. Place hidden fields outside of rows instead.
+**Note:** Rows are layout containers for horizontal arrangement, and hidden fields render nothing, so placing them in rows serves no purpose. Prefer top-level placement for non-rendering fields.
 
 ## Type Safety
 
@@ -171,10 +171,10 @@ if (isHiddenField(field)) {
 
 ## Value Exclusion
 
-The `HiddenField` type (`type: 'hidden'`) is **not affected** by value exclusion. Hidden fields:
+The `HiddenField` type (`type: 'hidden'`) is mostly unaffected by value exclusion. Hidden fields:
 
 - Have no reactive `hidden()` state (they don't render a component)
-- Are always included in submission output, regardless of `excludeValueIfHidden` settings
+- Are included in submission output by default; value exclusion only applies if the field or a flattened ancestor is statically marked hidden
 
 This is different from regular fields with `hidden: true` or fields hidden via conditional logic. Those fields have a reactive `hidden()` state that value exclusion checks.
 
@@ -188,6 +188,6 @@ See the **Value Exclusion** page under Recipes for full details.
 
 ## Next Steps
 
-- **[Text Components](/prebuilt/text-components)** — Display static or dynamic text content in forms
-- **[Value Exclusion](/recipes/value-exclusion)** — Control which field values are included in submission output
-- **[Field Types](/field-types/text-inputs)** — Explore all available input field types and their props
+- **[Text Components](/prebuilt/text-components)**: Display static or dynamic text content in forms
+- **[Value Exclusion](/recipes/value-exclusion)**: Control which field values are included in submission output
+- **[Field Types](/field-types/text-inputs)**: Explore all available input field types and their props

--- a/apps/docs/public/content/prebuilt/text-components.md
+++ b/apps/docs/public/content/prebuilt/text-components.md
@@ -136,6 +136,6 @@ Add custom classes via the `className` property:
 
 ## Next Steps
 
-- **[Hidden Fields](/prebuilt/hidden-fields)** — Store metadata and IDs without rendering UI
-- **[Field Types](/field-types/text-inputs)** — Explore all available input field types and their props
-- **[i18n](/dynamic-behavior/i18n)** — Translate text labels with Observables and Signals
+- **[Hidden Fields](/prebuilt/hidden-fields)**: Store metadata and IDs without rendering UI
+- **[Field Types](/field-types/text-inputs)**: Explore all available input field types and their props
+- **[i18n](/dynamic-behavior/i18n)**: Translate text labels with Observables and Signals

--- a/apps/docs/public/content/recipes/custom-fields.md
+++ b/apps/docs/public/content/recipes/custom-fields.md
@@ -1,17 +1,17 @@
 ---
 title: Custom Fields
-slug: advanced/custom-fields
+slug: recipes/custom-fields
 description: 'Add custom field types like rich text editors or file uploaders to any ng-forge adapter without building a full integration from scratch.'
 ---
 
-Add a custom field type alongside an existing ng-forge adapter — Material, Bootstrap, PrimeNG, or Ionic — without writing a full adapter from scratch.
+Add a custom field type alongside an existing ng-forge adapter (Material, Bootstrap, PrimeNG, or Ionic) without writing a full adapter from scratch.
 
 ## When to use this vs build a full adapter
 
-- **One or two extra fields** alongside an existing adapter (a rich text editor, file uploader, signature pad, rating widget) → this recipe.
-- **A whole new design system** (Spartan, an internal kit, a custom theme with many field types) → see [Building an Adapter](/building-an-adapter).
+- **One or two extra fields** alongside an existing adapter (a rich text editor, file uploader, signature pad, rating widget): this recipe.
+- **A whole new design system** (Spartan, an internal kit, a custom theme with many field types): see [Building an Adapter](/building-an-adapter).
 
-The mechanics are the same in both cases — every ng-forge field component composes the `NgForgeField` directive — but the recipe stays focused on registering one type alongside `withMaterialFields()` (or whichever adapter you already use).
+The mechanics are the same in both cases (every ng-forge field component composes the `NgForgeField` directive), but the recipe stays focused on registering one type alongside `withMaterialFields()` (or whichever adapter you already use).
 
 ## 1. Create the field component
 
@@ -61,8 +61,8 @@ export default class RichTextFieldComponent {
 A few things to note:
 
 - **No manual input declarations** for `field`/`key`/`label`/etc. The standard inputs come in via the `NgForgeFieldHost` wrapper (Shell carries `key`/`className`; `NgForgeField` carries the rest); `injectNgForgeField<T>()` returns a typed view of the value-field directive instance and re-exposes `key()`/`className()` for templates.
-- **No host bindings block** — Shell binds `[id]`/`[attr.data-testid]`/`[class]` from `key()`/`className()`, and `NgForgeField` binds `[attr.hidden]`/`[attr.aria-disabled]` from the field tree.
-- **`[ngForgeControl]`** on the canonical control element forwards meta attributes (`data-*`, `autocomplete`, etc.) AND aria attributes (`aria-invalid`, `aria-required`, `aria-describedby` — derived from field state) onto that element. The author doesn't bind aria-\* manually — the marker absorbs it. For shadow-DOM wrappers where you can't reach the inner input, see [`NgForgeHostControl`](/building-an-adapter#meta-forwarding) in the integration guide.
+- **No host bindings block**: Shell binds `[id]`/`[attr.data-testid]`/`[class]` from `key()`/`className()`, and `NgForgeField` binds `[attr.hidden]`/`[attr.aria-disabled]` from the field tree.
+- **`[ngForgeControl]`** on the canonical control element forwards meta attributes (`data-*`, `autocomplete`, etc.) AND aria attributes (`aria-invalid`, `aria-required`, `aria-describedby`, derived from field state) onto that element. The author doesn't bind aria-\* manually; the marker absorbs it. For shadow-DOM wrappers where you can't reach the inner input, see [`NgForgeHostControl`](/building-an-adapter#meta-forwarding) in the integration guide.
 - **`injectNgForgeField<string>()`** narrows `ngf.field()` to `Signal<FieldTree<string>>`, so the `[formField]="f"` binding type-checks. Use the appropriate generic for your value type (`boolean` for checkboxes, `Date | null` for datepickers, `ValueType[]` for multi-selects, etc.).
 
 ## 2. Register the field type
@@ -115,11 +115,11 @@ const config = {
 } as const satisfies FormConfig;
 ```
 
-Custom fields work with everything the built-in field types do — validation, derivations, conditional logic, dynamic text — without any extra wiring.
+Custom fields work with everything the built-in field types do (validation, derivations, conditional logic, dynamic text) without any extra wiring.
 
 ## Testing a custom field
 
-The form engine's outlet always binds `field` and `key` before triggering the first change-detection pass. Components instantiated directly — TestBed, Storybook, sandbox harnesses — bypass that ordering, so `NgForgeField`'s host bindings hit `input.required<>()` on first read and throw NG0950.
+The form engine's outlet always binds `field` and `key` before triggering the first change-detection pass. Components instantiated directly (TestBed, Storybook, sandbox harnesses) bypass that ordering, so `NgForgeField`'s host bindings hit `input.required<>()` on first read and throw NG0950.
 
 Use `createNgForgeFieldFixture` from `@ng-forge/dynamic-forms/integration` to build the fixture with `field` + `key` already bound. The harness wraps your value in a one-key form via `form()` in an injection context, sets the required inputs, and hands you back the fixture for assertions:
 
@@ -169,6 +169,6 @@ Both harnesses defer `detectChanges()` to the caller so you can set extra compon
 
 ## Going further
 
-- [Building an Adapter](/building-an-adapter) — full guide for shipping an adapter with many field types, adapter-level configuration cascades, and module augmentation for type-safety.
-- [Type Safety](/recipes/type-safety) — register your custom field shape with `FieldRegistryLeaves` so `FormConfig` autocompletes against it.
-- [Events](/recipes/events) — dispatch and subscribe to events from custom field components.
+- [Building an Adapter](/building-an-adapter): full guide for shipping an adapter with many field types, adapter-level configuration cascades, and module augmentation for type-safety.
+- [Type Safety](/recipes/type-safety): register your custom field shape with `FieldRegistryLeaves` so `FormConfig` autocompletes against it.
+- [Events](/recipes/events): dispatch and subscribe to events from custom field components.

--- a/apps/docs/public/content/recipes/events.md
+++ b/apps/docs/public/content/recipes/events.md
@@ -1,6 +1,6 @@
 ---
 title: Events
-slug: advanced/events
+slug: recipes/events
 description: 'Dispatch and subscribe to form events using EventBus (inside fields) and EventDispatcher (from host components). Drive array actions, resets, and more.'
 ---
 
@@ -13,15 +13,15 @@ The events API provides two complementary services for working with form events.
 | **Where to use**  | Inside DynamicForm (field components) | Outside DynamicForm (host components)                      |
 | **How to get it** | `inject(EventBus)`                    | `providers: [EventDispatcher]` + `inject(EventDispatcher)` |
 | **Dispatches**    | Constructor + args                    | Pre-built event instances                                  |
-| **Subscribes**    | Yes — `.on()` method                  | No                                                         |
+| **Subscribes**    | Yes, via `.on()`                      | No                                                         |
 
-> **Important:** `EventBus` is scoped to the `DynamicForm` component's injector tree. It is **only available to components rendered inside DynamicForm** (i.e. custom field components). If you inject `EventBus` in a parent or host component, you get a completely separate, disconnected instance that the form knows nothing about. Use `EventDispatcher` instead.
+> **Important:** `EventBus` is scoped to the `DynamicForm` component's injector tree. It is **only available to components rendered inside DynamicForm** (i.e. custom field components). Injecting `EventBus` in a parent or host component fails with a `NullInjectorError` (there is no provider at that level); providing your own `EventBus` only yields a disconnected instance the form knows nothing about. Use `EventDispatcher` from the host instead.
 
 ---
 
-## EventDispatcher — dispatching from outside DynamicForm
+## EventDispatcher: dispatching from outside DynamicForm
 
-Use `EventDispatcher` when you need to drive form behaviour **from the host component** — for example, appending array items in response to a field value change, triggering a form reset from a toolbar button, or reacting to external application state.
+Use `EventDispatcher` when you need to drive form behaviour **from the host component**: for example, appending array items in response to a field value change, triggering a form reset from a toolbar button, or reacting to external application state.
 
 ### Setup
 
@@ -85,17 +85,17 @@ For observing events from a host component, use the output bindings exposed dire
 
 ### Output bindings
 
-| Output                          | Emits                                                     |
-| ------------------------------- | --------------------------------------------------------- |
-| `(events)`                      | Every form event (full stream)                            |
-| `(submitted)`                   | Form value when submitted **and valid** (FormSubmitEvent) |
-| `(reset)`                       | When the form is reset to default values                  |
-| `(cleared)`                     | When the form is cleared to empty state                   |
-| `(onPageChange)`                | PageChangeEvent on each wizard page navigation            |
-| `(onPageNavigationStateChange)` | Navigation state changes (canGoNext, canGoPrevious, etc.) |
-| `(validityChange)`              | Boolean — whenever form validity changes                  |
-| `(dirtyChange)`                 | Boolean — whenever form dirty state changes               |
-| `(initialized)`                 | Once all field components are rendered and ready          |
+| Output                          | Emits                                                                                                          |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `(events)`                      | Every form event (full stream)                                                                                 |
+| `(submitted)`                   | Form value when submitted **and valid** (FormSubmitEvent)                                                      |
+| `(reset)`                       | When the form is reset to default values                                                                       |
+| `(cleared)`                     | When the form is cleared to empty state                                                                        |
+| `(onPageChange)`                | PageChangeEvent on each wizard page navigation                                                                 |
+| `(onPageNavigationStateChange)` | Navigation state changes (`currentPageIndex`, `totalPages`, `isFirstPage`, `isLastPage`, `navigationDisabled`) |
+| `(validityChange)`              | Boolean, whenever form validity changes                                                                        |
+| `(dirtyChange)`                 | Boolean, whenever form dirty state changes                                                                     |
+| `(initialized)`                 | Once all field components are rendered and ready                                                               |
 
 ### Examples
 
@@ -143,11 +143,11 @@ export class MyFormComponent {
 
 ---
 
-## EventBus — dispatching from inside DynamicForm
+## EventBus: dispatching from inside DynamicForm
 
 `EventBus` is the internal event bus scoped to each `DynamicForm` instance. Inject it inside **custom field components** to communicate with the parent form or other fields within the same form.
 
-> **Scoping reminder:** `EventBus` is provided by `DynamicForm` via its component injector. It is only resolvable from within field components rendered by that form. Do not inject it in host or parent components — you will get a disconnected, standalone instance.
+> **Scoping reminder:** `EventBus` is provided by `DynamicForm` via its component injector. It is only resolvable from within field components rendered by that form. Do not inject it in host or parent components: the injection fails with a `NullInjectorError` unless you provide your own instance, and a self-provided instance is disconnected from the form. Use `EventDispatcher` instead.
 
 ### Usage in custom field components
 
@@ -270,8 +270,8 @@ import { arrayEvent } from '@ng-forge/dynamic-forms';
 
 **Important:** A template is required for all add operations. The template defines the structure of the new item:
 
-- **Single FieldDef** → creates a **primitive item** (field value extracted directly)
-- **Array of FieldDefs** → creates an **object item** (fields merged into object)
+- **Single FieldDef** creates a **primitive item** (field value extracted directly)
+- **Array of FieldDefs** creates an **object item** (fields merged into object)
 
 ```typescript
 // Define templates
@@ -482,6 +482,6 @@ This is useful when you need the complete form state at the time an event occurr
 
 ## Next Steps
 
-- **[Form Submission](/dynamic-behavior/submission)** — Configure async submission with loading states and server errors
-- **[Custom Fields](/recipes/custom-fields)** — Build custom field components that use EventBus
-- **[Form Arrays](/prebuilt/form-arrays/simplified)** — Use array events to add and remove items programmatically
+- **[Form Submission](/dynamic-behavior/submission)**: Configure async submission with loading states and server errors
+- **[Custom Fields](/recipes/custom-fields)**: Build custom field components that use EventBus
+- **[Form Arrays](/prebuilt/form-arrays/simplified)**: Use array events to add and remove items programmatically

--- a/apps/docs/public/content/recipes/expression-parser.md
+++ b/apps/docs/public/content/recipes/expression-parser.md
@@ -1,6 +1,6 @@
 ---
 title: Expression Parser
-slug: advanced/expression-parser
+slug: recipes/expression-parser
 description: 'Learn how ng-forge safely evaluates JavaScript expressions for conditional logic, dynamic values, and validations while preventing code injection.'
 ---
 
@@ -77,12 +77,14 @@ Only safe methods can be called in expressions:
 
 ### Whitelisted Methods Reference
 
-| Category   | Methods                                                                                                                                                           |
-| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **String** | `toUpperCase`, `toLowerCase`, `trim`, `includes`, `startsWith`, `endsWith`, `slice`, `substring`, `charAt`, `indexOf`, `lastIndexOf`, `split`, `replace`, `match` |
-| **Array**  | `map`, `filter`, `some`, `every`, `find`, `findIndex`, `includes`, `indexOf`, `join`, `slice`, `flat`, `flatMap`                                                  |
-| **Number** | `toFixed`, `toString`, `valueOf`                                                                                                                                  |
-| **Object** | `hasOwnProperty`, `toString`, `valueOf`                                                                                                                           |
+| Category   | Methods                                                                                                                                                                                                                                                                 |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **String** | `charAt`, `charCodeAt`, `concat`, `endsWith`, `includes`, `indexOf`, `lastIndexOf`, `match`, `padEnd`, `padStart`, `repeat`, `replace`, `search`, `slice`, `split`, `startsWith`, `substring`, `toLowerCase`, `toUpperCase`, `trim`, `trimEnd`, `trimStart`, `toString` |
+| **Array**  | `concat`, `every`, `filter`, `find`, `findIndex`, `flat`, `flatMap`, `includes`, `indexOf`, `join`, `lastIndexOf`, `map`, `reduce`, `reduceRight`, `slice`, `some`, `toString`, `entries`, `keys`, `values`                                                             |
+| **Number** | `toExponential`, `toFixed`, `toPrecision`, `toString`                                                                                                                                                                                                                   |
+| **Date**   | `getDate`, `getDay`, `getFullYear`, `getHours`, `getMilliseconds`, `getMinutes`, `getMonth`, `getSeconds`, `getTime`, `getTimezoneOffset`, the matching `getUTC*` variants, `toDateString`, `toISOString`, `toJSON`, `toString`, `toTimeString`, `toUTCString`          |
+
+These lists mirror the parser's whitelists exactly. No methods are callable on plain objects: property access works, method calls do not.
 
 ### Properties: Open Access (Except Dangerous Ones)
 
@@ -257,30 +259,30 @@ const config = {
 
 For dynamic forms, the parser prevents:
 
-- ✅ **Code Injection**: Can't execute arbitrary code or create new code
-- ✅ **Prototype Pollution**: Can't access `constructor` or `__proto__`
-- ✅ **Unsafe Operations**: Can't call methods that modify state or access globals
+- **Code Injection**: Can't execute arbitrary code or create new code
+- **Prototype Pollution**: Can't access `constructor` or `__proto__`
+- **Unsafe Operations**: Can't call methods that modify state or access globals
 
 ## Custom Functions
 
-When providing custom functions for use in expressions, register them with the FunctionRegistryService:
+Register custom functions on the form config via `customFnConfig.customFunctions`:
 
 ```typescript
 // ✅ GOOD - Pure functions
-import { FunctionRegistryService } from '@ng-forge/dynamic-forms';
-
-const functionRegistry = inject(FunctionRegistryService);
-
-functionRegistry.registerCustomFunction('isValidEmail', (ctx) => {
-  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(ctx.fieldValue);
-});
-
-functionRegistry.registerCustomFunction('isAdult', (ctx) => {
-  return ctx.formValue.age >= 18;
-});
+const config = {
+  customFnConfig: {
+    customFunctions: {
+      isValidEmail: (ctx) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(ctx.fieldValue)),
+      isAdult: (ctx) => ctx.formValue.age >= 18,
+    },
+  },
+  fields: [
+    // ...
+  ],
+} satisfies FormConfig;
 ```
 
-Then use them with `type: 'custom'`:
+Then reference them by name with `type: 'custom'` and `functionName`:
 
 ```typescript
 {
@@ -293,7 +295,7 @@ Then use them with `type: 'custom'`:
       type: 'hidden',
       condition: {
         type: 'custom',
-        expression: 'isAdult'
+        functionName: 'isAdult'
       }
     }
   ]
@@ -304,11 +306,15 @@ Then use them with `type: 'custom'`:
 
 ```typescript
 // ❌ BAD - Side effects
-functionRegistry.registerCustomFunction('logValue', (ctx) => {
-  console.log(ctx.fieldValue); // Side effect!
-  trackAnalytics(ctx); // Side effect!
-  return true;
-});
+customFnConfig: {
+  customFunctions: {
+    logValue: (ctx) => {
+      console.log(ctx.fieldValue); // Side effect!
+      trackAnalytics(ctx); // Side effect!
+      return true;
+    },
+  },
+},
 ```
 
 ## Supported Expression Features
@@ -335,7 +341,7 @@ In JavaScript expressions (`type: 'javascript'`), you can use:
 expression: 'formValue.age >= 18 && formValue.email.includes("@example.com")';
 ```
 
-**Not Supported**: assignment (`x = 5`, `x++`), `new` keyword, function declarations, class declarations, spread (`[...arr]`), destructuring, template literals, regex literals. Method calls remain whitelist-only — arrow functions can only invoke methods that pass the whitelist (e.g., `.map`, `.filter`, `.reduce`), and the same blocklist (`constructor`, `__proto__`, etc.) applies to both dotted and computed member access.
+**Not Supported**: assignment (`x = 5`, `x++`), `new` keyword, function declarations, class declarations, spread (`[...arr]`), destructuring, template literals, regex literals. Method calls remain whitelist-only; arrow functions can only invoke methods that pass the whitelist (e.g., `.map`, `.filter`, `.reduce`), and the same blocklist (`constructor`, `__proto__`, etc.) applies to both dotted and computed member access.
 
 ## Summary
 
@@ -348,6 +354,6 @@ The expression parser lets you write flexible conditional logic while preventing
 
 ## Next Steps
 
-- **[Conditional Logic](/dynamic-behavior/overview)** — Use expressions to control field visibility and state
-- **[Type Safety](/recipes/type-safety)** — Leverage TypeScript inference for form values and field types
-- **[Value Derivation](/dynamic-behavior/derivation)** — Use expressions to compute field values dynamically
+- **[Conditional Logic](/dynamic-behavior/conditional-logic)**: Use expressions to control field visibility and state
+- **[Type Safety](/recipes/type-safety)**: Leverage TypeScript inference for form values and field types
+- **[Value Derivation](/dynamic-behavior/derivation)**: Use expressions to compute field values dynamically

--- a/apps/docs/public/content/recipes/type-safety.md
+++ b/apps/docs/public/content/recipes/type-safety.md
@@ -1,6 +1,6 @@
 ---
 title: Type Safety
-slug: advanced/type-safety
+slug: recipes/type-safety
 description: "Get full compile-time type inference for ng-forge form values using TypeScript's const satisfies pattern. Catch configuration errors before runtime."
 ---
 
@@ -27,7 +27,7 @@ const formConfig = {
 } as const satisfies FormConfig;
 
 // Type is automatically inferred based on value property:
-// { firstName?: string; email?: string; age?: number; newsletter?: boolean }
+// { firstName: string | undefined; email: string | undefined; age: number | undefined; newsletter: boolean | undefined }
 ```
 
 **How it works:**
@@ -46,18 +46,20 @@ const config = {
     { key: 'name', type: 'input', value: '' }, // string
     { key: 'age', type: 'input', value: 0 }, // number
     { key: 'active', type: 'checkbox', value: false }, // boolean
-    { key: 'tags', type: 'multi-checkbox', value: [] }, // string[]
+    { key: 'tags', type: 'multi-checkbox', value: ['news'] }, // string[]
   ],
 } as const satisfies FormConfig;
 
 // Inferred type:
 // {
-//   name?: string;
-//   age?: number;
-//   active?: boolean;
-//   tags?: string[];
+//   name: string | undefined;
+//   age: number | undefined;
+//   active: boolean | undefined;
+//   tags: string[] | undefined;
 // }
 ```
+
+> **Empty array literals:** `value: []` infers `never[]`, not `string[]`. Seed at least one element (as above) or assert the element type with `value: [] as string[]`.
 
 ## Field Registry System
 
@@ -121,11 +123,13 @@ const config = {
 
 // Inferred type:
 // {
-//   email: string;           // Required - no undefined
-//   name?: string;           // Optional - includes undefined
-//   age?: number;            // Optional - includes undefined
+//   email: string;             // Required - never undefined
+//   name: string | undefined;  // Always present; value may be undefined
+//   age: number | undefined;   // Always present; value may be undefined
 // }
 ```
+
+Note that non-required fields stay required **properties** in the inferred model; instead of marking the key optional with `?`, inference adds `undefined` to the value type. Object literals of that type must spell out every key.
 
 **In practice:**
 
@@ -154,9 +158,11 @@ export class UserFormComponent {
     ]
   } as const satisfies FormConfig;
 
-  // Extract type for signal
+  // Extract type for signal. Every inferred key must be present,
+  // so non-required fields are initialized with undefined.
   formValue = signal<InferFormValue<typeof this.config.fields>>({
     username: '',
+    age: undefined,
   });
 
   onSubmit() {
@@ -293,7 +299,7 @@ const config = {
 const config = {
   fields: [{ key: 'name', type: 'input', value: '' }],
 } as const satisfies FormConfig;
-// Type inferred: { name?: string }
+// Type inferred: { name: string | undefined }
 ```
 
 ### `satisfies` vs type annotation
@@ -314,9 +320,9 @@ const config = {
 
 ### Dynamic form configs
 
-Type inference only works for **static**, **compile-time constant** configurations. If your form configuration comes from an API or is built dynamically at runtime, `as const` has no effect — TypeScript can't infer the shape of data it doesn't see at compile time.
+Type inference only works for **static**, **compile-time constant** configurations. If your form configuration comes from an API or is built dynamically at runtime, `as const` has no effect; TypeScript can't infer the shape of data it doesn't see at compile time.
 
-For the complete guide on API-driven forms — including fetching configs, hydrating runtime features, and typing form values — see **[API-Driven Forms](/api-driven-forms)**.
+For the complete guide on API-driven forms (fetching configs, hydrating runtime features, and typing form values), see **[API-Driven Forms](/api-driven-forms)**.
 
 ## Container Fields
 
@@ -355,9 +361,9 @@ const config = {
 // Inferred type:
 // {
 //   address: {
-//     street?: string;
-//     city?: string;
-//     zip?: string;
+//     street: string | undefined;
+//     city: string | undefined;
+//     zip: string | undefined;
 //   }
 // }
 ```
@@ -394,7 +400,7 @@ const config = {
 //     street: string;
 //     city: string;
 //     state: string;
-//     zip?: string;
+//     zip: string | undefined;
 //   }
 // }
 
@@ -414,6 +420,7 @@ Rows organize fields horizontally for layout purposes, but flatten children to t
 const config = {
   fields: [
     {
+      key: 'nameRow',
       type: 'row',
       fields: [
         { key: 'firstName', type: 'input', value: '' },
@@ -425,8 +432,8 @@ const config = {
 
 // Inferred type (flattened):
 // {
-//   firstName?: string;
-//   lastName?: string;
+//   firstName: string | undefined;
+//   lastName: string | undefined;
 // }
 ```
 
@@ -441,13 +448,14 @@ const config = {
 ```typescript
 // Row - fields are flattened
 {
+  key: 'nameRow',
   type: 'row',
   fields: [
     { key: 'firstName', type: 'input', value: '' },
     { key: 'lastName', type: 'input', value: '' },
   ],
 }
-// Result: { firstName?: string, lastName?: string }
+// Result: { firstName: string | undefined, lastName: string | undefined }
 
 // Group - fields are nested
 {
@@ -458,7 +466,7 @@ const config = {
     { key: 'lastName', type: 'input', value: '' },
   ],
 }
-// Result: { name: { firstName?: string, lastName?: string } }
+// Result: { name: { firstName: string | undefined, lastName: string | undefined } }
 ```
 
 ### Page Fields
@@ -491,10 +499,10 @@ const config = {
 
 // Inferred type (all pages flattened):
 // {
-//   email?: string;
-//   password?: string;
-//   firstName?: string;
-//   lastName?: string;
+//   email: string | undefined;
+//   password: string | undefined;
+//   firstName: string | undefined;
+//   lastName: string | undefined;
 // }
 ```
 
@@ -527,13 +535,14 @@ const config1 = {
   ],
 } as const satisfies FormConfig;
 
-// ✗ Invalid: row inside row
+// ✗ Invalid: page inside group
 const config2 = {
   fields: [
     {
-      type: 'row',
+      type: 'group',
+      key: 'profile',
       fields: [
-        { type: 'row', fields: [] }, // TypeScript error!
+        { key: 'step1', type: 'page', fields: [] }, // TypeScript error!
       ],
     },
   ],
@@ -562,10 +571,11 @@ Fields without values are excluded from form values:
 ```typescript
 const config = {
   fields: [
-    { type: 'text', label: 'Enter your details:' }, // ✗ Excluded
+    { key: 'intro', type: 'text', label: 'Enter your details:' }, // ✗ Excluded
     { key: 'name', type: 'input', value: '' }, // ✓ Included
-    { type: 'submit', label: 'Save' }, // ✗ Excluded
+    { key: 'save', type: 'submit', label: 'Save' }, // ✗ Excluded
     {
+      key: 'cityRow',
       type: 'row', // ✗ Excluded (container)
       fields: [
         { key: 'city', type: 'input', value: '' }, // ✓ Included
@@ -576,8 +586,8 @@ const config = {
 
 // Only value-bearing fields:
 // {
-//   name?: string;
-//   city?: string;
+//   name: string | undefined;
+//   city: string | undefined;
 // }
 ```
 
@@ -591,7 +601,7 @@ const config = {
     {
       key: 'skills',
       type: 'select',
-      value: [],
+      value: ['js'],
       props: { multiple: true },
       options: [
         { value: 'js', label: 'JavaScript' },
@@ -602,7 +612,7 @@ const config = {
     {
       key: 'interests',
       type: 'multi-checkbox',
-      value: [],
+      value: ['sports'],
       options: [
         { value: 'sports', label: 'Sports' },
         { value: 'music', label: 'Music' },
@@ -612,7 +622,7 @@ const config = {
   ],
 } as const satisfies FormConfig;
 
-// Type: { skills?: string[]; interests?: string[] }
+// Type: { skills: string[] | undefined; interests: string[] | undefined }
 ```
 
 ## Advanced Patterns
@@ -832,7 +842,7 @@ const config = {
   ],
 } as const satisfies FormConfig;
 
-// Type: { accountType?: string; taxId?: string }
+// Type: { accountType: string | undefined; taxId: string | undefined }
 // Note: Conditional required doesn't affect type inference
 ```
 

--- a/apps/docs/public/content/recipes/value-exclusion.md
+++ b/apps/docs/public/content/recipes/value-exclusion.md
@@ -1,6 +1,6 @@
 ---
 title: Value Exclusion
-slug: advanced/value-exclusion
+slug: recipes/value-exclusion
 description: 'Control which field values appear in form submission output based on visibility, disabled, or readonly state. Configure at provider, form, or field level.'
 ---
 
@@ -10,7 +10,7 @@ Value exclusion controls which field values are included in the form submission 
 
 By default, field values are **excluded** from the `(submitted)` output when the field is hidden, disabled, or readonly. This prevents stale or irrelevant data from being sent to the server.
 
-**Key point:** Value exclusion always applies to the submission output. It also applies to the two-way bound model (`[value]` / `[(value)]`) **only when you opt in explicitly** at the field or form level — the global defaults configured via `withValueExclusionDefaults()` are intentionally not applied to the bound model, so the host's view of the form remains predictable. Internal form controls retain their values so they can be restored when an explicitly excluded field becomes visible, enabled, or editable again.
+**Key point:** Value exclusion always applies to the submission output. It also applies to the two-way bound model (`[value]` / `[(value)]`) **only when you opt in explicitly** at the field or form level; the global defaults configured via `withValueExclusionDefaults()` are intentionally not applied to the bound model, so the host's view of the form remains predictable. Internal form controls retain their values so they can be restored when an explicitly excluded field becomes visible, enabled, or editable again.
 
 ## Default Behavior
 
@@ -111,8 +111,8 @@ Given these settings:
 
 Resolution:
 
-- **Field A** uses form-level (`false`) because field-level is `undefined` &rarr; value is **included** when hidden
-- **Field B** uses field-level (`true`) &rarr; value is **excluded** when hidden
+- **Field A** uses form-level (`false`) because field-level is `undefined`, so its value is **included** when hidden
+- **Field B** uses field-level (`true`), so its value is **excluded** when hidden
 
 ## HiddenField Type
 
@@ -126,13 +126,12 @@ Value exclusion applies to the `hidden` **property** on regular fields (e.g., `{
 
 ## What's Excluded vs Retained
 
-| Aspect                     | Affected by exclusion?  | Details                                                                              |
-| -------------------------- | ----------------------- | ------------------------------------------------------------------------------------ |
-| `(submitted)` output       | Yes                     | Excluded fields are omitted (full Field > Form > Global hierarchy applies)           |
-| `filteredFormValue` signal | Yes                     | Same filtering as submission                                                         |
-| `formValue` signal         | No                      | Always contains all values                                                           |
-| `[(value)]` binding        | Only on explicit opt-in | Field- or form-level `excludeValueIf*: true` filters the bound model; global doesn't |
-| Internal form controls     | No                      | Fields keep their values for restoration                                             |
+| Aspect                 | Affected by exclusion?  | Details                                                                              |
+| ---------------------- | ----------------------- | ------------------------------------------------------------------------------------ |
+| `(submitted)` output   | Yes                     | Excluded fields are omitted (full Field > Form > Global hierarchy applies)           |
+| `formValue` signal     | No                      | Always contains all values                                                           |
+| `[(value)]` binding    | Only on explicit opt-in | Field- or form-level `excludeValueIf*: true` filters the bound model; global doesn't |
+| Internal form controls | No                      | Fields keep their values for restoration                                             |
 
 ## Migration from Previous Versions
 
@@ -164,6 +163,6 @@ const config: FormConfig = {
 
 ## Next Steps
 
-- **[Form Submission](/dynamic-behavior/submission)** — Configure async submission with automatic button disabling
-- **[Events](/recipes/events)** — Dispatch and subscribe to form events from inside or outside the form
-- **[Conditional Logic](/dynamic-behavior/overview)** — Control field visibility, required state, and disabled state
+- **[Form Submission](/dynamic-behavior/submission)**: Configure async submission with automatic button disabling
+- **[Events](/recipes/events)**: Dispatch and subscribe to form events from inside or outside the form
+- **[Conditional Logic](/dynamic-behavior/conditional-logic)**: Control field visibility, required state, and disabled state

--- a/apps/docs/public/content/schema-validation/angular-schema.md
+++ b/apps/docs/public/content/schema-validation/angular-schema.md
@@ -4,7 +4,7 @@ keyword: AngularSchemaPage
 description: "Use Angular's native signal forms Schema API for form-level validation in dynamic forms with zero extra dependencies."
 ---
 
-Angular's signal forms include a native `Schema<T>` API for form-level validation. This approach requires no additional dependencies and integrates seamlessly with Dynamic Forms.
+Angular's signal forms include native schema APIs for form-level validation. This approach requires no additional dependencies and works directly with Dynamic Forms.
 
 ## Raw Callback Pattern (Recommended)
 
@@ -44,46 +44,41 @@ This pattern gives you full access to Angular's validation APIs including `valid
 
 ## Combining Field and Schema Validation
 
-Field-level validators (like `required`, `minLength`) run **first**, then the schema callback runs for cross-field validation. Both work together seamlessly.
+Field-level validators (like `required`, `minLength`) and the schema callback both run reactively, and their errors are combined on the affected fields.
 
-## Using schema() Wrapper
+## The schema() Wrapper
 
-Alternatively, you can use Angular's `schema()` function to wrap your callback:
+Angular also exports a `schema()` function that wraps a callback into a `Schema<T>` object. Dynamic Forms does not accept this wrapper: the `schema` property of `FormConfig` takes either a raw callback `(path) => void` or a `standardSchema()` marker. A `Schema` object created with `schema()` is ignored.
 
-```typescript
-import { schema, required, validate } from '@angular/forms/signals';
-```
-
-Define your schema with cross-field validation:
+To reuse validation logic across forms, type and export the callback itself:
 
 ```typescript
+import { validate, SchemaPathTree } from '@angular/forms/signals';
+
 interface PasswordForm {
   password: string;
   confirmPassword: string;
 }
 
-const passwordSchema = schema<PasswordForm>(({ value }) =>
-  validate(value.password === value.confirmPassword, { confirmPassword: { passwordMismatch: true } }),
-);
+const passwordSchema = (p: SchemaPathTree<PasswordForm>) => {
+  validate(p.confirmPassword, ({ value, valueOf }) => (value() === valueOf(p.password) ? null : { kind: 'passwordMismatch' }));
+};
 ```
+
+The returned `passwordMismatch` kind maps to display text via the field's `validationMessages` (or form-level `defaultValidationMessages`).
 
 ## Using with Dynamic Forms
 
-Pass the Angular schema directly to your form configuration:
+Pass the raw callback to your form configuration. The callback receives the schema path tree, and you bind validators to paths inside it:
 
 ```typescript
 import { FormConfig } from '@ng-forge/dynamic-forms';
-import { schema, validate } from '@angular/forms/signals';
-
-interface PasswordForm {
-  password: string;
-  confirmPassword: string;
-}
+import { validate } from '@angular/forms/signals';
 
 const config = {
-  schema: schema<PasswordForm>(({ value }) =>
-    validate(value.password === value.confirmPassword, { confirmPassword: { passwordMismatch: true } }),
-  ),
+  schema: (path) => {
+    validate(path.confirmPassword, ({ value, valueOf }) => (value() === valueOf(path.password) ? null : { kind: 'passwordMismatch' }));
+  },
   fields: [
     {
       key: 'password',
@@ -114,44 +109,53 @@ const config = {
 
 ## Schema API Reference
 
-### `schema<T>(validator)`
+### The schema callback
 
-Creates a form-level schema validator.
+Dynamic Forms invokes your callback with the schema path tree for the form value. Navigate to a field's path with property access (`path.email`, `path.address.city`) and bind validation logic to it:
 
 ```typescript
-const mySchema = schema<MyFormType>(({ value, touched, dirty }) => {
-  // value: current form value
-  // touched: whether form has been touched
-  // dirty: whether form has been modified
-  return validate(/* condition */, /* errors */);
+schema: (path) => {
+  // path.fieldKey is a path object, not a value
+  // bind logic with validate(), validateTree(), required(), ...
+};
+```
+
+### `validate(path, logic)`
+
+Binds a validator to a path and returns `void`. The logic function receives a `FieldContext` and returns `ValidationError | ValidationError[] | null`. Use `value()` for the bound field's value and `valueOf(otherPath)` for other fields:
+
+```typescript
+validate(path.endDate, ({ value, valueOf }) => {
+  const start = valueOf(path.startDate);
+  const end = value();
+  if (!start || !end) return null;
+  return end >= start ? null : { kind: 'invalidRange' };
 });
 ```
 
-### `validate(condition, errors)`
+### `validateTree(path, logic)`
 
-Returns validation errors when condition is false.
+Like `validate`, but the returned errors can target specific fields in the subtree via `fieldTree` (see the password example above). Useful when one rule produces errors on several fields.
 
-```typescript
-validate(endDate > startDate, { endDate: { invalidRange: true } });
-```
+### `required(path, config?)`
 
-### `required(path)`
-
-Marks a field as conditionally required.
+Marks a field as required. Pass `when` for conditional requiredness:
 
 ```typescript
-schema<MyForm>(({ value }) => (value.hasEndDate ? required('endDate') : null));
+required(path.endDate, {
+  when: ({ valueOf }) => valueOf(path.hasEndDate) === true,
+});
 ```
 
 ### Combining Validators
 
-Return multiple validation results:
+Call as many validation functions as you need inside one callback:
 
 ```typescript
-schema<MyForm>(({ value }) => [
-  validate(value.password === value.confirmPassword, { confirmPassword: { passwordMismatch: true } }),
-  validate(value.endDate > value.startDate, { endDate: { invalidRange: true } }),
-]);
+schema: (path) => {
+  validate(path.confirmPassword, ({ value, valueOf }) => (value() === valueOf(path.password) ? null : { kind: 'passwordMismatch' }));
+  validate(path.endDate, ({ value, valueOf }) => (!value() || value() > valueOf(path.startDate) ? null : { kind: 'invalidRange' }));
+};
 ```
 
 ## Examples
@@ -159,17 +163,15 @@ schema<MyForm>(({ value }) => [
 ### Date Range Validation
 
 ```typescript
-interface DateRangeForm {
-  startDate: string;
-  endDate: string;
-}
-
-const dateRangeSchema = schema<DateRangeForm>(({ value }) =>
-  validate(!value.startDate || !value.endDate || new Date(value.endDate) >= new Date(value.startDate), { endDate: { invalidRange: true } }),
-);
-
 const config = {
-  schema: dateRangeSchema,
+  schema: (path) => {
+    validate(path.endDate, ({ value, valueOf }) => {
+      const start = valueOf(path.startDate);
+      const end = value();
+      if (!start || !end) return null;
+      return new Date(end) >= new Date(start) ? null : { kind: 'invalidRange' };
+    });
+  },
   fields: [
     {
       key: 'startDate',
@@ -193,51 +195,36 @@ const config = {
 ### Conditional Required Fields
 
 ```typescript
-interface ContactForm {
-  preferredContact: 'email' | 'phone';
-  email: string;
-  phone: string;
-}
-
-const contactSchema = schema<ContactForm>(({ value }) => [
-  value.preferredContact === 'email' && !value.email ? validate(false, { email: { required: true } }) : null,
-  value.preferredContact === 'phone' && !value.phone ? validate(false, { phone: { required: true } }) : null,
-]);
+const config = {
+  schema: (path) => {
+    required(path.email, { when: ({ valueOf }) => valueOf(path.preferredContact) === 'email' });
+    required(path.phone, { when: ({ valueOf }) => valueOf(path.preferredContact) === 'phone' });
+  },
+  fields: [
+    /* preferredContact, email, phone */
+  ],
+} as const satisfies FormConfig;
 ```
 
 ### Complex Business Rules
 
 ```typescript
-interface OrderForm {
-  quantity: number;
-  discount: number;
-  discountType: 'percentage' | 'fixed';
-  total: number;
-}
-
-const orderSchema = schema<OrderForm>(({ value }) => {
-  const errors = [];
-
-  // Percentage discount can't exceed 100%
-  if (value.discountType === 'percentage' && value.discount > 100) {
-    errors.push(
-      validate(false, {
-        discount: { maxPercentage: true },
-      }),
+const config = {
+  schema: (path) => {
+    // Percentage discount cannot exceed 100%
+    validate(path.discount, ({ value, valueOf }) =>
+      valueOf(path.discountType) === 'percentage' && value() > 100 ? { kind: 'maxPercentage' } : null,
     );
-  }
 
-  // Fixed discount can't exceed total
-  if (value.discountType === 'fixed' && value.discount > value.total) {
-    errors.push(
-      validate(false, {
-        discount: { exceedsTotal: true },
-      }),
+    // Fixed discount cannot exceed total
+    validate(path.discount, ({ value, valueOf }) =>
+      valueOf(path.discountType) === 'fixed' && value() > valueOf(path.total) ? { kind: 'exceedsTotal' } : null,
     );
-  }
-
-  return errors;
-});
+  },
+  fields: [
+    /* quantity, discount, discountType, total */
+  ],
+} as const satisfies FormConfig;
 ```
 
 ## Best Practices
@@ -246,14 +233,14 @@ const orderSchema = schema<OrderForm>(({ value }) => {
 
 ```typescript
 // Good - single responsibility
-const passwordMatchSchema = schema<PasswordForm>(({ value }) =>
-  validate(value.password === value.confirmPassword, { confirmPassword: { passwordMismatch: true } }),
-);
+schema: (path) => {
+  validate(path.confirmPassword, ({ value, valueOf }) => (value() === valueOf(path.password) ? null : { kind: 'passwordMismatch' }));
+};
 
-// Avoid - too many concerns
-const everythingSchema = schema<BigForm>(({ value }) => [
+// Avoid - too many concerns in one callback
+schema: (path) => {
   // 10+ validations...
-]);
+};
 ```
 
 **Use field validators for simple cases:**
@@ -267,11 +254,11 @@ const everythingSchema = schema<BigForm>(({ value }) => [
 }
 
 // Use schema for cross-field only
-schema: schema<Form>(({ value }) =>
-  validate(value.email !== value.alternateEmail, {
-    alternateEmail: { sameAsEmail: true }
-  })
-)
+schema: (path) => {
+  validate(path.alternateEmail, ({ value, valueOf }) =>
+    value() !== valueOf(path.email) ? null : { kind: 'sameAsEmail' },
+  );
+};
 ```
 
 ## When to Use Standard Schema Instead
@@ -285,6 +272,6 @@ Consider [Standard Schema (Zod)](/schema-validation/zod) if you:
 
 ## Next Steps
 
-- **[Standard Schema (Zod)](/schema-validation/zod)** — Use Zod, Valibot, or ArkType for cross-platform schema validation
-- **[Field Validation](/validation/basics)** — Add built-in and custom validators to individual fields
-- **[Schema Validation Overview](/schema-validation/overview)** — Compare Angular and Standard Schema approaches
+- **[Standard Schema (Zod)](/schema-validation/zod)**: Use Zod, Valibot, or ArkType for cross-platform schema validation
+- **[Field Validation](/validation/basics)**: Add built-in and custom validators to individual fields
+- **[Schema Validation Overview](/schema-validation/overview)**: Compare Angular and Standard Schema approaches

--- a/apps/docs/public/content/schema-validation/zod.md
+++ b/apps/docs/public/content/schema-validation/zod.md
@@ -4,7 +4,7 @@ keyword: ZodSchemaPage
 description: 'Validate dynamic forms with Zod schemas using the standardSchema() wrapper for cross-field validation, shared logic, and OpenAPI reuse.'
 ---
 
-Use [Zod](https://zod.dev) schemas to validate your dynamic forms. This lets you reuse existing schemas, share validation logic between frontend and backend, and leverage Zod's powerful cross-field validation like `.refine()`.
+Use [Zod](https://zod.dev) schemas to validate your dynamic forms. This lets you reuse existing schemas, share validation logic between frontend and backend, and use Zod's cross-field validation such as `.refine()`.
 
 ## Installation
 
@@ -170,10 +170,12 @@ Zod errors automatically map to form fields via the `path` property:
   issues: [{ path: ['confirmPassword'], message: 'Passwords must match' }];
 }
 
-// Dynamic Forms maps this to Angular's form errors:
-form.controls.confirmPassword.errors;
-// → { 'Passwords must match': true }
+// Angular's validateStandardSchema converts each issue to a field-level error
+// on the field at issue.path:
+// { kind: 'standardSchema', message: 'Passwords must match' }
 ```
+
+The error's message is displayed through the standard resolution chain: field-level `validationMessages.standardSchema` first, then form-level `defaultValidationMessages.standardSchema`, then the issue message itself.
 
 ## Combining with Field Validators
 
@@ -215,6 +217,6 @@ const config = { schema: standardSchema(schema), fields: [...] };
 
 ## Next Steps
 
-- **[Angular Schema](/schema-validation/angular-schema)** — Native Angular approach without additional dependencies
-- **[Field Validation](/validation/basics)** — Add built-in and custom validators to individual fields
-- **[Schema Validation Overview](/schema-validation/overview)** — Compare Angular and Standard Schema approaches
+- **[Angular Schema](/schema-validation/angular-schema)**: Native Angular approach without additional dependencies
+- **[Field Validation](/validation/basics)**: Add built-in and custom validators to individual fields
+- **[Schema Validation Overview](/schema-validation/overview)**: Compare Angular and Standard Schema approaches

--- a/apps/docs/public/content/validation/advanced.md
+++ b/apps/docs/public/content/validation/advanced.md
@@ -364,5 +364,5 @@ when: {
 
 - **[Validation Basics](/validation/basics)** - Shorthand validators
 - **[Validation Reference](/validation/reference)** - Complete API
-- **[Conditional Logic](/dynamic-behavior/overview)** - Field behavior changes
+- **[Conditional Logic](/dynamic-behavior/conditional-logic)** - Field behavior changes
 - **[Examples](/examples)** - Real-world patterns

--- a/apps/docs/public/content/validation/basics.md
+++ b/apps/docs/public/content/validation/basics.md
@@ -4,7 +4,7 @@ slug: validation/basics
 description: 'Learn how to add type-safe validation to dynamic forms using Angular signal forms, shorthand validators, and conditional rules.'
 ---
 
-Dynamic Forms provides powerful, type-safe validation that integrates directly with Angular's signal forms. Start with simple shorthand validators and progress to advanced conditional validation as your needs grow.
+Dynamic Forms provides type-safe validation that maps directly to Angular signal forms validators. Start with simple shorthand validators and progress to advanced conditional validation as your needs grow.
 
 ## Signal Forms Integration
 
@@ -104,7 +104,7 @@ Choose based on your validation complexity:
 
 - Dynamic field behavior
 - Conditional required fields
-- See [Conditional Logic](/dynamic-behavior/overview) for details
+- See [Conditional Logic](/dynamic-behavior/conditional-logic) for details
 
 ## Shorthand Validators
 
@@ -198,25 +198,19 @@ All validators must pass for the field to be valid.
 
 ## Validation Messages
 
-### Default Messages
+### Message Resolution
 
-Each validator has a built-in error message:
+Built-in validators map directly to Angular's `required()`, `email()`, `minLength()`, and related functions, which produce errors without any message text. For each error kind, the message is resolved in this order:
 
-```typescript
-{
-  required: true;
-} // → "This field is required"
-{
-  email: true;
-} // → "Please enter a valid email address"
-{
-  minLength: 8;
-} // → "Minimum length is 8 characters"
-```
+1. Field-level `validationMessages[kind]`
+2. Form-level `defaultValidationMessages[kind]`
+3. The error's own `message` property (present on schema validation errors, for example)
+
+If none of these produce a message, a console warning is logged and the error is not displayed. Configure a message for every validator you use.
 
 ### Custom Messages
 
-Override default messages for better UX:
+Configure messages per field:
 
 ```typescript
 {
@@ -302,17 +296,14 @@ const config = {
 
 ## When Validation Runs
 
-Validation occurs:
+Validators run reactively: every value change re-evaluates the field's validation state immediately. There is no `updateOn` setting. What is gated is the display of errors:
 
-- **On blur** - When user leaves a field
-- **On change** - As user types (after first blur)
-- **On submit** - When form is submitted
-
-Invalid fields prevent form submission and display error messages.
+- **Error display** - Error messages appear once a field is both invalid and touched
+- **Submit buttons** - Disabled by default while the form is invalid (configurable via `options.submitButton.disableWhenInvalid`)
 
 ## Next Steps
 
 - **[Validation Advanced](/validation/advanced)** - Conditional validation, dynamic values
 - **[Validation Reference](/validation/reference)** - Complete validator API
-- **[Conditional Logic](/dynamic-behavior/overview)** - Dynamic field behavior
+- **[Conditional Logic](/dynamic-behavior/conditional-logic)** - Dynamic field behavior
 - **[Examples](/examples)** - Real-world validation patterns

--- a/apps/docs/public/content/validation/custom-validators.md
+++ b/apps/docs/public/content/validation/custom-validators.md
@@ -1,7 +1,7 @@
 ---
 title: Custom Validators
 slug: validation/custom-validators
-description: 'Create custom sync, async, and HTTP validators for ng-forge dynamic forms with full FieldContext access and strict message resolution.'
+description: 'Create custom sync, async, and HTTP validators for ng-forge dynamic forms, with FieldContext access and configurable message resolution.'
 ---
 
 Custom validation functions for complex validation logic that goes beyond built-in validators.
@@ -23,15 +23,17 @@ Try the interactive example below to see both expression-based and function-base
 
 <docs-live-example scenario="examples/expression-validators-demo"></docs-live-example>
 
-## Message Resolution (STRICT)
+## Message Resolution
 
-All error messages MUST be explicitly configured. The framework enforces this strictly:
+Error messages are resolved per error kind in this order:
 
 1. **Field-level `validationMessages[kind]`** (highest priority - per-field customization)
 2. **Form-level `defaultValidationMessages[kind]`** (fallback for common messages)
-3. **No message configured = Console warning + error NOT displayed**
+3. **The error's own `message` property** (final fallback, used when the validator attaches one)
 
-**Important:** Validator-returned messages are NOT used as fallbacks. This enforces proper separation of concerns and i18n patterns.
+If none of these produce a message, a console warning is logged and the error is not displayed.
+
+**Recommendation:** Prefer configured messages over validator-returned ones. Returning only the error `kind` and configuring messages at the field or form level keeps validation logic separate from presentation and supports i18n.
 
 You can define messages at the form level for common validation errors:
 
@@ -54,10 +56,10 @@ ng-forge supports two patterns for custom validators:
 
 Function-based validators have two interchangeable authoring forms:
 
-- **Registered (`functionName`)** — JSON-serializable; safe to ship in configs loaded from APIs, OpenAPI, or databases.
-- **Inline (`fn`)** — code-only, type-safe; skips the registry round-trip but cannot survive JSON serialization. `fn` and `functionName` are mutually exclusive — TypeScript rejects setting both, and at runtime an explicit warning is logged before the inline form wins.
+- **Registered (`functionName`)**: JSON-serializable; safe to ship in configs loaded from APIs, OpenAPI, or databases.
+- **Inline (`fn`)**: code-only, type-safe; skips the registry round-trip but cannot survive JSON serialization. `fn` and `functionName` are mutually exclusive: TypeScript rejects setting both, and at runtime an explicit warning is logged before the inline form wins.
 
-The same `fn` / `asyncFn` alternative is available on conditions and derivations — see [Inline functions vs registered names](#inline-functions-vs-registered-names) below.
+The same `fn` / `asyncFn` alternative is available on conditions and derivations; see [Inline functions vs registered names](#inline-functions-vs-registered-names) below.
 
 ## Expression-Based Validators
 
@@ -177,7 +179,7 @@ Expressions use **secure AST-based parsing**. Only safe JavaScript operations ar
 
 ## Function-Based Validators
 
-Best for validation that needs field value and access to other fields via FieldContext.
+Best for reusable validation logic on the field's own value.
 
 ### Basic Example
 
@@ -238,37 +240,25 @@ const config = {
 };
 ```
 
-`fn` and `functionName` are mutually exclusive (XOR at the type level). The inline form is **not** JSON-serializable — for configs loaded from APIs, OpenAPI, or databases, stick to `functionName`.
+`fn` and `functionName` are mutually exclusive (XOR at the type level). The inline form is **not** JSON-serializable; for configs loaded from APIs, OpenAPI, or databases, stick to `functionName`.
 
 **See also:** the same XOR pattern applies to [conditions](/dynamic-behavior/conditional-logic#function-based-forms-registered-vs-inline) and [derivations](/dynamic-behavior/derivation/values#inline-alternative-fn). See [Configuration](/configuration) for `customFnConfig` setup and [AI Integration (MCP)](/ai-integration) for the MCP server, which emits configs using `functionName` exclusively.
 
 ### FieldContext API
 
-The `FieldContext` API provides access to:
+Custom validator functions receive Angular's raw `FieldContext`:
 
 - **`ctx.value()`** - Current field value (signal)
 - **`ctx.state`** - Field state (errors, touched, dirty, etc.)
-- **`ctx.valueOf(path)`** - Access other field values (PUBLIC API for cross-field validation)
-- **`ctx.stateOf(path)`** - Access other field states
-- **`ctx.field`** - Current field tree
+- **`ctx.fieldTree`** - The current field
+
+`FieldContext` also exposes `valueOf(path)` and `stateOf(path)`, but these take a `FieldPath` object from Angular's schema path tree, not a string. Custom validator functions have no access to path objects, so they cannot use `valueOf` to read other fields. For cross-field rules, use an expression-based validator (which can read `formValue`) or a form-level [schema](/schema-validation/angular-schema).
 
 ### Cross-Field Validation
 
-Use `ctx.valueOf()` to access other field values for comparison validators:
+Use an expression-based validator that reads `formValue` to compare against other fields:
 
 ```typescript
-import { CustomValidator } from '@ng-forge/dynamic-forms';
-
-const greaterThanMin: CustomValidator = (ctx) => {
-  const value = ctx.value();
-  const minValue = ctx.valueOf('minAge');
-
-  if (minValue !== undefined && value <= minValue) {
-    return { kind: 'notGreaterThanMin' };
-  }
-  return null;
-};
-
 // Note: Custom validators return only 'kind'. Built-in validators (min, max, etc.)
 // automatically include params for interpolation (e.g., {{min}}, {{max}}, etc.)
 const config = {
@@ -281,7 +271,8 @@ const config = {
       validators: [
         {
           type: 'custom',
-          functionName: 'greaterThanMin',
+          expression: 'fieldValue > formValue.minAge',
+          kind: 'notGreaterThanMin',
         },
       ],
       validationMessages: {
@@ -289,9 +280,6 @@ const config = {
       },
     },
   ],
-  customFnConfig: {
-    validators: { greaterThanMin },
-  },
 };
 ```
 
@@ -305,25 +293,15 @@ const config = {
 ### Password Confirmation Example
 
 ```typescript
-const passwordMatch: CustomValidator = (ctx) => {
-  const confirmPassword = ctx.value();
-  const password = ctx.valueOf('password');
-
-  if (!confirmPassword || !password) {
-    return null; // Let required validator handle empty case
-  }
-
-  if (password !== confirmPassword) {
-    return { kind: 'passwordMismatch' };
-  }
-  return null;
-};
-
-// In field config:
 {
   key: 'confirmPassword',
   type: 'input',
-  validators: [{ type: 'custom', functionName: 'passwordMatch' }],
+  validators: [{
+    type: 'custom',
+    // Pass while either field is empty so the required validator handles that case
+    expression: '!fieldValue || !formValue.password || fieldValue === formValue.password',
+    kind: 'passwordMismatch',
+  }],
   validationMessages: {
     passwordMismatch: 'Passwords do not match'
   }
@@ -351,10 +329,10 @@ const checkUsernameAvailable: AsyncCustomValidator = {
   factory: (params) => {
     const userService = inject(UserService);
     return rxResource({
-      request: params,
-      loader: ({ request }) => {
-        if (!request?.username) return of(null);
-        return userService.checkAvailability(request.username);
+      params,
+      stream: ({ params }) => {
+        if (!params?.username) return of(null);
+        return userService.checkAvailability(params.username);
       },
     });
   },
@@ -418,7 +396,7 @@ interface AsyncCustomValidator<TValue, TParams, TResult> {
 
 ## Declarative HTTP Validators
 
-The simplest way to validate against an HTTP endpoint. No function registration required — configure the request and response mapping inline.
+The simplest way to validate against an HTTP endpoint. No function registration required: configure the request and response mapping inline.
 
 ### Basic Example
 
@@ -437,7 +415,7 @@ The simplest way to validate against an HTTP endpoint. No function registration 
         },
       },
       responseMapping: {
-        validWhen: 'response.available', // Truthy = valid
+        validWhen: 'response.available', // Must evaluate to boolean true
         errorKind: 'usernameTaken',
       },
     },
@@ -452,7 +430,7 @@ The simplest way to validate against an HTTP endpoint. No function registration 
 
 - `fieldValue` is available as an expression in `params`, `queryParams`, and `body` (refers to the current field's value)
 - Use `params` with `:key` URL placeholders for path parameters (e.g. `url: '/api/users/:id'` + `params: { id: 'fieldValue' }`)
-- `validWhen` is evaluated with `{ response }` in scope — truthy means validation passed
+- `validWhen` is evaluated with `{ response }` in scope and must return boolean `true` for the field to be valid; non-boolean results log a warning
 - **Fail-closed:** if the HTTP request errors, the validator returns `{ kind: errorKind }` by default (prevents submission on network failure)
 
 ### POST with Body Expressions
@@ -501,10 +479,10 @@ Use `errorParams` to include response data in validation messages:
 
 ```typescript
 interface HttpValidationResponseMapping {
-  /** Expression evaluated with { response }. Truthy = valid (no error). */
+  /** Expression evaluated with { response }. Must evaluate to boolean true to be valid. */
   validWhen: string;
 
-  /** Error kind returned when validWhen is falsy — maps to validationMessages. */
+  /** Error kind returned when validWhen is not true; maps to validationMessages. */
   errorKind: string;
 
   /**
@@ -582,8 +560,7 @@ const config = {
 
 **Key Benefits:**
 
-- Automatic request cancellation when field changes
-- Built-in debouncing via resource API
+- Automatic cancellation of in-flight requests when the value changes
 - Prevents race conditions
 - Optimized for HTTP-specific validation
 
@@ -591,7 +568,7 @@ const config = {
 
 ### Inline Alternative (`fn`)
 
-For code-only projects, skip the `customFnConfig.httpValidators` registration and attach the validator inline. `FunctionHttpValidatorConfig.fn` is XOR with `functionName` — TypeScript rejects both keys at compile time, and the runtime warns + prefers inline if a JSON-loaded config sets them both.
+For code-only projects, skip the `customFnConfig.httpValidators` registration and attach the validator inline. `FunctionHttpValidatorConfig.fn` is XOR with `functionName`: TypeScript rejects both keys at compile time, and the runtime warns + prefers inline if a JSON-loaded config sets them both.
 
 ```typescript
 import type { HttpCustomValidator } from '@ng-forge/dynamic-forms';
@@ -627,8 +604,8 @@ interface HttpCustomValidator<TValue, TResult> {
   // Build HTTP request from field context
   readonly request: (ctx: FieldContext<TValue>) => HttpResourceRequest | string | undefined;
 
-  // Map successful response to validation error
-  readonly onSuccess?: (result: TResult, ctx: FieldContext<TValue>) => ValidationError | ValidationError[] | null;
+  // REQUIRED: map successful response to validation error
+  readonly onSuccess: (result: TResult, ctx: FieldContext<TValue>) => ValidationError | ValidationError[] | null;
 
   // Handle HTTP errors
   readonly onError?: (error: unknown, ctx: FieldContext<TValue>) => ValidationError | ValidationError[] | null;
@@ -637,7 +614,7 @@ interface HttpCustomValidator<TValue, TResult> {
 interface HttpResourceRequest {
   url: string;
   method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
-  body?: any;
+  body?: unknown;
   headers?: Record<string, string | string[]>;
 }
 ```
@@ -697,7 +674,7 @@ const config = {
 };
 ```
 
-The validator is only active when the `when` condition evaluates to `true`, allowing dynamic validation based on form state. See [Conditional Logic](/dynamic-behavior/overview) for all expression types and operators.
+The validator is only active when the `when` condition evaluates to `true`, allowing dynamic validation based on form state. See [Conditional Logic](/dynamic-behavior/conditional-logic) for all expression types and operators.
 
 ## Common Validation Patterns
 
@@ -733,48 +710,49 @@ const ageValidator: CustomValidator = (ctx) => {
 ### Conditional Required
 
 ```typescript
-const conditionalRequiredValidator: CustomValidator = (ctx) => {
-  const value = ctx.value();
-  const employmentStatus = ctx.valueOf('employmentStatus');
-
-  // Company name required if employed
-  if (employmentStatus === 'employed' && !value) {
-    return { kind: 'required' };
-  }
-  return null;
-};
+// Company name required if employed
+{
+  key: 'companyName',
+  type: 'input',
+  validators: [{
+    type: 'custom',
+    expression: "formValue.employmentStatus !== 'employed' || !!fieldValue",
+    kind: 'required',
+  }],
+}
 ```
 
 ### Date Range Validation
 
 ```typescript
-const dateRangeValidator: CustomValidator = (ctx) => {
-  const endDate = ctx.value();
-  const startDate = ctx.valueOf('startDate');
-
-  if (startDate && endDate && startDate > endDate) {
-    return { kind: 'invalidDateRange' };
-  }
-  return null;
-};
+{
+  key: 'endDate',
+  type: 'datepicker',
+  validators: [{
+    type: 'custom',
+    expression: '!formValue.startDate || !fieldValue || formValue.startDate <= fieldValue',
+    kind: 'invalidDateRange',
+  }],
+  validationMessages: {
+    invalidDateRange: 'End date must be after start date',
+  },
+}
 ```
 
 ## Multiple Errors
 
-Validators can return multiple errors for cross-field validation:
+Validators can return multiple errors:
 
 ```typescript
-const validateDateRange: CustomValidator = (ctx) => {
+const passwordStrength: CustomValidator = (ctx) => {
+  const value = ctx.value();
+  if (typeof value !== 'string' || !value) return null;
+
   const errors: ValidationError[] = [];
 
-  const startDate = ctx.valueOf('startDate');
-  const endDate = ctx.valueOf('endDate');
-
-  if (!startDate) errors.push({ kind: 'startDateRequired' });
-  if (!endDate) errors.push({ kind: 'endDateRequired' });
-  if (startDate && endDate && startDate > endDate) {
-    errors.push({ kind: 'invalidDateRange' });
-  }
+  if (!/[A-Z]/.test(value)) errors.push({ kind: 'missingUppercase' });
+  if (!/[0-9]/.test(value)) errors.push({ kind: 'missingNumber' });
+  if (value.length < 12) errors.push({ kind: 'tooShort' });
 
   return errors.length > 0 ? errors : null;
 };
@@ -824,13 +802,19 @@ import { TranslateService } from '@ngx-translate/core';
 
 ### Parameterized Messages
 
-Messages can interpolate params from ValidatorConfig using Angular template syntax (double curly braces around the param name).
+Messages interpolate values from the returned validation error's properties using double curly braces (same syntax as Angular templates). Interpolation reads the error object, not `ValidatorConfig.params`:
 
-**Syntax:** To interpolate a param, wrap its name in double curly braces (same syntax as Angular templates).
-
-**Example:** To access `params.label`, write the param name `label` wrapped in double curly braces in your message string.
+- Expression-based validators attach evaluated `errorParams` to the error automatically.
+- Declarative HTTP validators attach `responseMapping.errorParams` automatically.
+- Function-based validators must copy any values they want interpolated onto the returned error object.
 
 ```typescript
+const lessThanField: CustomValidator = (ctx, params) => {
+  // ... validation logic ...
+  // Copy interpolation values onto the returned error
+  return { kind: 'notLessThan', label: params?.['label'] };
+};
+
 {
   validators: [
     {
@@ -840,13 +824,13 @@ Messages can interpolate params from ValidatorConfig using Angular template synt
     }
   ],
   validationMessages: {
-    // Interpolate params.label using double curly braces
+    // Interpolates the error's label property
     notLessThan: 'Must be less than {{label}}'
   }
 }
 ```
 
-The validation message will render as **"Must be less than Minimum Age"** by interpolating the `label` param value.
+The validation message renders as **"Must be less than Minimum Age"** because the returned error carries `label: 'Minimum Age'`.
 
 ## Type Safety
 
@@ -900,8 +884,8 @@ const checkDomain: HttpCustomValidator<string, { valid: boolean }> = {
 1. **Separation of Concerns**: Return only error `kind`, configure messages separately
 2. **i18n Support**: Use Observable/Signal for validation messages
 3. **Graceful Degradation**: Handle async/HTTP errors without blocking the form
-4. **Cross-Field Validation**: Use `ctx.valueOf()` for accessing related fields
-5. **Type Safety**: Leverage TypeScript generics for type-safe validation
+4. **Cross-Field Validation**: Use expression-based validators that read `formValue`, or a form-level schema
+5. **Type Safety**: Use TypeScript generics for type-safe validation
 6. **Message Priority**: Use field-level messages for customization, form-level for common errors
 7. **Conditional Validation**: Use `when` property with `ConditionalExpression` for dynamic validators
 8. **Inverted Logic**: HTTP validators check validity, not data fetching success
@@ -922,7 +906,7 @@ Every validator/condition/derivation surface that accepts a `functionName` (or `
 
 Rules of thumb:
 
-- Use **`functionName` / `asyncFunctionName`** for configs that travel over the wire — API responses, OpenAPI schemas, JSON files, database rows. The MCP server only emits the registered form.
+- Use **`functionName` / `asyncFunctionName`** for configs that travel over the wire: API responses, OpenAPI schemas, JSON files, database rows. The MCP server only emits the registered form.
 - Use **`fn` / `asyncFn`** for code-only configs in TypeScript when you don't need JSON serializability. The function reference is captured directly, with no registry indirection.
 - The two are **mutually exclusive**. TypeScript rejects setting both at compile time; if a JSON-loaded config sneaks both keys through at runtime, a warning is logged and the inline form wins.
 

--- a/apps/docs/public/content/validation/reference.md
+++ b/apps/docs/public/content/validation/reference.md
@@ -127,7 +127,7 @@ Regular expression validation.
 
 ## Conditional Expressions
 
-Validators support a `when` property for conditional validation. See **[Conditional Logic](/dynamic-behavior/overview)** for the complete reference on:
+Validators support a `when` property for conditional validation. See **[Conditional Logic](/dynamic-behavior/conditional-logic)** for the complete reference on:
 
 - All operators (`equals`, `notEquals`, `greater`, `less`, `contains`, `matches`, etc.)
 - Expression types (`fieldValue`, `javascript`, `custom`)
@@ -166,6 +166,7 @@ interface BuiltInValidatorConfig {
 interface CustomValidatorConfig {
   type: 'custom';
   functionName?: string;
+  fn?: CustomValidator; // inline validator; mutually exclusive with functionName
   params?: Record<string, unknown>;
   expression?: string;
   kind?: string;
@@ -173,21 +174,21 @@ interface CustomValidatorConfig {
   when?: ConditionalExpression;
 }
 
-// Async validators (for debounced validation, database lookups)
-interface AsyncValidatorConfig {
+// Async validators (database lookups, resource-based async checks)
+// Exactly one of functionName or fn must be set (XOR)
+type AsyncValidatorConfig = {
   type: 'async';
-  functionName: string;
   params?: Record<string, unknown>;
   when?: ConditionalExpression;
-}
+} & ({ functionName: string; fn?: never } | { fn: AsyncCustomValidator; functionName?: never });
 
-// Function-based HTTP validators (requires a registered function)
-interface FunctionHttpValidatorConfig {
+// Function-based HTTP validators (registered function or inline fn)
+// Exactly one of functionName or fn must be set (XOR)
+type FunctionHttpValidatorConfig = {
   type: 'http';
-  functionName: string;
   params?: Record<string, unknown>;
   when?: ConditionalExpression;
-}
+} & ({ functionName: string; fn?: never } | { fn: HttpCustomValidator; functionName?: never });
 
 // Declarative HTTP validators (fully JSON-serializable, no function registration)
 interface DeclarativeHttpValidatorConfig {
@@ -205,7 +206,7 @@ type ValidatorConfig =
   | DeclarativeHttpValidatorConfig;
 ```
 
-> **Note:** `FunctionHttpValidatorConfig` and `DeclarativeHttpValidatorConfig` both use `type: 'http'`. They are discriminated by property presence: `functionName` indicates function-based, `http` + `responseMapping` indicates declarative.
+> **Note:** `FunctionHttpValidatorConfig` and `DeclarativeHttpValidatorConfig` both use `type: 'http'`. They are discriminated by property presence: `functionName` or `fn` indicates function-based, `http` + `responseMapping` indicates declarative.
 
 ### HttpRequestConfig
 
@@ -215,6 +216,7 @@ Used by `DeclarativeHttpValidatorConfig` to define the HTTP request:
 interface HttpRequestConfig {
   url: string;
   method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'; // defaults to 'GET'
+  params?: Record<string, string>; // URL path parameters for :key placeholders; values are expressions
   queryParams?: Record<string, string>; // values are expressions
   body?: Record<string, unknown>;
   evaluateBodyExpressions?: boolean; // when true, top-level string values in body are evaluated as expressions
@@ -228,7 +230,7 @@ Used by `DeclarativeHttpValidatorConfig` to interpret the HTTP response:
 
 ```typescript
 interface HttpValidationResponseMapping {
-  validWhen: string; // expression evaluated with { response } scope; truthy = valid
+  validWhen: string; // expression evaluated with { response } scope; must evaluate to boolean true
   errorKind: string; // error kind for validationMessages lookup
   errorParams?: Record<string, string>; // parameter expressions evaluated against { response }
 }
@@ -236,7 +238,7 @@ interface HttpValidationResponseMapping {
 
 ## ConditionalExpression Types
 
-`ConditionalExpression` is a discriminated union of six condition types. Each variant only allows the properties relevant to its type, providing compile-time safety against invalid property combinations.
+`ConditionalExpression` is a discriminated union of seven condition types. Each variant only allows the properties relevant to its type, providing compile-time safety against invalid property combinations.
 
 ```typescript
 // Compare a specific field's value
@@ -247,17 +249,33 @@ interface FieldValueCondition {
   value?: unknown;
 }
 
-// Invoke a registered custom function by name
-interface CustomCondition {
-  type: 'custom';
-  functionName: string;
-}
+// Invoke a registered custom function by name, or an inline function
+// Exactly one of functionName or fn must be set (XOR)
+type CustomCondition = { type: 'custom'; functionName: string; fn?: never } | { type: 'custom'; fn: CustomFunction; functionName?: never };
 
 // Evaluate a JavaScript expression via the secure AST-based parser
 interface JavascriptCondition {
   type: 'javascript';
   expression: string; // has access to formValue, fieldValue, externalData, etc.
 }
+
+// Evaluate based on an HTTP response
+interface HttpCondition {
+  type: 'http';
+  http: HttpRequestConfig;
+  responseExpression?: string; // expression with { response } scope; defaults to !!response
+  pendingValue?: boolean; // value while the request is in flight; defaults to false
+  cacheDurationMs?: number; // response cache duration; defaults to 30000
+  debounceMs?: number; // re-evaluation debounce; defaults to 300
+}
+
+// Resolve asynchronously via a custom function
+// Exactly one of asyncFunctionName or asyncFn must be set (XOR)
+type AsyncCondition = {
+  type: 'async';
+  pendingValue?: boolean; // value while resolution is pending; defaults to false
+  debounceMs?: number; // re-evaluation debounce; defaults to 300
+} & ({ asyncFunctionName: string; asyncFn?: never } | { asyncFn: AsyncConditionFunction; asyncFunctionName?: never });
 
 // Logical AND — all sub-conditions must be true
 interface AndCondition {
@@ -283,7 +301,14 @@ type ComparisonOperator =
   | 'endsWith'
   | 'matches';
 
-type ConditionalExpression = FieldValueCondition | CustomCondition | JavascriptCondition | AndCondition | OrCondition;
+type ConditionalExpression =
+  | FieldValueCondition
+  | CustomCondition
+  | JavascriptCondition
+  | HttpCondition
+  | AsyncCondition
+  | AndCondition
+  | OrCondition;
 ```
 
 ## Validation Messages
@@ -426,5 +451,5 @@ type ConditionalExpression = FieldValueCondition | CustomCondition | JavascriptC
 
 - **[Validation Basics](/validation/basics)** - Getting started with validation
 - **[Validation Advanced](/validation/advanced)** - Conditional validators
-- **[Conditional Logic](/dynamic-behavior/overview)** - Field behavior changes
+- **[Conditional Logic](/dynamic-behavior/conditional-logic)** - Field behavior changes
 - **[Type Safety](/recipes/type-safety)** - TypeScript integration

--- a/apps/docs/public/content/wrappers/overview.md
+++ b/apps/docs/public/content/wrappers/overview.md
@@ -4,11 +4,11 @@ slug: wrappers/overview
 description: 'Compose chrome around any dynamic form field without touching the field itself. Wrappers are Angular components chained around a field to add labels, cards, validation indicators, or other decoration.'
 ---
 
-Wrappers decorate a rendered field with extra UI chrome — a titled section, a validation indicator, a card, a collapsible panel — without modifying the field component itself. Multiple wrappers stack outermost → innermost.
+Wrappers decorate a rendered field with extra UI chrome (a titled section, a validation indicator, a card, a collapsible panel) without modifying the field component itself. Multiple wrappers stack from outermost to innermost.
 
 ## How a wrapper chain looks
 
-With `wrappers: [{ type: 'section' }, { type: 'css' }]` on a field, the outlet plugs each wrapper into the previous one's `#fieldComponent` slot — outermost first, field component last:
+With `wrappers: [{ type: 'section' }, { type: 'css' }]` on a field, the outlet plugs each wrapper into the previous one's `#fieldComponent` slot, outermost first and the field component last:
 
 <docs-wrapper-chain-visual></docs-wrapper-chain-visual>
 
@@ -29,19 +29,19 @@ The form below layers a custom `section` wrapper on one field, inherits a form-l
 
 <docs-live-example scenario="examples/wrapper-section"></docs-live-example>
 
-The horizontal layout you see everywhere else in these docs is also a wrapper in action — `{ type: 'row', fields: [...] }` resolves to the container field with an auto-injected `row` wrapper. You never write the wrapper explicitly; it's an implementation detail of the `row` type.
+The horizontal layout you see everywhere else in these docs is also a wrapper in action: `{ type: 'row', fields: [...] }` resolves to the container field with an auto-injected `row` wrapper. You never write the wrapper explicitly; it's an implementation detail of the `row` type.
 
 ## Built-in wrappers
 
 Two wrappers ship with the library and are registered automatically:
 
-- **`css`** — adds space-separated classes to a wrapping element. Accepts a `DynamicText` for `cssClasses` (string, `Signal<string>`, or `Observable<string>`):
+- **`css`**: adds space-separated classes to a wrapping element. Accepts a `DynamicText` for `cssClasses` (string, `Signal<string>`, or `Observable<string>`):
 
   ```typescript
   { type: 'css', cssClasses: 'card p-4' }
   ```
 
-- **`row`** — the flex/grid layout used under the hood when you write `{ type: 'row', fields: [...] }`. Keep writing `type: 'row'` — the wrapper plumbing is hidden.
+- **`row`**: the flex/grid layout used under the hood when you write `{ type: 'row', fields: [...] }`. Keep writing `type: 'row'`; the wrapper plumbing is hidden.
 
 ## When to reach for a wrapper
 
@@ -49,13 +49,13 @@ Wrappers are one of three extension points. Pick the smallest that solves the pr
 
 | Problem                                                               | Use                                              | Cost                            |
 | --------------------------------------------------------------------- | ------------------------------------------------ | ------------------------------- |
-| A static CSS class on the field's existing host                       | [`className`](/configuration) on the field       | Free — no wrapper instantiated  |
+| A static CSS class on the field's existing host                       | [`className`](/configuration) on the field       | Free (no wrapper instantiated)  |
 | Consistent chrome (card, section header, badge) around many fields    | **Wrapper**                                      | One component per wrapper level |
 | A brand-new control (rich-text editor, file picker, colour picker, …) | [Custom field](/recipes/custom-fields)           | New component + registration    |
 | Same chrome on every field in a form                                  | `FormConfig.defaultWrappers`                     | One line                        |
 | Auto-decorate all fields of a specific type (e.g. every `input`)      | Wrapper with `types: ['input']` auto-association | One line in registration        |
 
-Wrappers are **read-only** — they observe field state (value, validity, errors) but never mutate. Mutation belongs in the field component.
+Wrappers are **read-only**: they observe field state (value, validity, errors) but never mutate. Mutation belongs in the field component.
 
 ## SSR
 
@@ -63,5 +63,5 @@ Wrappers are SSR-safe. The component cache (`WRAPPER_COMPONENT_CACHE`) and regis
 
 ## Next
 
-1. **[Writing a wrapper](/wrappers/writing-a-wrapper)** — build your own wrapper component: the contract, reading field state, styling, testing.
-2. **[Registering and applying wrappers](/wrappers/registering-and-applying)** — `createWrappers(…)`, module augmentation, `wrappers` on a field, `defaultWrappers`, auto-associations, opting out.
+1. **[Writing a wrapper](/wrappers/writing-a-wrapper)**: build your own wrapper component (the contract, reading field state, styling, testing).
+2. **[Registering and applying wrappers](/wrappers/registering-and-applying)**: `createWrappers(…)`, module augmentation, `wrappers` on a field, `defaultWrappers`, auto-associations, opting out.

--- a/apps/docs/public/content/wrappers/registering-and-applying.md
+++ b/apps/docs/public/content/wrappers/registering-and-applying.md
@@ -4,9 +4,9 @@ slug: wrappers/registering-and-applying
 description: 'Register custom wrappers with createWrappers(), augment FieldRegistryWrappers once via InferWrapperRegistry, and apply them at the form or field level. Covers the merge order, null opt-out, and types-based auto-association.'
 ---
 
-Wrappers travel through the library as **registered types** — a `WrapperTypeDefinition` with a lazy-loaded component. Registration tells `provideDynamicForm(...)` how to resolve a config like `{ type: 'section' }` to your component class, and how to type-check wrapper configs in form definitions.
+Wrappers travel through the library as **registered types**: a `WrapperTypeDefinition` with a lazy-loaded component. Registration tells `provideDynamicForm(...)` how to resolve a config like `{ type: 'section' }` to your component class, and how to type-check wrapper configs in form definitions.
 
-> **Authoring inside an adapter library?** `createWrappers`, `wrapperProps`, and `InferWrapperRegistry` re-export from `@ng-forge/dynamic-forms/integration` — same symbols, same behavior. Use the integration import in adapter packages so field components and wrapper components share one import path. See [Building an Adapter](/building-an-adapter#custom-wrappers).
+> **Authoring inside an adapter library?** `createWrappers`, `wrapperProps`, and `InferWrapperRegistry` re-export from `@ng-forge/dynamic-forms/integration`; same symbols, same behavior. Use the integration import in adapter packages so field components and wrapper components share one import path. See [Building an Adapter](/building-an-adapter#custom-wrappers).
 
 ## 1. Register with `createWrappers`
 
@@ -23,7 +23,7 @@ export const appWrappers = createWrappers({
 });
 ```
 
-`wrapperProps<T>()` is a zero-cost type carrier — it returns `undefined` at runtime and exists purely so TypeScript can thread the config type `T` into the bundle.
+`wrapperProps<T>()` is a zero-cost type carrier: it returns `undefined` at runtime and exists purely so TypeScript can thread the config type `T` into the bundle.
 
 ## 2. Augment `FieldRegistryWrappers` once
 
@@ -52,7 +52,7 @@ export const appConfig: ApplicationConfig = {
 ```
 
 > [!NOTE]
-> `provideDynamicForm(...)` is an application-level provider — call it once in `ApplicationConfig.providers` (or the equivalent `bootstrapApplication` providers). It is not intended for `Route.providers` and the library does not support merging or overriding the wrapper registry per route. Register every field type and wrapper the app needs in that single call.
+> `provideDynamicForm(...)` is an application-level provider; call it once in `ApplicationConfig.providers` (or the equivalent `bootstrapApplication` providers). It is not intended for `Route.providers` and the library does not support merging or overriding the wrapper registry per route. Register every field type and wrapper the app needs in that single call.
 
 ## 4. Apply wrappers
 
@@ -71,7 +71,7 @@ Set `wrappers` on any field:
 }
 ```
 
-Multiple wrappers stack outermost → innermost. The first entry is the outermost. Mixing a custom wrapper with the built-in `css`:
+Multiple wrappers stack from outermost to innermost. The first entry is the outermost. Mixing a custom wrapper with the built-in `css`:
 
 ```typescript
 // section wraps css wraps the field. `section` must be registered first
@@ -114,23 +114,23 @@ Every `input` and `textarea` across the app now receives the `floatingLabel` wra
 
 ## Merge order
 
-The effective wrapper chain for one field is merged from three sources, outermost → innermost:
+The effective wrapper chain for one field is merged from three sources, from outermost to innermost:
 
-1. **Auto-association** — wrappers whose `types` array includes the field's `type`
-2. **Form defaults** — `FormConfig.defaultWrappers`
-3. **Field-level** — the field's own `wrappers` array
+1. **Auto-association**: wrappers whose `types` array includes the field's `type`
+2. **Form defaults**: `FormConfig.defaultWrappers`
+3. **Field-level**: the field's own `wrappers` array
 
 ## `wrappers` state cheatsheet
 
-| `wrappers` value | Effect                                             |
-| ---------------- | -------------------------------------------------- |
-| `undefined`      | Inherit (auto-associations + defaults apply)       |
-| `null`           | **Opt out** — render the field bare                |
-| `[]`             | Inherit (same as `undefined` — **not** an opt-out) |
-| `[{ …wrapper }]` | Append to auto-associations + defaults             |
+| `wrappers` value | Effect                                            |
+| ---------------- | ------------------------------------------------- |
+| `undefined`      | Inherit (auto-associations + defaults apply)      |
+| `null`           | **Opt out**: render the field bare                |
+| `[]`             | Inherit (same as `undefined`, **not** an opt-out) |
+| `[{ …wrapper }]` | Append to auto-associations + defaults            |
 
 > [!WARNING]
-> `wrappers: []` (an empty array) is **not** an opt-out. Auto-associations and `defaultWrappers` still apply — the field-level list just adds zero additional wrappers. Use `wrappers: null` to skip them entirely.
+> `wrappers: []` (an empty array) is **not** an opt-out. Auto-associations and `defaultWrappers` still apply; the field-level list just adds zero additional wrappers. Use `wrappers: null` to skip them entirely.
 
 ## Interactive example
 
@@ -140,13 +140,13 @@ The form below sets `defaultWrappers: [{ type: 'css', cssClasses: 'demo-field' }
 
 ## Troubleshooting
 
-- **Wrapper does not render.** Check that it's passed to `provideDynamicForm(...)` — `WRAPPER_REGISTRY` has no entry otherwise, and the outlet logs an `error`-level message via `DynamicFormLogger` plus a `console.error` with the `[Dynamic Forms]` prefix.
-- **`fieldComponent` is `undefined` in the wrapper's constructor.** Expected — it's a view query. Read it inside a `computed()` / `effect()` / template, never in the constructor.
+- **Wrapper does not render.** Check that it's passed to `provideDynamicForm(...)`; otherwise `WRAPPER_REGISTRY` has no entry and the outlet logs an `error`-level message via `DynamicFormLogger` (the default `ConsoleLogger` writes it to the console) with the `[Dynamic Forms]` prefix.
+- **`fieldComponent` is `undefined` in the wrapper's constructor.** Expected; it's a view query. Read it inside a `computed()` / `effect()` / template, never in the constructor.
 - **Wrapper config isn't typed.** Confirm the `declare module` block runs (TypeScript only picks up augmentations from files that are actually imported). Re-exporting `appWrappers` from an entry module is enough.
-- **Typed config prop does nothing.** A typo like `tilte` instead of `title` won't throw — the wrapper renders without that prop. Unknown keys are intentionally dropped so wrappers don't fight over unrelated config. Rely on the TypeScript augmentation to catch the typo at the config site.
-- **Wrapper re-renders on every keystroke.** Expected when the wrapper reads a mapper-driven input directly — read only the signals you need inside a `computed()` and rely on signal equality to short-circuit downstream reactivity.
+- **Typed config prop does nothing.** A typo like `tilte` instead of `title` won't throw; the wrapper renders without that prop. Unknown keys are intentionally dropped so wrappers don't fight over unrelated config. Rely on the TypeScript augmentation to catch the typo at the config site.
+- **Wrapper re-renders on every keystroke.** Expected when the wrapper reads a mapper-driven input directly; read only the signals you need inside a `computed()` and rely on signal equality to short-circuit downstream reactivity.
 
 ## Where to go from here
 
 - Back to **[Writing a wrapper](/wrappers/writing-a-wrapper)** for the component contract and field-state reading patterns.
-- **[Recipes → Adding Custom Fields](/recipes/custom-fields)** when a new wrapper isn't enough — you need a brand-new control.
+- **[Adding Custom Fields](/recipes/custom-fields)** when a new wrapper isn't enough and you need a brand-new control.

--- a/apps/docs/public/content/wrappers/writing-a-wrapper.md
+++ b/apps/docs/public/content/wrappers/writing-a-wrapper.md
@@ -8,11 +8,11 @@ Build a custom wrapper component that decorates any dynamic form field. This pag
 
 The example here is a `section` wrapper that renders a titled card around any field.
 
-> **Authoring inside an adapter library?** Import the same types from `@ng-forge/dynamic-forms/integration` instead of the root entry point — it re-exports the wrapper-authoring API so an adapter package keeps one import path across its field and wrapper components. See [Building an Adapter](/building-an-adapter#custom-wrappers).
+> **Authoring inside an adapter library?** Import the same types from `@ng-forge/dynamic-forms/integration` instead of the root entry point; it re-exports the wrapper-authoring API so an adapter package keeps one import path across its field and wrapper components. See [Building an Adapter](/building-an-adapter#custom-wrappers).
 
 ## 1. Implement the contract
 
-A wrapper is an Angular component whose template contains a `#fieldComponent` template reference pointing at a `ViewContainerRef`. The outlet creates the wrapper, finds the ref, and renders the next wrapper (or the field component) inside. Everything else — template, styling, DI — is yours.
+A wrapper is an Angular component whose template contains a `#fieldComponent` template reference pointing at a `ViewContainerRef`. The outlet creates the wrapper, finds the ref, and renders the next wrapper (or the field component) inside. Everything else (template, styling, DI) is yours.
 
 ```typescript name="section-wrapper.component.ts"
 import { ChangeDetectionStrategy, Component, input, ViewContainerRef, viewChild } from '@angular/core';
@@ -45,13 +45,13 @@ export default class SectionWrapperComponent implements FieldWrapper {
 ```
 
 > [!NOTE]
-> The `fieldComponent` query must be `viewChild.required('fieldComponent', { read: ViewContainerRef })`, and the `#fieldComponent` template ref cannot live inside an `@if`, `@defer`, or other conditional — the outlet needs the slot ready at creation time, not later. See [Contract pitfalls](#contract-pitfalls) below for the runtime errors you'll see when the contract is violated.
+> The `fieldComponent` query must be `viewChild.required('fieldComponent', { read: ViewContainerRef })`, and the `#fieldComponent` template ref cannot live inside an `@if`, `@defer`, or other conditional; the outlet needs the slot ready at creation time, not later. See [Contract pitfalls](#contract-pitfalls) below for the runtime errors you'll see when the contract is violated.
 
 ### The `#fieldComponent` slot must be unconditional
 
 The outlet reads the `ViewContainerRef` immediately after creating the wrapper and running one `detectChanges()` pass. If the ref isn't present at that moment, `viewChild.required` throws `NG0951` (REQUIRED_QUERY_NO_VALUE), the chain is torn down, and the field renders bare.
 
-✗ Wrong — the slot only materialises when `expanded()` is true:
+✗ Wrong: the slot only materialises when `expanded()` is true:
 
 ```html
 <div class="section">
@@ -61,9 +61,9 @@ The outlet reads the `ViewContainerRef` immediately after creating the wrapper a
 </div>
 ```
 
-Also broken — `@defer`, `@for`, `@switch`, `<ng-template>` (without projecting), or any structural directive that delays view creation.
+Also broken: `@defer`, `@for`, `@switch`, `<ng-template>` (without projecting), or any structural directive that delays view creation.
 
-✓ Right — always present, visibility toggled with CSS / attribute bindings:
+✓ Right: always present, visibility toggled with CSS or attribute bindings:
 
 ```html
 <div class="section" [class.section--collapsed]="!expanded()">
@@ -81,14 +81,14 @@ The outlet strips the `type` discriminant from the wrapper config and pushes eve
 { type: 'section', title: 'Contact details' }
 ```
 
-With `readonly title = input<string>();` on the component, `title()` returns `'Contact details'`. Keys the user wrote that the component doesn't declare are **silently dropped** — the outlet probes `reflectComponentType(ComponentRef.componentType).inputs` before calling `setInput()`, so the normal NG0303 ("input not declared") runtime error never fires. Config-key typos don't crash; they just render with an unset input.
+With `readonly title = input<string>();` on the component, `title()` returns `'Contact details'`. Keys the user wrote that the component doesn't declare are **silently dropped**: the outlet probes `reflectComponentType(ComponentRef.componentType).inputs` before calling `setInput()`, so the normal NG0303 ("input not declared") runtime error never fires. Config-key typos don't crash; they just render with an unset input.
 
 > [!WARNING]
-> A typo like `tilte` won't throw — the wrapper just renders without a title. Because unknown keys are suppressed, the safety net is TypeScript, not runtime: declaring a `FieldRegistryWrappers` augmentation for your wrapper (see [Registering and applying wrappers](/wrappers/registering-and-applying)) turns typos into compile errors at the call site.
+> A typo like `tilte` won't throw; the wrapper just renders without a title. Because unknown keys are suppressed, the safety net is TypeScript, not runtime: declaring a `FieldRegistryWrappers` augmentation for your wrapper (see [Registering and applying wrappers](/wrappers/registering-and-applying)) turns typos into compile errors at the call site.
 
 ### Dynamic config
 
-Any config prop can be a signal or observable instead of a literal. Angular's input system doesn't know the difference — pass a `Signal<string>` for `title` if you want the header text to react to form state, or an `Observable<string>` from a translation service. The built-in `css` wrapper uses this (`cssClasses: DynamicText = string | Signal<string> | Observable<string>`); adopt the same pattern in your own wrappers whenever config should flex at runtime.
+Any config prop can be a signal or observable instead of a literal. Angular's input system doesn't know the difference: pass a `Signal<string>` for `title` if you want the header text to react to form state, or an `Observable<string>` from a translation service. The built-in `css` wrapper uses this (`cssClasses: DynamicText = string | Signal<string> | Observable<string>`); adopt the same pattern in your own wrappers whenever config should flex at runtime.
 
 ## 3. Read field state via `fieldInputs`
 
@@ -97,6 +97,7 @@ Alongside config, every wrapper receives a single `fieldInputs` input of type `W
 ```typescript
 interface WrapperFieldInputs {
   readonly key: string;
+  readonly type?: string;
   readonly label?: string;
   readonly placeholder?: string;
   readonly className?: string;
@@ -104,11 +105,12 @@ interface WrapperFieldInputs {
   readonly validationMessages?: Record<string, string>;
   readonly defaultValidationMessages?: Record<string, string>;
   readonly field?: ReadonlyFieldTree;
+  readonly setValue?: (next: unknown) => void;
   readonly [key: string]: unknown;
 }
 ```
 
-Same set of inputs the mapper would push onto the field component, plus the field's `FieldTree` narrowed to a `ReadonlyFieldTree` — a whitelist of read-only signals (`value`, `valid`, `invalid`, `touched`, `dirty`, `required`, `disabled`, `hidden`, `errors`). Wrappers observe through this surface; they cannot write.
+Same set of inputs the mapper would push onto the field component, plus the field's `FieldTree` narrowed to a `ReadonlyFieldTree`: a whitelist of read-only signals (`value`, `valid`, `invalid`, `touched`, `dirty`, `required`, `disabled`, `hidden`, `errors`). Wrappers should treat this surface as read-only; the `setValue` writer exists for addons and must not be called from wrappers.
 
 A validation-aware section wrapper reads the field's validity:
 
@@ -144,14 +146,14 @@ export default class SectionWrapperComponent implements FieldWrapper {
 
 ### Wrappers on container fields
 
-A wrapper around a `type: 'container'` field wraps a **children template**, not a single field — no single `field` is in scope, so containers don't push a `fieldInputs.field`. If you need to decorate a container based on form state, pass the relevant key(s) through config and look them up from the form tree, or inject `FIELD_SIGNAL_CONTEXT` when you need the broader form root. For most wrappers this isn't necessary — design them to take what they need as props.
+A wrapper around a `type: 'container'` field wraps a **children template**, not a single field. No single `field` is in scope, so containers don't push a `fieldInputs.field`. If you need to decorate a container based on form state, pass the relevant key(s) through config and look them up from the form tree, or inject `FIELD_SIGNAL_CONTEXT` when you need the broader form root. For most wrappers this isn't necessary; design them to take what they need as props.
 
 ## 4. Inject outer wrappers and field tokens
 
 Wrappers are created with a merged injector. The library stacks them like this:
 
-- **Field-level tokens first** — `ARRAY_CONTEXT`, `FIELD_SIGNAL_CONTEXT`, anything provided on the field's `ResolvedField.injector`.
-- **Element injector behind** — the enclosing DOM chain, including every outer wrapper that's already been instantiated.
+- **Field-level tokens first**: `ARRAY_CONTEXT`, `FIELD_SIGNAL_CONTEXT`, anything provided on the field's `ResolvedField.injector`.
+- **Element injector behind**: the enclosing DOM chain, including every outer wrapper that's already been instantiated.
 
 This means a nested wrapper can `inject()` the wrapper that contains it. Precedence goes to the field-level injector when tokens overlap ("more specific context wins").
 
@@ -173,25 +175,25 @@ export default class InnerWrapperComponent implements FieldWrapper {
 }
 ```
 
-Use this sparingly — most wrappers should take what they need via config inputs. Ancestor injection is the right tool when two wrappers are **designed to cooperate** (e.g., a `collapsible` outer wrapper that exposes an `expanded` signal to a `header` inner wrapper).
+Use this sparingly; most wrappers should take what they need via config inputs. Ancestor injection is the right tool when two wrappers are **designed to cooperate** (e.g., a `collapsible` outer wrapper that exposes an `expanded` signal to a `header` inner wrapper).
 
 ## 5. Understand the rebuild lifecycle
 
 The outlet distinguishes **structural** changes from **transient flicker**:
 
-- **Structural change → teardown + rebuild.** The wrapper chain array differs by identity, OR the innermost component class changed. The outlet tears down every wrapper and re-renders from scratch. Focus / caret / scroll on the innermost field are preserved automatically (the hostView is detached and re-inserted).
-- **Transient `renderReady → false` flicker → no-op.** The mapper momentarily stops producing inputs mid-transition. The mounted chain stays alive, the controller ignores the gate, and the next truthy emission pushes new `fieldInputs` without rebuilding.
-- **`fieldInputs` update → push-through.** A fresh `WrapperFieldInputs` snapshot is pushed to every wrapper via `setInput()` without touching the DOM. Mappers must emit new object references per tick rather than mutating — the push-through dedupes by identity.
+- **Structural change: teardown and rebuild.** The wrapper chain array differs by identity, OR the innermost component class changed. The outlet tears down every wrapper and re-renders from scratch. Focus / caret / scroll on the innermost field are preserved automatically (the hostView is detached and re-inserted).
+- **Transient flicker when `renderReady` goes false: no-op.** The mapper momentarily stops producing inputs mid-transition. The mounted chain stays alive, the controller ignores the gate, and the next truthy emission pushes new `fieldInputs` without rebuilding.
+- **`fieldInputs` update: push-through.** A fresh `WrapperFieldInputs` snapshot is pushed to every wrapper via `setInput()` without touching the DOM. Mappers must emit new object references per tick rather than mutating; the push-through dedupes by identity.
 
-What this means for wrapper authors: don't put expensive setup in constructor / `ngOnInit` hoping it'll run rarely — structural rebuilds destroy the whole chain. Use `computed()` / `effect()` off the inputs, which re-run cheaply across the lifetime of a single mount.
+What this means for wrapper authors: don't put expensive setup in constructor / `ngOnInit` hoping it'll run rarely; structural rebuilds destroy the whole chain. Use `computed()` / `effect()` off the inputs, which re-run cheaply across the lifetime of a single mount.
 
 ## 6. Style the wrapped field
 
-Wrappers are ordinary Angular components — view-encapsulated styles, `:host` selectors, and global styles all work as usual. The wrapper-specific concern is **reaching across the encapsulation boundary** to the inner field. `::ng-deep` works for this but pierces encapsulation globally and is awkward to reason about; three cleaner patterns cover it:
+Wrappers are ordinary Angular components: view-encapsulated styles, `:host` selectors, and global styles all work as usual. The wrapper-specific concern is **reaching across the encapsulation boundary** to the inner field. `::ng-deep` works for this but pierces encapsulation globally and is awkward to reason about; three cleaner patterns cover it:
 
-- **CSS custom properties** — set something like `--field-spacing` on the wrapper host and read it in the field's stylesheet. Custom properties cross view encapsulation, so the field doesn't need to know a wrapper is even there.
-- **A class on the child** — set the field's own `className` property. The field applies it to its own host; the wrapper never has to cross the boundary.
-- **Global styles** — declare the rules in a global stylesheet and let them match both sides.
+- **CSS custom properties**: set something like `--field-spacing` on the wrapper host and read it in the field's stylesheet. Custom properties cross view encapsulation, so the field doesn't need to know a wrapper is even there.
+- **A class on the child**: set the field's own `className` property. The field applies it to its own host; the wrapper never has to cross the boundary.
+- **Global styles**: declare the rules in a global stylesheet and let them match both sides.
 
 The library's own `RowWrapperComponent` [uses `:host-context(.modifier)` + global grid classes](https://github.com/ng-forge/ng-forge/blob/main/packages/dynamic-forms/src/lib/wrappers/row/row-wrapper.component.scss) for a worked example.
 
@@ -208,7 +210,7 @@ Three wrapper-chain errors are logged with the `[Dynamic Forms]` prefix. If you 
 
 Either the wrapper name isn't registered in `WRAPPER_REGISTRY`, or the `loadComponent()` promise rejected (bad import path, a throw from the module, etc.).
 
-**Wrapper loading is fail-closed.** If any wrapper in a chain fails to resolve, the **entire chain is dropped** and the field renders bare — never half-wrapped. The error is logged once per failed load (per DI scope, because the cache is DI-scoped).
+**Wrapper loading is fail-closed.** If any wrapper in a chain fails to resolve, the **entire chain is dropped** and the field renders bare, never half-wrapped. The error is logged on each failed load attempt; only successful loads are cached.
 
 Fix: add the wrapper to your `provideDynamicForm(...)` call (see [Registering and applying wrappers](/wrappers/registering-and-applying)), or check that `loadComponent: () => import('./path')` resolves to the right module.
 
@@ -222,8 +224,8 @@ Fix: add the wrapper to your `provideDynamicForm(...)` call (see [Registering an
 
 Two possible causes:
 
-1. The wrapper component doesn't declare `fieldComponent = viewChild.required('fieldComponent', { read: ViewContainerRef })` — the outlet can't find a slot.
-2. The `#fieldComponent` template ref is inside an `@if`, `@defer`, `@for`, `@switch`, or `<ng-template>` that isn't rendered at query time — `viewChild.required` throws `NG0951` and the outlet catches it.
+1. The wrapper component doesn't declare `fieldComponent = viewChild.required('fieldComponent', { read: ViewContainerRef })`, so the outlet can't find a slot.
+2. The `#fieldComponent` template ref is inside an `@if`, `@defer`, `@for`, `@switch`, or `<ng-template>` that isn't rendered at query time; `viewChild.required` throws `NG0951` and the outlet catches it.
 
 See [The `#fieldComponent` slot must be unconditional](#the-fieldcomponent-slot-must-be-unconditional) for correct patterns. When this fires, the outlet unwinds the partial chain so the field renders bare.
 
@@ -233,13 +235,13 @@ See [The `#fieldComponent` slot must be unconditional](#the-fieldcomponent-slot-
 [Dynamic Forms] Wrapper chain render failed; tearing down partial state. <error>
 ```
 
-Something threw while the controller was building the chain — most commonly a wrapper template expression (the user reads `fieldInputs().field!.value()` without the guard) or the `renderInnermost` callback blew up. The controller catches the throw, clears the mounted state, and keeps the subscription alive so the next emission can still render.
+Something threw while the controller was building the chain, most commonly a wrapper template expression (the user reads `fieldInputs().field!.value()` without the guard) or the `renderInnermost` callback blew up. The controller catches the throw, clears the mounted state, and keeps the subscription alive so the next emission can still render.
 
-Check the stack in the attached error. If it points inside your wrapper's template, add a guard for `fieldInputs === undefined` — container wrappers don't push a `fieldInputs`.
+Check the stack in the attached error. If it points inside your wrapper's template, add a guard for `fieldInputs === undefined`; container wrappers don't push a `fieldInputs`.
 
 ## 7. Test the wrapper
 
-Wrappers are components — test them with `TestBed` like any other. A minimal spec that mounts the wrapper via `createComponent`, passes a `fieldInputs` signal, and asserts DOM:
+Wrappers are components; test them with `TestBed` like any other. A minimal spec that mounts the wrapper via `createComponent`, passes a `fieldInputs` signal, and asserts DOM:
 
 ```typescript name="section-wrapper.component.spec.ts"
 import { TestBed } from '@angular/core/testing';
@@ -268,10 +270,10 @@ describe('SectionWrapperComponent', () => {
 });
 ```
 
-For integration tests that exercise wrappers inside a live form (mapper + outlet + chain), the library's own [`container-field.component.spec.ts`](https://github.com/ng-forge/ng-forge/blob/main/packages/dynamic-forms/src/lib/fields/container/container-field.component.spec.ts) is a larger example — mock wrapper components, a `flushWrapperChain` helper, and assertions against the rendered chain.
+For integration tests that exercise wrappers inside a live form (mapper + outlet + chain), the library's own [`container-field.component.spec.ts`](https://github.com/ng-forge/ng-forge/blob/main/packages/dynamic-forms/src/lib/fields/container/container-field.component.spec.ts) is a larger example: mock wrapper components, a `flushWrapperChain` helper, and assertions against the rendered chain.
 
 ## Next
 
-You've built, styled, and tested a custom wrapper — now register it and reach for it in a form:
+You've built, styled, and tested a custom wrapper; now register it and reach for it in a form:
 
-- **[Registering and applying wrappers](/wrappers/registering-and-applying)** — wire the wrapper into `provideDynamicForm`, apply it per-field or via form-wide defaults, opt out with `wrappers: null`, and understand the merge order when multiple sources stack.
+- **[Registering and applying wrappers](/wrappers/registering-and-applying)**: wire the wrapper into `provideDynamicForm`, apply it per-field or via form-wide defaults, opt out with `wrappers: null`, and understand the merge order when multiple sources stack.

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Dynamic Forms provides a powerful way to create dynamic forms in Angular applications. Instead of manually building form templates, you define form structure through configuration objects, and ng-forge renders the appropriate UI components automatically.
+Dynamic Forms is a configuration-driven way to build forms in Angular applications. Instead of manually building form templates, you define form structure through configuration objects, and ng-forge renders the appropriate UI components automatically.
 
 ## Key Features
 
@@ -15,7 +15,7 @@ Dynamic Forms provides a powerful way to create dynamic forms in Angular applica
 - Value derivation for computed fields
 - Property derivation for dynamic field properties
 - Type-safe form configurations
-- Reactive forms under the hood (Angular Signal Forms)
+- Built on Angular Signal Forms (signal-based reactivity, not Reactive Forms or FormGroup)
 - Value exclusion for controlling submitted form data
 - AI integration via MCP server
 
@@ -26,16 +26,17 @@ Dynamic Forms provides a powerful way to create dynamic forms in Angular applica
 
 ### Configuration
 - /configuration: Configure your UI library integration (Material, PrimeNG, Ionic, Bootstrap)
+- /api-driven-forms: Drive forms from JSON shipped by a backend API
 
 ### Building an Adapter
 - /building-an-adapter: Creating custom UI library integrations
 
 ### Field Types
-- /field-types/text-inputs: Text input fields (input, textarea, datepicker)
-- /field-types/selection: Selection fields (select, checkbox, radio, toggle, multi-checkbox, slider)
-- /field-types/buttons: Button fields (button, submit, next, previous)
-- /field-types/utility: Utility fields
-- /field-types/advanced-controls: Advanced control fields
+- /field-types/text-inputs: Text input fields (input, textarea)
+- /field-types/selection: Selection fields (select, radio, checkbox, toggle, multi-checkbox)
+- /field-types/buttons: Button fields (submit, button, next, previous, array buttons)
+- /field-types/utility: Utility fields (text, hidden)
+- /field-types/advanced-controls: Advanced control fields (slider, datepicker)
 
 ### Validation
 - /validation/basics: Validation configuration basics
@@ -62,8 +63,19 @@ Dynamic Forms provides a powerful way to create dynamic forms in Angular applica
 - /prebuilt/form-rows: Row layout components
 - /prebuilt/form-arrays/simplified: Simplified array API (recommended)
 - /prebuilt/form-arrays/complete: Complete array API (advanced)
+- /prebuilt/container-field: Container for stacking wrappers without nesting form values
 - /prebuilt/text-components: Text and label components
 - /prebuilt/hidden-fields: Hidden field components
+
+### Wrappers
+- /wrappers/overview: Decorate fields with extra UI chrome (cards, panels, indicators)
+- /wrappers/writing-a-wrapper: Build a custom wrapper component
+- /wrappers/registering-and-applying: Register wrappers and apply them to fields
+
+### Addons
+- /addons/overview: Icons, buttons, and text in a field's prefix and suffix slots
+- /addons/presets-and-actions: Built-in presets (clear, reset, paste, copy, password toggle) and registered actions
+- /addons/custom-types: Register your own addon type
 
 ### Examples
 - /examples: Browse all examples
@@ -79,6 +91,10 @@ Dynamic Forms provides a powerful way to create dynamic forms in Angular applica
 - /examples/enterprise-features: Complex multi-condition form
 - /examples/simplified-array-form: Simplified array API example
 - /examples/array-form: Complete array API example
+- /examples/wrapper-array-actions: Wrapper that owns an array's add button
+- /examples/addon-clear-button: Clear-button addon pattern
+- /examples/addon-currency: Universal text addon (currency prefix)
+- /examples/addon-password-toggle: Password-visibility toggle addon
 
 ### Recipes
 - /recipes/type-safety: TypeScript type safety features
@@ -95,6 +111,9 @@ Dynamic Forms provides a powerful way to create dynamic forms in Angular applica
 
 ### AI Integration
 - /ai-integration: MCP server for AI-assisted form schema generation
+
+### OpenAPI Generator
+- /openapi-generator: Generate FormConfig and typed form values from an OpenAPI 3.x spec
 
 ### API Reference
 - /api-reference: Complete API documentation for all packages

--- a/apps/docs/scripts/generate-llms-full.ts
+++ b/apps/docs/scripts/generate-llms-full.ts
@@ -40,7 +40,7 @@ export function generateLlmsFull(): string {
   const mdFiles = collectMarkdownFiles(CONTENT_DIR).sort();
 
   const sections: string[] = [
-    '# ng-forge Dynamic Forms — Full Documentation',
+    '# ng-forge Dynamic Forms: Full Documentation',
     '',
     `> Generated from ${mdFiles.length} documentation files.`,
     `> Source: https://ng-forge.com/dynamic-forms/`,

--- a/apps/docs/scripts/generate-sitemap.spec.ts
+++ b/apps/docs/scripts/generate-sitemap.spec.ts
@@ -1,6 +1,12 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { generateSitemap, getGitLastmod } from './generate-sitemap';
 
+// generateSitemap() shells out to `git log` once per content file (60+ calls),
+// so a full run is several seconds of real subprocess I/O and scales with the
+// number of docs pages. Give this file headroom over the 5s default so it does
+// not flake under parallel test load.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 describe('generateSitemap', () => {
   let xml: string;
 
@@ -25,6 +31,12 @@ describe('generateSitemap', () => {
 
   it('includes the migration guide under /material/', () => {
     expect(xml).toContain('<loc>https://ng-forge.com/dynamic-forms/material/migrating-from-ngx-formly</loc>');
+  });
+
+  it('includes the addons pages', () => {
+    for (const page of ['overview', 'presets-and-actions', 'custom-types']) {
+      expect(xml).toContain(`<loc>https://ng-forge.com/dynamic-forms/material/addons/${page}</loc>`);
+    }
   });
 
   it('omits <lastmod> for the api-reference URL (content is build-time-generated)', () => {

--- a/apps/docs/scripts/generate-sitemap.ts
+++ b/apps/docs/scripts/generate-sitemap.ts
@@ -126,6 +126,11 @@ function collectEntries(): SitemapEntry[] {
     entries.push({ slug: `material/wrappers/${page}`, filePath: contentFile(`wrappers/${page}`) });
   }
 
+  // Addons
+  for (const page of ['overview', 'presets-and-actions', 'custom-types']) {
+    entries.push({ slug: `material/addons/${page}`, filePath: contentFile(`addons/${page}`) });
+  }
+
   // Recipes
   for (const page of ['custom-fields', 'expression-parser', 'type-safety', 'events', 'value-exclusion']) {
     entries.push({ slug: `material/recipes/${page}`, filePath: contentFile(`recipes/${page}`) });

--- a/apps/docs/src/app/components/addon-info/addon-info.component.ts
+++ b/apps/docs/src/app/components/addon-info/addon-info.component.ts
@@ -52,7 +52,7 @@ const ADAPTER_DATA: Record<UiAdapterName, AddonAdapterData> = {
     packageName: '@ng-forge/dynamic-forms-material',
     buttonShortName: 'mat-button',
     prefixSlotDescription:
-      "Addons render as direct <code>&lt;mat-form-field&gt;</code> children with <code>matPrefix</code> / <code>matSuffix</code> attribute directives applied to <code>&lt;df-addon-slot&gt;</code> — Material's native projection API.",
+      "Addons render as direct <code>&lt;mat-form-field&gt;</code> children with <code>matPrefix</code> / <code>matSuffix</code> attribute directives applied to <code>&lt;df-addon-slot&gt;</code>, Material's native projection API.",
   },
   bootstrap: {
     iconType: 'bs-icon',
@@ -119,7 +119,7 @@ const ADAPTER_DATA: Record<UiAdapterName, AddonAdapterData> = {
       <div class="addon-info-empty">
         <p>
           Pick a UI adapter (Material, Bootstrap, PrimeNG, or Ionic) from the adapter switcher to view its addon-specific reference. The
-          Custom adapter docs the underlying building blocks — addon configuration is identical to whichever UI adapter your custom adapter
+          Custom adapter docs the underlying building blocks; addon configuration is identical to whichever UI adapter your custom adapter
           is layered on top of.
         </p>
       </div>
@@ -169,12 +169,12 @@ const ADAPTER_DATA: Record<UiAdapterName, AddonAdapterData> = {
                 <tr>
                   <td><code>template</code></td>
                   <td>Named <code>&lt;ng-template&gt;</code></td>
-                  <td>Reference by <code>templateKey</code>. JSON-safe — backend ships the key, FE supplies the template.</td>
+                  <td>Reference by <code>templateKey</code>. JSON-safe: backend ships the key, FE supplies the template.</td>
                 </tr>
                 <tr>
                   <td><code>component</code></td>
                   <td>Arbitrary Angular component</td>
-                  <td>Code-only — dropped from JSON-derived configs.</td>
+                  <td>Code-only; dropped from JSON-derived configs.</td>
                 </tr>
               </tbody>
             </table>
@@ -255,7 +255,7 @@ import { ${d.withFieldsHelper} } from '${d.packageName}';
 // ${d.iconType} + ${d.buttonType} work out of the box.
 provideDynamicForm(...${d.withFieldsHelper}());
 
-// Standalone — addon types without the field types:
+// Standalone: addon types without the field types.
 // provideDynamicForm(...myCustomFields(), ${d.withAddonsHelper}());`;
   });
 
@@ -267,19 +267,19 @@ provideDynamicForm(...${d.withFieldsHelper}());
   }
 }
 
-// Now valid in TS — \`type: 'rating'\` is part of the ${d.inputComponentName} addon union.
+// Now valid in TS: \`type: 'rating'\` is part of the ${d.inputComponentName} addon union.
 { type: 'input', key: 'review', addons: [{ slot: 'suffix', type: 'rating', value: 4 }] }`;
   });
 
   protected readonly threeVariantsCode = computed(() => {
     const d = this.data();
-    return `// 1. Built-in preset — JSON-safe, no code required.
+    return `// 1. Built-in preset: JSON-safe, no code required.
 { slot: 'suffix', type: '${d.buttonType}', icon: '${d.clearIcon}', ariaLabel: 'Clear', preset: 'clear' }
 
-// 2. Registered handler — JSON-safe, looked up by name.
+// 2. Registered handler: JSON-safe, looked up by name.
 { slot: 'suffix', type: '${d.buttonType}', icon: '${d.searchIcon}', ariaLabel: 'Search', actionRef: 'runSearch' }
 
-// 3. Inline function — code-only, dropped from JSON-derived configs by the validator.
+// 3. Inline function: code-only, dropped from JSON-derived configs by the validator.
 { slot: 'suffix', type: '${d.buttonType}', icon: '${d.clearIcon}', ariaLabel: 'Append marker',
   action: (ctx) => ctx.setValue?.(((typeof ctx.value === 'string' ? ctx.value : '') + '+')) }`;
   });

--- a/apps/docs/src/app/components/configuration-view/configuration-view.component.ts
+++ b/apps/docs/src/app/components/configuration-view/configuration-view.component.ts
@@ -312,7 +312,7 @@ const config = {
         <section class="config-view__section">
           <h3 class="config-view__heading">Custom Adapter Config</h3>
           <p class="config-view__desc">
-            Custom adapters define their own config interface. The cascade pattern works the same way — implement a config merger in your
+            Custom adapters define their own config interface. The cascade pattern works the same way: implement a config merger in your
             adapter to support library-level and form-level defaults. See
             <a href="/building-an-adapter">Building an Adapter</a> for a full guide.
           </p>

--- a/apps/docs/src/app/components/feature-overview/feature-overview.component.ts
+++ b/apps/docs/src/app/components/feature-overview/feature-overview.component.ts
@@ -85,7 +85,7 @@ const NAV: readonly NavSection[] = [
       {
         icon: Palette,
         title: 'Pick a UI library',
-        description: 'Material, PrimeNG, Bootstrap, or Ionic — first-party adapters.',
+        description: 'Material, PrimeNG, Bootstrap, or Ionic: first-party adapters.',
         href: '/configuration',
       },
       {
@@ -112,7 +112,7 @@ const NAV: readonly NavSection[] = [
       {
         icon: Type,
         title: 'Text inputs',
-        description: 'input, textarea, datepicker — typing free-form data.',
+        description: 'input, textarea, datepicker: typing free-form data.',
         href: '/field-types/text-inputs',
       },
       {
@@ -145,13 +145,13 @@ const NAV: readonly NavSection[] = [
       {
         icon: Layers,
         title: 'Group fields',
-        description: 'Nest a section under a key — `user.address.street` shape.',
+        description: 'Nest a section under a key for a `user.address.street` shape.',
         href: '/prebuilt/form-groups',
       },
       {
         icon: Rows3,
         title: 'Rows + containers',
-        description: 'Flat layout primitives — no nesting in the form value.',
+        description: 'Flat layout primitives with no nesting in the form value.',
         href: '/prebuilt/form-rows',
       },
       {
@@ -184,7 +184,7 @@ const NAV: readonly NavSection[] = [
       {
         icon: CircleCheck,
         title: 'Built-in shorthand',
-        description: 'required, email, min, max, minLength, pattern — at field top level.',
+        description: 'required, email, min, max, minLength, pattern, all at field top level.',
         href: '/validation/basics',
       },
       {
@@ -196,7 +196,7 @@ const NAV: readonly NavSection[] = [
       {
         icon: FileCode,
         title: 'Schema-first (Zod, Valibot, ArkType)',
-        description: 'Standard Schema spec — one source of truth for shape + validation.',
+        description: 'Standard Schema spec: one source of truth for shape + validation.',
         href: '/schema-validation/zod',
       },
       {
@@ -218,7 +218,7 @@ const NAV: readonly NavSection[] = [
     icon: Zap,
     accent: '#ff4d00',
     title: 'Make fields react',
-    subtitle: 'Show, hide, compute, fetch — fields that respond to other fields.',
+    subtitle: 'Show, hide, compute, fetch: fields that respond to other fields.',
     cards: [
       {
         icon: Eye,
@@ -241,7 +241,7 @@ const NAV: readonly NavSection[] = [
       {
         icon: Send,
         title: 'Submit & events',
-        description: '(submitted), (events), formValue signal — full lifecycle access.',
+        description: '(submitted), (events), formValue signal: full lifecycle access.',
         href: '/dynamic-behavior/submission',
       },
       {
@@ -268,7 +268,7 @@ const NAV: readonly NavSection[] = [
       {
         icon: Funnel,
         title: 'Control submitted values',
-        description: 'excludeValueIfHidden / disabled / readonly — strip server-irrelevant fields.',
+        description: 'excludeValueIfHidden / disabled / readonly strip server-irrelevant fields.',
         href: '/recipes/value-exclusion',
       },
       {
@@ -319,7 +319,7 @@ const PITFALLS: readonly Pitfall[] = [
     href: '/dynamic-behavior/conditional-logic',
   },
   {
-    title: 'Select options blank — backend returns `id` / `name` keys',
+    title: 'Select options blank when the backend returns `id` / `name` keys',
     symptom: 'Dropdown shows empty rows or `[object Object]`.',
     fix: "`FieldOption` is fixed at `{ value, label, disabled? }`. Remap once at the source, or inside a `targetProperty: 'options'` derivation with `responseExpression`.",
     href: '/field-types/selection',
@@ -339,8 +339,8 @@ const PITFALLS: readonly Pitfall[] = [
     <div class="overview">
       <header class="overview__hero">
         <span class="overview__eyebrow">Feature overview</span>
-        <h1 class="overview__title">ng-forge — dynamic forms for Angular</h1>
-        <p class="overview__subtitle">Find your way around — six task-shaped paths into the docs.</p>
+        <h1 class="overview__title">ng-forge: dynamic forms for Angular</h1>
+        <p class="overview__subtitle">Find your way around: six task-shaped paths into the docs.</p>
         <p class="overview__lead">
           Pick what you're trying to do, jump straight to the page that answers it. A general FAQ and the most common pitfalls are at the
           bottom.
@@ -411,7 +411,7 @@ const PITFALLS: readonly Pitfall[] = [
           </span>
           <div>
             <h2 class="overview__h2">Common pitfalls</h2>
-            <p class="overview__h2-sub">The patterns that trip people up — symptom, fix, and a link to the canonical doc.</p>
+            <p class="overview__h2-sub">The patterns that trip people up: symptom, fix, and a link to the canonical doc.</p>
           </div>
         </header>
         <div class="pitfalls">

--- a/apps/docs/src/app/components/feature-overview/feature-overview.data.ts
+++ b/apps/docs/src/app/components/feature-overview/feature-overview.data.ts
@@ -25,7 +25,7 @@ export interface MigrationStep {
 export const FEATURE_OVERVIEW_FAQ: readonly FaqEntry[] = [
   {
     q: 'How do I add a field type ng-forge does not ship?',
-    a: "`provideDynamicForm(...)` is variadic — it takes a list of field-type registrations. Spread an adapter's bundle (`...withMaterialFields()` registers all the built-in Material fields), then append your own: `{ name: 'rich-text', loadComponent: () => import('./rich-text'), mapper: valueFieldMapper }`. Your component is a plain standalone Angular component that receives Signal Forms' `FieldTree<T>` via `input.required()`. See [Adding custom fields](/recipes/custom-fields).",
+    a: "`provideDynamicForm(...)` is variadic: it takes a list of field-type registrations. Spread an adapter's bundle (`...withMaterialFields()` registers all the built-in Material fields), then append your own: `{ name: 'rich-text', loadComponent: () => import('./rich-text'), mapper: valueFieldMapper }`. Your component is a plain standalone Angular component that receives Signal Forms' `FieldTree<T>` via `input.required()`. See [Adding custom fields](/recipes/custom-fields).",
   },
   {
     q: 'How do I add icons, buttons, or text inside an input (prefix / suffix)?',
@@ -41,35 +41,35 @@ export const FEATURE_OVERVIEW_FAQ: readonly FaqEntry[] = [
   },
   {
     q: 'How do I share a config across multiple forms?',
-    a: "`FormConfig` is a plain TypeScript object — extract reusable pieces (a field, a validator entry, a default `props` object) as named consts and import them. For application-wide defaults, use `defaultProps` on the form or adapter-level providers like `withMaterialFields({ appearance: 'fill' })`.",
+    a: "`FormConfig` is a plain TypeScript object: extract reusable pieces (a field, a validator entry, a default `props` object) as named consts and import them. For application-wide defaults, use `defaultProps` on the form or adapter-level providers like `withMaterialFields({ appearance: 'fill' })`.",
   },
   {
     q: 'How do I localise labels and validation messages?',
-    a: 'Labels, placeholders, and hint text accept `string | Signal<string> | Observable<string>` — wire them to your i18n service. Validation `kind`s map to messages via per-field `validationMessages` or form-level `defaultValidationMessages`. See the [i18n guide](/dynamic-behavior/i18n).',
+    a: 'Labels, placeholders, and hint text accept `string | Signal<string> | Observable<string>`; wire them to your i18n service. Validation `kind`s map to messages via per-field `validationMessages` or form-level `defaultValidationMessages`. See the [i18n guide](/dynamic-behavior/i18n).',
   },
   {
     q: 'How do I export the submitted form value as plain JSON?',
-    a: 'The `(submitted)` event emits the form value directly — `JSON.stringify(value)` is enough. To strip hidden, disabled, or readonly fields, set `excludeValueIfHidden` (and the sibling options) on the form config or via `withValueExclusionDefaults()`. See [Value exclusion](/recipes/value-exclusion).',
+    a: 'The `(submitted)` event emits the form value directly, so `JSON.stringify(value)` is enough. To strip hidden, disabled, or readonly fields, set `excludeValueIfHidden` (and the sibling options) on the form config or via `withValueExclusionDefaults()`. See [Value exclusion](/recipes/value-exclusion).',
   },
   {
     q: 'Are hidden field values still in the submitted form value?',
-    a: "Yes by default — ng-forge keeps hidden values live so a hide/show toggle preserves what the user typed. Opt out with `excludeValueIfHidden: true` to strip them at submission output time, or wire a `derivation` that clears the value when the hide condition is true (formly's `resetOnHide` behaviour).",
+    a: "Yes by default. ng-forge keeps hidden values live so a hide/show toggle preserves what the user typed. Opt out with `excludeValueIfHidden: true` to strip them at submission output time, or wire a `derivation` that clears the value when the hide condition is true (formly's `resetOnHide` behaviour).",
   },
   {
     q: 'How do I debounce a field, an HTTP derivation, or a custom condition?',
-    a: "Debouncing happens on the consumer side: set `trigger: 'debounced'` and `debounceMs` on the derivation, condition, or HTTP validator that reads the value. The Signal Forms substrate commits on every change — there is no `updateOn: 'blur'` equivalent today, so debouncing the consumers is the closest workaround for blur-style commit timing.",
+    a: "Debouncing happens on the consumer side: set `trigger: 'debounced'` and `debounceMs` on the derivation or condition that reads the value. HTTP validators do not currently debounce. The Signal Forms substrate commits on every change; there is no `updateOn: 'blur'` equivalent today, so debouncing the consumers is the closest workaround for blur-style commit timing.",
   },
   {
     q: 'Does ng-forge work without one of the four official UI adapters?',
-    a: 'Yes — every adapter is built on the same public surface, so you can ship a custom adapter for Kendo, NG-ZORRO, NativeScript, or an in-house design system. See [Building an adapter](/building-an-adapter).',
+    a: 'Yes. Every adapter is built on the same public surface, so you can ship a custom adapter for Kendo, NG-ZORRO, NativeScript, or an in-house design system. See [Building an adapter](/building-an-adapter).',
   },
   {
     q: 'Does ng-forge use Reactive Forms (`FormGroup` / `FormControl`)?',
-    a: "No. ng-forge is built on Angular Signal Forms (`@angular/forms/signals`). The primitive is `FieldTree<T>` — a signal-native tree of value, validity, dirty/touched state, and errors. Reactive Forms still works in Angular, but the two systems don't share types or APIs.",
+    a: "No. ng-forge is built on Angular Signal Forms (`@angular/forms/signals`). The primitive is `FieldTree<T>`, a signal-native tree of value, validity, dirty/touched state, and errors. Reactive Forms still works in Angular, but the two systems don't share types or APIs.",
   },
   {
     q: 'Is there a built-in file-upload field?',
-    a: "Not today — file inputs are not a built-in field type in any adapter. Implement one as a custom field with `valueFieldMapper`: a standalone component that renders an `<input type='file'>`, captures `File | FileList` into the field's value, and (optionally) uploads to your backend via a custom validator or value-derivation. See [Adding custom fields](/recipes/custom-fields).",
+    a: "Not today. File inputs are not a built-in field type in any adapter. Implement one as a custom field with `valueFieldMapper`: a standalone component that renders an `<input type='file'>`, captures `File | FileList` into the field's value, and (optionally) uploads to your backend via a custom validator or value-derivation. See [Adding custom fields](/recipes/custom-fields).",
   },
   {
     q: 'Is ng-forge SSR / hydration safe?',
@@ -77,15 +77,15 @@ export const FEATURE_OVERVIEW_FAQ: readonly FaqEntry[] = [
   },
   {
     q: 'Is there a codemod or automated migration tool from formly?',
-    a: 'No automated migration tool today — port manually. The concept-mapping table in the [migration guide](/migrating-from-ngx-formly) is the closest thing to a porting cheatsheet; the [MCP server](/ai-integration) lets an LLM in your IDE generate large chunks of the new config from a description of the old one. A codemod is on the wishlist but not committed work.',
+    a: 'No automated migration tool today; port manually. The concept-mapping table in the [migration guide](/migrating-from-ngx-formly) is the closest thing to a porting cheatsheet; the [MCP server](/ai-integration) lets an LLM in your IDE generate large chunks of the new config from a description of the old one. A codemod is on the wishlist but not committed work.',
   },
   {
     q: 'How big is the bundle?',
-    a: 'ng-forge is a **batteries-included framework** — the engine itself is intentionally large because it ships the full validation, conditional logic, derivation, schema, and array-management surface needed for API-driven forms (where the form shape is unknown at build time). What you do **not** pay for upfront: every adapter loads its field components via dynamic `import()` per field `type`, so a form that only uses `input` and `select` only fetches those two component bundles. UI adapters (Material, PrimeNG, Bootstrap, Ionic) themselves are independent packages — only the one you install ships.',
+    a: 'ng-forge is a **batteries-included framework**: the engine itself is intentionally large because it ships the full validation, conditional logic, derivation, schema, and array-management surface needed for API-driven forms (where the form shape is unknown at build time). What you do **not** pay for upfront: every adapter loads its field components via dynamic `import()` per field `type`, so a form that only uses `input` and `select` only fetches those two component bundles. UI adapters (Material, PrimeNG, Bootstrap, Ionic) themselves are independent packages, and only the one you install ships.',
   },
   {
     q: 'Which Angular and browser versions are supported?',
-    a: 'Angular 21+ (signal-native APIs depend on it). Browser-wise, ng-forge supports the same matrix as Angular 21 — modern evergreen browsers (Chrome / Edge / Firefox / Safari current and previous major). No IE 11.',
+    a: 'Angular 22. The published packages declare @angular/* peer dependencies of ~22.0.0 (Signal Forms became stable in Angular 22). Browser-wise, ng-forge supports the same matrix as Angular 22: modern evergreen browsers (Chrome / Edge / Firefox / Safari current and previous major). No IE 11.',
   },
 ];
 
@@ -100,15 +100,15 @@ export const FEATURE_OVERVIEW_FAQ: readonly FaqEntry[] = [
 export const MIGRATION_FAQ: readonly FaqEntry[] = [
   {
     q: 'Can I run ngx-formly and ng-forge side by side during a migration?',
-    a: 'Yes. They do not conflict — different package names, different injection tokens, different component selectors. Install ng-forge, port one form at a time, deprecate formly only when nothing imports @ngx-formly/*.',
+    a: 'Yes. They do not conflict: different package names, different injection tokens, different component selectors. Install ng-forge, port one form at a time, deprecate formly only when nothing imports @ngx-formly/*.',
   },
   {
-    q: 'Does ng-forge support Angular 21?',
-    a: 'Yes — ng-forge requires Angular 21+ as its baseline (signal-native APIs depend on it). If you are on Angular 20 or earlier, migrating to ng-forge implies an Angular upgrade first.',
+    q: 'Which Angular versions does ng-forge support?',
+    a: "Angular 22. The published packages declare @angular/* peer dependencies of ~22.0.0 (Signal Forms became stable in Angular 22). If you're on Angular 21 or earlier, migrating to ng-forge implies an Angular upgrade first.",
   },
   {
     q: 'Does ng-forge use Reactive Forms (FormGroup / FormControl)?',
-    a: 'No. ng-forge is built on Angular Signal Forms (@angular/forms/signals), a separate system with a different primitive — FieldTree<T> — that holds value, validity, dirty/touched state, and errors as signals. There is no FormGroup or FormControl involved. If your formly app exposes a formGroup to consumers (template parents, services, etc.), those touch-points have no direct equivalent and need to be rewritten against the Signal Forms surface.',
+    a: 'No. ng-forge is built on Angular Signal Forms (@angular/forms/signals), a separate system with a different primitive, FieldTree<T>, that holds value, validity, dirty/touched state, and errors as signals. There is no FormGroup or FormControl involved. If your formly app exposes a formGroup to consumers (template parents, services, etc.), those touch-points have no direct equivalent and need to be rewritten against the Signal Forms surface.',
   },
   {
     q: 'How do I report bugs or get help migrating?',
@@ -149,7 +149,7 @@ export const MIGRATION_CHECKLIST: readonly MigrationStep[] = [
   },
   {
     name: 'Port one read-only form first',
-    text: 'Port one read-only form first — typically a settings page or profile form. Fewer moving parts means an easier sanity check.',
+    text: 'Port one read-only form first, typically a settings page or profile form. Fewer moving parts means an easier sanity check.',
   },
   {
     name: 'Translate validators',

--- a/apps/docs/src/app/components/integration-view/integration-view.component.ts
+++ b/apps/docs/src/app/components/integration-view/integration-view.component.ts
@@ -18,7 +18,7 @@ interface IntegrationData {
 const INTEGRATION_DATA: Record<AdapterName, IntegrationData> = {
   material: {
     packages: '@ng-forge/dynamic-forms @ng-forge/dynamic-forms-material @angular/material @angular/cdk',
-    stylesCode: `// styles.scss — add a prebuilt Material theme (required)
+    stylesCode: `// styles.scss: add a prebuilt Material theme (required)
 @import '@angular/material/prebuilt-themes/azure-blue.css';`,
     setupCode: `import { provideDynamicForm, withLegacyStatusClasses } from '@ng-forge/dynamic-forms';
 import { withMaterialFields } from '@ng-forge/dynamic-forms-material';
@@ -154,7 +154,7 @@ export const appConfig: ApplicationConfig = {
       { name: 'FieldTypeDefinition', description: 'A field key, the Angular component to render, and an optional value mapper' },
       {
         name: 'NgForgeField',
-        description: 'Compose via hostDirectives — owns the 10 standard inputs + error/aria signals + universal host bindings',
+        description: 'Compose via hostDirectives; owns the nine standard inputs + error/aria signals + universal host bindings',
       },
       {
         name: 'NgForgeControl / NgForgeHostControl',
@@ -162,7 +162,7 @@ export const appConfig: ApplicationConfig = {
       },
       {
         name: 'withCustomFields()',
-        description: 'Bundle your field definitions into a provider factory — mirrors withMaterialFields() in structure',
+        description: 'Bundle your field definitions into a provider factory that mirrors withMaterialFields() in structure',
       },
     ],
   },

--- a/apps/docs/src/app/components/live-example/stackblitz-project.ts
+++ b/apps/docs/src/app/components/live-example/stackblitz-project.ts
@@ -25,8 +25,8 @@ const ADAPTER_META: Record<SupportedAdapter, AdapterMeta> = {
     configProviders:
       "    provideAnimations(),\n    provideDynamicForm(...withMaterialFields({ appearance: 'outline', color: 'primary' }), withLegacyStatusClasses()),",
     extraDeps: {
-      '@angular/material': '~21.2.0',
-      '@angular/cdk': '~21.2.0',
+      '@angular/material': '~22.0.0',
+      '@angular/cdk': '~22.0.0',
     },
     globalStyles: 'body { font-family: Roboto, sans-serif; margin: 0; }',
     extraStyles: ['@angular/material/prebuilt-themes/azure-blue.css'],
@@ -210,19 +210,18 @@ bootstrapApplication(AppComponent, appConfig);
 `;
 
   const deps: Record<string, string> = {
-    '@angular/animations': '~21.2.0',
-    '@angular/common': '~21.2.0',
-    '@angular/compiler': '~21.2.0',
-    '@angular/core': '~21.2.0',
-    '@angular/forms': '~21.2.0',
-    '@angular/platform-browser': '~21.2.0',
-    '@angular/platform-browser-dynamic': '~21.2.0',
-    '@angular/router': '~21.2.0',
+    '@angular/animations': '~22.0.0',
+    '@angular/common': '~22.0.0',
+    '@angular/compiler': '~22.0.0',
+    '@angular/core': '~22.0.0',
+    '@angular/forms': '~22.0.0',
+    '@angular/platform-browser': '~22.0.0',
+    '@angular/platform-browser-dynamic': '~22.0.0',
+    '@angular/router': '~22.0.0',
     '@ng-forge/dynamic-forms': 'latest',
     [meta.pkg]: 'latest',
     ...meta.extraDeps,
     rxjs: '^7.8.0',
-    'zone.js': '^0.15.0',
     tslib: '^2.6.0',
   };
 
@@ -238,10 +237,10 @@ bootstrapApplication(AppComponent, appConfig);
       },
       dependencies: deps,
       devDependencies: {
-        '@angular/cli': '~21.2.0',
-        '@angular/compiler-cli': '~21.2.0',
-        '@angular-devkit/build-angular': '~21.2.0',
-        typescript: '~5.9.0',
+        '@angular/cli': '~22.0.0',
+        '@angular/compiler-cli': '~22.0.0',
+        '@angular-devkit/build-angular': '~22.0.0',
+        typescript: '~6.0.3',
       },
     },
     null,

--- a/apps/docs/src/app/components/not-found/not-found.component.html
+++ b/apps/docs/src/app/components/not-found/not-found.component.html
@@ -185,7 +185,7 @@
 
   <div class="error-code">404</div>
   <h1>This form field doesn't exist</h1>
-  <p class="description">The page you're looking for wasn't forged yet — or it's been recast under a different name.</p>
+  <p class="description">The page you're looking for wasn't forged yet, or it's been recast under a different name.</p>
 
   <div class="actions">
     <a [routerLink]="gettingStartedLink()" class="btn btn-primary">

--- a/apps/docs/src/app/components/perf-pipeline/perf-pipeline.component.ts
+++ b/apps/docs/src/app/components/perf-pipeline/perf-pipeline.component.ts
@@ -2,9 +2,9 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 /**
  * Two-row pipeline comparing what runs on a single value change in
- * ngx-formly (zone-driven CD + full expression sweep) versus ng-forge
- * (signal-graph dependents only). Used in the migration-reasons section
- * to back up the performance claim with a concrete picture.
+ * ngx-formly (app-wide change detection under zone.js plus a whole-form
+ * expression sweep) versus ng-forge (signal-graph dependents only).
+ * Used on the migration page to back up the performance claim.
  */
 @Component({
   selector: 'docs-perf-pipeline',
@@ -31,7 +31,8 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
             </svg>
           </span>
           <div class="pp__step pp__step--cost">
-            <code>zone change-detection cycle</code>
+            <code>app-wide change detection</code>
+            <span class="pp__note">under zone.js, the Angular default</span>
           </div>
           <span class="pp__arrow" aria-hidden="true">
             <svg

--- a/apps/docs/src/app/components/validator-pillars/validator-pillars.component.ts
+++ b/apps/docs/src/app/components/validator-pillars/validator-pillars.component.ts
@@ -18,7 +18,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
       <div class="vp__pillar">
         <div class="vp__chip vp__chip--http">HTTP</div>
         <code class="vp__code">customFnConfig.httpValidators</code>
-        <p class="vp__desc">"Ping the server with this value" — uniqueness, availability, address lookup.</p>
+        <p class="vp__desc">"Ping the server with this value": uniqueness, availability, address lookup.</p>
         <code class="vp__sig">&#123; request, onSuccess &#125;</code>
       </div>
       <div class="vp__pillar">

--- a/apps/docs/src/app/pages/examples-index/examples.registry.ts
+++ b/apps/docs/src/app/pages/examples-index/examples.registry.ts
@@ -95,14 +95,14 @@ export const EXAMPLES_REGISTRY: ExampleItem[] = [
     id: 'wrapper-array-actions',
     title: 'Array With Wrapper Chrome',
     description:
-      'Wrap an array and its add button with a section wrapper — titles, framing, and action grouping without touching the array config',
+      'Wrap an array and its add button with a section wrapper: titles, framing, and action grouping without touching the array config',
     tags: ['Layout', 'Arrays', 'Wrappers'],
     path: '/examples/wrapper-array-actions',
   },
   {
     id: 'addon-clear-button',
     title: 'Addon Clear Button',
-    description: 'Canonical addon pattern — icon prefix + clear-preset button suffix, JSON-safe across all four adapters',
+    description: 'Canonical addon pattern: icon prefix + clear-preset button suffix, JSON-safe across all four adapters',
     tags: ['Addons'],
     path: '/examples/addon-clear-button',
   },
@@ -116,7 +116,7 @@ export const EXAMPLES_REGISTRY: ExampleItem[] = [
   {
     id: 'addon-currency',
     title: 'Addon Currency',
-    description: 'Universal text addons — dollar sign prefix and USD suffix on a numeric input',
+    description: 'Universal text addons: dollar sign prefix and USD suffix on a numeric input',
     tags: ['Addons'],
     path: '/examples/addon-currency',
   },

--- a/apps/docs/src/app/pages/landing/landing.component.html
+++ b/apps/docs/src/app/pages/landing/landing.component.html
@@ -262,14 +262,14 @@
             <span class="serializable-check icon icon--check" aria-hidden="true"></span>
             <div>
               <strong>Validation that hits your API.</strong>
-              An HTTP check is a declared request; debouncing and cancellation come with it.
+              An HTTP check is a declared request; in-flight requests are cancelled when inputs change.
             </div>
           </li>
           <li>
             <span class="serializable-check icon icon--check" aria-hidden="true"></span>
             <div>
               <strong>Computed values as expressions.</strong>
-              <code>derivation: 'qty * price'</code>, not a subscription you wire up by hand.
+              <code>derivation: 'formValue.qty * formValue.price'</code> replaces the subscription you'd otherwise wire up by hand.
             </div>
           </li>
           <li>

--- a/apps/docs/src/app/pages/landing/landing.component.ts
+++ b/apps/docs/src/app/pages/landing/landing.component.ts
@@ -112,7 +112,7 @@ export class LandingComponent {
   readonly installCommand = computed(() => {
     const pkg = this.packageManagers.find((p) => p.id === this.currentPackageManager());
     const ui = this.uiLibraries.find((u) => u.id === this.currentUiLibrary());
-    return `${pkg?.command ?? 'npm install'} @ng-forge/dynamic-forms ${ui?.package ?? '@ng-forge/material'}`;
+    return `${pkg?.command ?? 'npm install'} @ng-forge/dynamic-forms ${ui?.package ?? '@ng-forge/dynamic-forms-material'}`;
   });
 
   constructor() {

--- a/apps/docs/src/app/pages/landing/landing.constants.ts
+++ b/apps/docs/src/app/pages/landing/landing.constants.ts
@@ -54,7 +54,7 @@ export const INTEGRATIONS: Integration[] = [
     icon: 'assets/icons/primeng.webp',
     title: 'PrimeNG integration documentation',
     package: '@ng-forge/dynamic-forms-primeng',
-    importLine: "import { withPrimeNgFields } from '@ng-forge/dynamic-forms-primeng';",
+    importLine: "import { withPrimeNGFields } from '@ng-forge/dynamic-forms-primeng';",
   },
   {
     name: 'Ionic',
@@ -172,67 +172,6 @@ const config = {
   ],
 }`,
 
-  validation: `{ key: 'email', type: 'input', required: true, email: true },
-{ key: 'age', type: 'input', min: 18, max: 120 },
-{ key: 'username', type: 'input', minLength: 3, maxLength: 20 },
-{ key: 'website', type: 'input', pattern: /^https?:\\/\\/.+/ }`,
-
-  validationShowcase: `{
-  key: 'email',
-  type: 'input',
-  label: 'Email',
-  required: true,
-  email: true,
-},
-{
-  key: 'password',
-  type: 'input',
-  label: 'Password',
-  required: true,
-  minLength: 8,
-  pattern: /^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d).+$/,
-  validationMessages: {
-    pattern: 'Need uppercase, lowercase & number',
-  },
-},
-{
-  key: 'age',
-  type: 'input',
-  label: 'Age',
-  min: 18,
-  max: 120,
-},
-{
-  key: 'username',
-  type: 'input',
-  label: 'Username',
-  minLength: 3,
-  maxLength: 15,
-  pattern: /^[a-z0-9_]+$/,
-}`,
-
-  jsonConfig: `{
-  "fields": [
-    {
-      "key": "name",
-      "type": "input",
-      "label": "Full Name",
-      "required": true
-    },
-    {
-      "key": "feedback",
-      "type": "textarea",
-      "label": "Your Feedback"
-    },
-    {
-      "key": "rating",
-      "type": "select",
-      "label": "Rating",
-      "options": ["Excellent", "Good", "Average", "Poor"]
-    }
-  ]
-}`,
-
   jsonFetch: `export class SurveyComponent {
   private http = inject(HttpClient);
 
@@ -247,7 +186,6 @@ const config = {
   arrayField: `{
   key: 'contacts',
   type: 'array',
-  label: 'Contacts',
   fields: [
     {
       key: 'name',
@@ -280,6 +218,7 @@ const config = {
     {
       key: 'age',
       type: 'input',
+      required: true,
       props: { type: 'number' },
     },
   ],
@@ -350,13 +289,13 @@ export const CAPABILITIES: Capability[] = [
   {
     icon: 'workflow',
     title: 'Multi-step wizards',
-    description: 'Split a long form into pages that validate one step at a time, with navigation and a progress bar.',
+    description: 'Split a long form into pages that validate one step at a time, with next and previous navigation.',
     snippetKey: 'multiStepWizard',
   },
   {
     icon: 'layers',
     title: 'Repeatable arrays',
-    description: 'Repeatable rows, nested groups included, that users can add and reorder from the config.',
+    description: 'Repeatable rows, nested groups included, that users can add and remove from the config.',
     snippetKey: 'arrayField',
   },
 ];
@@ -375,8 +314,7 @@ export const USE_CASES: UseCase[] = [
   {
     icon: 'users',
     title: 'Accessible',
-    description:
-      'Built on adapter components that are accessible already, with ARIA and focus handled on top and verified against axe for WCAG AA.',
+    description: 'Built on adapter components that are accessible already, with ARIA and focus handled on top.',
   },
   {
     icon: 'book',


### PR DESCRIPTION
## Summary

A full pass over the docs site, checking every page against the real public API and rewriting copy that was wrong, stale, or AI-flavored. Anchored to the public entry points, Angular 22's installed typings, and the live example configs.

## Correctness

- **Performance framing.** The formly migration page implied zone.js was tied to Reactive Forms and that OnPush was the source of the performance win. Rewritten to state it plainly: the state layer is signal-driven, OnPush narrows per-change work, zoneless removes zone.js scheduling on top, and the two are complementary rather than a property of the forms layer. The perf-diagram component was relabeled to match.
- **Angular version.** Updated the baseline from 21 to 22 everywhere (published peers are `~22.0.0`; Signal Forms stabilized in 22), including the feature-overview FAQ JSON-LD and the StackBlitz template dependencies.
- **Nonexistent API removed or corrected.** `FieldConfig`, `f().valueChange`, `FunctionRegistryService`, `InputAddonExtensions`, `filteredFormValue`, `currentPage()`/`totalPages`, the `formValue` and custom-expression condition types, and the invented Angular `schema()` callback shape. The angular-schema page was rebuilt on the real `validate(path, logic)` / `valueOf` surface.
- **Wrong specifics.** Field-property placement (label/placeholder/options are top-level, not under props), the FieldOption shape, message-resolution order, validWhen (strict boolean, not truthy), HTTP-validator debounce claims, and the submission action signature (receives FieldTree).
- **form-pages.** Navigation is explicit next/previous fields, not auto-rendered; dropped the "smart prefetching" framing for the real immediate/idle defer behavior.
- **Example drift.** Aligned example-page snippets with the configs the live demos actually run.
- **Broken search nav.** Fixed five recipe pages whose stale `advanced/*` frontmatter slugs routed to nonexistent pages, and a `{#custom-id}` heading the renderer does not support.

## Prose

Removed em-dashes (357), arrows (32), emojis, and hype filler from rendered copy across content pages and site components, plus apostrophe cleanup.

## Verification

`nx build docs`, `nx test docs`, and `nx lint docs` all pass.

## Follow-ups (library-side, not in this PR)

- Submission server-error mapping does not work: `wrapSubmissionAction` discards the action's resolved value, so a returned `TreeValidationResult` never reaches `submit()`. The docs now describe current behavior; the feature looks unimplemented.
- The landing "v1.0 / production-ready" badge assumes the docs deploy ships with the 1.0.0 release (packages are at 0.9.0). Left as-is pending the release-timing call.