### PR TITLE
fix(dynamic-forms): fix conditional validator cache collisions and error params

### DIFF
--- a/packages/dynamic-forms/internal/src/lib/core/expressions/logic-function-factory.spec.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/expressions/logic-function-factory.spec.ts
@@ -539,6 +539,68 @@ describe('logic-function-factory', () => {
         expect(fn1).not.toBe(fn2);
       });
 
+      it('should not collide when two custom conditions use different inline fns', () => {
+        const expression1: ConditionalExpression = {
+          type: 'custom',
+          fn: () => true,
+        };
+
+        const expression2: ConditionalExpression = {
+          type: 'custom',
+          fn: () => false,
+        };
+
+        const result1 = runLogicFunctionTest(expression1, 'test');
+        const result2 = runLogicFunctionTest(expression2, 'test');
+
+        expect(result1).toBe(true);
+        expect(result2).toBe(false);
+      });
+
+      it('should not collide when inline fns are nested inside composites', () => {
+        const expression1: ConditionalExpression = {
+          type: 'and',
+          conditions: [{ type: 'custom', fn: () => true }],
+        };
+
+        const expression2: ConditionalExpression = {
+          type: 'and',
+          conditions: [{ type: 'custom', fn: () => false }],
+        };
+
+        const result1 = runLogicFunctionTest(expression1, 'test');
+        const result2 = runLogicFunctionTest(expression2, 'test');
+
+        expect(result1).toBe(true);
+        expect(result2).toBe(false);
+      });
+
+      it('should still share a cache entry for two identical serializable conditions', () => {
+        const expression1: ConditionalExpression = {
+          type: 'fieldValue',
+          fieldPath: 'username',
+          operator: 'equals',
+          value: 'test',
+        };
+
+        const expression2: ConditionalExpression = {
+          type: 'fieldValue',
+          fieldPath: 'username',
+          operator: 'equals',
+          value: 'test',
+        };
+
+        let fn1: unknown;
+        let fn2: unknown;
+
+        runInInjectionContext(injector, () => {
+          fn1 = createLogicFunction(expression1);
+          fn2 = createLogicFunction(expression2);
+        });
+
+        expect(fn1).toBe(fn2);
+      });
+
       it('should handle nested expressions in cache key', () => {
         const expression: ConditionalExpression = {
           type: 'and',

--- a/packages/dynamic-forms/internal/src/lib/core/expressions/logic-function-factory.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/expressions/logic-function-factory.ts
@@ -34,6 +34,24 @@ function validateNoNestedHttpConditions(expression: ConditionalExpression): void
 }
 
 /**
+ * Checks whether the expression tree contains any inline function.
+ * Inline functions serialize to nothing in stableStringify, so caching by
+ * serialized key would collide across distinct functions.
+ */
+function containsInlineFunction(expression: ConditionalExpression): boolean {
+  if (expression.type === 'and' || expression.type === 'or') {
+    return expression.conditions.some(containsInlineFunction);
+  }
+  if (expression.type === 'custom') {
+    return typeof expression.fn === 'function';
+  }
+  if (expression.type === 'async') {
+    return typeof expression.asyncFn === 'function';
+  }
+  return false;
+}
+
+/**
  * Create a logic function from a conditional expression.
  *
  * @param expression The conditional expression to evaluate
@@ -60,13 +78,18 @@ export function createLogicFunction<TValue>(expression: ConditionalExpression): 
   const fieldContextRegistry = inject(FieldContextRegistryService);
   const cacheService = inject(LogicFunctionCacheService);
 
+  // Inline functions serialize to nothing, so their cache keys would collide
+  const cacheable = !expression || !containsInlineFunction(expression);
+
   // Generate cache key from serialized expression
   const cacheKey = stableStringify(expression);
 
   // Check cache first
-  const cached = cacheService.logicFunctionCache.get(cacheKey);
-  if (cached) {
-    return cached as LogicFn<TValue, boolean>;
+  if (cacheable) {
+    const cached = cacheService.logicFunctionCache.get(cacheKey);
+    if (cached) {
+      return cached as LogicFn<TValue, boolean>;
+    }
   }
 
   const fn: LogicFn<TValue, boolean> = (ctx: FieldContext<TValue>) => {
@@ -78,7 +101,9 @@ export function createLogicFunction<TValue>(expression: ConditionalExpression): 
   };
 
   // Cache the function
-  cacheService.logicFunctionCache.set(cacheKey, fn as LogicFn<unknown, boolean>);
+  if (cacheable) {
+    cacheService.logicFunctionCache.set(cacheKey, fn as LogicFn<unknown, boolean>);
+  }
   return fn;
 }
 
@@ -111,13 +136,18 @@ export function createDebouncedLogicFunction<TValue>(expression: ConditionalExpr
   const injector = inject(Injector);
   const cacheService = inject(LogicFunctionCacheService);
 
+  // Inline functions serialize to nothing, so their cache keys would collide
+  const cacheable = !expression || !containsInlineFunction(expression);
+
   // Generate cache key including debounceMs
   const cacheKey = `${stableStringify(expression)}:${debounceMs}`;
 
   // Check cache first
-  const cached = cacheService.debouncedLogicFunctionCache.get(cacheKey);
-  if (cached) {
-    return cached as LogicFn<TValue, boolean>;
+  if (cacheable) {
+    const cached = cacheService.debouncedLogicFunctionCache.get(cacheKey);
+    if (cached) {
+      return cached as LogicFn<TValue, boolean>;
+    }
   }
 
   const fn: LogicFn<TValue, boolean> = (ctx: FieldContext<TValue>) => {
@@ -165,6 +195,8 @@ export function createDebouncedLogicFunction<TValue>(expression: ConditionalExpr
   };
 
   // Cache the function
-  cacheService.debouncedLogicFunctionCache.set(cacheKey, fn as LogicFn<unknown, boolean>);
+  if (cacheable) {
+    cacheService.debouncedLogicFunctionCache.set(cacheKey, fn as LogicFn<unknown, boolean>);
+  }
   return fn;
 }

--- a/packages/dynamic-forms/src/lib/core/schema-builder.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/schema-builder.spec.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { Injector, runInInjectionContext } from '@angular/core';
+import { Injector, runInInjectionContext, signal } from '@angular/core';
+import { form } from '@angular/forms/signals';
 import { createSchemaFromFields, fieldsToDefaultValues, CreateSchemaOptions } from './schema-builder';
 import { FieldTypeDefinition } from '@ng-forge/dynamic-forms/internal';
 import { FieldDef } from '@ng-forge/dynamic-forms/internal';
 import { FunctionRegistryService } from '@ng-forge/dynamic-forms/internal';
+import { interpolateParams } from '@ng-forge/dynamic-forms/internal';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 
 // Use vi.hoisted() to declare mocks before vi.mock() hoisting
@@ -573,6 +575,53 @@ describe('schema-builder', () => {
         expect(() =>
           runInInjectionContext(injector, () => createSchemaFromFields<FormWithBothValidations>(fields, registry, options)),
         ).not.toThrow();
+      });
+
+      it('should include the constraint value on conditional built-in cross-field errors', () => {
+        interface NameForm {
+          name: string;
+          other: string;
+        }
+
+        const crossFieldValidators = [
+          {
+            sourceFieldKey: 'name',
+            config: {
+              type: 'maxLength' as const,
+              value: 5,
+              when: {
+                type: 'fieldValue' as const,
+                fieldPath: 'other',
+                operator: 'equals' as const,
+                value: 'yes',
+              },
+            },
+          },
+        ];
+
+        const fields: FieldDef<any>[] = [
+          { type: 'input', key: 'name' },
+          { type: 'input', key: 'other' },
+        ];
+
+        runInInjectionContext(injector, () => {
+          const model = signal<NameForm>({ name: 'way too long', other: 'yes' });
+          const schema = createSchemaFromFields<NameForm>(fields, registry, { crossFieldValidators });
+          const formInstance = form(model, schema);
+
+          const errors = formInstance.name().errors();
+          const maxLengthError = errors.find((error) => error.kind === 'maxLength');
+
+          expect(maxLengthError).toBeDefined();
+          expect((maxLengthError as unknown as Record<string, unknown>)['maxLength']).toBe(5);
+
+          // extractErrorParams maps maxLength to requiredLength for message templates
+          const message = interpolateParams(
+            'Must be at most {{requiredLength}} characters',
+            maxLengthError as unknown as Parameters<typeof interpolateParams>[1],
+          );
+          expect(message).toBe('Must be at most 5 characters');
+        });
       });
 
       it('should maintain backwards compatibility with array-based crossFieldValidators', () => {

--- a/packages/dynamic-forms/src/lib/core/schema-builder.ts
+++ b/packages/dynamic-forms/src/lib/core/schema-builder.ts
@@ -332,10 +332,18 @@ function evaluateBuiltInCrossFieldValidator<TModel>(
     return null;
   }
 
-  return {
+  const errorObj: Record<string, unknown> = {
     kind: config.type,
     fieldTree: targetField,
-  } as ValidationError.WithOptionalField;
+  };
+
+  // Include the static constraint on the error, matching native built-in errors
+  // (e.g. { maxLength: 5 }) so message templates can interpolate it
+  if ('value' in config && config.value !== undefined) {
+    errorObj[config.type] = config.value;
+  }
+
+  return errorObj as unknown as ValidationError.WithOptionalField;
 }
 
 /**


### PR DESCRIPTION
Two patch-scope fixes for the conditional validator problems reported in #512.

Cache collision: createLogicFunction keyed its cache on a JSON serialization of the condition, and inline functions serialize to nothing, so every custom condition with an inline fn produced the same key and the first compiled condition won. Conditions containing inline functions (fn on custom nodes, asyncFn on async nodes, recursively through and/or composites) now skip the cache entirely. Serializable conditions keep caching exactly as before.

Error params: built-in validators with a cross-field when condition go through validateTree, which built the error without the constraint value, so field-level messages could not interpolate {{requiredLength}}. The error now carries the configured value keyed by validator type (maxLength, minLength, min, max, pattern), matching the native built-in error shape that extractErrorParams already maps.

Collision regression tests fail on the unfixed code (first condition served from cache for a different fn) and pass with the fix. Full suite green (3163 tests).

The third part of #512, making field().maxLength() reactive to when conditions, is a larger rework targeted at the next minor.

Refs #512