### PR TITLE
feat(dynamic-forms): support error-aware validation message functions

### DIFF
--- a/apps/docs/public/content/dynamic-behavior/i18n.md
+++ b/apps/docs/public/content/dynamic-behavior/i18n.md
@@ -235,7 +235,7 @@ export class MyFormComponent {
 
 With a translation file entry like `"maxLength": "Must be at most {{requiredLength}} characters"`, Transloco interpolates the value itself.
 
-The function can return any `DynamicText`: a string, an `Observable<string>`, or a `Signal<string>`. Message functions work for both field-level `validationMessages` and form-level `defaultValidationMessages`, and field-level functions still take precedence over form-level ones.
+The function can return any `DynamicText`: a string, an `Observable<string>`, or a `Signal<string>`. Message functions work for both field-level `validationMessages` and form-level `defaultValidationMessages`, and field-level functions still take precedence over form-level ones. A function that synchronously reads a signal and returns a plain string captures that value once and loses reactivity, so return the `Signal` or `Observable` itself instead.
 
 The older round-trip workaround also keeps working: if your translation returns a string that still contains `{{requiredLength}}` (or another error param), Dynamic Forms interpolates it from the error as a final pass. Note that some libraries, including Transloco, strip unknown `{{...}}` placeholders during their own interpolation, which is exactly what function messages avoid.
 

--- a/apps/docs/public/content/dynamic-behavior/i18n.md
+++ b/apps/docs/public/content/dynamic-behavior/i18n.md
@@ -194,6 +194,53 @@ export class MyFormComponent {
 }
 ```
 
+## Passing Error Params to Translations
+
+Validation errors carry parameters such as `maxLength`, `min`, or `max`. A plain Observable message is resolved before the error exists, so the translation library never sees those values. To hand them to the i18n layer directly, use a message function: any `validationMessages` or `defaultValidationMessages` value can be a function that receives the validation error and returns a `DynamicText`.
+
+```typescript
+import { Component, inject } from '@angular/core';
+import { TranslocoService } from '@jsverse/transloco';
+import { FormConfig, ValidationError } from '@ng-forge/dynamic-forms';
+
+@Component({...})
+export class MyFormComponent {
+  transloco = inject(TranslocoService);
+
+  formConfig: FormConfig = {
+    defaultValidationMessages: {
+      required: this.transloco.selectTranslate('validation.required'),
+      // Function message: receives the error, passes its params to Transloco
+      maxLength: (error: ValidationError) =>
+        this.transloco.selectTranslate('validation.maxLength', {
+          requiredLength: 'maxLength' in error ? error.maxLength : undefined,
+        }),
+      min: (error: ValidationError) =>
+        this.transloco.selectTranslate('validation.min', {
+          min: 'min' in error ? error.min : undefined,
+        }),
+    },
+    fields: [
+      {
+        key: 'username',
+        type: 'input',
+        label: this.transloco.selectTranslate('form.username'),
+        value: '',
+        maxLength: 20,
+      },
+    ],
+  };
+}
+```
+
+With a translation file entry like `"maxLength": "Must be at most {{requiredLength}} characters"`, Transloco interpolates the value itself.
+
+The function can return any `DynamicText`: a string, an `Observable<string>`, or a `Signal<string>`. Message functions work for both field-level `validationMessages` and form-level `defaultValidationMessages`, and field-level functions still take precedence over form-level ones.
+
+The older round-trip workaround also keeps working: if your translation returns a string that still contains `{{requiredLength}}` (or another error param), Dynamic Forms interpolates it from the error as a final pass. Note that some libraries, including Transloco, strip unknown `{{...}}` placeholders during their own interpolation, which is exactly what function messages avoid.
+
+Function messages are code, not data. If you serialize your form configs to JSON, keep using string templates with `{{param}}` placeholders.
+
 ## Example with Signals
 
 Use Angular signals for translations by wrapping the config in `computed()`:

--- a/apps/docs/public/content/validation/basics.md
+++ b/apps/docs/public/content/validation/basics.md
@@ -243,6 +243,27 @@ Use signals or observables for i18n:
 }
 ```
 
+### Function Messages
+
+Every message value can also be a function of the validation error. The function receives the error object, including params like `maxLength` or `min`, and returns a string, `Observable<string>`, or `Signal<string>`. Use this to pass error params to a translation library natively:
+
+```typescript
+{
+  key: 'username',
+  type: 'input',
+  value: '',
+  maxLength: 20,
+  validationMessages: {
+    maxLength: (error) =>
+      this.transloco.selectTranslate('validation.maxLength', {
+        requiredLength: 'maxLength' in error ? error.maxLength : undefined,
+      }),
+  },
+}
+```
+
+Plain string templates with `{{param}}` placeholders keep working and remain the right choice for JSON-serialized configs, since functions cannot be serialized. See [i18n](/dynamic-behavior/i18n) for the full pattern.
+
 ## Quick Examples
 
 ### User Registration

--- a/etc/dynamic-forms-integration.api.md
+++ b/etc/dynamic-forms-integration.api.md
@@ -26,7 +26,7 @@ import { StandardSchemaV1 } from '@standard-schema/spec';
 import { TemplateRef } from '@angular/core';
 import { TreeValidationResult } from '@angular/forms/signals';
 import { Type } from '@angular/core';
-import { ValidationError } from '@angular/forms/signals';
+import { ValidationError as ValidationError_2 } from '@angular/forms/signals';
 import { ViewContainerRef } from '@angular/core';
 import { WritableSignal } from '@angular/core';
 
@@ -581,7 +581,7 @@ export type InputType = Extract<HtmlInputType, 'email' | 'number' | 'password' |
 export function insertArrayItemButtonMapper<TProps>(fieldDef: BaseInsertArrayItemButtonField<TProps>): Signal<Record<string, unknown>>;
 
 // @public
-export function interpolateParams(message: string, error: ValidationError_2): string;
+export function interpolateParams(message: string, error: ValidationError): string;
 
 // @public (undocumented)
 export function isCheckedField<TProps, TMeta extends FieldMeta = FieldMeta>(field: FieldDef<TProps, TMeta>): field is BaseCheckedField<TProps, TMeta, boolean>;

--- a/etc/dynamic-forms-internal.api.md
+++ b/etc/dynamic-forms-internal.api.md
@@ -1843,24 +1843,30 @@ export interface ValidationExecutionConfig {
     readonly validateWhenHidden?: boolean;
 }
 
+// @public
+export type ValidationMessage = DynamicText | ValidationMessageResolver;
+
+// @public
+export type ValidationMessageResolver = (error: ValidationError) => DynamicText;
+
 // @public (undocumented)
 export interface ValidationMessages {
     // (undocumented)
-    [key: string]: DynamicText | undefined;
+    [key: string]: ValidationMessage | undefined;
     // (undocumented)
-    email?: DynamicText;
+    email?: ValidationMessage;
     // (undocumented)
-    max?: DynamicText;
+    max?: ValidationMessage;
     // (undocumented)
-    maxLength?: DynamicText;
+    maxLength?: ValidationMessage;
     // (undocumented)
-    min?: DynamicText;
+    min?: ValidationMessage;
     // (undocumented)
-    minLength?: DynamicText;
+    minLength?: ValidationMessage;
     // (undocumented)
-    pattern?: DynamicText;
+    pattern?: ValidationMessage;
     // (undocumented)
-    required?: DynamicText;
+    required?: ValidationMessage;
 }
 
 // @public

--- a/etc/dynamic-forms.api.md
+++ b/etc/dynamic-forms.api.md
@@ -1145,24 +1145,30 @@ export interface ValidationExecutionConfig {
     readonly validateWhenHidden?: boolean;
 }
 
+// @public
+export type ValidationMessage = DynamicText | ValidationMessageResolver;
+
+// @public
+export type ValidationMessageResolver = (error: ValidationError) => DynamicText;
+
 // @public (undocumented)
 export interface ValidationMessages {
     // (undocumented)
-    [key: string]: DynamicText | undefined;
+    [key: string]: ValidationMessage | undefined;
     // (undocumented)
-    email?: DynamicText;
+    email?: ValidationMessage;
     // (undocumented)
-    max?: DynamicText;
+    max?: ValidationMessage;
     // (undocumented)
-    maxLength?: DynamicText;
+    maxLength?: ValidationMessage;
     // (undocumented)
-    min?: DynamicText;
+    min?: ValidationMessage;
     // (undocumented)
-    minLength?: DynamicText;
+    minLength?: ValidationMessage;
     // (undocumented)
-    pattern?: DynamicText;
+    pattern?: ValidationMessage;
     // (undocumented)
-    required?: DynamicText;
+    required?: ValidationMessage;
 }
 
 // @public

--- a/packages/dynamic-form-mcp/src/registry/instructions.ts
+++ b/packages/dynamic-form-mcp/src/registry/instructions.ts
@@ -229,6 +229,18 @@ ALWAYS provide validation messages. Use template variables:
 - \`{{min}}\`, \`{{max}}\` - for min/max
 - \`{{requiredPattern}}\` - for pattern
 
+TypeScript-authored configs may also use error-aware message functions: any \`validationMessages\` or \`defaultValidationMessages\` value can be \`(error: ValidationError) => DynamicText\` instead of a string/Observable/Signal. The function receives the validation error (kind plus params like \`maxLength\`), so i18n layers can receive interpolation params natively:
+
+\`\`\`typescript
+validationMessages: {
+  maxLength: (error) => transloco.selectTranslate('validation.maxLength', {
+    requiredLength: 'maxLength' in error ? error.maxLength : undefined,
+  }),
+}
+\`\`\`
+
+Function messages are NOT JSON-serializable. JSON-driven configs MUST keep using string templates with \`{{param}}\` interpolation; MCP-generated configs should always emit string templates.
+
 ## Conditional Logic
 
 Use \`logic\` array for conditional behavior:

--- a/packages/dynamic-forms/integration/src/utils/create-resolved-errors-signal.ts
+++ b/packages/dynamic-forms/integration/src/utils/create-resolved-errors-signal.ts
@@ -3,7 +3,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FieldTree, ValidationError } from '@angular/forms/signals';
 import { combineLatest, Observable, of } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
-import { ValidationMessage, ValidationMessageResolver, ValidationMessages } from '@ng-forge/dynamic-forms/internal';
+import { DynamicText, ValidationMessage, ValidationMessageResolver, ValidationMessages } from '@ng-forge/dynamic-forms/internal';
 import { dynamicTextToObservable } from '@ng-forge/dynamic-forms/internal';
 import { interpolateParams } from '@ng-forge/dynamic-forms/internal';
 import { DynamicFormLogger } from '@ng-forge/dynamic-forms';
@@ -83,6 +83,20 @@ function isMessageResolver(message: ValidationMessage): message is ValidationMes
 }
 
 /**
+ * Invokes a message resolver, falling back to error.message when it throws or returns null/undefined
+ *
+ * @internal
+ */
+function resolveMessageFunction(resolver: ValidationMessageResolver, error: ValidationError, logger: Logger): DynamicText {
+  try {
+    return resolver(error) ?? error.message ?? '';
+  } catch (err) {
+    logger.error(`Validation message resolver for error kind "${error.kind}" threw; falling back to error.message.`, err);
+    return error.message ?? '';
+  }
+}
+
+/**
  * Resolves a single error message from DynamicText or error-aware function sources with fallback logic
  * Priority: field-level message → default message → error.message → no message (logs warning)
  *
@@ -117,7 +131,7 @@ function resolveErrorMessage(
   // error.message is always a plain string, not DynamicText
   const isSchemaMessage = fieldMessage === undefined && defaultMessage === undefined;
   // Message resolvers receive the error so params (e.g. maxLength) reach i18n layers natively
-  const messageText = isMessageResolver(messageToUse) ? messageToUse(error) : messageToUse;
+  const messageText = isMessageResolver(messageToUse) ? resolveMessageFunction(messageToUse, error, logger) : messageToUse;
   const messageObservable = isSchemaMessage
     ? of(messageToUse as string) // error.message is always string
     : dynamicTextToObservable(messageText, injector);

--- a/packages/dynamic-forms/integration/src/utils/create-resolved-errors-signal.ts
+++ b/packages/dynamic-forms/integration/src/utils/create-resolved-errors-signal.ts
@@ -1,9 +1,9 @@
-import { computed, inject, Injector, signal, Signal } from '@angular/core';
+import { computed, inject, Injector, isSignal, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FieldTree, ValidationError } from '@angular/forms/signals';
 import { combineLatest, Observable, of } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
-import { ValidationMessages } from '@ng-forge/dynamic-forms/internal';
+import { ValidationMessage, ValidationMessageResolver, ValidationMessages } from '@ng-forge/dynamic-forms/internal';
 import { dynamicTextToObservable } from '@ng-forge/dynamic-forms/internal';
 import { interpolateParams } from '@ng-forge/dynamic-forms/internal';
 import { DynamicFormLogger } from '@ng-forge/dynamic-forms';
@@ -74,7 +74,16 @@ export function createResolvedErrorsSignal<T>(
 }
 
 /**
- * Resolves a single error message from DynamicText sources with fallback logic
+ * Distinguishes error-aware message resolvers from other messages; isSignal() guards against Signal<string> (also a function)
+ *
+ * @internal
+ */
+function isMessageResolver(message: ValidationMessage): message is ValidationMessageResolver {
+  return typeof message === 'function' && !isSignal(message);
+}
+
+/**
+ * Resolves a single error message from DynamicText or error-aware function sources with fallback logic
  * Priority: field-level message → default message → error.message → no message (logs warning)
  *
  * @internal
@@ -107,9 +116,11 @@ function resolveErrorMessage(
   // If using error.message directly (from schema validators), wrap in of() instead of dynamicTextToObservable
   // error.message is always a plain string, not DynamicText
   const isSchemaMessage = fieldMessage === undefined && defaultMessage === undefined;
+  // Message resolvers receive the error so params (e.g. maxLength) reach i18n layers natively
+  const messageText = isMessageResolver(messageToUse) ? messageToUse(error) : messageToUse;
   const messageObservable = isSchemaMessage
     ? of(messageToUse as string) // error.message is always string
-    : dynamicTextToObservable(messageToUse, injector);
+    : dynamicTextToObservable(messageText, injector);
 
   // Apply parameter interpolation to support {{param}} syntax
   return messageObservable.pipe(

--- a/packages/dynamic-forms/internal/src/lib/models/index.ts
+++ b/packages/dynamic-forms/internal/src/lib/models/index.ts
@@ -33,7 +33,7 @@ export {
   GROUP_CONTEXT,
   injectFieldSignalContext,
 } from './field-signal-context.token';
-export type { ValidationError, ValidationMessages } from './validation-types';
+export type { ValidationError, ValidationMessage, ValidationMessageResolver, ValidationMessages } from './validation-types';
 export type { Prettify } from './prettify';
 
 // Validation

--- a/packages/dynamic-forms/internal/src/lib/models/validation-types.ts
+++ b/packages/dynamic-forms/internal/src/lib/models/validation-types.ts
@@ -7,13 +7,22 @@ import { DynamicText } from './types/dynamic-text';
  */
 export type ValidationError = AngularValidationError;
 
+/**
+ * Resolves a validation message from the validation error, so error params
+ * (e.g. maxLength, min) can be passed to an i18n layer natively.
+ */
+export type ValidationMessageResolver = (error: ValidationError) => DynamicText;
+
+/** A validation message: static or reactive text, or a function of the validation error. */
+export type ValidationMessage = DynamicText | ValidationMessageResolver;
+
 export interface ValidationMessages {
-  required?: DynamicText;
-  email?: DynamicText;
-  min?: DynamicText;
-  max?: DynamicText;
-  minLength?: DynamicText;
-  maxLength?: DynamicText;
-  pattern?: DynamicText;
-  [key: string]: DynamicText | undefined;
+  required?: ValidationMessage;
+  email?: ValidationMessage;
+  min?: ValidationMessage;
+  max?: ValidationMessage;
+  minLength?: ValidationMessage;
+  maxLength?: ValidationMessage;
+  pattern?: ValidationMessage;
+  [key: string]: ValidationMessage | undefined;
 }

--- a/packages/dynamic-forms/internal/src/lib/models/validation-types.type-test.ts
+++ b/packages/dynamic-forms/internal/src/lib/models/validation-types.type-test.ts
@@ -2,8 +2,10 @@
  * Exhaustive type tests for ValidationMessages type.
  */
 import { expectTypeOf } from 'vitest';
+import { of, type Observable } from 'rxjs';
+import { signal, type Signal } from '@angular/core';
 import type { DynamicText } from './types/dynamic-text';
-import type { ValidationMessages } from './validation-types';
+import type { ValidationError, ValidationMessage, ValidationMessageResolver, ValidationMessages } from './validation-types';
 
 // ============================================================================
 // ValidationMessages - Whitelist Test
@@ -33,8 +35,8 @@ describe('ValidationMessages - Exhaustive Whitelist', () => {
       anotherValidator: 'Another error message',
     };
 
-    expectTypeOf(messages['customValidator']).toMatchTypeOf<DynamicText | undefined>();
-    expectTypeOf(messages['anotherValidator']).toMatchTypeOf<DynamicText | undefined>();
+    expectTypeOf(messages['customValidator']).toMatchTypeOf<ValidationMessage | undefined>();
+    expectTypeOf(messages['anotherValidator']).toMatchTypeOf<ValidationMessage | undefined>();
   });
 
   it('should have all properties as optional', () => {
@@ -48,37 +50,41 @@ describe('ValidationMessages - Exhaustive Whitelist', () => {
 // ============================================================================
 
 describe('ValidationMessages - Property Types', () => {
-  it('required should be DynamicText', () => {
-    expectTypeOf<ValidationMessages['required']>().toEqualTypeOf<DynamicText | undefined>();
+  it('required should be ValidationMessage', () => {
+    expectTypeOf<ValidationMessages['required']>().toEqualTypeOf<ValidationMessage | undefined>();
   });
 
-  it('email should be DynamicText', () => {
-    expectTypeOf<ValidationMessages['email']>().toEqualTypeOf<DynamicText | undefined>();
+  it('email should be ValidationMessage', () => {
+    expectTypeOf<ValidationMessages['email']>().toEqualTypeOf<ValidationMessage | undefined>();
   });
 
-  it('min should be DynamicText', () => {
-    expectTypeOf<ValidationMessages['min']>().toEqualTypeOf<DynamicText | undefined>();
+  it('min should be ValidationMessage', () => {
+    expectTypeOf<ValidationMessages['min']>().toEqualTypeOf<ValidationMessage | undefined>();
   });
 
-  it('max should be DynamicText', () => {
-    expectTypeOf<ValidationMessages['max']>().toEqualTypeOf<DynamicText | undefined>();
+  it('max should be ValidationMessage', () => {
+    expectTypeOf<ValidationMessages['max']>().toEqualTypeOf<ValidationMessage | undefined>();
   });
 
-  it('minLength should be DynamicText', () => {
-    expectTypeOf<ValidationMessages['minLength']>().toEqualTypeOf<DynamicText | undefined>();
+  it('minLength should be ValidationMessage', () => {
+    expectTypeOf<ValidationMessages['minLength']>().toEqualTypeOf<ValidationMessage | undefined>();
   });
 
-  it('maxLength should be DynamicText', () => {
-    expectTypeOf<ValidationMessages['maxLength']>().toEqualTypeOf<DynamicText | undefined>();
+  it('maxLength should be ValidationMessage', () => {
+    expectTypeOf<ValidationMessages['maxLength']>().toEqualTypeOf<ValidationMessage | undefined>();
   });
 
-  it('pattern should be DynamicText', () => {
-    expectTypeOf<ValidationMessages['pattern']>().toEqualTypeOf<DynamicText | undefined>();
+  it('pattern should be ValidationMessage', () => {
+    expectTypeOf<ValidationMessages['pattern']>().toEqualTypeOf<ValidationMessage | undefined>();
   });
 
-  it('index signature should be DynamicText', () => {
+  it('index signature should be ValidationMessage', () => {
     type IndexSignature = ValidationMessages[string];
-    expectTypeOf<IndexSignature>().toEqualTypeOf<DynamicText | undefined>();
+    expectTypeOf<IndexSignature>().toEqualTypeOf<ValidationMessage | undefined>();
+  });
+
+  it('ValidationMessage should be DynamicText or a message resolver', () => {
+    expectTypeOf<ValidationMessage>().toEqualTypeOf<DynamicText | ValidationMessageResolver>();
   });
 });
 
@@ -235,6 +241,47 @@ describe('ValidationMessages - Complex Scenarios', () => {
     } as const satisfies ValidationMessages;
 
     expectTypeOf(messages).toMatchTypeOf<ValidationMessages>();
+  });
+
+  it('should accept function messages for every built-in and custom key', () => {
+    const messages: ValidationMessages = {
+      required: (error: ValidationError) => `Missing: ${error.kind}`,
+      email: (error) => `Invalid: ${error.kind}`,
+      min: (error) => `Too small: ${error.kind}`,
+      max: (error) => `Too large: ${error.kind}`,
+      minLength: (error) => `Too short: ${error.kind}`,
+      maxLength: (error) => `Too long: ${error.kind}`,
+      pattern: (error) => `Bad format: ${error.kind}`,
+      customValidator: (error) => `Custom: ${error.kind}`,
+    };
+
+    expectTypeOf(messages).toMatchTypeOf<ValidationMessages>();
+  });
+
+  it('should accept function messages returning Observable or Signal', () => {
+    const messages: ValidationMessages = {
+      maxLength: (error: ValidationError): Observable<string> => of(error.kind),
+      minLength: (error: ValidationError): Signal<string> => signal(error.kind),
+    };
+
+    expectTypeOf(messages).toMatchTypeOf<ValidationMessages>();
+    expectTypeOf<ValidationMessageResolver>().parameter(0).toEqualTypeOf<ValidationError>();
+    expectTypeOf<ValidationMessageResolver>().returns.toEqualTypeOf<DynamicText>();
+  });
+
+  it('should reject wrong function signatures', () => {
+    const wrongReturn: ValidationMessages = {
+      // @ts-expect-error — message functions must return DynamicText, not number
+      required: (error: ValidationError) => error.kind.length,
+    };
+
+    const wrongParam: ValidationMessages = {
+      // @ts-expect-error — message functions receive a ValidationError, not a string
+      required: (kind: string) => kind,
+    };
+
+    expectTypeOf(wrongReturn).toMatchTypeOf<ValidationMessages>();
+    expectTypeOf(wrongParam).toMatchTypeOf<ValidationMessages>();
   });
 
   it('should support conditional message selection', () => {

--- a/packages/dynamic-forms/src/lib/index.ts
+++ b/packages/dynamic-forms/src/lib/index.ts
@@ -115,7 +115,14 @@ export type { AddonWarning, SanitizedFormConfig, SanitizeFormConfigOptions } fro
 
 // Configuration Types
 export type { CustomFnConfig, FormConfig, FormOptions } from '@ng-forge/dynamic-forms/internal';
-export type { DynamicText, FieldOption, ValidationError, ValidationMessages } from '@ng-forge/dynamic-forms/internal';
+export type {
+  DynamicText,
+  FieldOption,
+  ValidationError,
+  ValidationMessage,
+  ValidationMessageResolver,
+  ValidationMessages,
+} from '@ng-forge/dynamic-forms/internal';
 
 // Submission Config
 export type { SubmissionConfig, SubmissionActionResult, SubmitButtonOptions, NextButtonOptions } from '@ng-forge/dynamic-forms/internal';

--- a/packages/dynamic-forms/src/lib/utils/create-resolved-errors-signal.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/create-resolved-errors-signal.spec.ts
@@ -1,7 +1,8 @@
 import { TestBed } from '@angular/core/testing';
 import { Injector, runInInjectionContext, signal } from '@angular/core';
-import type { FieldTree, SchemaPath } from '@angular/forms/signals';
+import type { FieldTree, SchemaPath, ValidationError } from '@angular/forms/signals';
 import { form, schema, validate, requiredError } from '@angular/forms/signals';
+import { of } from 'rxjs';
 import { createResolvedErrorsSignal } from '@ng-forge/dynamic-forms/integration';
 import { ValidationMessages } from '@ng-forge/dynamic-forms/internal';
 import { applyValidator } from '@ng-forge/dynamic-forms/internal';
@@ -242,6 +243,133 @@ describe('createResolvedErrorsSignal', () => {
         TestBed.flushEffects();
 
         expect(resolvedErrors()).toEqual([{ kind: 'required', message: 'Validator: required from validator' }]);
+      });
+    });
+  });
+
+  describe('function messages', () => {
+    /** Form with a single maxLength(5)-violating field, returning its FieldTree signal */
+    function createMaxLengthField() {
+      const initialValue = signal({ username: 'exceeds five' });
+      const testForm = form(
+        initialValue,
+        schema<{ username: string }>((path) => {
+          applyValidator({ type: 'maxLength', value: 5 }, path.username as SchemaPath<string>);
+        }),
+      );
+      return signal((testForm as unknown as Record<string, FieldTree<string>>)['username']);
+    }
+
+    it('should pass the validation error to the function and resolve its returned string', () => {
+      runInInjectionContext(injector, () => {
+        const usernameField = createMaxLengthField();
+
+        let receivedError: ValidationError | undefined;
+        const fieldMessages = signal<ValidationMessages>({
+          maxLength: (error) => {
+            receivedError = error;
+            const { maxLength } = error as ValidationError & { maxLength: number };
+            return `Must be at most ${maxLength} characters`;
+          },
+        });
+
+        const resolvedErrors = createResolvedErrorsSignal(usernameField, fieldMessages, signal<ValidationMessages>({}));
+
+        TestBed.flushEffects();
+
+        expect(receivedError?.kind).toBe('maxLength');
+        expect((receivedError as (ValidationError & { maxLength?: number }) | undefined)?.maxLength).toBe(5);
+        expect(resolvedErrors()).toEqual([{ kind: 'maxLength', message: 'Must be at most 5 characters' }]);
+      });
+    });
+
+    it('should resolve a function returning an Observable<string> (i18n case)', () => {
+      runInInjectionContext(injector, () => {
+        const usernameField = createMaxLengthField();
+
+        const fieldMessages = signal<ValidationMessages>({
+          maxLength: (error) => {
+            const { maxLength } = error as ValidationError & { maxLength: number };
+            return of(`Translated: at most ${maxLength} characters`);
+          },
+        });
+
+        const resolvedErrors = createResolvedErrorsSignal(usernameField, fieldMessages, signal<ValidationMessages>({}));
+
+        TestBed.flushEffects();
+
+        expect(resolvedErrors()).toEqual([{ kind: 'maxLength', message: 'Translated: at most 5 characters' }]);
+      });
+    });
+
+    it('should resolve a function returning a Signal<string>', () => {
+      runInInjectionContext(injector, () => {
+        const usernameField = createMaxLengthField();
+
+        const fieldMessages = signal<ValidationMessages>({
+          maxLength: (error) => {
+            const { maxLength } = error as ValidationError & { maxLength: number };
+            return signal(`Signal: at most ${maxLength} characters`);
+          },
+        });
+
+        const resolvedErrors = createResolvedErrorsSignal(usernameField, fieldMessages, signal<ValidationMessages>({}));
+
+        TestBed.flushEffects();
+
+        expect(resolvedErrors()).toEqual([{ kind: 'maxLength', message: 'Signal: at most 5 characters' }]);
+      });
+    });
+
+    it('should let a field-level function win over a default-level function', () => {
+      runInInjectionContext(injector, () => {
+        const usernameField = createMaxLengthField();
+
+        const fieldMessages = signal<ValidationMessages>({
+          maxLength: () => 'Field-level function message',
+        });
+        const defaultMessages = signal<ValidationMessages>({
+          maxLength: () => 'Default-level function message',
+        });
+
+        const resolvedErrors = createResolvedErrorsSignal(usernameField, fieldMessages, defaultMessages);
+
+        TestBed.flushEffects();
+
+        expect(resolvedErrors()).toEqual([{ kind: 'maxLength', message: 'Field-level function message' }]);
+      });
+    });
+
+    it('should keep plain DynamicText messages working unchanged alongside functions', () => {
+      runInInjectionContext(injector, () => {
+        const usernameField = createMaxLengthField();
+
+        const fieldMessages = signal<ValidationMessages>({
+          maxLength: 'Plain: too long ({{requiredLength}} max)',
+          required: () => 'Unrelated function message',
+        });
+
+        const resolvedErrors = createResolvedErrorsSignal(usernameField, fieldMessages, signal<ValidationMessages>({}));
+
+        TestBed.flushEffects();
+
+        expect(resolvedErrors()).toEqual([{ kind: 'maxLength', message: 'Plain: too long (5 max)' }]);
+      });
+    });
+
+    it('should interpolate {{param}} placeholders left in a function-returned string', () => {
+      runInInjectionContext(injector, () => {
+        const usernameField = createMaxLengthField();
+
+        const fieldMessages = signal<ValidationMessages>({
+          maxLength: () => 'Function: at most {{requiredLength}} characters',
+        });
+
+        const resolvedErrors = createResolvedErrorsSignal(usernameField, fieldMessages, signal<ValidationMessages>({}));
+
+        TestBed.flushEffects();
+
+        expect(resolvedErrors()).toEqual([{ kind: 'maxLength', message: 'Function: at most 5 characters' }]);
       });
     });
   });

--- a/packages/dynamic-forms/src/lib/utils/create-resolved-errors-signal.spec.ts
+++ b/packages/dynamic-forms/src/lib/utils/create-resolved-errors-signal.spec.ts
@@ -4,7 +4,7 @@ import type { FieldTree, SchemaPath, ValidationError } from '@angular/forms/sign
 import { form, schema, validate, requiredError } from '@angular/forms/signals';
 import { of } from 'rxjs';
 import { createResolvedErrorsSignal } from '@ng-forge/dynamic-forms/integration';
-import { ValidationMessages } from '@ng-forge/dynamic-forms/internal';
+import { ValidationMessage, ValidationMessages } from '@ng-forge/dynamic-forms/internal';
 import { applyValidator } from '@ng-forge/dynamic-forms/internal';
 import { FieldContextRegistryService } from '@ng-forge/dynamic-forms/internal';
 import { FunctionRegistryService } from '@ng-forge/dynamic-forms/internal';
@@ -254,6 +254,7 @@ describe('createResolvedErrorsSignal', () => {
       const testForm = form(
         initialValue,
         schema<{ username: string }>((path) => {
+          // Cast is safe: the schema generic declares `username: string`, so the field path is SchemaPath<string>
           applyValidator({ type: 'maxLength', value: 5 }, path.username as SchemaPath<string>);
         }),
       );
@@ -370,6 +371,59 @@ describe('createResolvedErrorsSignal', () => {
         TestBed.flushEffects();
 
         expect(resolvedErrors()).toEqual([{ kind: 'maxLength', message: 'Function: at most 5 characters' }]);
+      });
+    });
+
+    /** Form whose required validator attaches its own error.message, returning its FieldTree signal */
+    function createRequiredFieldWithMessage() {
+      const initialValue = signal({ email: '' });
+      const testForm = form(
+        initialValue,
+        schema<{ email: string }>((path) => {
+          validate(path.email as SchemaPath<string>, () => requiredError({ message: 'Validator fallback message' }));
+        }),
+      );
+      return signal((testForm as unknown as Record<string, FieldTree<string>>)['email']);
+    }
+
+    it('should fall back to error.message and log when a function throws', () => {
+      runInInjectionContext(injector, () => {
+        const emailField = createRequiredFieldWithMessage();
+
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        const fieldMessages = signal<ValidationMessages>({
+          required: () => {
+            throw new Error('resolver boom');
+          },
+        });
+
+        const resolvedErrors = createResolvedErrorsSignal(emailField, fieldMessages, signal<ValidationMessages>({}));
+
+        TestBed.flushEffects();
+
+        // A throwing resolver must not break the stream; it falls back to error.message
+        expect(resolvedErrors()).toEqual([{ kind: 'required', message: 'Validator fallback message' }]);
+        expect(errorSpy).toHaveBeenCalledWith('[Dynamic Forms]', expect.stringContaining('threw'), expect.any(Error));
+
+        errorSpy.mockRestore();
+      });
+    });
+
+    it('should fall back to error.message when a function returns null', () => {
+      runInInjectionContext(injector, () => {
+        const emailField = createRequiredFieldWithMessage();
+
+        const fieldMessages = signal<ValidationMessages>({
+          // Type-forbidden but reachable from JS: a resolver returning null
+          required: (() => null) as unknown as ValidationMessage,
+        });
+
+        const resolvedErrors = createResolvedErrorsSignal(emailField, fieldMessages, signal<ValidationMessages>({}));
+
+        TestBed.flushEffects();
+
+        expect(resolvedErrors()).toEqual([{ kind: 'required', message: 'Validator fallback message' }]);
       });
     });
   });


### PR DESCRIPTION
Validation messages resolve before the error is known, so i18n layers never see error params: Transloco strips unknown {{requiredLength}} placeholders before ng-forge can interpolate them. Accepted proposal from #513: every validationMessages and defaultValidationMessages value now also accepts (error: ValidationError) => DynamicText, so the error params can be handed straight to the i18n layer for native interpolation, plurals, and formatting.

New ValidationMessage and ValidationMessageResolver types, resolver support in createResolvedErrorsSignal (field-level precedence, schema-message fallback, and the {{param}} interpolation pass all unchanged; plain DynamicText messages behave exactly as before). The resolver guard uses isSignal() because a Signal is itself a function; a naive typeof check would have called signal messages once and severed their reactivity.

Includes type tests with ts-expect-error negatives, unit tests covering function messages returning strings, Observables, and Signals, MCP registry guidance that function messages are not JSON-serializable (JSON configs stay on string templates), docs for the Transloco pattern in i18n.md and validation/basics.md, and regenerated API Extractor baselines.

Verified: 3165 dynamic-forms tests, 396 dynamic-form-mcp tests, type-test programs, pnpm build:libs including api-check, lint, nx sync:check.

Fixes #513