### PR TITLE
fix(dynamic-forms): resolve signal dynamic text without NG0602 in reactive contexts

### DIFF
--- a/packages/dynamic-forms/internal/src/lib/pipes/dynamic-text/dynamic-text.pipe.spec.ts
+++ b/packages/dynamic-forms/internal/src/lib/pipes/dynamic-text/dynamic-text.pipe.spec.ts
@@ -1,8 +1,17 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { TestBed } from '@angular/core/testing';
 import { DynamicTextPipe } from './dynamic-text.pipe';
-import { signal, WritableSignal } from '@angular/core';
+import { Component, signal, WritableSignal } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
 import { firstValueFrom, lastValueFrom, of, Subject, take, toArray } from 'rxjs';
+
+@Component({
+  imports: [DynamicTextPipe, AsyncPipe],
+  template: `<span>{{ sig | dynamicText | async }}</span>`,
+})
+class SignalTemplateHostComponent {
+  readonly sig = signal('initial');
+}
 
 describe('DynamicTextPipe', () => {
   let pipe: DynamicTextPipe;
@@ -215,6 +224,20 @@ describe('DynamicTextPipe', () => {
       expect(values).toHaveLength(50);
       expect(values[0]).toBe('Signal 0');
       expect(values[49]).toBe('Signal 49');
+    });
+  });
+
+  describe('template rendering (NG0602 regression)', () => {
+    it('should resolve a signal in a template without throwing and stay reactive', () => {
+      const fixture = TestBed.createComponent(SignalTemplateHostComponent);
+
+      expect(() => fixture.detectChanges()).not.toThrow();
+      expect(fixture.nativeElement.textContent).toContain('initial');
+
+      fixture.componentInstance.sig.set('updated');
+      TestBed.flushEffects();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toContain('updated');
     });
   });
 

--- a/packages/dynamic-forms/internal/src/lib/pipes/dynamic-text/dynamic-text.pipe.ts
+++ b/packages/dynamic-forms/internal/src/lib/pipes/dynamic-text/dynamic-text.pipe.ts
@@ -1,7 +1,7 @@
-import { inject, Injector, isSignal, Pipe, PipeTransform } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
-import { isObservable, Observable, of } from 'rxjs';
+import { inject, Injector, Pipe, PipeTransform } from '@angular/core';
+import { Observable } from 'rxjs';
 import { DynamicText } from '../../models/types/dynamic-text';
+import { dynamicTextToObservable } from '../../utils/dynamic-text-to-observable';
 
 /**
  * Pipe that handles dynamic text resolution with support for static strings,
@@ -20,14 +20,7 @@ export class DynamicTextPipe implements PipeTransform {
    * @returns The resolved string value as an Observable
    */
   transform(value: DynamicText | undefined): Observable<string> {
-    if (isObservable(value)) {
-      return value;
-    }
-
-    if (isSignal(value)) {
-      return toObservable(value, { injector: this.injector });
-    }
-
-    return of(value || '');
+    // Normalize null to undefined so it resolves to an empty string
+    return dynamicTextToObservable(value ?? undefined, this.injector);
   }
 }

--- a/packages/dynamic-forms/internal/src/lib/utils/dynamic-text-to-observable.ts
+++ b/packages/dynamic-forms/internal/src/lib/utils/dynamic-text-to-observable.ts
@@ -1,4 +1,4 @@
-import { isSignal, Injector } from '@angular/core';
+import { isSignal, Injector, untracked } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { isObservable, Observable, of } from 'rxjs';
 import { DynamicText } from '../models/types/dynamic-text';
@@ -21,7 +21,8 @@ export function dynamicTextToObservable(value: DynamicText | undefined, injector
   }
 
   if (isSignal(value)) {
-    return toObservable(value, { injector });
+    // Wrap in untracked() to avoid NG0602: toObservable() internally calls effect(), which cannot be created inside a reactive context (template expression)
+    return untracked(() => toObservable(value, { injector }));
   }
 
   return of(String(value));

--- a/packages/dynamic-forms/src/lib/wrappers/css/css-wrapper.component.ts
+++ b/packages/dynamic-forms/src/lib/wrappers/css/css-wrapper.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, input, Signal, ViewContainerRef, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, Injector, input, Signal, ViewContainerRef, viewChild } from '@angular/core';
 import { pipe, switchMap } from 'rxjs';
 import { derivedFrom } from 'ngxtension/derived-from';
 import { FieldWrapper } from '@ng-forge/dynamic-forms/internal';
@@ -16,14 +16,20 @@ import { WrapperFieldInputs } from '@ng-forge/dynamic-forms/internal';
   },
 })
 export default class CssWrapperComponent implements FieldWrapper {
+  private readonly injector = inject(Injector);
+
   readonly fieldComponent = viewChild.required('fieldComponent', { read: ViewContainerRef });
 
   readonly cssClasses = input<DynamicText>();
   readonly fieldInputs = input<WrapperFieldInputs>();
 
-  readonly resolvedClasses: Signal<string> = derivedFrom([this.cssClasses], pipe(switchMap(([value]) => dynamicTextToObservable(value))), {
-    initialValue: '',
-  });
+  readonly resolvedClasses: Signal<string> = derivedFrom(
+    [this.cssClasses],
+    pipe(switchMap(([value]) => dynamicTextToObservable(value, this.injector))),
+    {
+      initialValue: '',
+    },
+  );
 }
 
 export { CssWrapperComponent };


### PR DESCRIPTION
Passing a Signal as DynamicText (for example a computed label) threw NG0602 because DynamicTextPipe.transform ran toObservable() inside the template's reactive context. The conversion is now wrapped in untracked() inside dynamicTextToObservable (same precedent as the debounced logic factory), the pipe delegates to that util instead of duplicating its branching, and CssWrapperComponent now passes an injector so signal cssClasses cannot hit NG0203 on re-emission. The pipe normalizes null to undefined before delegating so both existing spec contracts stay unchanged.

New regression test renders the pipe through a real template with a signal value: it throws NG0602 on the unfixed code and passes with the fix, and a follow-up set() asserts reactivity survives untracked. Full suite green (3160 tests).

Fixes #519