### PR TITLE
feat(dynamic-forms): projectable placeholder templates for field windowing

### DIFF
--- a/etc/dynamic-forms.api.md
+++ b/etc/dynamic-forms.api.md
@@ -353,6 +353,20 @@ export interface DeclarativeHttpValidatorConfig extends BaseValidatorConfig {
 export const DF_FIELD_TEMPLATES: InjectionToken<Signal<ReadonlyMap<string, TemplateRef<unknown>>>>;
 
 // @public
+export class DfPlaceholder {
+    readonly descriptor: Signal<PlaceholderDescriptor>;
+    readonly dfPlaceholder: _angular_core.InputSignal<string>;
+    readonly dfPlaceholderKey: _angular_core.InputSignal<string>;
+    static ngTemplateContextGuard(_dir: DfPlaceholder, ctx: unknown): ctx is FieldPlaceholderContext;
+    // (undocumented)
+    readonly templateRef: TemplateRef<FieldPlaceholderContext>;
+    // (undocumented)
+    static ɵdir: _angular_core.ɵɵDirectiveDeclaration<DfPlaceholder, "ng-template[dfPlaceholder], ng-template[dfPlaceholderKey]", ["dfPlaceholder"], { "dfPlaceholder": { "alias": "dfPlaceholder"; "required": false; "isSignal": true; }; "dfPlaceholderKey": { "alias": "dfPlaceholderKey"; "required": false; "isSignal": true; }; }, {}, never, never, true, never>;
+    // (undocumented)
+    static ɵfac: _angular_core.ɵɵFactoryDeclaration<DfPlaceholder, never>;
+}
+
+// @public
 export class DfTemplate {
     readonly dfTemplate: _angular_core.InputSignal<string>;
     readonly templateRef: TemplateRef<unknown>;
@@ -409,7 +423,9 @@ export class DynamicForm<TFields extends RegisteredFieldTypes[] = RegisteredFiel
     onPageChange: _angular_core.OutputRef<PageChangeEvent>;
     onPageNavigationStateChange: _angular_core.OutputRef<PageNavigationStateChangeEvent>;
     pageFieldDefinitions: Signal<_ng_forge_dynamic_forms.PageField<_ng_forge_dynamic_forms.PageAllowedChildren[]>[]>;
+    protected placeholderContext(field: ResolvedField): FieldPlaceholderContext;
     protected placeholderGridClass(field: ResolvedField): string;
+    protected placeholderTemplate(field: ResolvedField): TemplateRef<FieldPlaceholderContext> | null;
     renderPhase: Signal<"render" | "teardown">;
     reset: _angular_core.OutputRef<FormResetEvent>;
     protected resolvedFields: Signal<ResolvedField[]>;
@@ -424,7 +440,7 @@ export class DynamicForm<TFields extends RegisteredFieldTypes[] = RegisteredFiel
     value: _angular_core.ModelSignal<Partial<TModel> | undefined>;
     protected windowsField(field: ResolvedField, index: number): boolean;
     // (undocumented)
-    static ɵcmp: _angular_core.ɵɵComponentDeclaration<DynamicForm<any, any>, "form[dynamic-form]", never, { "config": { "alias": "dynamic-form"; "required": true; "isSignal": true; }; "formOptions": { "alias": "formOptions"; "required": false; "isSignal": true; }; "value": { "alias": "value"; "required": false; "isSignal": true; }; "source": { "alias": "source"; "required": false; "isSignal": true; }; }, { "value": "valueChange"; "validityChange": "validityChange"; "dirtyChange": "dirtyChange"; "submitted": "submitted"; "reset": "reset"; "cleared": "cleared"; "events": "events"; "initialized": "initialized"; "onPageChange": "onPageChange"; "onPageNavigationStateChange": "onPageNavigationStateChange"; }, ["_projectedTemplates"], never, true, never>;
+    static ɵcmp: _angular_core.ɵɵComponentDeclaration<DynamicForm<any, any>, "form[dynamic-form]", never, { "config": { "alias": "dynamic-form"; "required": true; "isSignal": true; }; "formOptions": { "alias": "formOptions"; "required": false; "isSignal": true; }; "value": { "alias": "value"; "required": false; "isSignal": true; }; "source": { "alias": "source"; "required": false; "isSignal": true; }; }, { "value": "valueChange"; "validityChange": "validityChange"; "dirtyChange": "dirtyChange"; "submitted": "submitted"; "reset": "reset"; "cleared": "cleared"; "events": "events"; "initialized": "initialized"; "onPageChange": "onPageChange"; "onPageNavigationStateChange": "onPageNavigationStateChange"; }, ["_projectedTemplates", "_projectedPlaceholders"], never, true, never>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<DynamicForm<any, any>, never>;
 }
@@ -571,6 +587,22 @@ export interface FieldOption<T = unknown> {
 export type FieldPathAccess<TValue> = {
     [K in keyof TValue]: SchemaPath<TValue[K]> | SchemaPathTree<TValue[K]>;
 };
+
+// @public
+export interface FieldPlaceholderContext {
+    // (undocumented)
+    readonly $implicit: FieldPlaceholderInfo;
+    // (undocumented)
+    readonly field: FieldPlaceholderInfo;
+}
+
+// @public
+export interface FieldPlaceholderInfo {
+    readonly col?: number;
+    readonly key: string;
+    readonly label?: string;
+    readonly type: string;
+}
 
 // @public
 export interface FieldRegistryContainers {

--- a/packages/dynamic-forms/src/lib/df-placeholder.integration.spec.ts
+++ b/packages/dynamic-forms/src/lib/df-placeholder.integration.spec.ts
@@ -1,0 +1,157 @@
+import { Component, input } from '@angular/core';
+import { ComponentFixture, DeferBlockBehavior, TestBed } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { delay } from '@ng-forge/utils';
+import { DynamicForm } from './dynamic-form.component';
+import { DfPlaceholder } from './directives/df-placeholder/df-placeholder.directive';
+import { BUILT_IN_FIELDS } from './providers/built-in-fields';
+import { FIELD_WINDOWING, FieldWindowingConfig } from './providers/features/field-windowing/field-windowing.token';
+import { FIELD_REGISTRY, FieldTypeDefinition, FormConfig } from '@ng-forge/dynamic-forms/internal';
+import { valueFieldMapper } from '@ng-forge/dynamic-forms/integration';
+
+// input + textarea both render via the same test harness — placeholder tests
+// never mount the real component (the fields stay windowed), only its type matters.
+const TEST_FIELD_TYPES: FieldTypeDefinition[] = ['input', 'textarea'].map((name) => ({
+  name,
+  loadComponent: () => import('../../test-utils/src/harnesses/test-input.harness').then((m) => m.default),
+  mapper: valueFieldMapper,
+}));
+
+// eager: 2 → f0/f1 mount; bio (textarea), plain (input), special (input) are all
+// windowed and, below the 30000px spacer, stay as placeholders.
+const CONFIG: FormConfig = {
+  fields: [
+    { key: 'f0', type: 'input', value: 'a' },
+    { key: 'f1', type: 'input', value: 'b' },
+    { key: 'bio', type: 'textarea', label: 'Biography', value: '' },
+    { key: 'plain', type: 'input', label: 'Plain', value: '' },
+    { key: 'special', type: 'input', label: 'Special', value: '' },
+    ...Array.from({ length: 5 }, (_, i) => ({ key: `p${i}`, type: 'input', value: '' })),
+  ],
+} as FormConfig;
+
+@Component({
+  selector: 'placeholder-test-host',
+  imports: [DynamicForm, DfPlaceholder],
+  template: `<div style="height: 30000px"></div>
+    <form [dynamic-form]="config()">
+      <ng-template dfPlaceholder let-field>
+        <span class="ph-default" [attr.data-ph-key]="field.key" [attr.data-ph-type]="field.type">default</span>
+      </ng-template>
+      <ng-template dfPlaceholder="textarea"><span class="ph-textarea">textarea skeleton</span></ng-template>
+      <ng-template dfPlaceholderKey="special"><span class="ph-key">key skeleton</span></ng-template>
+    </form>`,
+})
+class PlaceholderHost {
+  config = input.required<FormConfig>();
+}
+
+@Component({
+  selector: 'bare-placeholder-host',
+  imports: [DynamicForm],
+  template: `<div style="height: 30000px"></div>
+    <form [dynamic-form]="config()"></form>`,
+})
+class BareHost {
+  config = input.required<FormConfig>();
+}
+
+async function settle(fixture: ComponentFixture<unknown>, cycles = 4): Promise<void> {
+  for (let i = 0; i < cycles; i++) {
+    TestBed.flushEffects();
+    fixture.detectChanges();
+    await delay(0);
+  }
+  await fixture.whenStable();
+  await delay(100); // let the IntersectionObserver deliver its initial entries
+  TestBed.flushEffects();
+  fixture.detectChanges();
+}
+
+function ph(fixture: ComponentFixture<unknown>, key: string): HTMLElement | null {
+  return fixture.nativeElement.querySelector(`[data-field-key="${key}"].df-field-placeholder`);
+}
+
+describe('Field windowing — projected placeholders', () => {
+  beforeEach(() => {
+    window.scrollTo(0, 0);
+    TestBed.configureTestingModule({
+      deferBlockBehavior: DeferBlockBehavior.Playthrough,
+      providers: [
+        {
+          provide: FIELD_REGISTRY,
+          useFactory: () => {
+            const registry = new Map();
+            BUILT_IN_FIELDS.forEach((t) => registry.set(t.name, t));
+            TEST_FIELD_TYPES.forEach((t) => registry.set(t.name, t));
+            return registry;
+          },
+        },
+        { provide: FIELD_WINDOWING, useValue: { enabled: true, eager: 2, placeholderHeight: '40px' } satisfies FieldWindowingConfig },
+      ],
+    });
+  });
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('renders the type-matched template for a windowed field of that type', async () => {
+    const fixture = TestBed.createComponent(PlaceholderHost);
+    fixture.componentRef.setInput('config', CONFIG);
+    await settle(fixture);
+
+    // bio is a textarea → the dfPlaceholder="textarea" template wins.
+    expect(ph(fixture, 'bio')?.querySelector('.ph-textarea')).toBeTruthy();
+    expect(ph(fixture, 'bio')?.querySelector('.ph-default')).toBeNull();
+  });
+
+  it('renders the default template for a windowed field with no type/key match, with correct context', async () => {
+    const fixture = TestBed.createComponent(PlaceholderHost);
+    fixture.componentRef.setInput('config', CONFIG);
+    await settle(fixture);
+
+    const def = ph(fixture, 'plain')?.querySelector('.ph-default');
+    expect(def).toBeTruthy();
+    // let-field context carries the narrow field info.
+    expect(def?.getAttribute('data-ph-key')).toBe('plain');
+    expect(def?.getAttribute('data-ph-type')).toBe('input');
+  });
+
+  it('prefers a key-matched template over the type/default templates', async () => {
+    const fixture = TestBed.createComponent(PlaceholderHost);
+    fixture.componentRef.setInput('config', CONFIG);
+    await settle(fixture);
+
+    // `special` is an input, but its KEY template must win over the default.
+    expect(ph(fixture, 'special')?.querySelector('.ph-key')).toBeTruthy();
+    expect(ph(fixture, 'special')?.querySelector('.ph-default')).toBeNull();
+  });
+
+  it('renders the built-in bare div (no projected content) when no placeholder templates are provided', async () => {
+    const fixture = TestBed.createComponent(BareHost);
+    fixture.componentRef.setInput('config', CONFIG);
+    await settle(fixture);
+
+    const bare = ph(fixture, 'bio');
+    expect(bare).toBeTruthy();
+    expect(bare?.children.length).toBe(0);
+  });
+
+  it('still mounts the real field when its placeholder scrolls into view', async () => {
+    const fixture = TestBed.createComponent(PlaceholderHost);
+    fixture.componentRef.setInput('config', CONFIG);
+    await settle(fixture);
+
+    const placeholder = ph(fixture, 'plain');
+    expect(placeholder?.querySelector('.ph-default')).toBeTruthy();
+    placeholder!.scrollIntoView();
+
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      await delay(50);
+      TestBed.flushEffects();
+      fixture.detectChanges();
+      if (ph(fixture, 'plain') === null) break; // placeholder replaced by the mounted field
+    }
+    expect(ph(fixture, 'plain')).toBeNull();
+  });
+});

--- a/packages/dynamic-forms/src/lib/directives/df-placeholder/df-placeholder.directive.spec.ts
+++ b/packages/dynamic-forms/src/lib/directives/df-placeholder/df-placeholder.directive.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Component, TemplateRef, viewChildren, type Signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { DfPlaceholder, DfPlaceholderRegistry, type FieldPlaceholderContext, type PlaceholderDescriptor } from './df-placeholder.directive';
+
+@Component({
+  imports: [DfPlaceholder],
+  template: `
+    <ng-template dfPlaceholder let-field>default</ng-template>
+    <ng-template dfPlaceholder="textarea">type</ng-template>
+    <ng-template dfPlaceholderKey="username">key</ng-template>
+    <ng-template dfPlaceholder="input" dfPlaceholderKey="special">both</ng-template>
+  `,
+})
+class HostComponent {
+  readonly placeholders: Signal<readonly DfPlaceholder[]> = viewChildren(DfPlaceholder);
+}
+
+const tpl = (name: string) => ({ __name: name }) as unknown as TemplateRef<FieldPlaceholderContext>;
+
+describe('DfPlaceholder directive', () => {
+  it('classifies each projected template by descriptor kind (key beats type beats default)', () => {
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+
+    const kinds = fixture.componentInstance.placeholders().map((p) => p.descriptor());
+
+    expect(kinds[0]).toMatchObject({ kind: 'default', value: '' });
+    expect(kinds[1]).toMatchObject({ kind: 'type', value: 'textarea' });
+    expect(kinds[2]).toMatchObject({ kind: 'key', value: 'username' });
+    // Both inputs set → key wins.
+    expect(kinds[3]).toMatchObject({ kind: 'key', value: 'special' });
+  });
+});
+
+describe('DfPlaceholderRegistry', () => {
+  let registry: DfPlaceholderRegistry;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [DfPlaceholderRegistry] });
+    registry = TestBed.inject(DfPlaceholderRegistry);
+  });
+
+  it('defaults to empty buckets and no default template', () => {
+    const p = registry.placeholders();
+    expect(p.byKey.size).toBe(0);
+    expect(p.byType.size).toBe(0);
+    expect(p.default).toBeUndefined();
+  });
+
+  it('folds descriptors into the cascade buckets', () => {
+    const keyTpl = tpl('key');
+    const typeTpl = tpl('type');
+    const defaultTpl = tpl('default');
+    const descriptors: PlaceholderDescriptor[] = [
+      { kind: 'key', value: 'username', templateRef: keyTpl },
+      { kind: 'type', value: 'textarea', templateRef: typeTpl },
+      { kind: 'default', value: '', templateRef: defaultTpl },
+    ];
+
+    registry.set(descriptors);
+    const p = registry.placeholders();
+
+    expect(p.byKey.get('username')).toBe(keyTpl);
+    expect(p.byType.get('textarea')).toBe(typeTpl);
+    expect(p.default).toBe(defaultTpl);
+  });
+
+  it('last wins when two templates register under the same bucket entry', () => {
+    const first = tpl('first');
+    const second = tpl('second');
+    registry.set([
+      { kind: 'type', value: 'input', templateRef: first },
+      { kind: 'type', value: 'input', templateRef: second },
+    ]);
+
+    expect(registry.placeholders().byType.get('input')).toBe(second);
+  });
+});

--- a/packages/dynamic-forms/src/lib/directives/df-placeholder/df-placeholder.directive.ts
+++ b/packages/dynamic-forms/src/lib/directives/df-placeholder/df-placeholder.directive.ts
@@ -1,0 +1,116 @@
+import { computed, Directive, Injectable, inject, InjectionToken, input, Signal, signal, TemplateRef } from '@angular/core';
+
+/**
+ * Field metadata handed to a projected placeholder template as its context —
+ * both `$implicit` (for `let-field`) and the named `field`. Deliberately narrow
+ * and stable: it is NOT the internal `ResolvedField`.
+ */
+export interface FieldPlaceholderInfo {
+  /** The field's key. */
+  readonly key: string;
+  /** The field's type (e.g. `input`, `textarea`, `select`). */
+  readonly type: string;
+  /** The field's label, if any. */
+  readonly label?: string;
+  /** The field's grid column span, if any. */
+  readonly col?: number;
+}
+
+/** Template context for a projected `dfPlaceholder`. */
+export interface FieldPlaceholderContext {
+  readonly $implicit: FieldPlaceholderInfo;
+  readonly field: FieldPlaceholderInfo;
+}
+
+/** How a projected placeholder template is matched to fields. */
+export type PlaceholderKind = 'key' | 'type' | 'default';
+
+/** A projected placeholder template plus how it should be matched. */
+export interface PlaceholderDescriptor {
+  readonly kind: PlaceholderKind;
+  /** Field key (kind `key`) or field type (kind `type`); empty for `default`. */
+  readonly value: string;
+  readonly templateRef: TemplateRef<FieldPlaceholderContext>;
+}
+
+/**
+ * Resolved placeholder templates, indexed for the resolution cascade
+ * (key → type → default). Empty maps + no default means "use the built-in
+ * bare div", preserving the pre-projection behaviour.
+ */
+export interface ResolvedPlaceholders {
+  readonly byKey: ReadonlyMap<string, TemplateRef<FieldPlaceholderContext>>;
+  readonly byType: ReadonlyMap<string, TemplateRef<FieldPlaceholderContext>>;
+  readonly default?: TemplateRef<FieldPlaceholderContext>;
+}
+
+const EMPTY_PLACEHOLDERS: ResolvedPlaceholders = { byKey: new Map(), byType: new Map() };
+
+/**
+ * Marks an `<ng-template>` projected into `<form dynamic-form>` content as a
+ * field-windowing placeholder. Mirrors {@link DfTemplate}: the template is
+ * captured by `DynamicForm` via `contentChildren` and published through
+ * {@link DF_FIELD_PLACEHOLDERS} so dynamically-rendered pages can resolve it.
+ *
+ * - `<ng-template dfPlaceholder let-field>` — default, used for any field
+ * - `<ng-template dfPlaceholder="textarea">` — matched by field type
+ * - `<ng-template dfPlaceholderKey="username">` — matched by a specific field key
+ */
+@Directive({
+  selector: 'ng-template[dfPlaceholder], ng-template[dfPlaceholderKey]',
+  exportAs: 'dfPlaceholder',
+})
+export class DfPlaceholder {
+  /** Field-type match, or empty for the default placeholder. */
+  readonly dfPlaceholder = input<string>('');
+  /** Field-key match (escape hatch); wins over a type match. */
+  readonly dfPlaceholderKey = input<string>('');
+
+  readonly templateRef = inject(TemplateRef) as TemplateRef<FieldPlaceholderContext>;
+
+  /** Which cascade bucket this template registers under. Key beats type beats default. */
+  readonly descriptor: Signal<PlaceholderDescriptor> = computed(() => {
+    const key = this.dfPlaceholderKey();
+    if (key) return { kind: 'key', value: key, templateRef: this.templateRef };
+    const type = this.dfPlaceholder();
+    if (type) return { kind: 'type', value: type, templateRef: this.templateRef };
+    return { kind: 'default', value: '', templateRef: this.templateRef };
+  });
+
+  /** Types `let-field` in `<ng-template dfPlaceholder let-field>`. */
+  static ngTemplateContextGuard(_dir: DfPlaceholder, ctx: unknown): ctx is FieldPlaceholderContext {
+    return true;
+  }
+}
+
+/**
+ * Holder service published at the `<form dynamic-form>` component scope.
+ * `DynamicForm` collects projected `<ng-template dfPlaceholder>` via
+ * `contentChildren(DfPlaceholder)` and folds them into the cascade structure.
+ * The {@link DF_FIELD_PLACEHOLDERS} token exposes the resulting signal so
+ * page/container renderers resolve placeholders without coupling to the host
+ * form's generic class.
+ */
+@Injectable()
+export class DfPlaceholderRegistry {
+  private readonly _placeholders = signal<ResolvedPlaceholders>(EMPTY_PLACEHOLDERS);
+
+  /** Reactive view consumed via {@link DF_FIELD_PLACEHOLDERS}. */
+  readonly placeholders: Signal<ResolvedPlaceholders> = this._placeholders.asReadonly();
+
+  /** Fold projected descriptors into the cascade structure (last wins per bucket). */
+  set(descriptors: readonly PlaceholderDescriptor[]): void {
+    const byKey = new Map<string, TemplateRef<FieldPlaceholderContext>>();
+    const byType = new Map<string, TemplateRef<FieldPlaceholderContext>>();
+    let fallback: TemplateRef<FieldPlaceholderContext> | undefined;
+    for (const d of descriptors) {
+      if (d.kind === 'key') byKey.set(d.value, d.templateRef);
+      else if (d.kind === 'type') byType.set(d.value, d.templateRef);
+      else fallback = d.templateRef;
+    }
+    this._placeholders.set({ byKey, byType, default: fallback });
+  }
+}
+
+/** Reactive resolved placeholders, provided at the DynamicForm scope. */
+export const DF_FIELD_PLACEHOLDERS = new InjectionToken<Signal<ResolvedPlaceholders>>('DF_FIELD_PLACEHOLDERS');

--- a/packages/dynamic-forms/src/lib/directives/df-placeholder/resolve-placeholder-template.spec.ts
+++ b/packages/dynamic-forms/src/lib/directives/df-placeholder/resolve-placeholder-template.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import type { TemplateRef } from '@angular/core';
+import { resolvePlaceholderTemplate } from './resolve-placeholder-template';
+import type { FieldPlaceholderContext, ResolvedPlaceholders } from './df-placeholder.directive';
+
+// Distinct sentinel templates — we only compare identity, never render them.
+const tpl = (name: string) => ({ __name: name }) as unknown as TemplateRef<FieldPlaceholderContext>;
+
+describe('resolvePlaceholderTemplate', () => {
+  const keyTpl = tpl('key');
+  const typeTpl = tpl('type');
+  const defaultTpl = tpl('default');
+
+  const full: ResolvedPlaceholders = {
+    byKey: new Map([['username', keyTpl]]),
+    byType: new Map([['textarea', typeTpl]]),
+    default: defaultTpl,
+  };
+
+  it('prefers a key match over type and default', () => {
+    expect(resolvePlaceholderTemplate(full, { key: 'username', type: 'textarea' })).toBe(keyTpl);
+  });
+
+  it('falls back to a type match when no key matches', () => {
+    expect(resolvePlaceholderTemplate(full, { key: 'bio', type: 'textarea' })).toBe(typeTpl);
+  });
+
+  it('falls back to the default template when neither key nor type matches', () => {
+    expect(resolvePlaceholderTemplate(full, { key: 'bio', type: 'input' })).toBe(defaultTpl);
+  });
+
+  it('returns null when nothing matches and there is no default (built-in bare div)', () => {
+    const noDefault: ResolvedPlaceholders = { byKey: new Map(), byType: new Map() };
+    expect(resolvePlaceholderTemplate(noDefault, { key: 'bio', type: 'input' })).toBeNull();
+  });
+
+  it('keeps key and type namespaces separate (a key equal to a type name does not cross-match)', () => {
+    const placeholders: ResolvedPlaceholders = {
+      byKey: new Map(),
+      byType: new Map([['input', typeTpl]]),
+    };
+    // A field whose KEY is 'input' must not pick up the 'input' TYPE template via the key bucket.
+    expect(resolvePlaceholderTemplate(placeholders, { key: 'input', type: 'select' })).toBeNull();
+    expect(resolvePlaceholderTemplate(placeholders, { key: 'anything', type: 'input' })).toBe(typeTpl);
+  });
+});

--- a/packages/dynamic-forms/src/lib/directives/df-placeholder/resolve-placeholder-template.ts
+++ b/packages/dynamic-forms/src/lib/directives/df-placeholder/resolve-placeholder-template.ts
@@ -1,0 +1,15 @@
+import type { TemplateRef } from '@angular/core';
+import type { FieldPlaceholderContext, ResolvedPlaceholders } from './df-placeholder.directive';
+
+/**
+ * Resolves the projected placeholder template for a windowed field, following
+ * the cascade: a key match wins over a type match, which wins over the default
+ * template. Returns `null` when nothing matches, so the caller renders the
+ * built-in bare placeholder div (the pre-projection behaviour).
+ */
+export function resolvePlaceholderTemplate(
+  placeholders: ResolvedPlaceholders,
+  field: { key: string; type: string },
+): TemplateRef<FieldPlaceholderContext> | null {
+  return placeholders.byKey.get(field.key) ?? placeholders.byType.get(field.type) ?? placeholders.default ?? null;
+}

--- a/packages/dynamic-forms/src/lib/dynamic-form.component.ts
+++ b/packages/dynamic-forms/src/lib/dynamic-form.component.ts
@@ -41,6 +41,14 @@ import { provideDynamicFormDI } from './providers/dynamic-form-di';
 import { FormIdPrefixService } from './core/registry/form-id-prefix.service';
 import { EventDispatcher } from './events/event-dispatcher';
 import { DfTemplate, DfFieldTemplateRegistry } from './directives/df-template.directive';
+import { NgTemplateOutlet } from '@angular/common';
+import {
+  DfPlaceholder,
+  DfPlaceholderRegistry,
+  DF_FIELD_PLACEHOLDERS,
+  type FieldPlaceholderContext,
+} from './directives/df-placeholder/df-placeholder.directive';
+import { resolvePlaceholderTemplate } from './directives/df-placeholder/resolve-placeholder-template';
 import { DF_FIELD_TEMPLATES } from '@ng-forge/dynamic-forms/internal';
 import { getGridClassString } from '@ng-forge/dynamic-forms/internal';
 import { ResolvedField } from './utils/resolve-field/resolve-field';
@@ -79,7 +87,7 @@ import { resolveFieldWindowing } from './providers/features/field-windowing/reso
  */
 @Component({
   selector: 'form[dynamic-form]',
-  imports: [DfFieldOutlet, PageOrchestratorComponent],
+  imports: [DfFieldOutlet, PageOrchestratorComponent, NgTemplateOutlet],
   template: `
     @if (shouldRender()) {
       @switch (formModeDetection().mode) {
@@ -102,7 +110,11 @@ import { resolveFieldWindowing } from './providers/features/field-windowing/reso
                     [style.min-height]="fieldWindowing().placeholderHeight"
                     [attr.data-field-key]="field.key"
                     aria-hidden="true"
-                  ></div>
+                  >
+                    @if (placeholderTemplate(field); as tpl) {
+                      <ng-container [ngTemplateOutlet]="tpl" [ngTemplateOutletContext]="placeholderContext(field)" />
+                    }
+                  </div>
                 }
               } @else {
                 <ng-container *dfFieldOutlet="field; environmentInjector: environmentInjector" />
@@ -121,6 +133,8 @@ import { resolveFieldWindowing } from './providers/features/field-windowing/reso
     provideDynamicFormDI(),
     DfFieldTemplateRegistry,
     { provide: DF_FIELD_TEMPLATES, useFactory: () => inject(DfFieldTemplateRegistry).map },
+    DfPlaceholderRegistry,
+    { provide: DF_FIELD_PLACEHOLDERS, useFactory: () => inject(DfPlaceholderRegistry).placeholders },
   ],
   host: {
     class: 'df-dynamic-form df-form',
@@ -170,6 +184,8 @@ export class DynamicForm<
   private logger = inject(DynamicFormLogger);
   private dispatcher = inject(EventDispatcher, { optional: true });
   private templateRegistry = inject(DfFieldTemplateRegistry);
+  private placeholderRegistry = inject(DfPlaceholderRegistry);
+  private fieldPlaceholders = inject(DF_FIELD_PLACEHOLDERS);
   private globalFieldWindowing = inject(FIELD_WINDOWING);
 
   // ─────────────────────────────────────────────────────────────────────────────
@@ -178,6 +194,12 @@ export class DynamicForm<
 
   /** All `<ng-template dfTemplate="...">` instances projected into this form. */
   private readonly _projectedTemplates = contentChildren(DfTemplate);
+
+  /** All `<ng-template dfPlaceholder>` instances projected into this form. */
+  private readonly _projectedPlaceholders = contentChildren(DfPlaceholder);
+
+  /** Per-field placeholder template context, memoised by key to avoid re-allocating each CD. */
+  private readonly _placeholderCtx = new Map<string, FieldPlaceholderContext>();
 
   private readonly stateManager = this.connectDeps();
 
@@ -378,6 +400,23 @@ export class DynamicForm<
     return grid ? `df-field-placeholder ${grid}` : 'df-field-placeholder';
   }
 
+  /** Projected placeholder template for a windowed field, or null for the built-in bare div. */
+  protected placeholderTemplate(field: ResolvedField): TemplateRef<FieldPlaceholderContext> | null {
+    return resolvePlaceholderTemplate(this.fieldPlaceholders(), { key: field.key, type: field.fieldDef.type });
+  }
+
+  /** Memoised template context for a windowed field's projected placeholder. */
+  protected placeholderContext(field: ResolvedField): FieldPlaceholderContext {
+    let ctx = this._placeholderCtx.get(field.key);
+    if (!ctx) {
+      const label = typeof field.fieldDef.label === 'string' ? field.fieldDef.label : undefined;
+      const info = { key: field.key, type: field.fieldDef.type, label, col: field.fieldDef.col };
+      ctx = { $implicit: info, field: info };
+      this._placeholderCtx.set(field.key, ctx);
+    }
+    return ctx;
+  }
+
   // ─────────────────────────────────────────────────────────────────────────────
   // Private Methods
   // ─────────────────────────────────────────────────────────────────────────────
@@ -410,6 +449,13 @@ export class DynamicForm<
         map.set(t.dfTemplate(), t.templateRef);
       }
       this.templateRegistry.set(map);
+    });
+
+    // Mirror projected `<ng-template dfPlaceholder>` into the placeholder registry
+    // so windowed pages/fields (including dynamically-rendered ones) can resolve them.
+    explicitEffect([this._projectedPlaceholders], ([placeholders]) => {
+      this.placeholderRegistry.set(placeholders.map((p) => p.descriptor()));
+      this._placeholderCtx.clear();
     });
   }
 

--- a/packages/dynamic-forms/src/lib/fields/page/page-field.component.ts
+++ b/packages/dynamic-forms/src/lib/fields/page/page-field.component.ts
@@ -1,5 +1,18 @@
-import { ChangeDetectionStrategy, Component, computed, DestroyRef, EnvironmentInjector, inject, Injector, input } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  DestroyRef,
+  EnvironmentInjector,
+  inject,
+  Injector,
+  input,
+  TemplateRef,
+} from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
 import { DfFieldOutlet } from '../../directives/df-field-outlet/df-field-outlet.directive';
+import { DF_FIELD_PLACEHOLDERS, type FieldPlaceholderContext } from '../../directives/df-placeholder/df-placeholder.directive';
+import { resolvePlaceholderTemplate } from '../../directives/df-placeholder/resolve-placeholder-template';
 import { outputFromObservable } from '@angular/core/rxjs-interop';
 import { explicitEffect } from 'ngxtension/explicit-effect';
 import { derivedFromDeferred } from '@ng-forge/dynamic-forms/internal';
@@ -20,7 +33,7 @@ import { resolveFieldWindowing } from '../../providers/features/field-windowing/
 /** Renders a single page in multi-page (wizard) forms. */
 @Component({
   selector: 'section[page-field]',
-  imports: [DfFieldOutlet],
+  imports: [DfFieldOutlet, NgTemplateOutlet],
   template: `
     @for (field of resolvedFields(); track field.key; let i = $index) {
       @if (!field.hidden()) {
@@ -33,7 +46,11 @@ import { resolveFieldWindowing } from '../../providers/features/field-windowing/
               [style.min-height]="fieldWindowing().placeholderHeight"
               [attr.data-field-key]="field.key"
               aria-hidden="true"
-            ></div>
+            >
+              @if (placeholderTemplate(field); as tpl) {
+                <ng-container [ngTemplateOutlet]="tpl" [ngTemplateOutletContext]="placeholderContext(field)" />
+              }
+            </div>
           }
         } @else {
           <ng-container *dfFieldOutlet="field; environmentInjector: environmentInjector" />
@@ -67,6 +84,8 @@ export default class PageFieldComponent {
   private readonly logger = inject(DynamicFormLogger);
   private readonly formOptions = inject(FORM_OPTIONS, { optional: true });
   private readonly globalFieldWindowing = inject(FIELD_WINDOWING);
+  private readonly fieldPlaceholders = inject(DF_FIELD_PLACEHOLDERS, { optional: true });
+  private readonly placeholderCtx = new Map<string, FieldPlaceholderContext>();
 
   // ─────────────────────────────────────────────────────────────────────────────
   // Inputs
@@ -160,6 +179,24 @@ export default class PageFieldComponent {
   protected placeholderGridClass(field: ResolvedField): string {
     const grid = getGridClassString(field.fieldDef);
     return grid ? `df-field-placeholder ${grid}` : 'df-field-placeholder';
+  }
+
+  /** Projected placeholder template for a windowed field, or null for the built-in bare div. */
+  protected placeholderTemplate(field: ResolvedField): TemplateRef<FieldPlaceholderContext> | null {
+    const placeholders = this.fieldPlaceholders?.();
+    return placeholders ? resolvePlaceholderTemplate(placeholders, { key: field.key, type: field.fieldDef.type }) : null;
+  }
+
+  /** Memoised template context for a windowed field's projected placeholder. */
+  protected placeholderContext(field: ResolvedField): FieldPlaceholderContext {
+    let ctx = this.placeholderCtx.get(field.key);
+    if (!ctx) {
+      const label = typeof field.fieldDef.label === 'string' ? field.fieldDef.label : undefined;
+      const info = { key: field.key, type: field.fieldDef.type, label, col: field.fieldDef.col };
+      ctx = { $implicit: info, field: info };
+      this.placeholderCtx.set(field.key, ctx);
+    }
+    return ctx;
   }
 
   // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/dynamic-forms/src/lib/index.ts
+++ b/packages/dynamic-forms/src/lib/index.ts
@@ -101,6 +101,10 @@ export type { DynamicValue } from '@ng-forge/dynamic-forms/internal';
 
 // Addon Components & Directives (end-user authoring: template projection + built-in renderers)
 export { DfTemplate } from './directives/df-template.directive';
+
+// Field-windowing placeholder projection (customize the placeholder shown before a windowed field mounts)
+export { DfPlaceholder } from './directives/df-placeholder/df-placeholder.directive';
+export type { FieldPlaceholderInfo, FieldPlaceholderContext } from './directives/df-placeholder/df-placeholder.directive';
 export { TextAddonComponent } from './addons/text-addon.component';
 export { TemplateAddonComponent } from './addons/template-addon.component';
 export { ComponentAddonComponent } from './addons/component-addon.component';


### PR DESCRIPTION
## What

Field windowing renders a placeholder while a field is deferred (off-screen). Until now that placeholder was a fixed bare `<div>`. This lets consumers project their own placeholder templates — a skeleton, a shimmer, whatever — customized by field type or specific field key.

```html
<form [dynamic-form]="config">
  <ng-template dfPlaceholder let-field>          <!-- default; typed context -->
    <div class="skeleton"></div>
  </ng-template>
  <ng-template dfPlaceholder="textarea">         <!-- matched by field type -->
    <div class="skeleton tall"></div>
  </ng-template>
  <ng-template dfPlaceholderKey="avatar">        <!-- matched by a specific field key -->
    <div class="skeleton circle"></div>
  </ng-template>
</form>
```

Import `DfPlaceholder` into the host component (same as `DfTemplate`). Resolution cascades: key match, then type match, then the default template, then the built-in bare div (unchanged behavior when nothing is projected).

## Design

Mirrors the existing `DfTemplate` mechanism exactly. Projected templates are captured via `contentChildren(DfPlaceholder)` and published through a `DF_FIELD_PLACEHOLDERS` DI token, so dynamically-rendered pages (which never see the projected content directly) resolve them the same way — this token hop is why it is not pure content projection, same reason `DfTemplate` uses a token.

Deliberate choices:

- **View-side only, no config surface.** Placeholder selection is view-authoring, keyed on metadata already present (type/key). Config carries behavior and semantic hints, not rendered components, so there is no new `FormOptions`/schema field and nothing for the MCP config generator to emit.
- **The library keeps owning the layout reservation.** The grid-class host div and `min-height` stay library-owned (so the placeholder occupies the right column and reserves height); the projected template just fills it. Consumers never touch grid classes.
- **Narrow, stable context.** `let-field` receives `FieldPlaceholderInfo { key; type; label?; col? }`, not the internal `ResolvedField`, with an `ngTemplateContextGuard` for authoring-time typing. Context objects are memoized by key to avoid per-CD allocation.
- **Scope.** Only the not-yet-rendered (windowing) case. The async data-loading case stays the consumer's responsibility, as agreed.

## Tests (strict red-first)

- `resolve-placeholder-template.spec.ts` and `df-placeholder.directive.spec.ts` were written and confirmed red before the implementation.
- `df-placeholder.integration.spec.ts` runs in browser mode with a real IntersectionObserver: type-matched template, default template with correct `let-field` context, key-beats-type, the no-projection bare-div regression, and scroll-into-view still swapping the placeholder for the real field.
- Mutation-checked: forcing the resolver to return null fails the three template tests and the resolver unit tests, while the bare-div and scroll tests correctly still pass.

## Verification

`nx test dynamic-forms` 3261 passed, plus lint, build, api-check, and all four adapter suites green. API report updated for the new `DfPlaceholder` export and `FieldPlaceholderInfo`/`FieldPlaceholderContext` types.

## Deferred (non-breaking to add later)

An app-wide provider default (a component-type fallback for reuse across many forms) if per-form projection proves insufficient.
