### PR TITLE
fix(dynamic-forms): make externalData reactive in dynamic values and validators

### DIFF
--- a/packages/dynamic-forms/internal/src/lib/core/registry/field-context-registry.service.spec.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/registry/field-context-registry.service.spec.ts
@@ -380,6 +380,81 @@ describe('FieldContextRegistryService', () => {
     });
   });
 
+  // Regression for #508 bug 4: dynamic values and sync validators build their
+  // context via createEvaluationContext, which previously read externalData
+  // untracked, so a dynamic label or validator threshold bound to externalData
+  // rendered once and never updated.
+  describe('external data reactivity in createEvaluationContext', () => {
+    it('should re-resolve when an inner external data signal changes', () => {
+      const threshold = signal(10);
+      externalDataSignal.set({ threshold });
+      const fieldContext = createMockFieldContext('test');
+
+      const resolved = computed(() => {
+        const ctx = service.createEvaluationContext(fieldContext);
+        return (ctx.externalData as Record<string, unknown>)?.['threshold'];
+      });
+
+      expect(resolved()).toBe(10);
+
+      threshold.set(25);
+      expect(resolved()).toBe(25);
+    });
+
+    it('should re-resolve when the external data record is replaced', () => {
+      externalDataSignal.set({ siteName: signal('alpha') });
+      const fieldContext = createMockFieldContext('test');
+
+      const resolved = computed(() => {
+        const ctx = service.createEvaluationContext(fieldContext);
+        return (ctx.externalData as Record<string, unknown>)?.['siteName'];
+      });
+
+      expect(resolved()).toBe('alpha');
+
+      externalDataSignal.set({ siteName: signal('beta') });
+      expect(resolved()).toBe('beta');
+    });
+
+    it('should track external data inside an array-scoped context', () => {
+      mockEntity.set({ items: [{ label: 'a' }] });
+      const threshold = signal(1);
+      externalDataSignal.set({ threshold });
+      const fieldContext: any = createMockFieldContext('a', ['items', '0', 'label']);
+      fieldContext.key = signal('label');
+
+      const resolved = computed(() => {
+        const ctx = service.createEvaluationContext(fieldContext);
+        return (ctx.externalData as Record<string, unknown>)?.['threshold'];
+      });
+
+      expect(resolved()).toBe(1);
+
+      threshold.set(2);
+      expect(resolved()).toBe(2);
+    });
+
+    it('should keep the field value untracked (no reactive dependency on it)', () => {
+      const fieldContext = createMockFieldContext('initial');
+      externalDataSignal.set({ note: signal('x') });
+
+      let evaluations = 0;
+      const derived = computed(() => {
+        evaluations++;
+        return service.createEvaluationContext(fieldContext).fieldValue;
+      });
+
+      expect(derived()).toBe('initial');
+      expect(evaluations).toBe(1);
+
+      // Mutating the field's own value signal must NOT re-run a context read:
+      // fieldValue stays untracked to preserve the validator -> valid cycle guard.
+      (fieldContext.value as ReturnType<typeof signal>).set('changed');
+      derived();
+      expect(evaluations).toBe(1);
+    });
+  });
+
   describe('array-scoped context creation via pathKeys', () => {
     const arrayFormValue = {
       addresses: [

--- a/packages/dynamic-forms/internal/src/lib/core/registry/field-context-registry.service.spec.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/registry/field-context-registry.service.spec.ts
@@ -434,6 +434,28 @@ describe('FieldContextRegistryService', () => {
       expect(resolved()).toBe(2);
     });
 
+    it('should not subscribe to externalData when the expression never reads it', () => {
+      const flag = signal(false);
+      externalDataSignal.set({ flag });
+      const fieldContext = createMockFieldContext('v');
+
+      let evaluations = 0;
+      const derived = computed(() => {
+        evaluations++;
+        // Reads only fieldValue; never touches ctx.externalData.
+        return service.createEvaluationContext(fieldContext).fieldValue;
+      });
+
+      expect(derived()).toBe('v');
+      expect(evaluations).toBe(1);
+
+      // externalData is resolved lazily via a getter, so a context read that
+      // doesn't access it establishes no dependency and must not re-run.
+      flag.set(true);
+      derived();
+      expect(evaluations).toBe(1);
+    });
+
     it('should keep the field value untracked (no reactive dependency on it)', () => {
       const fieldContext = createMockFieldContext('initial');
       externalDataSignal.set({ note: signal('x') });

--- a/packages/dynamic-forms/internal/src/lib/core/registry/field-context-registry.service.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/registry/field-context-registry.service.ts
@@ -82,19 +82,22 @@ export class FieldContextRegistryService {
       return this.buildArrayScopedContext(rootFormValue, arrayScope, fieldValue, customFunctions, false, fieldContext);
     }
 
-    // Use getters for fieldState/formFieldState to defer signal reads until
-    // the expression actually accesses them. Validators that only use fieldValue
-    // will never trigger these getters, avoiding reactive cycles in Angular's
-    // internal signal graph (validator → state → valid → validator).
+    // Use getters for externalData/fieldState/formFieldState to defer signal reads
+    // until the expression actually accesses them. Validators that only use fieldValue
+    // will never trigger these getters, so they subscribe to nothing extra and avoid
+    // reactive cycles in Angular's internal signal graph (validator → state → valid → validator).
     const rootFormSignal = this.rootFormRegistry.rootForm;
+    const resolveExternalData = () => this.resolveExternalData();
     return {
       fieldValue,
       formValue: rootFormValue,
       fieldPath: localKey,
       customFunctions: customFunctions || {},
-      externalData: this.resolveExternalData(),
       logger: this.logger,
       deprecationTracker: this.deprecationTracker ?? undefined,
+      get externalData() {
+        return resolveExternalData();
+      },
       get fieldState() {
         return readFieldStateInfo(extractFieldState(fieldContext), false);
       },
@@ -144,6 +147,7 @@ export class FieldContextRegistryService {
     // Same rationale as createEvaluationContext — avoids reactive cycles
     // when expressions don't actually access these properties.
     const rootFormSignal = this.rootFormRegistry.rootForm;
+    const resolveExternalData = () => this.resolveExternalData();
     const fieldStateGetter = fieldContext ? () => readFieldStateInfo(extractFieldState(fieldContext), reactive) : () => undefined;
     const formFieldStateGetter = () =>
       createFormFieldStateMap((reactive ? rootFormSignal() : untracked(rootFormSignal)) as FieldTree<unknown>, reactive);
@@ -155,9 +159,11 @@ export class FieldContextRegistryService {
         formValue: rootFormValue,
         fieldPath: localKey,
         customFunctions: customFunctions || {},
-        externalData: this.resolveExternalData(),
         logger: this.logger,
         deprecationTracker: this.deprecationTracker ?? undefined,
+        get externalData() {
+          return resolveExternalData();
+        },
         get fieldState() {
           return fieldStateGetter();
         },
@@ -175,9 +181,11 @@ export class FieldContextRegistryService {
       arrayPath: arrayKey,
       fieldPath: `${arrayKey}.${index}.${localKey}`,
       customFunctions: customFunctions || {},
-      externalData: this.resolveExternalData(),
       logger: this.logger,
       deprecationTracker: this.deprecationTracker ?? undefined,
+      get externalData() {
+        return resolveExternalData();
+      },
       get fieldState() {
         return fieldStateGetter();
       },
@@ -236,15 +244,18 @@ export class FieldContextRegistryService {
 
     const localKey = this.extractFieldPath(fieldContext);
     const rootFormSignal = this.rootFormRegistry.rootForm;
+    const resolveExternalData = () => this.resolveExternalData();
 
     return {
       fieldValue,
       formValue: rootFormValue,
       fieldPath: localKey,
       customFunctions: customFunctions || {},
-      externalData: this.resolveExternalData(),
       logger: this.logger,
       deprecationTracker: this.deprecationTracker ?? undefined,
+      get externalData() {
+        return resolveExternalData();
+      },
       get fieldState() {
         return readFieldStateInfo(extractFieldState(fieldContext), true);
       },
@@ -275,15 +286,18 @@ export class FieldContextRegistryService {
     }
 
     const rootFormSignal = this.rootFormRegistry.rootForm;
+    const resolveExternalData = () => this.resolveExternalData();
 
     return {
       fieldValue: undefined,
       formValue: rootFormValue,
       fieldPath,
       customFunctions: customFunctions || {},
-      externalData: this.resolveExternalData(),
       logger: this.logger,
       deprecationTracker: this.deprecationTracker ?? undefined,
+      get externalData() {
+        return resolveExternalData();
+      },
       get formFieldState() {
         return createFormFieldStateMap(rootFormSignal() as FieldTree<unknown>, true);
       },

--- a/packages/dynamic-forms/internal/src/lib/core/registry/field-context-registry.service.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/registry/field-context-registry.service.ts
@@ -92,7 +92,7 @@ export class FieldContextRegistryService {
       formValue: rootFormValue,
       fieldPath: localKey,
       customFunctions: customFunctions || {},
-      externalData: this.resolveExternalData(false),
+      externalData: this.resolveExternalData(),
       logger: this.logger,
       deprecationTracker: this.deprecationTracker ?? undefined,
       get fieldState() {
@@ -155,7 +155,7 @@ export class FieldContextRegistryService {
         formValue: rootFormValue,
         fieldPath: localKey,
         customFunctions: customFunctions || {},
-        externalData: this.resolveExternalData(reactive),
+        externalData: this.resolveExternalData(),
         logger: this.logger,
         deprecationTracker: this.deprecationTracker ?? undefined,
         get fieldState() {
@@ -175,7 +175,7 @@ export class FieldContextRegistryService {
       arrayPath: arrayKey,
       fieldPath: `${arrayKey}.${index}.${localKey}`,
       customFunctions: customFunctions || {},
-      externalData: this.resolveExternalData(reactive),
+      externalData: this.resolveExternalData(),
       logger: this.logger,
       deprecationTracker: this.deprecationTracker ?? undefined,
       get fieldState() {
@@ -190,15 +190,20 @@ export class FieldContextRegistryService {
   /**
    * Resolves external data signals to their current values.
    *
-   * @param reactive - If true, reads signals reactively (creates dependencies).
-   *                   If false, reads signals with untracked() (no dependencies).
+   * Always reads reactively. Unlike the field value and form value (which are
+   * read untracked to break the validator -> state -> valid -> validator cycle),
+   * externalData is one-directional external input that validation output can
+   * never feed back into, so tracking it cannot cause a cycle. Reading it
+   * reactively is what lets dynamic values and validators bound to externalData
+   * update when it changes.
+   *
    * @returns Record of resolved external data values, or undefined if no external data.
    */
-  private resolveExternalData(reactive: boolean): Record<string, unknown> | undefined {
+  private resolveExternalData(): Record<string, unknown> | undefined {
     const externalDataSignal = this.externalDataSignal;
     if (!externalDataSignal) return undefined;
 
-    const externalDataRecord = reactive ? externalDataSignal() : untracked(() => externalDataSignal());
+    const externalDataRecord = externalDataSignal();
 
     if (!externalDataRecord) {
       return undefined;
@@ -209,7 +214,7 @@ export class FieldContextRegistryService {
       if (!isSignal(value)) {
         throw new DynamicFormError(`externalData["${key}"] must be a Signal. Got: ${typeof value}. Wrap it with signal(yourValue).`);
       }
-      resolved[key] = reactive ? (value as Signal<unknown>)() : untracked(() => (value as Signal<unknown>)());
+      resolved[key] = (value as Signal<unknown>)();
     }
 
     return resolved;
@@ -237,7 +242,7 @@ export class FieldContextRegistryService {
       formValue: rootFormValue,
       fieldPath: localKey,
       customFunctions: customFunctions || {},
-      externalData: this.resolveExternalData(true),
+      externalData: this.resolveExternalData(),
       logger: this.logger,
       deprecationTracker: this.deprecationTracker ?? undefined,
       get fieldState() {
@@ -276,7 +281,7 @@ export class FieldContextRegistryService {
       formValue: rootFormValue,
       fieldPath,
       customFunctions: customFunctions || {},
-      externalData: this.resolveExternalData(true),
+      externalData: this.resolveExternalData(),
       logger: this.logger,
       deprecationTracker: this.deprecationTracker ?? undefined,
       get formFieldState() {

--- a/packages/dynamic-forms/internal/src/lib/core/values/dynamic-value-factory.spec.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/values/dynamic-value-factory.spec.ts
@@ -1,10 +1,11 @@
 import { vi } from 'vitest';
 import { FieldContext, FieldTree } from '@angular/forms/signals';
-import { signal, Injector, runInInjectionContext } from '@angular/core';
+import { computed, signal, Injector, runInInjectionContext, Signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { createDynamicValueFunction } from './dynamic-value-factory';
 import { RootFormRegistryService } from '../registry/root-form-registry.service';
 import { FieldContextRegistryService } from '../registry/field-context-registry.service';
+import { EXTERNAL_DATA } from '../../models/field-signal-context.token';
 import { FormStateManager } from '../../../../../src/lib/state/form-state-manager';
 import { DynamicFormLogger } from '../../providers/features/logger/logger.token';
 import { ConsoleLogger } from '../../../../../src/lib/providers/features/logger/console-logger';
@@ -14,6 +15,7 @@ describe('dynamic-value-factory', () => {
   let injector: Injector;
   const mockEntity = signal<Record<string, unknown>>({});
   const mockFormSignal = signal<any>(undefined);
+  const externalDataSignal = signal<Record<string, Signal<unknown>> | undefined>(undefined);
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -21,6 +23,7 @@ describe('dynamic-value-factory', () => {
         { provide: RootFormRegistryService, useValue: { formValue: mockEntity, rootForm: mockFormSignal } },
         { provide: FormStateManager, useValue: { activeConfig: signal(undefined) } },
         FieldContextRegistryService,
+        { provide: EXTERNAL_DATA, useValue: externalDataSignal },
         // Provide ConsoleLogger to enable logging in tests
         { provide: DynamicFormLogger, useValue: new ConsoleLogger() },
         DynamicValueFunctionCacheService,
@@ -30,6 +33,7 @@ describe('dynamic-value-factory', () => {
     injector = TestBed.inject(Injector);
     mockEntity.set({});
     mockFormSignal.set(undefined);
+    externalDataSignal.set(undefined);
   });
 
   describe('createDynamicValueFunction', () => {
@@ -109,6 +113,27 @@ describe('dynamic-value-factory', () => {
       });
 
       expect(result).toBe(true);
+    });
+
+    // Regression for #508 bug 4: a dynamic value bound to externalData (e.g. a
+    // dynamic validator threshold `externalData.threshold`) must recompute when
+    // the external signal changes, not render once and freeze.
+    it('should recompute when an externalData signal it reads changes', () => {
+      const threshold = signal(10);
+      externalDataSignal.set({ threshold });
+
+      const evaluated = runInInjectionContext(injector, () => {
+        const dynamicFn = createDynamicValueFunction<string, number>('externalData.threshold');
+        const fieldContext = createMockFieldContext('anything');
+        // Angular Signal Forms invokes the LogicFn inside a reactive computed;
+        // mirror that so the reactive externalData read establishes a dependency.
+        return computed(() => dynamicFn(fieldContext));
+      });
+
+      expect(evaluated()).toBe(10);
+
+      threshold.set(42);
+      expect(evaluated()).toBe(42);
     });
 
     it('should access form values in expressions', () => {


### PR DESCRIPTION
Fixes a reactivity bug (bug 4 of the deferred #508 set): a dynamic value or sync validator bound to `externalData` renders once and never updates when the external signal changes. A dynamic label `externalData.siteName`, or a dynamic validator threshold like `min: "externalData.threshold"`, stays frozen at its initial value; it only picks up the new value the next time validation happens to re-run for another reason (e.g. the user edits the field), so it looks intermittently stuck.

## Root cause

`FieldContextRegistryService.createEvaluationContext` (used by `createDynamicValueFunction` and the sync expression validator) read externalData through `resolveExternalData(false)`, i.e. `untracked()`. So even though the context is built inside a reactive computed, no dependency on the external signals is established and the dynamic value never recomputes when they change.

The untracked read was collateral. The reads that genuinely have to be untracked are the field value and form value, which guard the `validator -> state -> valid -> validator` cycle; externalData rode along with them. But externalData is one-directional external input, and validation output (errors) can never feed back into it, so tracking it cannot close a cycle. The reactive context (`createReactiveEvaluationContext`) and the display-only context already read externalData reactively inside the same Signal Forms machinery without cycling, which is the existing precedent.

## Fix

`resolveExternalData` now always reads reactively; the `reactive` flag is removed from it (it was only ever needed to gate the field/form/state reads, which stay untracked). `buildArrayScopedContext` keeps its `reactive` parameter, which still gates `fieldState`/`formFieldState` only, so array-scoped fields get reactive externalData without flipping field state to reactive.

Scope note: this also covers dynamic validator params (`min`/`max`/`minLength`/`maxLength`/`pattern` with expression thresholds), which go through the same dynamic-value path, not just dynamic labels.

## Tests (written first, confirmed red on the previous code)

- Registry level: `createEvaluationContext` re-resolves when an inner external signal changes, when the whole external record is replaced, and inside an array-scoped context; plus a guard proving the field value stays untracked (mutating it does not re-run a context read).
- Consumer level: a dynamic value function evaluating `externalData.threshold` recomputes when the signal changes.

All four new reactivity assertions fail on the pre-fix code (verified by temporarily reverting the reactive read) and pass with it.

Verification: `nx run dynamic-forms:test` (3237 tests, 158 files), `nx build dynamic-forms`, `nx lint dynamic-forms`, `nx run dynamic-forms:api-check`, `nx sync:check` all pass locally.

## Update: lazy externalData resolution

Following review feedback on eager-vs-lazy resolution: externalData is now exposed as a deferred getter in every context builder, matching the existing `fieldState`/`formFieldState` getter pattern in the same service. The expression evaluator looks up identifiers via `name in scope` then `scope[name]`, and `in` does not invoke a getter, so an expression that never references `externalData` never triggers the getter and subscribes to nothing. This removes the over-subscription where a validator reading only `fieldValue` would otherwise re-run whenever any externalData signal changed. A new guard test asserts a fieldValue-only context read does not re-run when externalData changes (confirmed red before the getter change).