### PR TITLE
fix(dynamic-forms): ignore symbol-keyed metadata when comparing form values

### DIFF
--- a/packages/dynamic-forms/internal/src/lib/utils/object-utils.spec.ts
+++ b/packages/dynamic-forms/internal/src/lib/utils/object-utils.spec.ts
@@ -1,5 +1,5 @@
 import { vi } from 'vitest';
-import { deepMergeDefaults, omit, keyBy, mapValues, memoize } from './object-utils';
+import { deepMergeDefaults, getChangedKeys, isEqual, omit, keyBy, mapValues, memoize } from './object-utils';
 
 describe('object-utils', () => {
   describe('omit', () => {
@@ -471,6 +471,58 @@ describe('object-utils', () => {
       const result = deepMergeDefaults(defaults, value);
 
       expect(result).toEqual({ a: 2 });
+    });
+  });
+
+  describe('isEqual', () => {
+    it('should compare nested structures deeply', () => {
+      expect(isEqual({ a: { b: [1, 2] } }, { a: { b: [1, 2] } })).toBe(true);
+      expect(isEqual({ a: { b: [1, 2] } }, { a: { b: [1, 3] } })).toBe(false);
+    });
+
+    // Angular Signal Forms stamps enumerable symbol-keyed tracking metadata onto
+    // array item value objects (childValue[identitySymbol] ??= Symbol(...)), so
+    // value comparison must ignore symbol keys or write-back loops never converge.
+    it('should ignore symbol-keyed metadata on otherwise equal objects', () => {
+      const stamped: Record<string | symbol, unknown> = { name: 'first', count: 2 };
+      stamped[Symbol('tracking')] = Symbol('id:1');
+
+      expect(isEqual(stamped, { name: 'first', count: 2 })).toBe(true);
+    });
+
+    it('should ignore symbol metadata stamped under different keys on both sides', () => {
+      const a: Record<string | symbol, unknown> = { name: 'item' };
+      a[Symbol('tracking')] = Symbol('id:1');
+      const b: Record<string | symbol, unknown> = { name: 'item' };
+      b[Symbol('tracking')] = Symbol('id:2');
+
+      expect(isEqual(a, b)).toBe(true);
+    });
+
+    it('should ignore symbol metadata on array items', () => {
+      const stampedItem: Record<string | symbol, unknown> = { label: 'a' };
+      stampedItem[Symbol('tracking')] = Symbol('id:1');
+
+      expect(isEqual([stampedItem, { label: 'b' }], [{ label: 'a' }, { label: 'b' }])).toBe(true);
+    });
+
+    it('should still detect string-keyed differences on stamped objects', () => {
+      const stamped: Record<string | symbol, unknown> = { name: 'one' };
+      stamped[Symbol('tracking')] = Symbol('id:1');
+
+      expect(isEqual(stamped, { name: 'two' })).toBe(false);
+      expect(isEqual(stamped, { name: 'one', extra: true })).toBe(false);
+    });
+  });
+
+  describe('getChangedKeys', () => {
+    it('should not flag arrays whose items differ only by symbol metadata', () => {
+      const stampedItem: Record<string | symbol, unknown> = { street: 'main' };
+      stampedItem[Symbol('tracking')] = Symbol('id:1');
+
+      const changed = getChangedKeys({ items: [stampedItem] }, { items: [{ street: 'main' }] });
+
+      expect(changed.size).toBe(0);
     });
   });
 });

--- a/packages/dynamic-forms/internal/src/lib/utils/object-utils.ts
+++ b/packages/dynamic-forms/internal/src/lib/utils/object-utils.ts
@@ -110,12 +110,15 @@ function isEqualInternal(a: unknown, b: unknown, seenA: WeakMap<object, object>,
   }
 
   // Handle plain objects
-  const recordA = a as Record<string | symbol, unknown>;
-  const recordB = b as Record<string | symbol, unknown>;
+  const recordA = a as Record<string, unknown>;
+  const recordB = b as Record<string, unknown>;
 
-  // Get both string and symbol keys
-  const keysA = [...Object.keys(recordA), ...Object.getOwnPropertySymbols(recordA)];
-  const keysB = [...Object.keys(recordB), ...Object.getOwnPropertySymbols(recordB)];
+  // String keys only: Signal Forms stamps enumerable symbol-keyed tracking
+  // metadata onto array item values (fresh Symbol per rebuild), so comparing
+  // symbol keys makes structurally equal form values compare unequal and
+  // write-back loops never converge.
+  const keysA = Object.keys(recordA);
+  const keysB = Object.keys(recordB);
 
   if (keysA.length !== keysB.length) return false;
 

--- a/packages/dynamic-forms/internal/src/lib/utils/object-utils.ts
+++ b/packages/dynamic-forms/internal/src/lib/utils/object-utils.ts
@@ -8,9 +8,13 @@ import { DynamicFormError } from '../errors/dynamic-form-error';
 /**
  * Performs a deep equality comparison between two values.
  *
+ * Symbol-keyed properties are intentionally ignored: form values carry
+ * enumerable symbol metadata stamped by Angular Signal Forms, and comparing it
+ * would make structurally equal values compare unequal. Only string keys count.
+ *
  * @param a - First value
  * @param b - Second value
- * @returns true if values are deeply equal
+ * @returns true if values are deeply equal by their string-keyed properties
  */
 export function isEqual(a: unknown, b: unknown): boolean {
   return isEqualInternal(a, b, new WeakMap(), new WeakMap());


### PR DESCRIPTION
Fixes an infinite value write-back loop that freezes the page when an array with derivation logic gets items added around form initialization, reported directly by a user after several days of debugging.

Angular Signal Forms stamps identity tracking metadata straight onto array item value objects as an enumerable symbol-keyed property (childValue[identitySymbol] ??= Symbol(...) in the signals bundle). Every FieldNode structure instance uses its own identity symbol and every stamp is a fresh Symbol, so any array rebuild changes the symbol keys on the user's value objects.

Our isEqual included Object.getOwnPropertySymbols in the compared key sets. A stamped item therefore never compared equal to a structurally identical unstamped or re-stamped one. The equality checks that exist precisely to stop write cycles (derivation applicator, entity write-back in FormStateManager, getChangedKeys, the async and http derivation streams, the property override store) all report a false difference, the value is written again, Signal Forms rebuilds the array and stamps new symbols, and the loop never converges.

The fix compares string keys only. Form values are structured entity data; symbol-keyed properties on them are runtime metadata by convention, and Angular's symbol is per-instance and unexported so there is no way to filter it specifically. Written test-first: the four new specs (stamped vs plain object, different symbol keys on both sides, stamped array items, and a getChangedKeys variant) fail on the previous implementation and pass with the fix, alongside guards proving string-keyed differences are still detected.

Verification: nx run dynamic-forms:test (3232 tests, 158 files), nx build dynamic-forms, nx lint dynamic-forms and api-check all pass locally.