### PR TITLE
chore(release): bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+## [1.1.0](https://github.com/ng-forge/ng-forge/compare/v1.0.0...v1.1.0) (2026-07-22)
+
+### 🚀 Features
+
+- **dynamic-forms:** support error-aware validation message functions ([#528](https://github.com/ng-forge/ng-forge/pull/528))
+- **dynamic-forms:** apply conditional built-in validators natively with reactive constraints ([#529](https://github.com/ng-forge/ng-forge/pull/529))
+- **dynamic-forms:** add public testing entrypoint for field fixtures ([#530](https://github.com/ng-forge/ng-forge/pull/530))
+
+### 🐛 Bug Fixes
+
+- **bootstrap:** drop stray size attribute on select when htmlSize is unset ([#522](https://github.com/ng-forge/ng-forge/pull/522))
+- **dynamic-forms:** evaluate container/button logic with externalData and custom functions ([#508](https://github.com/ng-forge/ng-forge/pull/508))
+- **dynamic-forms:** fix conditional validator cache collisions and error params ([#525](https://github.com/ng-forge/ng-forge/pull/525))
+- **dynamic-forms:** resolve signal dynamic text without NG0602 in reactive contexts ([#524](https://github.com/ng-forge/ng-forge/pull/524))
+- **dynamic-forms:** clear interaction state on form reset and clear events ([45ab62237](https://github.com/ng-forge/ng-forge/commit/45ab62237))
+- **dynamic-forms:** add actionable error for uninitialized TestBed in fixtures ([#526](https://github.com/ng-forge/ng-forge/pull/526))
+- **dynamic-forms:** apply grid column class to outermost wrapper host ([#527](https://github.com/ng-forge/ng-forge/pull/527))
+- **dynamic-forms:** ignore symbol-keyed metadata when comparing form values ([#535](https://github.com/ng-forge/ng-forge/pull/535))
+- **dynamic-forms:** make externalData reactive in dynamic values and validators ([#537](https://github.com/ng-forge/ng-forge/pull/537))
+- **dynamic-forms:** support formSubmitting logic on value fields ([#514](https://github.com/ng-forge/ng-forge/pull/514))
+
+### 📚 Documentation
+
+- **mcp:** document error-aware validation message functions in lookup topic ([#536](https://github.com/ng-forge/ng-forge/pull/536))
+
+### ✅ Tests
+
+- **dynamic-forms:** cover nested field interaction state on reset and clear ([c29c5e722](https://github.com/ng-forge/ng-forge/commit/c29c5e722))
+
+### ❤️ Thank You
+
+- Antim Prisacaru @antimprisacaru
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ng-forge/source",
   "type": "module",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/packages/dynamic-form-mcp/package.json
+++ b/packages/dynamic-form-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-form-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "MCP server for ng-forge dynamic forms - AI-assisted form schema generation",
   "type": "module",
   "license": "MIT",
@@ -54,11 +54,11 @@
     "zod-to-json-schema": "^3.23.0"
   },
   "devDependencies": {
-    "@ng-forge/dynamic-forms": "^1.0.0",
-    "@ng-forge/dynamic-forms-bootstrap": "^1.0.0",
-    "@ng-forge/dynamic-forms-ionic": "^1.0.0",
-    "@ng-forge/dynamic-forms-material": "^1.0.0",
-    "@ng-forge/dynamic-forms-primeng": "^1.0.0",
+    "@ng-forge/dynamic-forms": "^1.1.0",
+    "@ng-forge/dynamic-forms-bootstrap": "^1.1.0",
+    "@ng-forge/dynamic-forms-ionic": "^1.1.0",
+    "@ng-forge/dynamic-forms-material": "^1.1.0",
+    "@ng-forge/dynamic-forms-primeng": "^1.1.0",
     "tsx": "^4.19.0"
   }
 }

--- a/packages/dynamic-forms-bootstrap/package.json
+++ b/packages/dynamic-forms-bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-bootstrap",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Bootstrap 5 integration for @ng-forge/dynamic-forms. Pre-built Bootstrap form components.",
   "type": "module",
   "license": "MIT",
@@ -37,7 +37,7 @@
     "@angular/common": "^22.0.0",
     "@angular/core": "^22.0.0",
     "@angular/forms": "^22.0.0",
-    "@ng-forge/dynamic-forms": "~1.0.0",
+    "@ng-forge/dynamic-forms": "~1.1.0",
     "rxjs": ">=7.0.0"
   },
   "dependencies": {

--- a/packages/dynamic-forms-ionic/package.json
+++ b/packages/dynamic-forms-ionic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-ionic",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Ionic integration for @ng-forge/dynamic-forms. Pre-built Ionic form components for mobile and desktop.",
   "type": "module",
   "license": "MIT",
@@ -39,7 +39,7 @@
     "@angular/core": "^22.0.0",
     "@angular/forms": "^22.0.0",
     "@ionic/angular": ">=8.0.0",
-    "@ng-forge/dynamic-forms": "~1.0.0",
+    "@ng-forge/dynamic-forms": "~1.1.0",
     "rxjs": ">=7.0.0"
   },
   "dependencies": {

--- a/packages/dynamic-forms-material/package.json
+++ b/packages/dynamic-forms-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-material",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Angular Material integration for @ng-forge/dynamic-forms. Pre-built Material Design form components.",
   "type": "module",
   "license": "MIT",
@@ -38,7 +38,7 @@
     "@angular/core": "^22.0.0",
     "@angular/forms": "^22.0.0",
     "@angular/material": "^22.0.0",
-    "@ng-forge/dynamic-forms": "~1.0.0",
+    "@ng-forge/dynamic-forms": "~1.1.0",
     "rxjs": ">=7.0.0"
   },
   "dependencies": {

--- a/packages/dynamic-forms-primeng/package.json
+++ b/packages/dynamic-forms-primeng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-primeng",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "PrimeNG integration for @ng-forge/dynamic-forms. Pre-built PrimeNG form components.",
   "type": "module",
   "license": "MIT",
@@ -37,7 +37,7 @@
     "@angular/common": "^22.0.0",
     "@angular/core": "^22.0.0",
     "@angular/forms": "^22.0.0",
-    "@ng-forge/dynamic-forms": "~1.0.0",
+    "@ng-forge/dynamic-forms": "~1.1.0",
     "primeng": ">=21.0.0",
     "rxjs": ">=7.0.0"
   },

--- a/packages/dynamic-forms/package.json
+++ b/packages/dynamic-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Type-safe, signal-powered dynamic forms for Angular. Build complex forms from configuration with full TypeScript inference.",
   "type": "module",
   "license": "MIT",

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/openapi-generator",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Generate @ng-forge/dynamic-forms configurations from OpenAPI specs",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump all packages to 1.1.0 (fixed versioning)
- Update inter-package peerDependencies to ^1.1.0
- Generate changelog from v1.0.0

## Packages updated (1.0.0 -> 1.1.0)
- @ng-forge/dynamic-forms
- @ng-forge/dynamic-forms-bootstrap
- @ng-forge/dynamic-forms-ionic
- @ng-forge/dynamic-forms-material
- @ng-forge/dynamic-forms-primeng
- @ng-forge/dynamic-form-mcp

## Highlights
Features
- Error-aware validation message functions (#528)
- Native conditional built-in validators with reactive constraints (#529)
- Public /testing entrypoint for field fixtures (#530)

Fixes
- Bootstrap select stray size attribute (#522)
- Conditional validator cache collisions and error params (#525)
- NG0602 on signal dynamic text (#524)
- Interaction state cleared on reset/clear (#523)
- Actionable TestBed error in fixtures (#526)
- Grid column class on wrapper hosts (#527)
- Symbol-metadata form-value comparison freeze (#535)
- externalData reactive in dynamic values and validators (#537)
- formSubmitting logic on value fields (#514)

Docs
- MCP lookup topic documents error-aware message functions (#536)

Also on this release train: transitive toolchain security advisories patched (#538).

## Next steps
After merge, trigger the Release workflow manually from GitHub Actions to tag v1.1.0, create the GitHub release, and publish to npm.