### PR TITLE
fix(dynamic-forms): add actionable error for uninitialized TestBed in fixtures

### DIFF
--- a/apps/docs/public/content/recipes/custom-fields.md
+++ b/apps/docs/public/content/recipes/custom-fields.md
@@ -173,6 +173,8 @@ Vitest externalizes packages from `node_modules` by default while inlining your 
 
 ```typescript
 // vitest.config.ts
+import { defineConfig } from 'vitest/config';
+
 export default defineConfig({
   test: {
     server: { deps: { inline: ['@ng-forge/dynamic-forms'] } },

--- a/apps/docs/public/content/recipes/custom-fields.md
+++ b/apps/docs/public/content/recipes/custom-fields.md
@@ -167,6 +167,19 @@ it('dispatches FormSubmitEvent through EventBus on click', () => {
 
 Both harnesses defer `detectChanges()` to the caller so you can set extra component-specific inputs between bind and render. Look at `create-field-fixture.spec.ts` in the integration package for the full surface.
 
+### Running the fixtures under Vitest
+
+Vitest externalizes packages from `node_modules` by default while inlining your specs. That gives the fixtures a second copy of `@angular/core/testing` whose test environment your setup file never initialized, and the first TestBed call crashes with `Cannot read properties of null (reading 'ngModule')`. Inline the package so your specs and the fixtures share one testing instance:
+
+```typescript
+// vitest.config.ts
+export default defineConfig({
+  test: {
+    server: { deps: { inline: ['@ng-forge/dynamic-forms'] } },
+  },
+});
+```
+
 ## Going further
 
 - [Building an Adapter](/building-an-adapter): full guide for shipping an adapter with many field types, adapter-level configuration cascades, and module augmentation for type-safety.

--- a/packages/dynamic-forms/integration/src/testing/create-field-fixture.spec.ts
+++ b/packages/dynamic-forms/integration/src/testing/create-field-fixture.spec.ts
@@ -1,13 +1,14 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { getTestBed, TestBed } from '@angular/core/testing';
+import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
 import { required } from '@angular/forms/signals';
 import { FormEvent } from '@ng-forge/dynamic-forms';
-import { EventBus } from '@ng-forge/dynamic-forms/internal';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NgForgeActionHost, NgForgeFieldHost } from '../directives/host-directive-presets';
 import { injectNgForgeField } from '../directives/ng-forge-field.directive';
 import { injectNgForgeAction } from '../directives/ng-forge-action.directive';
 import { createNgForgeActionFixture, createNgForgeFieldFixture, provideTestValidationMessages } from './create-field-fixture';
+import { ZonelessTestModule } from '../../../src/test-setup';
 
 @Component({
   selector: 'test-harness-field',
@@ -123,5 +124,22 @@ describe('createNgForgeActionFixture', () => {
     });
     fixture.detectChanges();
     expect((fixture.nativeElement as HTMLElement).getAttribute('aria-disabled')).toBe('true');
+  });
+});
+
+describe('uninitialized test environment guard', () => {
+  it('throws an actionable error from both fixtures when the test environment is not initialized', () => {
+    getTestBed().resetTestEnvironment();
+    try {
+      expect(() => createNgForgeFieldFixture(TestHarnessFieldComponent, { key: 'username', value: '' })).toThrowError(
+        /server\.deps\.inline/,
+      );
+      expect(() => createNgForgeActionFixture(TestHarnessActionComponent, { key: 'submit', label: 'Save' })).toThrowError(
+        /server\.deps\.inline/,
+      );
+    } finally {
+      // Restore the exact environment from src/test-setup.ts so later tests are unaffected
+      getTestBed().initTestEnvironment([BrowserTestingModule, ZonelessTestModule], platformBrowserTesting());
+    }
   });
 });

--- a/packages/dynamic-forms/integration/src/testing/create-field-fixture.ts
+++ b/packages/dynamic-forms/integration/src/testing/create-field-fixture.ts
@@ -32,9 +32,10 @@ function assertTestEnvironmentInitialized(): void {
   if (getTestBed().platform) return;
   throw new Error(
     '[Dynamic Forms] The Angular test environment was never initialized for the @angular/core/testing instance this fixture resolved. ' +
-      'This typically happens under Vitest when your specs are inlined but @ng-forge/dynamic-forms is externalized, creating a second testing instance. ' +
+      'Under Vitest this typically means your specs are inlined but @ng-forge/dynamic-forms is externalized, creating a second testing instance. ' +
       "Fix: add the package to Vitest's server.deps.inline:\n" +
-      "test: { server: { deps: { inline: ['@ng-forge/dynamic-forms'] } } }",
+      "test: { server: { deps: { inline: ['@ng-forge/dynamic-forms'] } } }\n" +
+      'On Jest or Karma this instead means initTestEnvironment was never called; add it to your test setup file (e.g. getTestBed().initTestEnvironment(...)).',
   );
 }
 

--- a/packages/dynamic-forms/integration/src/testing/create-field-fixture.ts
+++ b/packages/dynamic-forms/integration/src/testing/create-field-fixture.ts
@@ -1,5 +1,5 @@
 import { EnvironmentInjector, Provider, runInInjectionContext, signal, type Type, type WritableSignal } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, getTestBed, TestBed } from '@angular/core/testing';
 import { type FieldTree, form, schema, type SchemaPath } from '@angular/forms/signals';
 import { type FormEvent, type FormEventConstructor } from '@ng-forge/dynamic-forms';
 import { EventBus } from '@ng-forge/dynamic-forms/internal';
@@ -27,6 +27,17 @@ export interface NgForgeFieldFixture<C, TValue = unknown> {
   readonly rootValue: WritableSignal<Record<string, TValue>>;
 }
 
+/** Guards against a second, uninitialized @angular/core/testing instance (Vitest externalization). */
+function assertTestEnvironmentInitialized(): void {
+  if (getTestBed().platform) return;
+  throw new Error(
+    '[Dynamic Forms] The Angular test environment was never initialized for the @angular/core/testing instance this fixture resolved. ' +
+      'This typically happens under Vitest when your specs are inlined but @ng-forge/dynamic-forms is externalized, creating a second testing instance. ' +
+      "Fix: add the package to Vitest's server.deps.inline:\n" +
+      "test: { server: { deps: { inline: ['@ng-forge/dynamic-forms'] } } }",
+  );
+}
+
 /**
  * Builds a `ComponentFixture` for an `NgForgeField`-composing component with
  * `field` + `key` bound BEFORE `detectChanges()` — sidesteps the NG0950 that
@@ -36,6 +47,7 @@ export function createNgForgeFieldFixture<C, TValue = unknown>(
   component: Type<C>,
   options: CreateNgForgeFieldFixtureOptions<TValue>,
 ): NgForgeFieldFixture<C, TValue> {
+  assertTestEnvironmentInitialized();
   TestBed.configureTestingModule({ imports: [component], providers: [...(options.providers ?? [])] });
 
   const key = options.key;
@@ -94,6 +106,7 @@ export function createNgForgeActionFixture<C, TEvent extends FormEvent = FormEve
   component: Type<C>,
   options: CreateNgForgeActionFixtureOptions<TEvent>,
 ): NgForgeActionFixture<C> {
+  assertTestEnvironmentInitialized();
   TestBed.configureTestingModule({ imports: [component], providers: [EventBus, ...(options.providers ?? [])] });
 
   const fixture = TestBed.createComponent(component);


### PR DESCRIPTION
Under Vitest the app's specs are inlined while this package is externalized, so the fixtures resolve a second @angular/core/testing instance whose test environment was never initialized, and the first TestBed call crashes with a cryptic ngModule error. The fixtures now detect the uninitialized environment (getTestBed().platform is null) and throw an error explaining the cause and the fix, with the exact server.deps.inline snippet. The custom-fields recipe gained a subsection documenting the Vitest setup.

The guard test resets the test environment, asserts both fixtures throw the actionable message, and restores the exact zoneless setup from test-setup.ts so the shared suite is unaffected. Full suite green (3160 tests).

The structural follow-up, a dedicated testing entrypoint so the integration bundle stops importing test infrastructure, is targeted at the next minor.

Refs #515