### PR TITLE
ci: key node_modules and playwright caches by lockfile hash

### DIFF
--- a/.github/actions/setup-node-restore/action.yml
+++ b/.github/actions/setup-node-restore/action.yml
@@ -28,16 +28,23 @@ runs:
         node-version: ${{ inputs.node-version }}
 
     - name: Restore node_modules
+      id: cache
       uses: actions/cache/restore@v5
       with:
         path: node_modules
         key: ${{ inputs.cache-key }}
-        fail-on-cache-miss: true
 
-    - name: Verify cache restored
+    - name: Install dependencies (cache miss fallback)
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        echo "::warning::node_modules cache miss for '${{ inputs.cache-key }}' — installing from lockfile"
+        pnpm install --frozen-lockfile
+
+    - name: Verify node_modules
       shell: bash
       run: |
         if [ ! -d "node_modules" ] || [ ! -f "node_modules/.pnpm/lock.yaml" ]; then
-          echo "::error::node_modules cache appears corrupted or incomplete"
+          echo "::error::node_modules missing or incomplete after restore/install"
           exit 1
         fi

--- a/.github/workflows/_build-test.yml
+++ b/.github/workflows/_build-test.yml
@@ -17,8 +17,8 @@ permissions:
   contents: read
 
 env:
-  NODE_MODULES_CACHE_KEY: modules-${{ github.run_id }}
-  PLAYWRIGHT_CACHE_KEY: playwright-${{ github.run_id }}
+  # modules/playwright keys are lockfile-hashed in `setup` (hashFiles needs a
+  # checkout, so they can't live here) and passed down as job outputs.
   BUILD_CACHE_KEY: build-${{ github.sha }}
 
 jobs:
@@ -28,6 +28,8 @@ jobs:
     timeout-minutes: 10
     outputs:
       packages: ${{ steps.packages.outputs.list }}
+      modules-key: ${{ steps.cache-keys.outputs.modules }}
+      playwright-key: ${{ steps.cache-keys.outputs.playwright }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -37,6 +39,12 @@ jobs:
       - name: Fetch base branch for affected detection
         if: inputs.affected
         run: git fetch origin main:main
+
+      - name: Compute cache keys
+        id: cache-keys
+        run: |
+          echo "modules=modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}" >> "$GITHUB_OUTPUT"
+          echo "playwright=playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}" >> "$GITHUB_OUTPUT"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5
@@ -128,13 +136,13 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: node_modules
-          key: ${{ env.NODE_MODULES_CACHE_KEY }}
+          key: ${{ steps.cache-keys.outputs.modules }}
 
       - name: Cache Playwright browsers
         uses: actions/cache/save@v5
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ env.PLAYWRIGHT_CACHE_KEY }}
+          key: ${{ steps.cache-keys.outputs.playwright }}
 
   build:
     name: Build & Verify
@@ -155,7 +163,7 @@ jobs:
       - name: Setup Node and restore cache
         uses: ./.github/actions/setup-node-restore
         with:
-          cache-key: ${{ env.NODE_MODULES_CACHE_KEY }}
+          cache-key: ${{ needs.setup.outputs.modules-key }}
 
       - name: Restore Nx computation cache
         uses: actions/cache@v5
@@ -238,14 +246,18 @@ jobs:
       - name: Setup Node and restore cache
         uses: ./.github/actions/setup-node-restore
         with:
-          cache-key: ${{ env.NODE_MODULES_CACHE_KEY }}
+          cache-key: ${{ needs.setup.outputs.modules-key }}
 
       - name: Restore Playwright browsers
+        id: playwright-cache
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ env.PLAYWRIGHT_CACHE_KEY }}
-          fail-on-cache-miss: true
+          key: ${{ needs.setup.outputs.playwright-key }}
+
+      - name: Install Playwright browsers (cache miss fallback)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install chromium --with-deps
 
       - name: Restore build artifacts
         uses: actions/cache/restore@v5
@@ -326,7 +338,7 @@ jobs:
       - name: Setup Node and restore cache
         uses: ./.github/actions/setup-node-restore
         with:
-          cache-key: ${{ env.NODE_MODULES_CACHE_KEY }}
+          cache-key: ${{ needs.setup.outputs.modules-key }}
 
       - name: Restore build artifacts
         uses: actions/cache/restore@v5
@@ -446,7 +458,7 @@ jobs:
     name: E2E Tests (${{ matrix.app }}${{ matrix.shard && format(' [{0}]', matrix.shard) || '' }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [lint-and-test, build-apps]
+    needs: [setup, lint-and-test, build-apps]
     if: needs.build-apps.outputs.has-e2e == 'true'
     strategy:
       fail-fast: false
@@ -461,15 +473,19 @@ jobs:
         if: ${{ !matrix.docker }}
         uses: ./.github/actions/setup-node-restore
         with:
-          cache-key: ${{ env.NODE_MODULES_CACHE_KEY }}
+          cache-key: ${{ needs.setup.outputs.modules-key }}
 
       - name: Restore Playwright browsers
+        id: playwright-cache
         if: ${{ !matrix.docker }}
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ env.PLAYWRIGHT_CACHE_KEY }}
-          fail-on-cache-miss: true
+          key: ${{ needs.setup.outputs.playwright-key }}
+
+      - name: Install Playwright browsers (cache miss fallback)
+        if: ${{ !matrix.docker && steps.playwright-cache.outputs.cache-hit != 'true' }}
+        run: pnpm exec playwright install chromium --with-deps
 
       - name: Install Playwright system dependencies
         if: ${{ !matrix.docker }}


### PR DESCRIPTION
## Problem

`modules-${{ github.run_id }}` and `playwright-${{ github.run_id }}` are unique per run, so the `node_modules` (~265 MB) and Playwright (~271 MB) caches are written once and never reused by any later run. Every run adds ~536 MB of dead-weight cache.

The repo sits over GitHub's 10 GB per-repo cache budget (observed: ~10.6 GB, 64 entries), so LRU eviction runs constantly. Under that pressure a cache saved by `setup` can be evicted (or transiently miss) before the parallel `Lint & Test` and `Build Apps` jobs restore it. Because the restores use `fail-on-cache-miss: true`, the jobs hard-fail at setup with:

```
Failed to restore cache entry. Exiting as fail-on-cache-miss is set. Input key: modules-<run_id>
```

This was the failure on PR #492 (a dependabot bump unrelated to the diff). A re-run cleared it, confirming a transient cache miss rather than a code problem.

## Change

1. Key both caches by `hashFiles('pnpm-lock.yaml')` instead of `run_id`. The keys are computed in `setup` (after checkout, since `hashFiles` needs the workspace) and passed to downstream jobs as outputs. Caches are now shared across every run on the same lockfile, so the count stays bounded and eviction pressure drops.
2. Replace `fail-on-cache-miss: true` on the `node_modules` and Playwright restores with a graceful fallback: on a miss, run `pnpm install --frozen-lockfile` / `playwright install chromium --with-deps` instead of failing the job.

The `build-${{ github.sha }}` artifact cache and its `fail-on-cache-miss: ${{ !inputs.affected }}` are left as-is: it is produced by the `build` job in the same run, is tiny, and the hard-fail there is a meaningful invariant for full builds.

## Verification

- YAML parses; `prettier --check` (3.8.4, repo config) passes on both files.
- Logic verified by hand: full hit path unchanged and faster than install; miss path degrades instead of failing. Not exercised in CI until this PR runs.