### PR TITLE
docs: fix package homepage and README doc links to /dynamic-forms base path

### DIFF
--- a/packages/dynamic-form-mcp/package.json
+++ b/packages/dynamic-form-mcp/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "author": "ng-forge",
-  "homepage": "https://ng-forge.com/dynamic-forms/ai-integration",
+  "homepage": "https://ng-forge.com/dynamic-forms/material/ai-integration",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ng-forge/ng-forge.git",

--- a/packages/dynamic-forms-bootstrap/README.md
+++ b/packages/dynamic-forms-bootstrap/README.md
@@ -90,7 +90,7 @@ Input, Select, Checkbox, Toggle, Button, Submit, Next, Previous, Textarea, Radio
 ## Documentation
 
 - [Feature overview](https://ng-forge.com/dynamic-forms/bootstrap/feature-overview)
-- [Bootstrap Integration](https://ng-forge.com/dynamic-forms/bootstrap/configuration)
+- [Getting Started](https://ng-forge.com/dynamic-forms/bootstrap/getting-started)
 - [Field Types](https://ng-forge.com/dynamic-forms/bootstrap/field-types/text-inputs)
 - [Validation](https://ng-forge.com/dynamic-forms/bootstrap/validation/basics)
 - [Conditional Logic](https://ng-forge.com/dynamic-forms/bootstrap/dynamic-behavior/conditional-logic)

--- a/packages/dynamic-forms-bootstrap/README.md
+++ b/packages/dynamic-forms-bootstrap/README.md
@@ -89,11 +89,11 @@ Input, Select, Checkbox, Toggle, Button, Submit, Next, Previous, Textarea, Radio
 
 ## Documentation
 
-- [Feature overview](https://ng-forge.com/bootstrap/feature-overview)
-- [Bootstrap Integration](https://ng-forge.com/bootstrap)
-- [Field Types](https://ng-forge.com/bootstrap/field-types/text-inputs)
-- [Validation](https://ng-forge.com/bootstrap/validation/basics)
-- [Conditional Logic](https://ng-forge.com/bootstrap/dynamic-behavior/conditional-logic)
+- [Feature overview](https://ng-forge.com/dynamic-forms/bootstrap/feature-overview)
+- [Bootstrap Integration](https://ng-forge.com/dynamic-forms/bootstrap/configuration)
+- [Field Types](https://ng-forge.com/dynamic-forms/bootstrap/field-types/text-inputs)
+- [Validation](https://ng-forge.com/dynamic-forms/bootstrap/validation/basics)
+- [Conditional Logic](https://ng-forge.com/dynamic-forms/bootstrap/dynamic-behavior/conditional-logic)
 
 ## Changelog
 

--- a/packages/dynamic-forms-bootstrap/package.json
+++ b/packages/dynamic-forms-bootstrap/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "author": "ng-forge",
-  "homepage": "https://ng-forge.com/dynamic-forms/ui-libs-integrations/bootstrap",
+  "homepage": "https://ng-forge.com/dynamic-forms/bootstrap/configuration",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ng-forge/ng-forge.git",

--- a/packages/dynamic-forms-bootstrap/package.json
+++ b/packages/dynamic-forms-bootstrap/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "author": "ng-forge",
-  "homepage": "https://ng-forge.com/dynamic-forms/bootstrap/configuration",
+  "homepage": "https://ng-forge.com/dynamic-forms/bootstrap/getting-started",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ng-forge/ng-forge.git",

--- a/packages/dynamic-forms-ionic/README.md
+++ b/packages/dynamic-forms-ionic/README.md
@@ -106,11 +106,11 @@ Input, Textarea, Select, Checkbox, Radio, Toggle, Datepicker, Slider, Multi-Chec
 
 ## Documentation
 
-- [Feature overview](https://ng-forge.com/ionic/feature-overview)
-- [Ionic Integration](https://ng-forge.com/ionic)
-- [Field Types](https://ng-forge.com/ionic/field-types/text-inputs)
-- [Validation](https://ng-forge.com/ionic/validation/basics)
-- [Conditional Logic](https://ng-forge.com/ionic/dynamic-behavior/conditional-logic)
+- [Feature overview](https://ng-forge.com/dynamic-forms/ionic/feature-overview)
+- [Ionic Integration](https://ng-forge.com/dynamic-forms/ionic/configuration)
+- [Field Types](https://ng-forge.com/dynamic-forms/ionic/field-types/text-inputs)
+- [Validation](https://ng-forge.com/dynamic-forms/ionic/validation/basics)
+- [Conditional Logic](https://ng-forge.com/dynamic-forms/ionic/dynamic-behavior/conditional-logic)
 
 ## Changelog
 

--- a/packages/dynamic-forms-ionic/README.md
+++ b/packages/dynamic-forms-ionic/README.md
@@ -107,7 +107,7 @@ Input, Textarea, Select, Checkbox, Radio, Toggle, Datepicker, Slider, Multi-Chec
 ## Documentation
 
 - [Feature overview](https://ng-forge.com/dynamic-forms/ionic/feature-overview)
-- [Ionic Integration](https://ng-forge.com/dynamic-forms/ionic/configuration)
+- [Getting Started](https://ng-forge.com/dynamic-forms/ionic/getting-started)
 - [Field Types](https://ng-forge.com/dynamic-forms/ionic/field-types/text-inputs)
 - [Validation](https://ng-forge.com/dynamic-forms/ionic/validation/basics)
 - [Conditional Logic](https://ng-forge.com/dynamic-forms/ionic/dynamic-behavior/conditional-logic)

--- a/packages/dynamic-forms-ionic/package.json
+++ b/packages/dynamic-forms-ionic/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "author": "ng-forge",
-  "homepage": "https://ng-forge.com/dynamic-forms/ui-libs-integrations/ionic",
+  "homepage": "https://ng-forge.com/dynamic-forms/ionic/configuration",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ng-forge/ng-forge.git",

--- a/packages/dynamic-forms-ionic/package.json
+++ b/packages/dynamic-forms-ionic/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "author": "ng-forge",
-  "homepage": "https://ng-forge.com/dynamic-forms/ionic/configuration",
+  "homepage": "https://ng-forge.com/dynamic-forms/ionic/getting-started",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ng-forge/ng-forge.git",

--- a/packages/dynamic-forms-material/README.md
+++ b/packages/dynamic-forms-material/README.md
@@ -93,7 +93,7 @@ Input, Textarea, Select, Checkbox, Radio, Datepicker, Slider, Toggle, Multi-Chec
 ## Documentation
 
 - [Feature overview](https://ng-forge.com/dynamic-forms/material/feature-overview)
-- [Material Integration](https://ng-forge.com/dynamic-forms/material/configuration)
+- [Getting Started](https://ng-forge.com/dynamic-forms/material/getting-started)
 - [Field Types](https://ng-forge.com/dynamic-forms/material/field-types/text-inputs)
 - [Validation](https://ng-forge.com/dynamic-forms/material/validation/basics)
 - [Conditional Logic](https://ng-forge.com/dynamic-forms/material/dynamic-behavior/conditional-logic)

--- a/packages/dynamic-forms-material/README.md
+++ b/packages/dynamic-forms-material/README.md
@@ -92,11 +92,11 @@ Input, Textarea, Select, Checkbox, Radio, Datepicker, Slider, Toggle, Multi-Chec
 
 ## Documentation
 
-- [Feature overview](https://ng-forge.com/material/feature-overview)
-- [Material Integration](https://ng-forge.com/material)
-- [Field Types](https://ng-forge.com/material/field-types/text-inputs)
-- [Validation](https://ng-forge.com/material/validation/basics)
-- [Conditional Logic](https://ng-forge.com/material/dynamic-behavior/conditional-logic)
+- [Feature overview](https://ng-forge.com/dynamic-forms/material/feature-overview)
+- [Material Integration](https://ng-forge.com/dynamic-forms/material/configuration)
+- [Field Types](https://ng-forge.com/dynamic-forms/material/field-types/text-inputs)
+- [Validation](https://ng-forge.com/dynamic-forms/material/validation/basics)
+- [Conditional Logic](https://ng-forge.com/dynamic-forms/material/dynamic-behavior/conditional-logic)
 
 ## Changelog
 

--- a/packages/dynamic-forms-material/package.json
+++ b/packages/dynamic-forms-material/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "author": "ng-forge",
-  "homepage": "https://ng-forge.com/dynamic-forms/material/configuration",
+  "homepage": "https://ng-forge.com/dynamic-forms/material/getting-started",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ng-forge/ng-forge.git",

--- a/packages/dynamic-forms-material/package.json
+++ b/packages/dynamic-forms-material/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "author": "ng-forge",
-  "homepage": "https://ng-forge.com/dynamic-forms/ui-libs-integrations/material",
+  "homepage": "https://ng-forge.com/dynamic-forms/material/configuration",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ng-forge/ng-forge.git",

--- a/packages/dynamic-forms-primeng/README.md
+++ b/packages/dynamic-forms-primeng/README.md
@@ -102,15 +102,15 @@ Input, Textarea, Select, Checkbox, Toggle, Radio, Multi-Checkbox, Datepicker, Sl
 
 `prime-input` ships first-class `prefix` / `suffix` addon slots accepting the PrimeNG-specific `prime-icon` / `prime-button` kinds plus the universal `text` / `template` / `component` kinds. `withPrimeNGFields()` auto-registers them — no extra setup needed.
 
-See [Addons / Overview](https://ng-forge.com/primeng/addons/overview), [Presets and Actions](https://ng-forge.com/primeng/addons/presets-and-actions), and [Custom Kinds](https://ng-forge.com/primeng/addons/custom-types) for the full surface (slots, kinds, presets, `actionRef`, reactive `hidden` / `disabled`, custom kind registration).
+See [Addons / Overview](https://ng-forge.com/dynamic-forms/primeng/addons/overview), [Presets and Actions](https://ng-forge.com/dynamic-forms/primeng/addons/presets-and-actions), and [Custom Kinds](https://ng-forge.com/dynamic-forms/primeng/addons/custom-types) for the full surface (slots, kinds, presets, `actionRef`, reactive `hidden` / `disabled`, custom kind registration).
 
 ## Documentation
 
-- [Feature overview](https://ng-forge.com/primeng/feature-overview)
-- [PrimeNG Integration](https://ng-forge.com/primeng)
-- [Field Types](https://ng-forge.com/primeng/field-types/text-inputs)
-- [Validation](https://ng-forge.com/primeng/validation/basics)
-- [Conditional Logic](https://ng-forge.com/primeng/dynamic-behavior/conditional-logic)
+- [Feature overview](https://ng-forge.com/dynamic-forms/primeng/feature-overview)
+- [PrimeNG Integration](https://ng-forge.com/dynamic-forms/primeng/configuration)
+- [Field Types](https://ng-forge.com/dynamic-forms/primeng/field-types/text-inputs)
+- [Validation](https://ng-forge.com/dynamic-forms/primeng/validation/basics)
+- [Conditional Logic](https://ng-forge.com/dynamic-forms/primeng/dynamic-behavior/conditional-logic)
 
 ## Changelog
 

--- a/packages/dynamic-forms-primeng/README.md
+++ b/packages/dynamic-forms-primeng/README.md
@@ -102,7 +102,7 @@ Input, Textarea, Select, Checkbox, Toggle, Radio, Multi-Checkbox, Datepicker, Sl
 
 `prime-input` ships first-class `prefix` / `suffix` addon slots accepting the PrimeNG-specific `prime-icon` / `prime-button` kinds plus the universal `text` / `template` / `component` kinds. `withPrimeNGFields()` auto-registers them — no extra setup needed.
 
-See [Addons / Overview](https://ng-forge.com/dynamic-forms/primeng/addons/overview), [Presets and Actions](https://ng-forge.com/dynamic-forms/primeng/addons/presets-and-actions), and [Custom Kinds](https://ng-forge.com/dynamic-forms/primeng/addons/custom-types) for the full surface (slots, kinds, presets, `actionRef`, reactive `hidden` / `disabled`, custom kind registration).
+See [Addons / Overview](https://ng-forge.com/dynamic-forms/primeng/addons/overview), [Presets and Actions](https://ng-forge.com/dynamic-forms/primeng/addons/presets-and-actions), and [Custom Types](https://ng-forge.com/dynamic-forms/primeng/addons/custom-types) for the full surface (slots, kinds, presets, `actionRef`, reactive `hidden` / `disabled`, custom kind registration).
 
 ## Documentation
 

--- a/packages/dynamic-forms-primeng/README.md
+++ b/packages/dynamic-forms-primeng/README.md
@@ -107,7 +107,7 @@ See [Addons / Overview](https://ng-forge.com/dynamic-forms/primeng/addons/overvi
 ## Documentation
 
 - [Feature overview](https://ng-forge.com/dynamic-forms/primeng/feature-overview)
-- [PrimeNG Integration](https://ng-forge.com/dynamic-forms/primeng/configuration)
+- [Getting Started](https://ng-forge.com/dynamic-forms/primeng/getting-started)
 - [Field Types](https://ng-forge.com/dynamic-forms/primeng/field-types/text-inputs)
 - [Validation](https://ng-forge.com/dynamic-forms/primeng/validation/basics)
 - [Conditional Logic](https://ng-forge.com/dynamic-forms/primeng/dynamic-behavior/conditional-logic)

--- a/packages/dynamic-forms-primeng/package.json
+++ b/packages/dynamic-forms-primeng/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "author": "ng-forge",
-  "homepage": "https://ng-forge.com/dynamic-forms/primeng/configuration",
+  "homepage": "https://ng-forge.com/dynamic-forms/primeng/getting-started",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ng-forge/ng-forge.git",

--- a/packages/dynamic-forms-primeng/package.json
+++ b/packages/dynamic-forms-primeng/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "author": "ng-forge",
-  "homepage": "https://ng-forge.com/dynamic-forms/ui-libs-integrations/primeng",
+  "homepage": "https://ng-forge.com/dynamic-forms/primeng/configuration",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ng-forge/ng-forge.git",

--- a/packages/dynamic-forms/README.md
+++ b/packages/dynamic-forms/README.md
@@ -104,20 +104,20 @@ This core library requires a UI integration. Choose one:
 | [@ng-forge/dynamic-forms-primeng](https://www.npmjs.com/package/@ng-forge/dynamic-forms-primeng)     | PrimeNG          |
 | [@ng-forge/dynamic-forms-ionic](https://www.npmjs.com/package/@ng-forge/dynamic-forms-ionic)         | Ionic            |
 
-Or [create your own](https://ng-forge.com/material/building-an-adapter).
+Or [create your own](https://ng-forge.com/dynamic-forms/custom/building-an-adapter).
 
 ## Documentation
 
-- [Feature overview](https://ng-forge.com/material/feature-overview)
-- [Installation](https://ng-forge.com/material/getting-started)
-- [Field Types](https://ng-forge.com/material/field-types/text-inputs)
-- [Validation](https://ng-forge.com/material/validation/basics)
-- [Conditional Logic](https://ng-forge.com/material/dynamic-behavior/conditional-logic)
-- [Value Derivation](https://ng-forge.com/material/dynamic-behavior/derivation/values)
-- [Type Safety](https://ng-forge.com/material/recipes/type-safety)
-- [Events](https://ng-forge.com/material/recipes/events)
-- [i18n](https://ng-forge.com/material/dynamic-behavior/i18n)
-- [Custom Integrations](https://ng-forge.com/material/building-an-adapter)
+- [Feature overview](https://ng-forge.com/dynamic-forms/material/feature-overview)
+- [Installation](https://ng-forge.com/dynamic-forms/material/getting-started)
+- [Field Types](https://ng-forge.com/dynamic-forms/material/field-types/text-inputs)
+- [Validation](https://ng-forge.com/dynamic-forms/material/validation/basics)
+- [Conditional Logic](https://ng-forge.com/dynamic-forms/material/dynamic-behavior/conditional-logic)
+- [Value Derivation](https://ng-forge.com/dynamic-forms/material/dynamic-behavior/derivation/values)
+- [Type Safety](https://ng-forge.com/dynamic-forms/material/recipes/type-safety)
+- [Events](https://ng-forge.com/dynamic-forms/material/recipes/events)
+- [i18n](https://ng-forge.com/dynamic-forms/material/dynamic-behavior/i18n)
+- [Custom Integrations](https://ng-forge.com/dynamic-forms/custom/building-an-adapter)
 
 ## Changelog
 

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "author": "ng-forge",
-  "homepage": "https://ng-forge.com/dynamic-forms/openapi-generator",
+  "homepage": "https://ng-forge.com/dynamic-forms/material/openapi-generator",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ng-forge/ng-forge.git",


### PR DESCRIPTION
## What

The docs site serves under the `/dynamic-forms` base path, so the canonical URL is `https://ng-forge.com/dynamic-forms/{adapter}/{slug}` (see `SITE_ORIGIN` in `apps/docs/src/app/pages/doc-page/doc-page.component.ts`). The published package metadata and READMEs were pointing at stale URLs.

Two issues fixed across all library packages:

1. README doc links were missing the `/dynamic-forms` base segment (e.g. `ng-forge.com/material/...`).
2. `package.json` `homepage` fields used the removed `ui-libs-integrations/{adapter}` slug (renamed to `configuration` in `content-redirect.guard.ts`), and the mcp/openapi homepages were missing the adapter segment entirely.

## Changes

- 5 READMEs (core + material, bootstrap, ionic, primeng): added the `/dynamic-forms` prefix to every doc link. The bare adapter "Integration" entries now link to "Getting Started" (`{adapter}/getting-started`). `building-an-adapter` uses the `custom/` prefix since it is a custom-only route.
- 8 `package.json` `homepage` fields: the four UI adapters now point to `{adapter}/getting-started`; mcp becomes `material/ai-integration`; openapi becomes `material/openapi-generator`.
- Core `@ng-forge/dynamic-forms` homepage was already valid (`https://ng-forge.com/dynamic-forms`) and is unchanged.

## Verification

Every slug in the updated links maps to an existing file under `apps/docs/public/content/`. No `ui-libs-integrations` references remain, and no `ng-forge.com/{adapter}` link is missing the base prefix.