### PR TITLE
fix(dynamic-forms): clear interaction state on form reset and clear events

### DIFF
--- a/packages/dynamic-forms/src/lib/state/form-state-manager.spec.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-manager.spec.ts
@@ -493,6 +493,34 @@ describe('FormStateManager', () => {
       expect(stateManager.touched()).toBe(false);
       expect(stateManager.dirty()).toBe(false);
     });
+
+    it('should clear touched and dirty state on a nested field', () => {
+      const { stateManager } = initManager({
+        fields: [
+          {
+            type: 'group',
+            key: 'address',
+            fields: [{ type: 'input', key: 'street', label: 'Street', value: 'Default' }],
+          },
+        ],
+      } as TestFormConfig);
+
+      const nestedForm = stateManager.form() as unknown as FieldTree<{ address: { street: string } }>;
+      const childField = nestedForm.address.street();
+      childField.markAsTouched();
+      childField.markAsDirty();
+      expect(childField.touched()).toBe(true);
+      expect(childField.dirty()).toBe(true);
+      expect(stateManager.touched()).toBe(true);
+      expect(stateManager.dirty()).toBe(true);
+
+      stateManager.reset();
+
+      expect(childField.touched()).toBe(false);
+      expect(childField.dirty()).toBe(false);
+      expect(stateManager.touched()).toBe(false);
+      expect(stateManager.dirty()).toBe(false);
+    });
   });
 
   describe('clear', () => {
@@ -523,6 +551,34 @@ describe('FormStateManager', () => {
 
       stateManager.clear();
 
+      expect(stateManager.touched()).toBe(false);
+      expect(stateManager.dirty()).toBe(false);
+    });
+
+    it('should clear touched and dirty state on a nested field', () => {
+      const { stateManager } = initManager({
+        fields: [
+          {
+            type: 'group',
+            key: 'address',
+            fields: [{ type: 'input', key: 'street', label: 'Street', value: 'Default' }],
+          },
+        ],
+      } as TestFormConfig);
+
+      const nestedForm = stateManager.form() as unknown as FieldTree<{ address: { street: string } }>;
+      const childField = nestedForm.address.street();
+      childField.markAsTouched();
+      childField.markAsDirty();
+      expect(childField.touched()).toBe(true);
+      expect(childField.dirty()).toBe(true);
+      expect(stateManager.touched()).toBe(true);
+      expect(stateManager.dirty()).toBe(true);
+
+      stateManager.clear();
+
+      expect(childField.touched()).toBe(false);
+      expect(childField.dirty()).toBe(false);
       expect(stateManager.touched()).toBe(false);
       expect(stateManager.dirty()).toBe(false);
     });

--- a/packages/dynamic-forms/src/lib/state/form-state-manager.spec.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-manager.spec.ts
@@ -476,6 +476,23 @@ describe('FormStateManager', () => {
 
       expect(valueSignal()).toEqual(expect.objectContaining({ name: 'Default' }));
     });
+
+    it('should clear touched and dirty state', () => {
+      const { stateManager } = initManager({
+        fields: [{ type: 'input', key: 'name', label: 'Name', value: 'Default' }],
+      } as TestFormConfig);
+
+      const rootField = stateManager.form()();
+      rootField.markAsTouched();
+      rootField.markAsDirty();
+      expect(stateManager.touched()).toBe(true);
+      expect(stateManager.dirty()).toBe(true);
+
+      stateManager.reset();
+
+      expect(stateManager.touched()).toBe(false);
+      expect(stateManager.dirty()).toBe(false);
+    });
   });
 
   describe('clear', () => {
@@ -491,6 +508,23 @@ describe('FormStateManager', () => {
       stateManager.clear();
 
       expect(valueSignal()).toEqual({});
+    });
+
+    it('should clear touched and dirty state', () => {
+      const { stateManager } = initManager({
+        fields: [{ type: 'input', key: 'name', label: 'Name', value: 'Default' }],
+      } as TestFormConfig);
+
+      const rootField = stateManager.form()();
+      rootField.markAsTouched();
+      rootField.markAsDirty();
+      expect(stateManager.touched()).toBe(true);
+      expect(stateManager.dirty()).toBe(true);
+
+      stateManager.clear();
+
+      expect(stateManager.touched()).toBe(false);
+      expect(stateManager.dirty()).toBe(false);
     });
   });
 

--- a/packages/dynamic-forms/src/lib/state/form-state-manager.ts
+++ b/packages/dynamic-forms/src/lib/state/form-state-manager.ts
@@ -888,18 +888,22 @@ export class FormStateManager<
 
   /** Resets the form to default values. */
   reset(): void {
+    const rootField = this.form()();
     this.excludedValueStore.set({});
     const defaults = this.defaultValues();
-    (this.form()().value as WritableSignal<TModel>).set(defaults);
+    (rootField.value as WritableSignal<TModel>).set(defaults);
     this.deps.value.set(defaults as Partial<TModel>);
+    rootField.reset();
   }
 
   /** Clears the form to empty state. */
   clear(): void {
+    const rootField = this.form()();
     this.excludedValueStore.set({});
     const emptyValue = {} as TModel;
-    (this.form()().value as WritableSignal<TModel>).set(emptyValue);
+    (rootField.value as WritableSignal<TModel>).set(emptyValue);
     this.deps.value.set(emptyValue);
+    rootField.reset();
   }
 
   /** Triggers form submission. */


### PR DESCRIPTION
FormStateManager.reset() and clear() only wrote values back, leaving the Signal Forms touched/dirty state intact. After submit marked the tree touched, validation errors stayed visible on a freshly reset form. Both methods now call the root FieldState.reset() after the value writes, which clears touched and dirty recursively without changing values, mirroring the existing resetFieldState pattern in the derivation utils. Config transition and page navigation paths write to the model signal and are unaffected.

Tests in the reset and clear describe blocks mark the root field touched and dirty and assert both flags clear, with nested-field variants that mark a child field inside a group and confirm both the child and the aggregated root state go pristine after reset and clear. Full suite green (3163 tests).

Because touched and dirty now clear on reset and clear, dirtyChange emits false following either call. Consumers that track unsaved changes off dirty state will observe the form returning to a pristine state, which is the intended semantic here.

Fixes #516