### PR TITLE
docs(mcp): document error-aware validation message functions in lookup topic

### DIFF
--- a/packages/dynamic-form-mcp/src/tools/data/lookup-topics.ts
+++ b/packages/dynamic-form-mcp/src/tools/data/lookup-topics.ts
@@ -1623,7 +1623,36 @@ validators: [{
 }]
 \`\`\`
 
-**Built-in Kinds:** required, email, min, max, minlength, maxlength, pattern`,
+**Built-in Kinds:** required, email, min, max, minlength, maxlength, pattern
+
+## Template parameters
+
+String messages interpolate error params with \`{{param}}\`:
+
+\`\`\`typescript
+validationMessages: {
+  minLength: 'Must be at least {{requiredLength}} characters',
+  min: 'Must be at least {{min}}',
+  max: 'Must be at most {{max}}',
+  pattern: 'Does not match {{requiredPattern}}',
+}
+\`\`\`
+
+## Error-aware message functions (TypeScript configs only)
+
+Any \`validationMessages\` or \`defaultValidationMessages\` value can be a function \`(error: ValidationError) => DynamicText\` instead of a string. The function receives the validation error (its \`kind\` plus params such as \`maxLength\`), so an i18n layer gets the interpolation params natively:
+
+\`\`\`typescript
+validationMessages: {
+  maxLength: (error) => transloco.selectTranslate('validation.maxLength', {
+    requiredLength: 'maxLength' in error ? error.maxLength : undefined,
+  }),
+}
+\`\`\`
+
+A resolver may return static text, an \`Observable\`, or a \`Signal\`, and those stay reactive. Returning a plain string after synchronously reading a signal severs reactivity — return the \`Signal\`/\`Observable\` itself instead.
+
+**⚠️ Not JSON-serializable.** Function messages only work in TypeScript-authored configs. JSON-driven configs (and MCP-generated output) MUST use string templates with \`{{param}}\` interpolation.`,
   },
 
   buttons: {

--- a/packages/dynamic-form-mcp/src/tools/lookup.tool.spec.ts
+++ b/packages/dynamic-form-mcp/src/tools/lookup.tool.spec.ts
@@ -161,6 +161,16 @@ describe('Lookup Tool', () => {
       expect(content).toContain('hidden');
     });
 
+    it('documents error-aware message functions and their JSON caveat in validation-messages', async () => {
+      const result = await registeredTool.handler({ topic: 'validation-messages', depth: 'full' });
+      const content = (result as { content: [{ text: string }] }).content[0].text;
+
+      expect(content).toContain('(error: ValidationError) => DynamicText');
+      expect(content).toContain('{{requiredLength}}');
+      // The resolver is TS-only; MCP-generated JSON configs must keep string templates.
+      expect(content).toContain('Not JSON-serializable');
+    });
+
     it('returns derivation documentation', async () => {
       const result = await registeredTool.handler({ topic: 'derivation', depth: 'full' });
       const content = (result as { content: [{ text: string }] }).content[0].text;


### PR DESCRIPTION
Completes the MCP-server sync for the error-aware validation message resolvers shipped in #528 (issue #513).

The main `instructions.ts` guidance was updated in #528, but the `validation-messages` lookup topic (returned by the MCP lookup tool) still described only static string messages and `{{param}}` templates. An agent querying that topic would not learn the resolver form exists.

This adds a section to the `validation-messages` full topic covering:
- the `(error: ValidationError) => DynamicText` resolver form and how it hands interpolation params to an i18n layer
- the reactivity note (return a Signal or Observable, do not synchronously read a signal and return a plain string)
- the critical caveat that function messages are not JSON-serializable, so JSON-driven and MCP-generated configs must keep using string templates

It also folds the existing template-parameter list (`{{requiredLength}}`, `{{min}}`, `{{max}}`, `{{requiredPattern}}`) into the same topic so the reference is complete in one place.

A lookup-tool spec now pins that the topic mentions the resolver signature, the template param, and the JSON caveat, so the sync cannot silently regress.

Verification: nx run dynamic-form-mcp:test (397 tests), nx build dynamic-form-mcp, nx lint dynamic-form-mcp all pass locally.