### PR TITLE
fix(bootstrap): drop stray size attribute on select when htmlSize is unset

### DIFF
--- a/packages/dynamic-forms-bootstrap/src/lib/fields/select/bs-select.component.spec.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/select/bs-select.component.spec.ts
@@ -1,0 +1,68 @@
+import { Type } from '@angular/core';
+import { type AddonTypeDefinition, DynamicFormLogger } from '@ng-forge/dynamic-forms';
+import { ADDON_ACTION_REGISTRY, ADDON_TYPE_COMPONENT_CACHE, ADDON_TYPE_REGISTRY } from '@ng-forge/dynamic-forms/integration';
+import { createNgForgeFieldFixture, provideTestValidationMessages } from '@ng-forge/dynamic-forms/integration';
+import { describe, expect, it, vi } from 'vitest';
+import BsSelectFieldComponent from './bs-select.component';
+
+// #517: [size]="props()?.htmlSize" coerced undefined to size="0", which matches Bootstrap's
+// .form-select[size]:not([size="1"]) rule and strips the dropdown chevron. The binding is now
+// [attr.size] so an unset htmlSize removes the attribute entirely. These tests pin the DOM.
+
+function createFixture(inputs: Record<string, unknown>) {
+  return createNgForgeFieldFixture<BsSelectFieldComponent, string>(BsSelectFieldComponent, {
+    key: 'field-1',
+    value: '',
+    inputs,
+    providers: [
+      { provide: ADDON_TYPE_REGISTRY, useValue: new Map<string, AddonTypeDefinition>() },
+      { provide: ADDON_TYPE_COMPONENT_CACHE, useFactory: () => new Map<string, Type<unknown>>() },
+      { provide: ADDON_ACTION_REGISTRY, useValue: new Map() },
+      { provide: DynamicFormLogger, useValue: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() } },
+      provideTestValidationMessages({}),
+    ],
+  });
+}
+
+const options = [
+  { value: 'a', label: 'Option A' },
+  { value: 'b', label: 'Option B' },
+];
+
+describe('BsSelectFieldComponent — size attribute (#517)', () => {
+  it('renders no size attribute when htmlSize is unset', async () => {
+    const { fixture } = createFixture({ options });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const select = fixture.nativeElement.querySelector('select.form-select') as HTMLSelectElement | null;
+    expect(select).toBeTruthy();
+    expect(select?.hasAttribute('size')).toBe(false);
+  });
+
+  it('renders size="5" when htmlSize is 5', async () => {
+    const { fixture } = createFixture({ options, props: { htmlSize: 5 } });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const select = fixture.nativeElement.querySelector('select.form-select') as HTMLSelectElement | null;
+    expect(select).toBeTruthy();
+    expect(select?.getAttribute('size')).toBe('5');
+  });
+
+  it('renders label and options', async () => {
+    const { fixture } = createFixture({ options, label: 'Pick one' });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const label = fixture.nativeElement.querySelector('label.form-label') as HTMLLabelElement | null;
+    expect(label?.textContent?.trim()).toBe('Pick one');
+
+    const rendered = Array.from(fixture.nativeElement.querySelectorAll('option')) as HTMLOptionElement[];
+    expect(rendered.map((o) => o.textContent?.trim())).toEqual(['Option A', 'Option B']);
+    expect(rendered.map((o) => o.value)).toEqual(['a', 'b']);
+  });
+});

--- a/packages/dynamic-forms-bootstrap/src/lib/fields/select/bs-select.component.ts
+++ b/packages/dynamic-forms-bootstrap/src/lib/fields/select/bs-select.component.ts
@@ -28,7 +28,7 @@ import { AsyncPipe } from '@angular/common';
         [class.form-select-lg]="props()?.size === 'lg'"
         [class.is-invalid]="f().invalid() && f().touched()"
         [multiple]="props()?.multiple || false"
-        [size]="props()?.htmlSize"
+        [attr.size]="props()?.htmlSize ?? null"
       >
         @if (ngf.placeholder(); as placeholder) {
           <option value="" disabled [selected]="!f().value()">{{ placeholder | dynamicText | async }}</option>


### PR DESCRIPTION
The select template property-bound size, so an unset htmlSize coerced undefined to 0 and the reflected size="0" attribute matched Bootstrap's listbox rule, stripping the dropdown chevron from every default select. Switched to a null-guarded attribute binding, same pattern the template already uses for tabindex.

New bs-select spec asserts the attribute is absent when htmlSize is unset and present when set. Docker screenshot run on this branch passed 152/152 with no baseline changes (the chevron delta is below the 1% diff tolerance), so the attribute assertions are the regression guard.

Fixes #517