### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/setup-node-restore/action.yml
+++ b/.github/actions/setup-node-restore/action.yml
@@ -18,18 +18,18 @@ runs:
   using: 'composite'
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v5
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       with:
         version: ${{ inputs.pnpm-version }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: ${{ inputs.node-version }}
 
     - name: Restore node_modules
       id: cache
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: node_modules
         key: ${{ inputs.cache-key }}

--- a/.github/workflows/_build-test.yml
+++ b/.github/workflows/_build-test.yml
@@ -32,7 +32,7 @@ jobs:
       playwright-key: ${{ steps.cache-keys.outputs.playwright }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: ${{ inputs.affected && '0' || '1' }}
 
@@ -47,12 +47,12 @@ jobs:
           echo "playwright=playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}" >> "$GITHUB_OUTPUT"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: 10.28.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -133,13 +133,13 @@ jobs:
           pnpm nx show projects --affected --base=origin/main --with-target=build || true
 
       - name: Cache node_modules
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: node_modules
           key: ${{ steps.cache-keys.outputs.modules }}
 
       - name: Cache Playwright browsers
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ steps.cache-keys.outputs.playwright }}
@@ -152,7 +152,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: ${{ inputs.affected && '0' || '1' }}
 
@@ -166,7 +166,7 @@ jobs:
           cache-key: ${{ needs.setup.outputs.modules-key }}
 
       - name: Restore Nx computation cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .nx/cache
           key: nx-${{ runner.os }}-${{ github.sha }}
@@ -222,7 +222,7 @@ jobs:
         run: pnpm nx affected -t api-check --base=origin/main
 
       - name: Cache build artifacts
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: dist/packages
           key: ${{ env.BUILD_CACHE_KEY }}
@@ -235,7 +235,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: ${{ inputs.affected && '0' || '1' }}
 
@@ -250,7 +250,7 @@ jobs:
 
       - name: Restore Playwright browsers
         id: playwright-cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ needs.setup.outputs.playwright-key }}
@@ -260,7 +260,7 @@ jobs:
         run: pnpm exec playwright install chromium --with-deps
 
       - name: Restore build artifacts
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: dist/packages
           key: ${{ env.BUILD_CACHE_KEY }}
@@ -269,7 +269,7 @@ jobs:
           fail-on-cache-miss: ${{ !inputs.affected }}
 
       - name: Restore Nx computation cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .nx/cache
           key: nx-${{ runner.os }}-${{ github.sha }}
@@ -308,7 +308,7 @@ jobs:
           fi
 
       - name: Upload coverage reports
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           directory: ./coverage
           flags: unittests
@@ -327,7 +327,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: ${{ inputs.affected && '0' || '1' }}
 
@@ -341,7 +341,7 @@ jobs:
           cache-key: ${{ needs.setup.outputs.modules-key }}
 
       - name: Restore build artifacts
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: dist/packages
           key: ${{ env.BUILD_CACHE_KEY }}
@@ -365,7 +365,7 @@ jobs:
 
       - name: Upload docs artifacts
         if: ${{ !inputs.affected }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: docs-dist
           path: dist/apps/docs/
@@ -466,7 +466,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       # Native setup — only needed for core-examples (non-Docker)
       - name: Setup Node and restore cache
@@ -478,7 +478,7 @@ jobs:
       - name: Restore Playwright browsers
         id: playwright-cache
         if: ${{ !matrix.docker }}
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ needs.setup.outputs.playwright-key }}
@@ -505,7 +505,7 @@ jobs:
         run: node scripts/playwright-job-summary.mjs ${{ matrix.app }} apps/e2e/${{ matrix.short }}/test-results
 
       - name: Upload test artifacts on failure
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: playwright-results-${{ matrix.app }}${{ matrix.shardId && format('-{0}', matrix.shardId) || '' }}

--- a/.github/workflows/_vercel-deploy.yml
+++ b/.github/workflows/_vercel-deploy.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
@@ -74,12 +74,12 @@ jobs:
           git commit --amend --reset-author --no-edit
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: 10.28.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24'
           cache: 'pnpm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,6 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Verify all jobs succeeded
-        uses: re-actors/alls-green@v1.2.2
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: javascript-typescript
           config: |
@@ -38,6 +38,6 @@ jobs:
               - 'internal/**'
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: '/language:javascript-typescript'

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Check latest CI run
         id: check
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             // Get the branch that triggered this workflow

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Verify all jobs succeeded
-        uses: re-actors/alls-green@v1.2.2
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           # build-test is skipped for release branches (see should-run)
           allowed-skips: build-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check CI workflow status
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -140,7 +140,7 @@ jobs:
       tag_ns: ${{ steps.gate.outputs.tag_ns }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: main
           fetch-depth: 0
@@ -311,7 +311,7 @@ jobs:
         # the output is actually emitted.
         if: steps.gate.outputs.should_publish == 'true'
         id: ci-check
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             // Fail-safe default: if anything below throws before we explicitly flip this
@@ -364,7 +364,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           # Pin to an immutable SHA so a commit landing between gate/check-ci and release
           # can't be silently published:
@@ -377,12 +377,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           version: 10.28.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -447,7 +447,7 @@ jobs:
         # schedule|next), so a single shared token is sufficient.
         if: inputs.mode == 'publish' || github.event_name == 'schedule' || inputs.mode == 'next'
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -561,7 +561,7 @@ jobs:
         # `id` is consumed by the Notify Discord step below to gate on actual success.
         id: gh-release
         if: inputs.mode == 'publish'
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           tag_name: v${{ env.VERSION }}
           target_commitish: ${{ github.sha }}
@@ -611,7 +611,7 @@ jobs:
         id: gh-prerelease
         if: github.event_name == 'schedule' || inputs.mode == 'next'
         continue-on-error: true
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           target_commitish: ${{ needs.next-gate.outputs.sha }}


### PR DESCRIPTION
Addresses the zizmor `unpinned-uses` finding CodeRabbit raised while reviewing #494. Version tags (`@v6`) are mutable refs an upstream owner can reassign, so a compromised tag would execute in CI with repo permissions. Pinning to the immutable commit SHA removes that vector.

## What changed

Every `uses:` reference across all workflows and the composite action is pinned to the exact commit SHA its current tag resolves to, with the tag kept as a trailing comment:

```
uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
```

Applied repo-wide (40 references, 11 distinct actions) rather than only the lines flagged in #494, since the policy applies to every action equally. The trailing `# v6` comment keeps versions readable and lets Dependabot's `github-actions` updater continue bumping the pins (it rewrites both the SHA and the comment).

## Safety

No behavior change: each SHA is the commit the tag already pointed to at the time of this change. Diff is 40 `uses:` lines, 1:1 replacements, nothing else touched. YAML parses and `prettier --check` passes on all 8 files.