### PR TITLE
fix(dynamic-forms): support formSubmitting logic on value fields

### DIFF
--- a/etc/dynamic-forms-internal.api.md
+++ b/etc/dynamic-forms-internal.api.md
@@ -669,9 +669,6 @@ export const EMIT_FORM_VALUE_ON_EVENTS: InjectionToken<boolean>;
 export function evaluateCondition(expression: ConditionalExpression, context: EvaluationContext): boolean;
 
 // @public
-export function evaluateFormStateCondition(condition: FormStateCondition, state: FormStateAccessors): boolean;
-
-// @public
 export function evaluateNonFieldDisabled(ctx: NonFieldLogicContext): boolean;
 
 // @public
@@ -1015,13 +1012,6 @@ export interface FormOptions {
     nextButton?: NextButtonOptions;
     submitButton?: SubmitButtonOptions;
     validateWhenHidden?: boolean;
-}
-
-// @public
-export interface FormStateAccessors {
-    currentPageValid?: () => boolean;
-    formSubmitting(): boolean;
-    formValid(): boolean;
 }
 
 // @public

--- a/etc/dynamic-forms-internal.api.md
+++ b/etc/dynamic-forms-internal.api.md
@@ -454,6 +454,9 @@ export function createDynamicValueFunction<TValue, TReturn>(expression: string):
 export function createFormFieldStateMap(rootForm: FieldTree<unknown>, reactive: boolean): FormFieldStateMap;
 
 // @public
+export function createFormStateLogicFunction<TValue>(condition: FormStateCondition): LogicFn<TValue, boolean>;
+
+// @public
 export function createInitializationTracker(eventBus: EventBus, expectedCount: number): Observable<boolean>;
 
 // @public
@@ -664,6 +667,9 @@ export const EMIT_FORM_VALUE_ON_EVENTS: InjectionToken<boolean>;
 
 // @public
 export function evaluateCondition(expression: ConditionalExpression, context: EvaluationContext): boolean;
+
+// @public
+export function evaluateFormStateCondition(condition: FormStateCondition, state: FormStateAccessors): boolean;
 
 // @public
 export function evaluateNonFieldDisabled(ctx: NonFieldLogicContext): boolean;
@@ -1009,6 +1015,13 @@ export interface FormOptions {
     nextButton?: NextButtonOptions;
     submitButton?: SubmitButtonOptions;
     validateWhenHidden?: boolean;
+}
+
+// @public
+export interface FormStateAccessors {
+    currentPageValid?: () => boolean;
+    formSubmitting(): boolean;
+    formValid(): boolean;
 }
 
 // @public

--- a/packages/dynamic-forms/internal/src/lib/core/expressions/logic-function-factory.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/expressions/logic-function-factory.ts
@@ -7,6 +7,9 @@ import { DynamicFormError } from '../../errors/dynamic-form-error';
 import { stableStringify } from '../../utils/stable-stringify';
 import { FieldContextRegistryService } from '../registry/field-context-registry.service';
 import { FunctionRegistryService } from '../registry/function-registry.service';
+import { RootFormRegistryService } from '../registry/root-form-registry.service';
+import { FormStateCondition } from '../../models/logic/logic-config';
+import { evaluateFormStateCondition } from '../logic/form-state-condition';
 import { evaluateCondition } from './condition-evaluator';
 import { createHttpConditionLogicFunction } from './http-condition-logic-function';
 import { createAsyncConditionLogicFunction } from './async-condition-logic-function';
@@ -80,6 +83,25 @@ export function createLogicFunction<TValue>(expression: ConditionalExpression): 
   // Cache the function
   cacheService.logicFunctionCache.set(cacheKey, fn as LogicFn<unknown, boolean>);
   return fn;
+}
+
+/**
+ * Create a logic function for a form-state condition (`formInvalid` / `formSubmitting` /
+ * `pageInvalid`) on a value field. Reads the root form state reactively so the field
+ * re-evaluates when validity/submitting changes, matching the non-field logic path.
+ */
+export function createFormStateLogicFunction<TValue>(condition: FormStateCondition): LogicFn<TValue, boolean> {
+  const rootFormRegistry = inject(RootFormRegistryService);
+  return () => {
+    const rootForm = rootFormRegistry.rootForm();
+    if (!rootForm) return false;
+    const state = rootForm();
+    return evaluateFormStateCondition(condition, {
+      formValid: () => state.valid(),
+      formSubmitting: () => state.submitting(),
+      // `pageInvalid` has no page context on a leaf field, so it resolves to false here.
+    });
+  };
 }
 
 /**

--- a/packages/dynamic-forms/internal/src/lib/core/expressions/logic-function-factory.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/expressions/logic-function-factory.ts
@@ -96,10 +96,11 @@ export function createFormStateLogicFunction<TValue>(condition: FormStateConditi
     const rootForm = rootFormRegistry.rootForm();
     if (!rootForm) return false;
     const state = rootForm();
+    // applyLogic only routes formSubmitting here; formValid is unreached on leaves by design
+    // (formInvalid is rejected upstream), which is what keeps leaf fields cycle-safe.
     return evaluateFormStateCondition(condition, {
       formValid: () => state.valid(),
       formSubmitting: () => state.submitting(),
-      // `pageInvalid` has no page context on a leaf field, so it resolves to false here.
     });
   };
 }

--- a/packages/dynamic-forms/internal/src/lib/core/logic/form-state-condition.spec.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/logic/form-state-condition.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateFormStateCondition } from './form-state-condition';
+
+describe('evaluateFormStateCondition', () => {
+  const base = { formValid: () => true, formSubmitting: () => false };
+
+  it('formInvalid reflects negated validity', () => {
+    expect(evaluateFormStateCondition('formInvalid', { ...base, formValid: () => false })).toBe(true);
+    expect(evaluateFormStateCondition('formInvalid', { ...base, formValid: () => true })).toBe(false);
+  });
+
+  it('formSubmitting reflects the submitting flag', () => {
+    expect(evaluateFormStateCondition('formSubmitting', { ...base, formSubmitting: () => true })).toBe(true);
+    expect(evaluateFormStateCondition('formSubmitting', { ...base, formSubmitting: () => false })).toBe(false);
+  });
+
+  it('pageInvalid uses currentPageValid, and is false when it is absent', () => {
+    expect(evaluateFormStateCondition('pageInvalid', { ...base, currentPageValid: () => false })).toBe(true);
+    expect(evaluateFormStateCondition('pageInvalid', { ...base, currentPageValid: () => true })).toBe(false);
+    expect(evaluateFormStateCondition('pageInvalid', base)).toBe(false);
+  });
+
+  it('does not read formValid when evaluating formSubmitting (cycle-safety on value fields)', () => {
+    let validRead = false;
+    evaluateFormStateCondition('formSubmitting', {
+      formValid: () => {
+        validRead = true;
+        return true;
+      },
+      formSubmitting: () => false,
+    });
+    expect(validRead).toBe(false);
+  });
+});

--- a/packages/dynamic-forms/internal/src/lib/core/logic/form-state-condition.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/logic/form-state-condition.ts
@@ -1,0 +1,28 @@
+import { FormStateCondition } from '../../models/logic/logic-config';
+
+/** Accessors for the form/page state a {@link FormStateCondition} depends on. */
+export interface FormStateAccessors {
+  /** Whether the root form is currently valid. */
+  formValid(): boolean;
+  /** Whether the root form is currently submitting. */
+  formSubmitting(): boolean;
+  /** Whether the current page is valid (paged forms only). Absent → `pageInvalid` is false. */
+  currentPageValid?: () => boolean;
+}
+
+/**
+ * Shared evaluator for form-state conditions (`formInvalid` / `formSubmitting` / `pageInvalid`),
+ * used by both the leaf (Signal Forms schema) and non-field logic paths so the two agree.
+ */
+export function evaluateFormStateCondition(condition: FormStateCondition, state: FormStateAccessors): boolean {
+  switch (condition) {
+    case 'formInvalid':
+      return !state.formValid();
+    case 'formSubmitting':
+      return state.formSubmitting();
+    case 'pageInvalid':
+      return state.currentPageValid ? !state.currentPageValid() : false;
+    default:
+      return false;
+  }
+}

--- a/packages/dynamic-forms/internal/src/lib/core/logic/non-field-logic-resolver.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/logic/non-field-logic-resolver.ts
@@ -7,6 +7,7 @@ import { evaluateCondition } from '../expressions';
 import { FieldContextRegistryService } from '../registry/field-context-registry.service';
 import { FunctionRegistryService } from '../registry/function-registry.service';
 import { ARRAY_CONTEXT } from '../../models/field-signal-context.token';
+import { evaluateFormStateCondition as evaluateSharedFormStateCondition } from './form-state-condition';
 import type { EvaluationContext } from '../../models/expressions/evaluation-context';
 import type { Logger } from '../../providers/features/logger/logger.interface';
 
@@ -120,20 +121,11 @@ const DEFAULT_NEXT_BUTTON_OPTIONS: Required<NextButtonOptions> = {
  */
 function evaluateFormStateCondition(condition: FormStateCondition, ctx: ButtonLogicContext): boolean {
   const form = ctx.form();
-
-  switch (condition) {
-    case 'formInvalid':
-      return !form.valid();
-
-    case 'formSubmitting':
-      return form.submitting();
-
-    case 'pageInvalid':
-      return ctx.currentPageValid ? !ctx.currentPageValid() : false;
-
-    default:
-      return false;
-  }
+  return evaluateSharedFormStateCondition(condition, {
+    formValid: () => form.valid(),
+    formSubmitting: () => form.submitting(),
+    currentPageValid: ctx.currentPageValid,
+  });
 }
 
 /**

--- a/packages/dynamic-forms/internal/src/public_api.ts
+++ b/packages/dynamic-forms/internal/src/public_api.ts
@@ -33,7 +33,6 @@ export * from './lib/core/expressions/value-utils';
 export * from './lib/core/field-tree-utils';
 export * from './lib/core/http/http-condition-cache';
 export * from './lib/core/http/http-request-resolver';
-export * from './lib/core/logic/form-state-condition';
 export * from './lib/core/logic/non-field-logic-resolver';
 export * from './lib/core/registry/field-context-registry.service';
 export * from './lib/core/registry/function-registry.service';

--- a/packages/dynamic-forms/internal/src/public_api.ts
+++ b/packages/dynamic-forms/internal/src/public_api.ts
@@ -33,6 +33,7 @@ export * from './lib/core/expressions/value-utils';
 export * from './lib/core/field-tree-utils';
 export * from './lib/core/http/http-condition-cache';
 export * from './lib/core/http/http-request-resolver';
+export * from './lib/core/logic/form-state-condition';
 export * from './lib/core/logic/non-field-logic-resolver';
 export * from './lib/core/registry/field-context-registry.service';
 export * from './lib/core/registry/function-registry.service';

--- a/packages/dynamic-forms/src/lib/core/logic/logic-applicator.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/logic/logic-applicator.spec.ts
@@ -360,4 +360,58 @@ describe('logic-applicator', () => {
       });
     });
   });
+
+  describe('form-state conditions', () => {
+    // `formSubmitting` reads a form-level flag independent of field validity, so it is
+    // cycle-free on leaf fields (unlike formInvalid/pageInvalid, which read form.valid()).
+    it('disables a leaf value field via formSubmitting without cycling (not submitting → not disabled)', () => {
+      runInInjectionContext(injector, () => {
+        const formValue = signal({ info: 'x' });
+        mockEntity.set(formValue());
+
+        const formInstance = form(
+          formValue,
+          schema<{ info: string }>((path) => {
+            applyLogic({ type: 'disabled', condition: 'formSubmitting' }, path.info);
+          }),
+        );
+        mockFormSignal.set(formInstance);
+
+        // Form is not submitting → not disabled, and reading it does not throw a cycle error.
+        expect(formInstance.info().disabled()).toBe(false);
+      });
+    });
+
+    it('rejects formInvalid on a value field at setup (would cycle against form validity)', () => {
+      runInInjectionContext(injector, () => {
+        const formValue = signal({ info: 'x' });
+        mockEntity.set(formValue());
+
+        expect(() =>
+          form(
+            formValue,
+            schema<{ info: string }>((path) => {
+              applyLogic({ type: 'hidden', condition: 'formInvalid' }, path.info);
+            }),
+          ),
+        ).toThrow(/not supported on value-field logic/);
+      });
+    });
+
+    it('rejects pageInvalid on a value field at setup', () => {
+      runInInjectionContext(injector, () => {
+        const formValue = signal({ info: 'x' });
+        mockEntity.set(formValue());
+
+        expect(() =>
+          form(
+            formValue,
+            schema<{ info: string }>((path) => {
+              applyLogic({ type: 'disabled', condition: 'pageInvalid' }, path.info);
+            }),
+          ),
+        ).toThrow(/not supported on value-field logic/);
+      });
+    });
+  });
 });

--- a/packages/dynamic-forms/src/lib/core/logic/logic-applicator.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/logic/logic-applicator.spec.ts
@@ -362,8 +362,8 @@ describe('logic-applicator', () => {
   });
 
   describe('form-state conditions', () => {
-    // `formSubmitting` reads a form-level flag independent of field validity, so it is
-    // cycle-free on leaf fields (unlike formInvalid/pageInvalid, which read form.valid()).
+    // formSubmitting is cycle-free (independent flag); formInvalid cycles and pageInvalid
+    // has no leaf page context, so both are rejected.
     it('disables a leaf value field via formSubmitting without cycling (not submitting → not disabled)', () => {
       runInInjectionContext(injector, () => {
         const formValue = signal({ info: 'x' });
@@ -398,7 +398,7 @@ describe('logic-applicator', () => {
       });
     });
 
-    it('rejects pageInvalid on a value field at setup', () => {
+    it('rejects pageInvalid on a value field at setup (no page context, not a cycle)', () => {
       runInInjectionContext(injector, () => {
         const formValue = signal({ info: 'x' });
         mockEntity.set(formValue());
@@ -410,7 +410,7 @@ describe('logic-applicator', () => {
               applyLogic({ type: 'disabled', condition: 'pageInvalid' }, path.info);
             }),
           ),
-        ).toThrow(/not supported on value-field logic/);
+        ).toThrow(/no page context/);
       });
     });
   });

--- a/packages/dynamic-forms/src/lib/core/logic/logic-applicator.ts
+++ b/packages/dynamic-forms/src/lib/core/logic/logic-applicator.ts
@@ -5,11 +5,12 @@ import {
   LogicConfig,
   isStateLogicConfig,
   isDerivationLogicConfig,
+  isFormStateCondition,
   LogicTrigger,
   type StateLogicType,
 } from '@ng-forge/dynamic-forms/internal';
 import { ConditionalExpression } from '@ng-forge/dynamic-forms/internal';
-import { createLogicFunction, createDebouncedLogicFunction } from '@ng-forge/dynamic-forms/internal';
+import { createLogicFunction, createDebouncedLogicFunction, createFormStateLogicFunction } from '@ng-forge/dynamic-forms/internal';
 import { DEFAULT_DEBOUNCE_MS } from '../../utils/debounce/debounce';
 import { DynamicFormError } from '@ng-forge/dynamic-forms/internal';
 
@@ -56,6 +57,23 @@ export function applyLogic<TValue>(config: LogicConfig, fieldPath: SchemaPath<TV
 
   if (typeof config.condition === 'boolean') {
     applyLogicFn(config.type, path, () => config.condition as boolean);
+    return;
+  }
+
+  // Form-state conditions read root form state, not the expression evaluator.
+  if (isFormStateCondition(config.condition)) {
+    // `formInvalid`/`pageInvalid` read `form.valid()`, which on a value field cycles against the
+    // field's own validity: hidden/disabled/readonly feed Angular's `shouldSkipValidation` →
+    // `valid()`. Reject at setup — these only work on buttons/containers (not validation nodes).
+    // `formSubmitting` reads an independent form flag, so it is cycle-free on value fields.
+    if (config.condition === 'formInvalid' || config.condition === 'pageInvalid') {
+      throw new DynamicFormError(
+        `The '${config.condition}' form-state condition is not supported on value-field logic ` +
+          `because it would create a validation cycle against the form's own validity. ` +
+          `Use 'formSubmitting', or apply this condition to a button or container instead.`,
+      );
+    }
+    applyLogicFn(config.type, path, createFormStateLogicFunction(config.condition));
     return;
   }
 

--- a/packages/dynamic-forms/src/lib/core/logic/logic-applicator.ts
+++ b/packages/dynamic-forms/src/lib/core/logic/logic-applicator.ts
@@ -62,14 +62,15 @@ export function applyLogic<TValue>(config: LogicConfig, fieldPath: SchemaPath<TV
 
   // Form-state conditions read root form state, not the expression evaluator.
   if (isFormStateCondition(config.condition)) {
-    // `formInvalid`/`pageInvalid` read `form.valid()`, which on a value field cycles against the
-    // field's own validity: hidden/disabled/readonly feed Angular's `shouldSkipValidation` →
-    // `valid()`. Reject at setup — these only work on buttons/containers (not validation nodes).
-    // `formSubmitting` reads an independent form flag, so it is cycle-free on value fields.
+    // formInvalid cycles against the field's own validity; pageInvalid has no leaf page context.
+    // Only formSubmitting (an independent flag) is cycle-free on value fields.
     if (config.condition === 'formInvalid' || config.condition === 'pageInvalid') {
+      const reason =
+        config.condition === 'formInvalid'
+          ? `it would create a validation cycle against the form's own validity`
+          : `a value field has no page context for it to resolve against`;
       throw new DynamicFormError(
-        `The '${config.condition}' form-state condition is not supported on value-field logic ` +
-          `because it would create a validation cycle against the form's own validity. ` +
+        `The '${config.condition}' form-state condition is not supported on value-field logic because ${reason}. ` +
           `Use 'formSubmitting', or apply this condition to a button or container instead.`,
       );
     }

--- a/tools/workspace-plugin/src/generators/gen-public-api/generator.ts
+++ b/tools/workspace-plugin/src/generators/gen-public-api/generator.ts
@@ -23,6 +23,7 @@ const EXCLUDE = new Set<string>([
   './lib/core/expressions/parser/parser',
   './lib/core/expressions/parser/tokenizer',
   './lib/core/http/http-response-evaluator',
+  './lib/core/logic/form-state-condition',
   './lib/mappers/apply-hidden-logic',
   './lib/models/prettify',
   './lib/utils/grid-classes/grid-classes',


### PR DESCRIPTION
## Summary

Form-state condition strings (`formSubmitting`, `formInvalid`, `pageInvalid`) worked on buttons and containers but silently no-opped on value (leaf) fields. `applyLogic` cast them to `ConditionalExpression` and passed them to the expression evaluator, which has no form-state branch, so they fell through to `false`.

This is the first of the follow-up "unify condition dispatch" items.

## Change

- A shared `evaluateFormStateCondition` (internal) takes form-state accessors and is now used by both the leaf (Signal Forms schema) path and the non-field (button/container) path, so the two agree.
- `applyLogic` dispatches form-state conditions to a new `createFormStateLogicFunction`, which reads the root form state reactively — `formSubmitting` on a value field now works (for example, disable an input while the form is submitting).

## Why `formInvalid` / `pageInvalid` are rejected on value fields

They read `form.valid()`. On a value field that creates a genuine cycle: Angular's `shouldSkipValidation` is `hidden() || disabled() || readonly() || isOrphaned()` (`@angular/forms` source), so a field's hidden/disabled/readonly state feeds `form.valid()`. If that same field's logic reads `form.valid()`, the graph is circular and Angular throws `Detected cycle in computations`. It is not fixable by decoupling — for a field that affects validity it becomes a logical paradox (hide a required field when invalid, but hiding it makes it valid), which oscillates.

So these two are rejected at form setup with a clear `DynamicFormError` pointing at `formSubmitting` or applying the condition to a button/container. Buttons/containers are unaffected (they are not validation nodes, so no cycle) and continue to support all three.

## Tests

- `logic-applicator.spec.ts`: `formSubmitting` disables a value field without cycling; `formInvalid` and `pageInvalid` on a value field throw at setup.
- `form-state-condition.spec.ts`: the shared evaluator across all three conditions, including that `formSubmitting` never reads `formValid` (cycle-safety).

`nx test dynamic-forms` passes (3166); lint and build clean.

## Note

While adding this I found the `packages/dynamic-forms/testing/src/integration/` specs (`logic-transformation`, `button-logic`) are not included in the project's vitest globs (`src`, `integration/src`, `internal/src` only), so they do not run. Flagging as a separate pre-existing gap, not addressed here.

https://claude.ai/code/session_01JYyiSqPnsyzfcr9iAmASnD

## Review follow-ups (commit ca292bdc9)

- Corrected the pageInvalid rejection rationale: it is rejected because a leaf field has no page context, not because of a validation cycle (only formInvalid cycles). Error message, code comments, and the spec assertion now reflect this.
- Noted in createFormStateLogicFunction that formValid is intentionally never reached on leaves (formInvalid is rejected upstream), which is what keeps leaf fields cycle-safe.
- Dropped evaluateFormStateCondition and FormStateAccessors from the published /internal surface. They are only relative-imported within internal/src/lib, so they are now in the gen-public-api EXCLUDE list; the internal API baseline is regenerated.

## Behavior change note

Configs that previously carried formInvalid or pageInvalid on a value field used to be silently ignored; they now throw a DynamicFormError at form setup. This is intentional (fail loud on a config that never did anything), but it is a visible change for any existing config that carried these uselessly. Worth a changelog line on release.

## Known coverage gap (pre-existing, out of scope)

The button-side form-state path is exercised by integration specs under test-utils/src/integration/ that the vitest include globs do not pick up. This PR routes the button path through the shared evaluator, so those specs would be worth re-enabling in a follow-up; the shared evaluator itself is covered by unit tests.