### PR TITLE
feat(dynamic-forms): apply conditional built-in validators natively with reactive constraints

### DIFF
--- a/apps/docs/public/content/validation/advanced.md
+++ b/apps/docs/public/content/validation/advanced.md
@@ -59,6 +59,8 @@ Activate validators only when conditions are met.
 
 The max validator only applies when `discountType === 'percentage'`.
 
+Conditional built-in validators are applied through Angular Signal Forms' native `when` support. While the condition is active, the field exposes its constraint state (for example the `maxlength` attribute and `field().maxLength()`), and error messages can interpolate the constraint with placeholders like `{{max}}` or `{{requiredLength}}`.
+
 ### Based on Form Value
 
 Validate against the entire form state:

--- a/etc/dynamic-forms-internal.api.md
+++ b/etc/dynamic-forms-internal.api.md
@@ -1111,7 +1111,7 @@ export function hasChildFields<T>(field: FieldDef<T>): field is FieldDef<T> & {
     fields: FieldDef<unknown>[] | Record<string, FieldDef<unknown>>;
 };
 
-// @public
+// @public @deprecated
 export function hasCrossFieldWhenCondition(config: ValidatorConfig, context?: CrossFieldDetectionContext): boolean;
 
 // @public
@@ -1566,6 +1566,9 @@ export type RegisteredWrapperTypes = keyof DynamicFormFieldRegistry['wrappers'];
 
 // @public
 export type RenderReadyInput = 'field' | (string & {});
+
+// @public
+export function requiresTreeValidation(config: ValidatorConfig): boolean;
 
 // @public
 export type ResolvedValidationExecutionConfig = Required<ValidationExecutionConfig>;

--- a/packages/dynamic-form-mcp/src/registry/validators.ts
+++ b/packages/dynamic-form-mcp/src/registry/validators.ts
@@ -2,12 +2,26 @@
 
 import type { ValidatorInfo } from './index.js';
 
+/**
+ * Shared `when` parameter: every validator config accepts an optional condition
+ * gating whether the validator runs.
+ */
+const WHEN_PARAMETER = {
+  when: {
+    name: 'when',
+    type: 'ConditionalExpression',
+    description:
+      'Optional condition gating the validator. Accepts the same shapes as logic conditions: fieldValue comparisons, and/or composites, expression strings, functionName (registered condition), or http. Built-in validators apply the condition natively through Angular Signal Forms, so constraint metadata (e.g. field().maxLength()) stays in sync with the condition reactively. Cross-field conditions are supported. Constraints: http conditions require provideHttpClient() at the application level, and http/async conditions cannot be nested inside and/or composites (schema build throws).',
+    required: false,
+  },
+} as const;
+
 export const VALIDATORS: ValidatorInfo[] = [
   {
     type: 'required',
     category: 'built-in',
     description: 'Validates that a field has a non-empty value',
-    parameters: {},
+    parameters: { ...WHEN_PARAMETER },
     example: `{ type: 'required' }
 // or shorthand: required: true`,
   },
@@ -15,7 +29,7 @@ export const VALIDATORS: ValidatorInfo[] = [
     type: 'email',
     category: 'built-in',
     description: 'Validates email format',
-    parameters: {},
+    parameters: { ...WHEN_PARAMETER },
     example: `{ type: 'email' }
 // or shorthand: email: true`,
   },
@@ -24,6 +38,7 @@ export const VALIDATORS: ValidatorInfo[] = [
     category: 'built-in',
     description: 'Validates minimum numeric value',
     parameters: {
+      ...WHEN_PARAMETER,
       value: {
         name: 'value',
         type: 'number',
@@ -39,6 +54,7 @@ export const VALIDATORS: ValidatorInfo[] = [
     category: 'built-in',
     description: 'Validates maximum numeric value',
     parameters: {
+      ...WHEN_PARAMETER,
       value: {
         name: 'value',
         type: 'number',
@@ -54,6 +70,7 @@ export const VALIDATORS: ValidatorInfo[] = [
     category: 'built-in',
     description: 'Validates minimum string length',
     parameters: {
+      ...WHEN_PARAMETER,
       value: {
         name: 'value',
         type: 'number',
@@ -69,6 +86,7 @@ export const VALIDATORS: ValidatorInfo[] = [
     category: 'built-in',
     description: 'Validates maximum string length',
     parameters: {
+      ...WHEN_PARAMETER,
       value: {
         name: 'value',
         type: 'number',
@@ -77,13 +95,16 @@ export const VALIDATORS: ValidatorInfo[] = [
       },
     },
     example: `{ type: 'maxLength', value: 100 }
-// or shorthand: maxLength: 100`,
+// or shorthand: maxLength: 100
+// conditional: only enforced while accountType is 'personal'
+{ type: 'maxLength', value: 100, when: { type: 'fieldValue', fieldPath: 'accountType', operator: 'equals', value: 'personal' } }`,
   },
   {
     type: 'pattern',
     category: 'built-in',
     description: 'Validates against a regular expression pattern',
     parameters: {
+      ...WHEN_PARAMETER,
       value: {
         name: 'value',
         type: 'string | RegExp',
@@ -100,6 +121,7 @@ export const VALIDATORS: ValidatorInfo[] = [
     description:
       "Custom synchronous validator using registered function or expression. IMPORTANT: The validator returns { kind: 'errorKind' } on failure. The actual error MESSAGE is defined in 'validationMessages' at the FIELD level, NOT in the validator config. NOTE: TypeScript-authored configs may also use an inline `fn: CustomValidator` instead of `functionName` (XOR with `functionName`, code-only — not JSON-serializable); MCP-generated configs should use `functionName`.",
     parameters: {
+      ...WHEN_PARAMETER,
       functionName: {
         name: 'functionName',
         type: 'string',
@@ -153,6 +175,7 @@ export const VALIDATORS: ValidatorInfo[] = [
     description:
       'Async validator using registered async function (resource-based). Register the function via customFnConfig.asyncValidators. NOTE: TypeScript-authored configs may also use an inline `fn: AsyncCustomValidator` instead of `functionName` (XOR with `functionName`, code-only — not JSON-serializable); MCP-generated configs should use `functionName`.',
     parameters: {
+      ...WHEN_PARAMETER,
       functionName: {
         name: 'functionName',
         type: 'string',
@@ -177,6 +200,7 @@ export const VALIDATORS: ValidatorInfo[] = [
     description:
       'HTTP validator — supports two modes: (1) Declarative (fully JSON-serializable, no function registration) using http + responseMapping properties, or (2) Function-based using functionName to reference a registered HTTP validator function. Query param values and (optionally) body values are expressions evaluated against the form context. Response mapping uses validWhen (truthy = valid) and errorKind (maps to field-level validationMessages). NOTE: TypeScript-authored configs may also use an inline `fn: HttpCustomValidator` instead of `functionName` (XOR with `functionName`, code-only — not JSON-serializable); MCP-generated configs should use `functionName` or declarative mode.',
     parameters: {
+      ...WHEN_PARAMETER,
       functionName: {
         name: 'functionName',
         type: 'string',

--- a/packages/dynamic-forms/internal/src/lib/core/cross-field/cross-field-detector.spec.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/cross-field/cross-field-detector.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { requiresTreeValidation } from './cross-field-detector';
+import { ValidatorConfig } from '../../models/validation/validator-config';
+import { ConditionalExpression } from '../../models/expressions/conditional-expression';
+
+const crossFieldWhen: ConditionalExpression = {
+  type: 'javascript',
+  expression: 'formValue.other === true',
+};
+
+const localWhen: ConditionalExpression = {
+  type: 'javascript',
+  expression: 'fieldValue !== ""',
+};
+
+describe('requiresTreeValidation()', () => {
+  describe('custom validators', () => {
+    it('returns true for a cross-field expression', () => {
+      const config: ValidatorConfig = { type: 'custom', expression: 'fieldValue === formValue.password' };
+      expect(requiresTreeValidation(config)).toBe(true);
+    });
+
+    it('returns true for a cross-field expression with a when condition', () => {
+      const config: ValidatorConfig = {
+        type: 'custom',
+        expression: 'fieldValue === formValue.password',
+        when: crossFieldWhen,
+      };
+      expect(requiresTreeValidation(config)).toBe(true);
+    });
+
+    it('returns false for a field-local expression', () => {
+      const config: ValidatorConfig = { type: 'custom', expression: 'fieldValue.length > 3' };
+      expect(requiresTreeValidation(config)).toBe(false);
+    });
+
+    it('returns false for a field-local expression with a cross-field when', () => {
+      const config: ValidatorConfig = { type: 'custom', expression: 'fieldValue.length > 3', when: crossFieldWhen };
+      expect(requiresTreeValidation(config)).toBe(false);
+    });
+
+    it('returns false for fn-based validators even with a cross-field when', () => {
+      const config: ValidatorConfig = { type: 'custom', fn: () => null, when: crossFieldWhen };
+      expect(requiresTreeValidation(config)).toBe(false);
+    });
+
+    it('returns false for functionName-based validators with a cross-field when', () => {
+      const config: ValidatorConfig = { type: 'custom', functionName: 'myValidator', when: crossFieldWhen };
+      expect(requiresTreeValidation(config)).toBe(false);
+    });
+  });
+
+  describe('built-in validators', () => {
+    it('returns true for a cross-field dynamic value expression', () => {
+      const config: ValidatorConfig = { type: 'maxLength', expression: 'formValue.limit' };
+      expect(requiresTreeValidation(config)).toBe(true);
+    });
+
+    it('returns true for a cross-field dynamic value expression with a when condition', () => {
+      const config: ValidatorConfig = { type: 'maxLength', expression: 'formValue.limit', when: crossFieldWhen };
+      expect(requiresTreeValidation(config)).toBe(true);
+    });
+
+    it('returns false for a static value with a cross-field when', () => {
+      const config: ValidatorConfig = { type: 'maxLength', value: 20, when: crossFieldWhen };
+      expect(requiresTreeValidation(config)).toBe(false);
+    });
+
+    it('returns false for a static value with a field-local when', () => {
+      const config: ValidatorConfig = { type: 'maxLength', value: 20, when: localWhen };
+      expect(requiresTreeValidation(config)).toBe(false);
+    });
+
+    it('returns false for a non-cross-field dynamic value expression with a when', () => {
+      const config: ValidatorConfig = { type: 'min', expression: '18', when: crossFieldWhen };
+      expect(requiresTreeValidation(config)).toBe(false);
+    });
+
+    it('returns false for required with a cross-field when', () => {
+      const config: ValidatorConfig = { type: 'required', when: crossFieldWhen };
+      expect(requiresTreeValidation(config)).toBe(false);
+    });
+
+    it('returns false for email with a cross-field when', () => {
+      const config: ValidatorConfig = { type: 'email', when: crossFieldWhen };
+      expect(requiresTreeValidation(config)).toBe(false);
+    });
+
+    it('returns false for a plain static built-in', () => {
+      const config: ValidatorConfig = { type: 'minLength', value: 3 };
+      expect(requiresTreeValidation(config)).toBe(false);
+    });
+  });
+
+  describe('resource-based validators', () => {
+    it('returns false for async validators with a cross-field when', () => {
+      const config = { type: 'async', functionName: 'checkUsername', when: crossFieldWhen } as ValidatorConfig;
+      expect(requiresTreeValidation(config)).toBe(false);
+    });
+
+    it('returns false for http validators with a cross-field when', () => {
+      const config: ValidatorConfig = {
+        type: 'http',
+        http: { url: '/api/check', method: 'GET' },
+        responseMapping: { validWhen: 'response.ok', errorKind: 'taken' },
+        when: crossFieldWhen,
+      };
+      expect(requiresTreeValidation(config)).toBe(false);
+    });
+
+    it('returns false for async/http validators carrying a stray cross-field expression property', () => {
+      const asyncConfig = { type: 'async', functionName: 'check', expression: 'formValue.other' } as unknown as ValidatorConfig;
+      const httpConfig = {
+        type: 'http',
+        http: { url: '/api/check', method: 'GET' },
+        responseMapping: { validWhen: 'response.ok', errorKind: 'taken' },
+        expression: 'formValue.other',
+      } as unknown as ValidatorConfig;
+
+      expect(requiresTreeValidation(asyncConfig)).toBe(false);
+      expect(requiresTreeValidation(httpConfig)).toBe(false);
+    });
+  });
+});

--- a/packages/dynamic-forms/internal/src/lib/core/cross-field/cross-field-detector.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/cross-field/cross-field-detector.ts
@@ -201,12 +201,30 @@ export function isResourceBasedValidator(config: ValidatorConfig): boolean {
  * @param config The validator configuration to check
  * @param context Optional context providing function scope lookup
  * @returns true if the when condition references other fields
+ * @deprecated No longer used for validator routing; `when` conditions are applied natively
+ * via Angular's validator `when` config. Use {@link requiresTreeValidation} for routing.
  */
 export function hasCrossFieldWhenCondition(config: ValidatorConfig, context?: CrossFieldDetectionContext): boolean {
   if (!('when' in config) || !config.when) {
     return false;
   }
   return isCrossFieldExpression(config.when as ConditionalExpression, context);
+}
+
+/**
+ * True only when the validator must be evaluated by the root validateTree:
+ * a cross-field dynamic-value/validation EXPRESSION. A `when` condition alone
+ * never requires tree validation; it is applied natively via Angular's
+ * validator `when` config (built-ins) or whenLogic gating (custom/async/http).
+ */
+export function requiresTreeValidation(config: ValidatorConfig): boolean {
+  if (isResourceBasedValidator(config)) {
+    return false;
+  }
+  if (config.type === 'custom') {
+    return isCrossFieldValidator(config);
+  }
+  return isCrossFieldBuiltInValidator(config);
 }
 
 // ============================================================================

--- a/packages/dynamic-forms/internal/src/lib/core/expressions/logic-function-factory.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/expressions/logic-function-factory.ts
@@ -151,6 +151,8 @@ export function createDebouncedLogicFunction<TValue>(expression: ConditionalExpr
   }
 
   const fn: LogicFn<TValue, boolean> = (ctx: FieldContext<TValue>) => {
+    // debouncedSignalStore keys are per-field-path only; the key must also include the
+    // serialized expression before validator when + debounceMs ever routes through here
     const contextKey = safeReadPathKeys(ctx as FieldContext<unknown>).join('.');
     let signalPair = cacheService.debouncedSignalStore.get(contextKey);
 

--- a/packages/dynamic-forms/internal/src/lib/core/validation/validator-factory.spec.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/validation/validator-factory.spec.ts
@@ -938,7 +938,7 @@ describe('validator-factory', () => {
       });
     });
 
-    it('honors a field-local when on maxLength (previously silently dropped)', () => {
+    it('honors a field-local when on maxLength (previously the when was ignored and maxLength applied unconditionally)', () => {
       runInInjectionContext(injector, () => {
         const formValue = signal({ name: 'ignore-me' });
 

--- a/packages/dynamic-forms/internal/src/lib/core/validation/validator-factory.spec.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/validation/validator-factory.spec.ts
@@ -804,6 +804,272 @@ describe('validator-factory', () => {
     });
   });
 
+  describe('conditional built-in validators (native when routing)', () => {
+    const crossFieldWhen = { type: 'javascript' as const, expression: 'formValue.other === true' };
+
+    it('applies maxLength natively with reactive constraint metadata gated by a cross-field when', () => {
+      runInInjectionContext(injector, () => {
+        const formValue = signal({ name: 'way too long value', other: false });
+        mockEntity.set({ name: 'way too long value', other: false });
+        const config: ValidatorConfig = { type: 'maxLength', value: 20, when: crossFieldWhen };
+
+        const formInstance = form(
+          formValue,
+          schema<typeof formValue>((path) => {
+            applyValidator(config, path.name);
+          }),
+        );
+        mockFormSignal.set(formInstance);
+
+        // Condition false: constraint metadata absent, no error
+        expect(formInstance.name().maxLength?.()).toBeUndefined();
+        expect(formInstance.name().errors()).toEqual([]);
+
+        // Flip the OTHER field only - the validated field is untouched
+        mockEntity.set({ name: 'way too long value', other: true });
+        expect(formInstance.name().maxLength?.()).toBe(20);
+        expect(formInstance.name().errors()).toEqual([]);
+
+        formValue.set({ name: 'x'.repeat(25), other: true });
+        const errors = formInstance.name().errors();
+        expect(errors).toHaveLength(1);
+        expect(errors[0].kind).toBe('maxLength');
+        expect((errors[0] as unknown as Record<string, unknown>)['maxLength']).toBe(20);
+
+        // Flip back off: error clears, metadata gone
+        mockEntity.set({ name: 'x'.repeat(25), other: false });
+        expect(formInstance.name().errors()).toEqual([]);
+        expect(formInstance.name().maxLength?.()).toBeUndefined();
+      });
+    });
+
+    it('applies min, max, and minLength natively with reactive constraints', () => {
+      runInInjectionContext(injector, () => {
+        const formValue = signal({ age: 10, count: 100, code: 'ab', other: false });
+        mockEntity.set({ ...formValue() });
+
+        const formInstance = form(
+          formValue,
+          schema<typeof formValue>((path) => {
+            applyValidator({ type: 'min', value: 18, when: crossFieldWhen }, path.age);
+            applyValidator({ type: 'max', value: 50, when: crossFieldWhen }, path.count);
+            applyValidator({ type: 'minLength', value: 3, when: crossFieldWhen }, path.code);
+          }),
+        );
+        mockFormSignal.set(formInstance);
+
+        expect(formInstance.age().min?.()).toBeUndefined();
+        expect(formInstance.count().max?.()).toBeUndefined();
+        expect(formInstance.code().minLength?.()).toBeUndefined();
+        expect(formInstance().valid()).toBe(true);
+
+        mockEntity.set({ ...formValue(), other: true });
+        expect(formInstance.age().min?.()).toBe(18);
+        expect(formInstance.count().max?.()).toBe(50);
+        expect(formInstance.code().minLength?.()).toBe(3);
+        expect(formInstance.age().errors()[0]?.kind).toBe('min');
+        expect(formInstance.count().errors()[0]?.kind).toBe('max');
+        expect(formInstance.code().errors()[0]?.kind).toBe('minLength');
+      });
+    });
+
+    it('applies pattern natively with string and RegExp values gated by when', () => {
+      runInInjectionContext(injector, () => {
+        const formValue = signal({ codeA: '123', codeB: '456', other: false });
+        mockEntity.set({ ...formValue() });
+
+        const formInstance = form(
+          formValue,
+          schema<typeof formValue>((path) => {
+            applyValidator({ type: 'pattern', value: '^[a-z]+$', when: crossFieldWhen }, path.codeA);
+            applyValidator({ type: 'pattern', value: /^[a-z]+$/, when: crossFieldWhen }, path.codeB);
+          }),
+        );
+        mockFormSignal.set(formInstance);
+
+        expect(formInstance.codeA().errors()).toEqual([]);
+        expect(formInstance.codeB().errors()).toEqual([]);
+
+        mockEntity.set({ ...formValue(), other: true });
+        expect(formInstance.codeA().errors()[0]?.kind).toBe('pattern');
+        expect(formInstance.codeB().errors()[0]?.kind).toBe('pattern');
+      });
+    });
+
+    it('toggles field().required() reactively for required with a cross-field when', () => {
+      runInInjectionContext(injector, () => {
+        const formValue = signal({ name: '', other: false });
+        mockEntity.set({ name: '', other: false });
+
+        const formInstance = form(
+          formValue,
+          schema<typeof formValue>((path) => {
+            applyValidator({ type: 'required', when: crossFieldWhen }, path.name);
+          }),
+        );
+        mockFormSignal.set(formInstance);
+
+        expect(formInstance.name().required()).toBe(false);
+        expect(formInstance.name().errors()).toEqual([]);
+
+        mockEntity.set({ name: '', other: true });
+        expect(formInstance.name().required()).toBe(true);
+        expect(formInstance.name().errors()[0]?.kind).toBe('required');
+      });
+    });
+
+    it('applies email natively gated by a cross-field when', () => {
+      runInInjectionContext(injector, () => {
+        const formValue = signal({ contact: 'not-an-email', other: false });
+        mockEntity.set({ ...formValue() });
+
+        const formInstance = form(
+          formValue,
+          schema<typeof formValue>((path) => {
+            applyValidator({ type: 'email', when: crossFieldWhen }, path.contact);
+          }),
+        );
+        mockFormSignal.set(formInstance);
+
+        expect(formInstance.contact().errors()).toEqual([]);
+
+        mockEntity.set({ ...formValue(), other: true });
+        expect(formInstance.contact().errors()[0]?.kind).toBe('email');
+      });
+    });
+
+    it('honors a field-local when on maxLength (previously silently dropped)', () => {
+      runInInjectionContext(injector, () => {
+        const formValue = signal({ name: 'ignore-me' });
+
+        const formInstance = form(
+          formValue,
+          schema<typeof formValue>((path) => {
+            applyValidator(
+              { type: 'maxLength', value: 5, when: { type: 'javascript', expression: 'fieldValue !== "ignore-me"' } },
+              path.name,
+            );
+          }),
+        );
+        mockFormSignal.set(formInstance);
+
+        // Gate is false for the sentinel value: no error despite length > 5
+        expect(formInstance.name().errors()).toEqual([]);
+
+        formValue.set({ name: 'much too long' });
+        expect(formInstance.name().errors()[0]?.kind).toBe('maxLength');
+      });
+    });
+
+    it('applies both a non-cross-field dynamic value expression and a when gate', () => {
+      runInInjectionContext(injector, () => {
+        const formValue = signal({ age: 10, other: false });
+        mockEntity.set({ age: 10, other: false });
+
+        const formInstance = form(
+          formValue,
+          schema<typeof formValue>((path) => {
+            applyValidator({ type: 'min', value: 1, expression: '18', when: crossFieldWhen }, path.age);
+          }),
+        );
+        mockFormSignal.set(formInstance);
+
+        expect(formInstance.age().errors()).toEqual([]);
+
+        mockEntity.set({ age: 10, other: true });
+        const errors = formInstance.age().errors();
+        expect(errors[0]?.kind).toBe('min');
+        // Dynamic value expression wins over the static value
+        expect((errors[0] as unknown as Record<string, unknown>)['min']).toBe(18);
+      });
+    });
+
+    it('combines multiple conditional maxLength validators with a static one on the same field', () => {
+      runInInjectionContext(injector, () => {
+        const formValue = signal({ name: 'x'.repeat(12), gateA: false, gateB: false });
+        mockEntity.set({ ...formValue() });
+
+        const formInstance = form(
+          formValue,
+          schema<typeof formValue>((path) => {
+            applyValidator({ type: 'maxLength', value: 10 }, path.name);
+            applyValidator(
+              { type: 'maxLength', value: 5, when: { type: 'javascript', expression: 'formValue.gateA === true' } },
+              path.name,
+            );
+            applyValidator(
+              { type: 'maxLength', value: 3, when: { type: 'javascript', expression: 'formValue.gateB === true' } },
+              path.name,
+            );
+          }),
+        );
+        mockFormSignal.set(formInstance);
+
+        // Only the static rule active
+        expect(formInstance.name().maxLength?.()).toBe(10);
+        expect(formInstance.name().errors()).toHaveLength(1);
+
+        // gateA active: metadata is the min of active contributions, errors independent
+        mockEntity.set({ ...formValue(), gateA: true });
+        expect(formInstance.name().maxLength?.()).toBe(5);
+        expect(formInstance.name().errors()).toHaveLength(2);
+
+        mockEntity.set({ ...formValue(), gateA: true, gateB: true });
+        expect(formInstance.name().maxLength?.()).toBe(3);
+        expect(formInstance.name().errors()).toHaveLength(3);
+        expect(
+          formInstance
+            .name()
+            .errors()
+            .every((e) => e.kind === 'maxLength'),
+        ).toBe(true);
+      });
+    });
+
+    it('applies custom functionName validators natively with a cross-field when gate', () => {
+      runInInjectionContext(injector, () => {
+        const registry = TestBed.inject(FunctionRegistryService);
+        registry.registerValidator('alwaysFails', () => ({ kind: 'customFail' }));
+
+        const formValue = signal({ name: 'value', other: false });
+        mockEntity.set({ name: 'value', other: false });
+        const config: ValidatorConfig = { type: 'custom', functionName: 'alwaysFails', when: crossFieldWhen };
+
+        const formInstance = form(
+          formValue,
+          schema<typeof formValue>((path) => {
+            applyValidator(config, path.name);
+          }),
+        );
+        mockFormSignal.set(formInstance);
+
+        expect(formInstance.name().errors()).toEqual([]);
+
+        mockEntity.set({ name: 'value', other: true });
+        expect(formInstance.name().errors()[0]?.kind).toBe('customFail');
+      });
+    });
+
+    it('pins native required semantics: false fails, whitespace-only passes', () => {
+      runInInjectionContext(injector, () => {
+        const formValue = signal({ accepted: false, note: '  ', other: true });
+        mockEntity.set({ ...formValue() });
+
+        const formInstance = form(
+          formValue,
+          schema<typeof formValue>((path) => {
+            applyValidator({ type: 'required', when: crossFieldWhen }, path.accepted);
+            applyValidator({ type: 'required', when: crossFieldWhen }, path.note);
+          }),
+        );
+        mockFormSignal.set(formInstance);
+
+        expect(formInstance.accepted().errors()[0]?.kind).toBe('required');
+        expect(formInstance.note().errors()).toEqual([]);
+      });
+    });
+  });
+
   describe('declarative HTTP validator callback behavior', () => {
     // These tests mock validateHttp to capture the options object and verify
     // the behavior of request/onSuccess/onError callbacks in isolation.

--- a/packages/dynamic-forms/internal/src/lib/core/validation/validator-factory.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/validation/validator-factory.ts
@@ -33,57 +33,71 @@ import { ConditionalExpression } from '../../models/expressions/conditional-expr
 import { FunctionRegistryService } from '../registry/function-registry.service';
 import { FieldContextRegistryService } from '../registry/field-context-registry.service';
 import { ExpressionParser } from '../expressions/parser/expression-parser';
-import {
-  isCrossFieldValidator,
-  isCrossFieldBuiltInValidator,
-  hasCrossFieldWhenCondition,
-  isResourceBasedValidator,
-} from '../cross-field/cross-field-detector';
+import { requiresTreeValidation } from '../cross-field/cross-field-detector';
 
-function applyEmailValidator(path: SchemaPath<string>): void {
-  email(path);
+// Safe cast target: the when LogicFn only reads FieldContext members that exist for every TValue
+type WhenLogic = LogicFn<unknown, boolean> | undefined;
+
+function applyEmailValidator(path: SchemaPath<string>, when?: WhenLogic): void {
+  email(path, when ? { when: when as LogicFn<string, boolean> } : undefined);
 }
 
-function applyMinValidator(path: SchemaPath<number>, value: number, expression?: string): void {
+function applyMinValidator(path: SchemaPath<number>, value: number, expression?: string, when?: WhenLogic): void {
+  const opts = when ? { when: when as LogicFn<number, boolean> } : undefined;
   if (expression) {
-    min(path, createDynamicValueFunction<string | number | null, number | undefined>(expression));
+    // Safe cast: the dynamic value fn only reads generic FieldContext members
+    min(
+      path,
+      createDynamicValueFunction<string | number | null, number | undefined>(expression) as LogicFn<number, number | undefined>,
+      opts,
+    );
   } else {
-    min(path, value);
+    min(path, value, opts);
   }
 }
 
-function applyMaxValidator(path: SchemaPath<number>, value: number, expression?: string): void {
+function applyMaxValidator(path: SchemaPath<number>, value: number, expression?: string, when?: WhenLogic): void {
+  const opts = when ? { when: when as LogicFn<number, boolean> } : undefined;
   if (expression) {
-    max(path, createDynamicValueFunction<string | number | null, number | undefined>(expression));
+    // Safe cast: the dynamic value fn only reads generic FieldContext members
+    max(
+      path,
+      createDynamicValueFunction<string | number | null, number | undefined>(expression) as LogicFn<number, number | undefined>,
+      opts,
+    );
   } else {
-    max(path, value);
+    max(path, value, opts);
   }
 }
 
-function applyMinLengthValidator(path: SchemaPath<string>, value: number, expression?: string): void {
+function applyMinLengthValidator(path: SchemaPath<string>, value: number, expression?: string, when?: WhenLogic): void {
+  const opts = when ? { when: when as LogicFn<string, boolean> } : undefined;
   if (expression) {
-    minLength(path, createDynamicValueFunction<string, number>(expression));
+    minLength(path, createDynamicValueFunction<string, number>(expression), opts);
   } else {
-    minLength(path, value);
+    minLength(path, value, opts);
   }
 }
 
-function applyMaxLengthValidator(path: SchemaPath<string>, value: number, expression?: string): void {
+function applyMaxLengthValidator(path: SchemaPath<string>, value: number, expression?: string, when?: WhenLogic): void {
+  const opts = when ? { when: when as LogicFn<string, boolean> } : undefined;
   if (expression) {
-    maxLength(path, createDynamicValueFunction<string, number>(expression));
+    maxLength(path, createDynamicValueFunction<string, number>(expression), opts);
   } else {
-    maxLength(path, value);
+    maxLength(path, value, opts);
   }
 }
 
-function applyPatternValidator(path: SchemaPath<string>, value: RegExp, expression?: string): void {
+function applyPatternValidator(path: SchemaPath<string>, value: RegExp, expression?: string, when?: WhenLogic): void {
+  const opts = when ? { when: when as LogicFn<string, boolean> } : undefined;
   if (expression) {
     pattern(
       path,
       createDynamicValueFunction<string | undefined, RegExp | undefined>(expression) as LogicFn<string | undefined, RegExp | undefined>,
+      opts,
     );
   } else {
-    pattern(path, value);
+    pattern(path, value, opts);
   }
 }
 
@@ -95,39 +109,35 @@ function createConditionalLogic(when: ConditionalExpression | undefined): LogicF
 export function applyValidator(config: ValidatorConfig, fieldPath: SchemaPath<any> | SchemaPathTree<any>): void {
   const path = fieldPath as SchemaPath<unknown>;
 
-  if (!isResourceBasedValidator(config) && (isCrossFieldBuiltInValidator(config) || hasCrossFieldWhenCondition(config))) {
+  if (requiresTreeValidation(config)) {
     return;
   }
 
   switch (config.type) {
     case 'required':
-      if (config.when) {
-        required(path, { when: createLogicFunction(config.when) });
-      } else {
-        required(path);
-      }
+      required(path, config.when ? { when: createConditionalLogic(config.when) } : undefined);
       break;
     case 'email':
-      applyEmailValidator(fieldPath as SchemaPath<string>);
+      applyEmailValidator(fieldPath as SchemaPath<string>, createConditionalLogic(config.when));
       break;
     case 'min':
       if (typeof config.value === 'number') {
-        applyMinValidator(fieldPath as SchemaPath<number>, config.value, config.expression);
+        applyMinValidator(fieldPath as SchemaPath<number>, config.value, config.expression, createConditionalLogic(config.when));
       }
       break;
     case 'max':
       if (typeof config.value === 'number') {
-        applyMaxValidator(fieldPath as SchemaPath<number>, config.value, config.expression);
+        applyMaxValidator(fieldPath as SchemaPath<number>, config.value, config.expression, createConditionalLogic(config.when));
       }
       break;
     case 'minLength':
       if (typeof config.value === 'number') {
-        applyMinLengthValidator(fieldPath as SchemaPath<string>, config.value, config.expression);
+        applyMinLengthValidator(fieldPath as SchemaPath<string>, config.value, config.expression, createConditionalLogic(config.when));
       }
       break;
     case 'maxLength':
       if (typeof config.value === 'number') {
-        applyMaxLengthValidator(fieldPath as SchemaPath<string>, config.value, config.expression);
+        applyMaxLengthValidator(fieldPath as SchemaPath<string>, config.value, config.expression, createConditionalLogic(config.when));
       }
       break;
     case 'pattern':
@@ -144,7 +154,7 @@ export function applyValidator(config: ValidatorConfig, fieldPath: SchemaPath<an
         } else {
           regexPattern = config.value;
         }
-        applyPatternValidator(fieldPath as SchemaPath<string>, regexPattern, config.expression);
+        applyPatternValidator(fieldPath as SchemaPath<string>, regexPattern, config.expression, createConditionalLogic(config.when));
       }
       break;
     case 'custom':
@@ -160,10 +170,6 @@ export function applyValidator(config: ValidatorConfig, fieldPath: SchemaPath<an
 }
 
 function applyCustomValidator(config: CustomValidatorConfig, fieldPath: SchemaPath<unknown>): void {
-  if (isCrossFieldValidator(config)) {
-    return;
-  }
-
   let validatorFn: (ctx: FieldContext<unknown>) => ValidationError | ValidationError[] | null;
 
   if (config.expression) {

--- a/packages/dynamic-forms/src/lib/core/conditional-validator-routing.integration.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/conditional-validator-routing.integration.spec.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { Injector, runInInjectionContext, signal, WritableSignal } from '@angular/core';
+import { form } from '@angular/forms/signals';
+import { createSchemaFromFields } from './schema-builder';
+import { collectCrossFieldEntries } from './cross-field/cross-field-collector';
+import { SchemaRegistryService } from './registry/schema-registry.service';
+import { FormStateManager } from '../state/form-state-manager';
+import {
+  DEPRECATION_WARNING_TRACKER,
+  DynamicValueFunctionCacheService,
+  FieldContextRegistryService,
+  FieldDef,
+  FieldTypeDefinition,
+  FunctionRegistryService,
+  HttpConditionFunctionCacheService,
+  interpolateParams,
+  LogicFunctionCacheService,
+  RootFormRegistryService,
+} from '@ng-forge/dynamic-forms/internal';
+import { createWarningTracker } from '@ng-forge/dynamic-forms/internal';
+
+/**
+ * Integration coverage for issue #512 native routing: built-in validators with a
+ * static value and a `when` condition are applied natively via Angular Signal Forms
+ * instead of the root validateTree.
+ */
+describe('conditional validator routing (native when)', () => {
+  const mockEntity = signal<Record<string, unknown>>({});
+  const mockFormSignal = signal<unknown>(undefined);
+
+  let injector: Injector;
+  let registry: Map<string, FieldTypeDefinition>;
+
+  const crossFieldWhen = { type: 'javascript' as const, expression: 'formValue.other === "yes"' };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        SchemaRegistryService,
+        FunctionRegistryService,
+        FieldContextRegistryService,
+        { provide: RootFormRegistryService, useValue: { formValue: mockEntity, rootForm: mockFormSignal } },
+        { provide: FormStateManager, useValue: { activeConfig: signal(undefined) } },
+        { provide: DEPRECATION_WARNING_TRACKER, useFactory: createWarningTracker },
+        LogicFunctionCacheService,
+        HttpConditionFunctionCacheService,
+        DynamicValueFunctionCacheService,
+      ],
+    });
+
+    injector = TestBed.inject(Injector);
+    registry = new Map<string, FieldTypeDefinition>();
+    registry.set('input', { name: 'input', mapper: () => [], valueHandling: 'include' });
+    registry.set('checkbox', { name: 'checkbox', mapper: () => [], valueHandling: 'include' });
+    registry.set('array', { name: 'array', mapper: () => [], valueHandling: 'include' });
+
+    mockEntity.set({});
+    mockFormSignal.set(undefined);
+  });
+
+  /** Builds the same pipeline as FormStateManager: collector output feeds the schema. */
+  function buildForm<T extends Record<string, unknown>>(fields: FieldDef<unknown>[], initial: T) {
+    return runInInjectionContext(injector, () => {
+      const model = signal<T>(initial);
+      mockEntity.set(initial);
+      const collection = collectCrossFieldEntries(fields);
+      const formSchema = createSchemaFromFields<T>(fields, registry, { crossFieldValidators: collection.validators });
+      const formInstance = form(model, formSchema);
+      mockFormSignal.set(formInstance);
+      return { model, formInstance, collection };
+    });
+  }
+
+  function setValue<T extends Record<string, unknown>>(model: WritableSignal<T>, value: T): void {
+    model.set(value);
+    mockEntity.set(value);
+  }
+
+  it('emits exactly one native error for a violated conditional built-in and interpolates the constraint', () => {
+    const fields: FieldDef<unknown>[] = [
+      { type: 'input', key: 'name', validators: [{ type: 'maxLength', value: 5, when: crossFieldWhen }] } as FieldDef<unknown>,
+      { type: 'input', key: 'other' } as FieldDef<unknown>,
+    ];
+
+    const { model, formInstance, collection } = buildForm(fields, { name: 'way too long', other: 'no' });
+
+    // Lockstep tripwire: the when-only validator must not be collected into the tree
+    expect(collection.validators).toHaveLength(0);
+    expect(formInstance.name().errors()).toEqual([]);
+
+    setValue(model, { name: 'way too long', other: 'yes' });
+
+    const errors = formInstance.name().errors();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].kind).toBe('maxLength');
+    expect(formInstance.name().maxLength?.()).toBe(5);
+
+    const message = interpolateParams(
+      'Must be at most {{requiredLength}} characters',
+      errors[0] as unknown as Parameters<typeof interpolateParams>[1],
+    );
+    expect(message).toBe('Must be at most 5 characters');
+  });
+
+  it('clears the error when the condition flips mid-edit', () => {
+    const fields: FieldDef<unknown>[] = [
+      { type: 'input', key: 'name', validators: [{ type: 'maxLength', value: 5, when: crossFieldWhen }] } as FieldDef<unknown>,
+      { type: 'input', key: 'other' } as FieldDef<unknown>,
+    ];
+
+    const { model, formInstance } = buildForm(fields, { name: 'way too long', other: 'yes' });
+
+    expect(formInstance.name().errors()).toHaveLength(1);
+
+    setValue(model, { name: 'way too long', other: 'no' });
+    expect(formInstance.name().errors()).toEqual([]);
+    expect(formInstance().valid()).toBe(true);
+  });
+
+  it('honors validateWhenHidden: false for a conditional required on a hidden field', () => {
+    const fields: FieldDef<unknown>[] = [
+      { type: 'input', key: 'secret', hidden: true, validators: [{ type: 'required', when: crossFieldWhen }] } as FieldDef<unknown>,
+      { type: 'input', key: 'other' } as FieldDef<unknown>,
+    ];
+
+    const { formInstance } = buildForm(fields, { secret: '', other: 'yes' });
+
+    // Condition is met but the field is hidden - validation is gated off, form submittable
+    expect(formInstance.secret().errors()).toEqual([]);
+    expect(formInstance().valid()).toBe(true);
+  });
+
+  it('applies conditional validators declared in a named SchemaDefinition', () => {
+    runInInjectionContext(injector, () => {
+      const schemaRegistry = TestBed.inject(SchemaRegistryService);
+      schemaRegistry.registerSchema({
+        name: 'nameRules',
+        validators: [{ type: 'maxLength', value: 5, when: crossFieldWhen }],
+      });
+    });
+
+    const fields: FieldDef<unknown>[] = [
+      { type: 'input', key: 'name', schemas: [{ type: 'apply', schema: 'nameRules' }] } as FieldDef<unknown>,
+      { type: 'input', key: 'other' } as FieldDef<unknown>,
+    ];
+
+    const { model, formInstance } = buildForm(fields, { name: 'way too long', other: 'no' });
+
+    expect(formInstance.name().errors()).toEqual([]);
+
+    setValue(model, { name: 'way too long', other: 'yes' });
+    const errors = formInstance.name().errors();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].kind).toBe('maxLength');
+  });
+
+  it('reports conditional array-item errors on the correct index', () => {
+    // Array-item evaluation contexts scope formValue to the item; the root is rootFormValue
+    const rootScopedWhen = { type: 'javascript' as const, expression: 'rootFormValue.other === "yes"' };
+    const fields: FieldDef<unknown>[] = [
+      {
+        type: 'array',
+        key: 'contacts',
+        fields: [[{ type: 'input', key: 'email', validators: [{ type: 'maxLength', value: 5, when: rootScopedWhen }] }]],
+      } as unknown as FieldDef<unknown>,
+      { type: 'input', key: 'other' } as FieldDef<unknown>,
+    ];
+
+    const initial = { contacts: [{ email: 'ok' }, { email: 'way too long' }], other: 'no' };
+    const { model, formInstance, collection } = buildForm(fields, initial);
+
+    expect(collection.validators).toHaveLength(0);
+    expect(formInstance.contacts[1].email().errors()).toEqual([]);
+
+    setValue(model, { ...initial, other: 'yes' });
+
+    expect(formInstance.contacts[0].email().errors()).toEqual([]);
+    const itemErrors = formInstance.contacts[1].email().errors();
+    expect(itemErrors).toHaveLength(1);
+    expect(itemErrors[0].kind).toBe('maxLength');
+  });
+});

--- a/packages/dynamic-forms/src/lib/core/cross-field/cross-field-collector.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/cross-field/cross-field-collector.spec.ts
@@ -197,6 +197,110 @@ describe('collectCrossFieldEntries()', () => {
     });
   });
 
+  describe('native when routing (validators not collected into the tree)', () => {
+    const crossFieldWhen = { type: 'javascript' as const, expression: 'formValue.other === true' };
+
+    it('does not collect built-in validators with a static value and cross-field when', () => {
+      const fields: FieldDef<any>[] = [
+        {
+          type: 'input',
+          key: 'name',
+          validators: [{ type: 'maxLength', value: 20, when: crossFieldWhen }],
+        },
+      ];
+
+      const { validators } = collectCrossFieldEntries(fields);
+
+      expect(validators).toHaveLength(0);
+    });
+
+    it('does not collect required/email validators with a cross-field when', () => {
+      const fields: FieldDef<any>[] = [
+        {
+          type: 'input',
+          key: 'name',
+          validators: [
+            { type: 'required', when: crossFieldWhen },
+            { type: 'email', when: crossFieldWhen },
+          ],
+        },
+      ];
+
+      const { validators } = collectCrossFieldEntries(fields);
+
+      expect(validators).toHaveLength(0);
+    });
+
+    it('does not collect custom fn validators with a cross-field when', () => {
+      const fields: FieldDef<any>[] = [
+        {
+          type: 'input',
+          key: 'name',
+          validators: [{ type: 'custom', fn: () => null, when: crossFieldWhen }],
+        },
+      ];
+
+      const { validators } = collectCrossFieldEntries(fields);
+
+      expect(validators).toHaveLength(0);
+    });
+
+    it('does not collect async or http validators with a cross-field when', () => {
+      const fields: FieldDef<any>[] = [
+        {
+          type: 'input',
+          key: 'name',
+          validators: [
+            { type: 'async', functionName: 'check', when: crossFieldWhen },
+            {
+              type: 'http',
+              http: { url: '/api/check', method: 'GET' },
+              responseMapping: { validWhen: 'response.ok', errorKind: 'taken' },
+              when: crossFieldWhen,
+            },
+          ],
+        },
+      ];
+
+      const { validators } = collectCrossFieldEntries(fields);
+
+      expect(validators).toHaveLength(0);
+    });
+
+    it('still collects built-in validators with a cross-field expression, preserving when on the converted config', () => {
+      const fields: FieldDef<any>[] = [
+        {
+          type: 'input',
+          key: 'name',
+          validators: [{ type: 'maxLength', expression: 'formValue.limit', when: crossFieldWhen }],
+        },
+      ];
+
+      const { validators } = collectCrossFieldEntries(fields);
+
+      expect(validators).toHaveLength(1);
+      expect(validators[0].validatorType).toBe('maxLength');
+      expect(validators[0].config.type).toBe('custom');
+      expect(validators[0].config.when).toEqual(crossFieldWhen);
+      expect(validators[0].dependsOn).toContain('limit');
+    });
+
+    it('still collects custom validators with a cross-field expression', () => {
+      const fields: FieldDef<any>[] = [
+        {
+          type: 'input',
+          key: 'name',
+          validators: [{ type: 'custom', expression: 'fieldValue === formValue.password', kind: 'mismatch' }],
+        },
+      ];
+
+      const { validators } = collectCrossFieldEntries(fields);
+
+      expect(validators).toHaveLength(1);
+      expect(validators[0].dependsOn).toContain('password');
+    });
+  });
+
   describe('array fields are not traversed', () => {
     it('does not recurse into array items', () => {
       const fields: FieldDef<any>[] = [

--- a/packages/dynamic-forms/src/lib/core/cross-field/cross-field-collector.ts
+++ b/packages/dynamic-forms/src/lib/core/cross-field/cross-field-collector.ts
@@ -8,9 +8,7 @@ import { hasChildFields, isGroupField } from '@ng-forge/dynamic-forms/internal';
 import { normalizeFieldsArray } from '@ng-forge/dynamic-forms/internal';
 import { DynamicFormError } from '@ng-forge/dynamic-forms/internal';
 import {
-  isCrossFieldValidator,
-  isCrossFieldBuiltInValidator,
-  hasCrossFieldWhenCondition,
+  requiresTreeValidation,
   isCrossFieldStateLogic,
   isCrossFieldSchema,
   extractExpressionDependencies,
@@ -98,46 +96,30 @@ function collectFromField(field: FieldDef<unknown>, collection: CrossFieldCollec
   }
 }
 
-/** Returns a validator entry if cross-field, null otherwise. */
+/** Returns a validator entry if it requires tree validation, null otherwise. */
 function tryCreateValidatorEntry(fieldKey: string, config: ValidatorConfig): CrossFieldValidatorEntry | null {
-  // Check for custom validators with cross-field expressions
+  if (!requiresTreeValidation(config)) {
+    return null; // `when`-only conditionals are applied natively in applyValidator
+  }
+
   if (config.type === 'custom') {
     const customConfig = config as CustomValidatorConfig;
-    if (isCrossFieldValidator(customConfig)) {
-      return {
-        sourceFieldKey: fieldKey,
-        config,
-        dependsOn: extractStringDependencies(customConfig.expression || ''),
-        category: 'validator',
-      };
-    }
-  }
-
-  // Check for built-in validators with cross-field dynamic expressions
-  if (isCrossFieldBuiltInValidator(config)) {
-    const builtInConfig = config as BuiltInValidatorConfig;
-    return {
-      sourceFieldKey: fieldKey,
-      config: convertBuiltInToCustomValidator(builtInConfig),
-      validatorType: config.type,
-      dependsOn: extractStringDependencies(builtInConfig.expression || ''),
-      category: 'validator',
-    };
-  }
-
-  // Check for validators with cross-field when conditions
-  if (hasCrossFieldWhenCondition(config)) {
-    const whenCondition = config.when as ConditionalExpression;
     return {
       sourceFieldKey: fieldKey,
       config,
-      validatorType: config.type,
-      dependsOn: extractExpressionDependencies(whenCondition),
+      dependsOn: extractStringDependencies(customConfig.expression || ''),
       category: 'validator',
     };
   }
 
-  return null;
+  const builtInConfig = config as BuiltInValidatorConfig;
+  return {
+    sourceFieldKey: fieldKey,
+    config: convertBuiltInToCustomValidator(builtInConfig),
+    validatorType: config.type,
+    dependsOn: extractStringDependencies(builtInConfig.expression || ''),
+    category: 'validator',
+  };
 }
 
 /** Returns a logic entry if cross-field state logic, null otherwise. */

--- a/packages/dynamic-forms/src/lib/core/schema-application.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/schema-application.spec.ts
@@ -180,6 +180,41 @@ describe('schema-application', () => {
         expect(consoleSpy).not.toHaveBeenCalled();
       });
 
+      it('should warn and skip schema definition validators with cross-field expressions', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const testSchema: SchemaDefinition = {
+          name: 'cross-field-schema',
+          validators: [{ type: 'maxLength', expression: 'formValue.limit' }],
+        };
+        schemaRegistry.registerSchema(testSchema);
+
+        const formValue = signal({ name: 'a value beyond any limit', limit: 3 });
+        const config: SchemaApplicationConfig = {
+          type: 'apply',
+          schema: 'cross-field-schema',
+        };
+
+        let formInstance: ReturnType<typeof form>;
+
+        expect(() => {
+          runInInjectionContext(injector, () => {
+            formInstance = form(
+              formValue,
+              schema<typeof formValue>((path) => {
+                applySchema(config, path.name);
+              }),
+            );
+            mockFormSignal.set(formInstance);
+          });
+        }).not.toThrow();
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          '[Dynamic Forms]',
+          expect.stringContaining('schema definition "cross-field-schema" uses a cross-field expression'),
+        );
+        warnSpy.mockRestore();
+      });
+
       it('should apply inline schema definition', () => {
         const formValue = signal({ name: '' });
         const inlineSchema: SchemaDefinition = {

--- a/packages/dynamic-forms/src/lib/core/schema-application.ts
+++ b/packages/dynamic-forms/src/lib/core/schema-application.ts
@@ -6,8 +6,9 @@ import { SchemaRegistryService } from './registry/schema-registry.service';
 import { createLogicFunction } from '@ng-forge/dynamic-forms/internal';
 import { createTypePredicateFunction } from './values/type-predicate-factory';
 import { applyValidator } from '@ng-forge/dynamic-forms/internal';
+import { requiresTreeValidation } from '@ng-forge/dynamic-forms/internal';
 import { applyLogic } from './logic/logic-applicator';
-import { DynamicFormLogger } from '@ng-forge/dynamic-forms/internal';
+import { DynamicFormLogger, type Logger } from '@ng-forge/dynamic-forms/internal';
 
 /**
  * Apply schema configuration.
@@ -28,7 +29,7 @@ export function applySchema(config: SchemaApplicationConfig, fieldPath: SchemaPa
     return;
   }
 
-  const schemaFn = createSchemaFunction(schema);
+  const schemaFn = createSchemaFunction(schema, logger);
 
   // Cast to suppress union type errors - safe because we only use signal forms (see function docs)
   const path = fieldPath as SchemaPath<unknown>;
@@ -59,10 +60,19 @@ export function applySchema(config: SchemaApplicationConfig, fieldPath: SchemaPa
 }
 
 /** Create a schema function from schema definition. */
-export function createSchemaFunction(schema: SchemaDefinition): SchemaOrSchemaFn<unknown> {
+export function createSchemaFunction(schema: SchemaDefinition, logger?: Logger): SchemaOrSchemaFn<unknown> {
   return (path: SchemaPathTree<unknown>) => {
     // Apply validators - path is SchemaPathTree which is accepted by applyValidator
     schema.validators?.forEach((validatorConfig) => {
+      // Cross-field expressions are collected from field definitions only; schema
+      // definition validators never reach the tree collector, so drop them loudly.
+      if (requiresTreeValidation(validatorConfig)) {
+        logger?.warn(
+          `Validator "${validatorConfig.type}" in schema definition "${schema.name}" uses a cross-field expression, ` +
+            `which is not supported on schema definition validators; it was skipped.`,
+        );
+        return;
+      }
       applyValidator(validatorConfig, path);
     });
 

--- a/packages/dynamic-forms/src/lib/core/schema-builder.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/schema-builder.spec.ts
@@ -621,6 +621,53 @@ describe('schema-builder', () => {
         warnSpy.mockRestore();
       });
 
+      it('should warn about non-custom tree entries once at schema build, not per validation run', () => {
+        interface NameForm {
+          name: string;
+          other: string;
+        }
+
+        const crossFieldValidators = [
+          {
+            sourceFieldKey: 'name',
+            config: {
+              type: 'maxLength' as const,
+              value: 5,
+              when: {
+                type: 'fieldValue' as const,
+                fieldPath: 'other',
+                operator: 'equals' as const,
+                value: 'yes',
+              },
+            },
+          },
+        ];
+
+        const fields: FieldDef<any>[] = [
+          { type: 'input', key: 'name' },
+          { type: 'input', key: 'other' },
+        ];
+
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        runInInjectionContext(injector, () => {
+          const model = signal<NameForm>({ name: 'first', other: 'yes' });
+          const schema = createSchemaFromFields<NameForm>(fields, registry, { crossFieldValidators });
+          const formInstance = form(model, schema);
+
+          formInstance.name().errors();
+          model.set({ name: 'second value', other: 'no' });
+          formInstance.name().errors();
+          model.set({ name: 'third value here', other: 'yes' });
+          formInstance.name().errors();
+
+          const guardWarnings = warnSpy.mock.calls.filter((call) => String(call[1]).includes('Unexpected non-custom validator'));
+          expect(guardWarnings).toHaveLength(1);
+        });
+
+        warnSpy.mockRestore();
+      });
+
       it('should include the constraint value on converted built-in cross-field expression errors', () => {
         interface NameForm {
           name: string;

--- a/packages/dynamic-forms/src/lib/core/schema-builder.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/schema-builder.spec.ts
@@ -577,7 +577,9 @@ describe('schema-builder', () => {
         ).not.toThrow();
       });
 
-      it('should include the constraint value on conditional built-in cross-field errors', () => {
+      it('should ignore non-custom validator entries in the cross-field tree with a warning', () => {
+        // Conditional built-ins are applied natively now; the collector never routes
+        // them to the tree. Hand-built raw entries hit the guard and are ignored.
         interface NameForm {
           name: string;
           other: string;
@@ -604,8 +606,47 @@ describe('schema-builder', () => {
           { type: 'input', key: 'other' },
         ];
 
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
         runInInjectionContext(injector, () => {
           const model = signal<NameForm>({ name: 'way too long', other: 'yes' });
+          const schema = createSchemaFromFields<NameForm>(fields, registry, { crossFieldValidators });
+          const formInstance = form(model, schema);
+
+          const errors = formInstance.name().errors();
+          expect(errors.find((error) => error.kind === 'maxLength')).toBeUndefined();
+          expect(warnSpy).toHaveBeenCalledWith('[Dynamic Forms]', expect.stringContaining('Unexpected non-custom validator'));
+        });
+
+        warnSpy.mockRestore();
+      });
+
+      it('should include the constraint value on converted built-in cross-field expression errors', () => {
+        interface NameForm {
+          name: string;
+          limit: number;
+        }
+
+        // Shape produced by the collector for built-in + cross-field expression
+        const crossFieldValidators = [
+          {
+            sourceFieldKey: 'name',
+            config: {
+              type: 'custom' as const,
+              expression: 'fieldValue == null || fieldValue.length <= (formValue.limit)',
+              kind: 'maxLength',
+              errorParams: { maxLength: 'formValue.limit' },
+            },
+          },
+        ];
+
+        const fields: FieldDef<any>[] = [
+          { type: 'input', key: 'name' },
+          { type: 'input', key: 'limit' },
+        ];
+
+        runInInjectionContext(injector, () => {
+          const model = signal<NameForm>({ name: 'way too long', limit: 5 });
           const schema = createSchemaFromFields<NameForm>(fields, registry, { crossFieldValidators });
           const formInstance = form(model, schema);
 

--- a/packages/dynamic-forms/src/lib/core/schema-builder.ts
+++ b/packages/dynamic-forms/src/lib/core/schema-builder.ts
@@ -9,7 +9,7 @@ import { CrossFieldValidatorEntry } from './cross-field/cross-field-types';
 import { FunctionRegistryService } from '@ng-forge/dynamic-forms/internal';
 import { ExpressionParser } from '@ng-forge/dynamic-forms/internal';
 import { evaluateCondition } from '@ng-forge/dynamic-forms/internal';
-import { CustomValidatorConfig, ValidatorConfig } from '@ng-forge/dynamic-forms/internal';
+import { CustomValidatorConfig } from '@ng-forge/dynamic-forms/internal';
 import { hasChildFields } from '@ng-forge/dynamic-forms/internal';
 import { DynamicFormLogger } from '@ng-forge/dynamic-forms/internal';
 import type { Logger } from '@ng-forge/dynamic-forms/internal';
@@ -20,8 +20,6 @@ import { applyFormLevelSchema } from './form-schema-merger';
 import type { FormSchema } from '@ng-forge/dynamic-forms/schema';
 import { VALIDATION_EXECUTION_DEFAULTS } from '../providers/features/validation-execution/validation-execution.token';
 import { FieldTreeMappingContext, resolveDescendantContext, resolveFieldOwnContext } from './field-tree-mapping-context';
-
-const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 /** Gets a FieldTree by key, supporting nested paths with dot notation. */
 function getFieldTreeByKey<TModel>(ctx: FieldContext<TModel>, key: string): FieldTree<unknown> | undefined {
@@ -218,13 +216,13 @@ function evaluateCrossFieldValidator<TModel>(
     logger,
   };
 
-  // Check if this is a custom validator (with expression) or a built-in validator (with when condition)
-  if (config.type === 'custom') {
-    return evaluateCustomCrossFieldValidator(config as CustomValidatorConfig, evaluationContext, sourceFieldKey, ctx);
-  } else {
-    // Built-in validator with cross-field when condition
-    return evaluateBuiltInCrossFieldValidator(config, evaluationContext, sourceFieldKey, ctx);
+  // The collector only routes custom validators (raw or converted built-ins) to the tree.
+  // Guard against hand-built entries passed directly to createSchemaFromFields.
+  if (config.type !== 'custom') {
+    logger.warn(`Unexpected non-custom validator in cross-field tree for "${sourceFieldKey}"; ignoring.`);
+    return null;
   }
+  return evaluateCustomCrossFieldValidator(config as CustomValidatorConfig, evaluationContext, sourceFieldKey, ctx);
 }
 
 /** Evaluates a custom cross-field validator with an expression. */
@@ -288,143 +286,6 @@ function evaluateCustomCrossFieldValidator<TModel>(
   }
 
   return errorObj as unknown as ValidationError.WithOptionalField;
-}
-
-/**
- * Evaluates a built-in validator with a cross-field when condition.
- * First checks the when condition, then applies the built-in validation logic.
- */
-function evaluateBuiltInCrossFieldValidator<TModel>(
-  config: ValidatorConfig,
-  evaluationContext: EvaluationContext,
-  sourceFieldKey: string,
-  ctx: FieldContext<TModel>,
-): ValidationError.WithOptionalField | null {
-  const { fieldValue, formValue, logger, customFunctions } = evaluationContext;
-
-  // First, evaluate the when condition
-  // If the condition is false, the validator doesn't apply (validation passes)
-  if (config.when) {
-    const conditionMet = evaluateCondition(config.when, {
-      fieldValue,
-      formValue,
-      fieldPath: sourceFieldKey,
-      customFunctions: customFunctions || {},
-      logger,
-    });
-
-    if (!conditionMet) {
-      return null; // Condition not met, skip validation
-    }
-  }
-
-  // Now apply the built-in validation logic based on the validator type
-  const isValid = applyBuiltInValidationLogic(config, fieldValue);
-
-  if (isValid) {
-    return null; // Validation passed
-  }
-
-  // Validation failed - create error targeting the source field
-  const targetField = getFieldTreeByKey(ctx, sourceFieldKey);
-  if (!targetField) {
-    logger.warn(`Cross-field validator references non-existent field "${sourceFieldKey}"`);
-    return null;
-  }
-
-  const errorObj: Record<string, unknown> = {
-    kind: config.type,
-    fieldTree: targetField,
-  };
-
-  // Include the static constraint on the error, matching native built-in errors
-  // (e.g. { maxLength: 5 }) so message templates can interpolate it
-  if ('value' in config && config.value !== undefined) {
-    errorObj[config.type] = config.value;
-  }
-
-  return errorObj as unknown as ValidationError.WithOptionalField;
-}
-
-/**
- * Applies built-in validation logic based on the validator type.
- * Returns true if validation passes, false if it fails.
- */
-function applyBuiltInValidationLogic(config: ValidatorConfig, fieldValue: unknown): boolean {
-  switch (config.type) {
-    case 'required':
-      // Required: value must be non-null, non-undefined, and non-empty string
-      if (fieldValue === null || fieldValue === undefined) {
-        return false;
-      }
-      if (typeof fieldValue === 'string' && fieldValue.trim() === '') {
-        return false;
-      }
-      return true;
-
-    case 'min':
-      // Min: numeric value must be >= min
-      if (fieldValue === null || fieldValue === undefined) {
-        return true; // Empty values pass min validation (use required for emptiness)
-      }
-      if ('value' in config && typeof config.value === 'number') {
-        return (fieldValue as number) >= config.value;
-      }
-      return true;
-
-    case 'max':
-      // Max: numeric value must be <= max
-      if (fieldValue === null || fieldValue === undefined) {
-        return true;
-      }
-      if ('value' in config && typeof config.value === 'number') {
-        return (fieldValue as number) <= config.value;
-      }
-      return true;
-
-    case 'minLength':
-      // MinLength: string length must be >= minLength
-      if (fieldValue === null || fieldValue === undefined || fieldValue === '') {
-        return true;
-      }
-      if ('value' in config && typeof config.value === 'number') {
-        return String(fieldValue).length >= config.value;
-      }
-      return true;
-
-    case 'maxLength':
-      // MaxLength: string length must be <= maxLength
-      if (fieldValue === null || fieldValue === undefined || fieldValue === '') {
-        return true;
-      }
-      if ('value' in config && typeof config.value === 'number') {
-        return String(fieldValue).length <= config.value;
-      }
-      return true;
-
-    case 'email':
-      // Email: must match email pattern
-      if (fieldValue === null || fieldValue === undefined || fieldValue === '') {
-        return true;
-      }
-
-      return emailPattern.test(String(fieldValue));
-
-    case 'pattern':
-      // Pattern: must match regex pattern
-      if (fieldValue === null || fieldValue === undefined || fieldValue === '') {
-        return true;
-      }
-      if ('value' in config && config.value) {
-        const regex = config.value instanceof RegExp ? config.value : new RegExp(String(config.value));
-        return regex.test(String(fieldValue));
-      }
-      return true;
-
-    default:
-      // Unknown validator type, consider valid
-      return true;
-  }
 }
 
 /** Utility to convert field definitions to default values object */

--- a/packages/dynamic-forms/src/lib/core/schema-builder.ts
+++ b/packages/dynamic-forms/src/lib/core/schema-builder.ts
@@ -157,8 +157,19 @@ function applyCrossFieldTreeValidator<TModel>(
   // Get custom functions for expression evaluation
   const customFunctions = functionRegistry.getCustomFunctions();
 
+  // The collector only routes custom validators (raw or converted built-ins) to the tree.
+  // Filter hand-built entries passed directly to createSchemaFromFields once at schema
+  // build so the warning doesn't repeat on every validation run.
+  const customValidators = validators.filter((entry) => {
+    if (entry.config.type !== 'custom') {
+      logger.warn(`Unexpected non-custom validator in cross-field tree for "${entry.sourceFieldKey}"; ignoring.`);
+      return false;
+    }
+    return true;
+  });
+
   validateTree(rootPath as SchemaPath<TModel>, (ctx: FieldContext<TModel>) => {
-    if (validators.length === 0) {
+    if (customValidators.length === 0) {
       return null; // ValidationSuccess - no errors
     }
 
@@ -166,7 +177,7 @@ function applyCrossFieldTreeValidator<TModel>(
     const formValue = ctx.value() as Record<string, unknown>;
     const errors: ValidationError.WithOptionalField[] = [];
 
-    for (const entry of validators) {
+    for (const entry of customValidators) {
       const { sourceFieldKey, config } = entry;
 
       try {
@@ -216,12 +227,7 @@ function evaluateCrossFieldValidator<TModel>(
     logger,
   };
 
-  // The collector only routes custom validators (raw or converted built-ins) to the tree.
-  // Guard against hand-built entries passed directly to createSchemaFromFields.
-  if (config.type !== 'custom') {
-    logger.warn(`Unexpected non-custom validator in cross-field tree for "${sourceFieldKey}"; ignoring.`);
-    return null;
-  }
+  // Entries are pre-filtered to custom validators at schema build in applyCrossFieldTreeValidator.
   return evaluateCustomCrossFieldValidator(config as CustomValidatorConfig, evaluationContext, sourceFieldKey, ctx);
 }
 

--- a/packages/dynamic-forms/src/lib/core/validation/index.ts
+++ b/packages/dynamic-forms/src/lib/core/validation/index.ts
@@ -5,5 +5,6 @@ export {
   isCrossFieldBuiltInValidator,
   hasCrossFieldWhenCondition,
   isResourceBasedValidator,
+  requiresTreeValidation,
 } from '@ng-forge/dynamic-forms/internal';
 export type { CrossFieldValidatorEntry } from '../cross-field/cross-field-types';


### PR DESCRIPTION
Stacked on #525 (the inline-condition cache skip there is load-bearing for this change); GitHub will retarget to main when #525 merges.

Built-in validators with a static value and a when condition were routed to the root validateTree, so Angular's native validators never ran: field().maxLength() stayed empty, adapters could not bind constraint attributes, and native error params were missing. Angular 22's built-in validators accept a first-class when config that gates both the validation rule and the published constraint metadata, so this change routes those validators natively with the when condition compiled through createLogicFunction (reactive evaluation context).

A single shared requiresTreeValidation predicate now drives both applyValidator and the cross-field collector, so the two routing decisions cannot drift: only cross-field dynamic-value expressions go to validateTree; a when condition never does. The dead hand-rolled built-in tree evaluation was deleted (~150 lines). Hand-built entries passed through the compat array signature are filtered once at schema build with a single warning instead of warning on every validation run.

Behavior notes for the changelog:
- field().maxLength()/required() and friends are now reactive for conditional validators; constraint attributes render and {{requiredLength}}/{{min}}/{{max}} interpolate. Error kinds unchanged.
- validateWhenHidden is now honored for conditional validators.
- Conditional required aligns with native isEmpty semantics (whitespace-only passes, boolean false fails); conditional email uses Angular's native regex.
- Field-local when on non-required built-ins was previously applied unconditionally, ignoring the condition. It is now correctly gated, so those configs produce fewer errors after upgrade, only while the condition holds.
- Two classes of previously silently-dropped configs now validate: custom fn/functionName validators with a cross-field when, and when-conditioned validators inside named SchemaDefinitions. Net-new errors may surface in existing apps.
- SchemaDefinition validators with a cross-field dynamic-value expression remain unsupported, but they now log a build-time warning naming the schema and validator type instead of disappearing silently.
- Multiple conditional validators of the same type on one field compose natively (metadata reflects the strictest active constraint, errors stay independent).

New throws for previously accepted configs:
- http or async conditions nested inside and/or when composites now throw at schema build time instead of being silently mis-evaluated.
- A top-level http when condition requires provideHttpClient() at the application level.

MCP registry: the validators registry now documents the when parameter on every validator type, including the native reactive constraint behavior and the http condition constraints above.

Coverage: routing truth-table spec for the predicate, native application and reactivity specs (metadata flips driven by other fields' values, mid-edit condition flips, array-item indexing), collector lockstep assertions, warn-once assertion across repeated validation runs, schema-definition drop warning spec, and an integration spec covering interpolation, validateWhenHidden, and SchemaDefinition validators. 3204 tests green, build with api-check green, internal API baseline updated (requiresTreeValidation added, hasCrossFieldWhenCondition deprecated).

Closes #512