### PR TITLE
test(examples): add perf regression gates for field windowing and page preload

### DIFF
--- a/apps/e2e/material/src/app/testing/performance/perf-scaling.spec.ts
+++ b/apps/e2e/material/src/app/testing/performance/perf-scaling.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+import { assertPerf, runPerfBench, type BenchResult } from '@ng-forge/examples-shared-testing/perf-spec';
+
+/**
+ * Regression gates for the two large-form scaling features:
+ * - Field windowing (opt-in @defer-on-viewport for large flat forms)
+ * - Page preload window (paged forms mount only nearby pages)
+ *
+ * Both keep a large form cheap by mounting only a bounded subset of fields. The
+ * gates below break if that bound is lost (all fields mount again). Only runs on
+ * Chromium — the harness needs ng.ɵsetProfiler + Long Animation Frame APIs.
+ */
+
+const cdPerTrial = (r: BenchResult): number => r.cdTimePerTrialBreakdown.allTemplatesTotalMedian;
+const loafPerTrial = (r: BenchResult): number => r.longAnimationFrames.countPerTrial?.median ?? 0;
+
+async function bench(page: import('@playwright/test').Page, path: string): Promise<BenchResult> {
+  await page.goto(path, { waitUntil: 'networkidle' });
+  // Let @defer + form resolution settle before benching.
+  await page.waitForTimeout(2500);
+  return runPerfBench(page);
+}
+
+test.describe('Material — field windowing perf', () => {
+  test.beforeEach(async ({ browserName }) => {
+    test.skip(browserName !== 'chromium', 'Perf bench only runs on Chromium (uses ng.ɵsetProfiler + LoAF APIs)');
+  });
+
+  test('windowing bounds the mounted field count on a large flat form', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    // Windowing's benefit is initial render — only the eager head plus whatever
+    // is in the viewport mounts, instead of every field. The reliable,
+    // machine-independent signal for that is the mounted DOM count, not
+    // per-keystroke timing (the aggregate form-value recompute is O(N) either
+    // way, so windowed and un-windowed keystroke cost are effectively equal).
+    await page.goto('/#/test/performance/perf-flat-300', { waitUntil: 'networkidle' });
+    await page.waitForTimeout(2000);
+    const plainInputs = await page.locator('input').count();
+
+    await page.goto('/#/test/performance/perf-flat-300-windowed', { waitUntil: 'networkidle' });
+    await page.waitForTimeout(2000);
+    const windowedInputs = await page.locator('input').count();
+
+    console.log(`[windowing] plain mounted inputs=${plainInputs} | windowed mounted inputs=${windowedInputs}`);
+
+    // Sanity: the un-windowed form mounts the full field set.
+    expect(plainInputs).toBeGreaterThan(200);
+    // Windowing must bound what mounts. If it breaks and every field mounts, this
+    // jumps to ~plainInputs. A quarter of the full set is a wide, viewport-safe
+    // bound (windowed mounts a couple dozen; the full form is ~240+).
+    expect(windowedInputs, `windowed mounted ${windowedInputs} inputs; should be a small fraction of the full ${plainInputs}`).toBeLessThan(
+      plainInputs * 0.25,
+    );
+
+    // Per-keystroke behaviour must still stay under the loose absolute thresholds.
+    const windowed = await bench(page, '/#/test/performance/perf-flat-300-windowed');
+    assertPerf(windowed, { label: 'flat-300-windowed' });
+  });
+});
+
+test.describe('Material — page preload perf', () => {
+  test.beforeEach(async ({ browserName }) => {
+    test.skip(browserName !== 'chromium', 'Perf bench only runs on Chromium (uses ng.ɵsetProfiler + LoAF APIs)');
+  });
+
+  test('a 50-page form stays cheap with the preload window active', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    const result = await bench(page, '/#/test/performance/perf-stress-standard');
+
+    console.log(
+      `[preload] stress-standard (50 pages) CD=${cdPerTrial(result)}ms keystroke median=${result.keystrokes.perKeystrokeMs?.median}ms loaf=${loafPerTrial(result)}`,
+    );
+
+    // Only the current page ± preload window mounts. If preload breaks and all 50
+    // pages mount, CD/keystroke/LoAF exceed the thresholds and this fails.
+    assertPerf(result, { label: 'stress-standard-50pages' });
+  });
+});


### PR DESCRIPTION
## What

Adds per-PR perf regression gates for the two large-form scaling features shipped in #541 — field windowing and the page preload window — which currently have no perf coverage. Reuses the existing `runPerfBench`/`assertPerf` harness (the cross-adapter perf bench infra from #435) that already runs `perf-stress.spec.ts` in the e2e CI, so this is one new auto-atomized Chromium shard, no new workflow or infrastructure.

## Why these two gates take different shapes

**Preload — absolute threshold works.** `assertPerf` on `perf-stress-standard` (50 pages x 10 fields). With the preload window active only a couple of pages mount, so it stays well under the loose thresholds (measured locally: CD 7ms, keystroke median 16.7ms, 0 long frames). If preload regresses and every page mounts, ~25x more views blow the CD/keystroke thresholds and the gate fails.

**Windowing — a structural gate, not timing.** This is the interesting part. I first tried a per-keystroke comparison and it did not discriminate: on `perf-flat-300`, the windowed form's per-keystroke change-detection (~23ms) is effectively equal to the un-windowed form's (~19ms). Windowing's benefit is initial render (only the eager head plus what is in the viewport mounts), and the aggregate form-value recompute is O(N) regardless of what is mounted, so keystroke cost is the same either way. The reliable, machine-independent signal is the mounted DOM count: the windowed form mounts 10 inputs versus the full 242. The gate asserts windowed mounts a small fraction of the full set; if windowing breaks and everything mounts, it jumps to ~242 and fails. A per-keystroke `assertPerf` on the windowed form is kept as a secondary check that typing stays cheap.

## Verification

Ran locally on Chromium against the material e2e app:

```
[windowing] plain mounted inputs=242 | windowed mounted inputs=10
[preload] stress-standard (50 pages) CD=7.1ms keystroke median=16.7ms loaf=0
2 passed
```

Lint clean; the spec auto-registers as `e2e-ci--src/app/testing/performance/perf-scaling.spec.ts`.

## Note

Considered a separate nightly benchmark workflow with email-on-anomaly, but the existing harness already provides per-PR regression gating with runner-noise-calibrated thresholds, so extending it is the idiomatic, lower-risk path. A nightly would be largely redundant.

https://claude.ai/code/session_01VYJ7DF7Vp3BnexyuJdoUho
