### PR TITLE
style(config): apply prettier 3.9.6 formatting and check full repo on branches

### DIFF
--- a/.github/workflows/_build-test.yml
+++ b/.github/workflows/_build-test.yml
@@ -87,32 +87,16 @@ jobs:
           echo "Validating PR title against Angular convention..."
           echo "$PR_TITLE" | pnpm commitlint --verbose
 
-      - name: Check formatting (full)
-        if: ${{ !inputs.affected }}
+      # Always checks the whole repo, on branches and on main alike. Checking only
+      # affected files let a prettier version bump pass on the branch and then fail
+      # on main, since bumping the version does not mark the reformatted files as
+      # affected. The full check takes ~20s, so scoping it down is not worth it.
+      - name: Check formatting
         run: |
           echo "Checking code formatting with Prettier..."
           pnpm exec prettier --check "**/*.{ts,js,json,md,yml,yaml,html,css,scss}" || {
             echo ""
             echo "❌ Formatting issues found!"
-            echo "Run 'pnpm exec prettier --write .' to fix formatting issues"
-            exit 1
-          }
-
-      - name: Check formatting on affected files
-        if: inputs.affected
-        run: |
-          echo "Checking code formatting on affected files..."
-          AFFECTED_FILES=$(git diff --name-only --diff-filter=ACMRT origin/main...HEAD | grep -E '\.(ts|js|json|md|yml|yaml|html|css|scss)$' || true)
-          if [ -z "$AFFECTED_FILES" ]; then
-            echo "No affected files to check"
-            exit 0
-          fi
-          echo "Affected files to check:"
-          echo "$AFFECTED_FILES"
-          echo ""
-          echo "$AFFECTED_FILES" | xargs pnpm exec prettier --check || {
-            echo ""
-            echo "❌ Formatting issues found in affected files!"
             echo "Run 'pnpm exec prettier --write .' to fix formatting issues"
             exit 1
           }

--- a/CODING_STANDARDS_QUICK_REFERENCE.md
+++ b/CODING_STANDARDS_QUICK_REFERENCE.md
@@ -76,9 +76,7 @@ template: `{{ calculateTotal() }}`  // Don't call functions - use computed()
 ### Component Structure (Order Matters!)
 
 ```typescript
-@Component({
-  /* ... */
-})
+@Component({/* ... */})
 export class MyComponent {
   // 1. Inputs (required first, then optional)
   readonly field = input.required<FieldTree<string>>();

--- a/apps/docs/public/content/building-an-adapter.md
+++ b/apps/docs/public/content/building-an-adapter.md
@@ -544,9 +544,7 @@ export const MY_ADAPTER_CONFIG = new InjectionToken<MyAdapterConfig>('MY_ADAPTER
 In each field component, layer the lookups: per-field `props` win, adapter config falls in next, hard-coded default last.
 
 ```typescript
-@Component({
-  /* ... */
-})
+@Component({/* ... */})
 export default class MyInputComponent {
   private readonly config = inject(MY_ADAPTER_CONFIG, { optional: true });
   protected readonly ngf = injectNgForgeField<string>();

--- a/apps/docs/public/content/dynamic-behavior/conditional-logic.md
+++ b/apps/docs/public/content/dynamic-behavior/conditional-logic.md
@@ -1108,16 +1108,7 @@ type ConditionalExpression =
   | AsyncCondition;
 
 type Operator =
-  | 'equals'
-  | 'notEquals'
-  | 'greater'
-  | 'less'
-  | 'greaterOrEqual'
-  | 'lessOrEqual'
-  | 'contains'
-  | 'startsWith'
-  | 'endsWith'
-  | 'matches';
+  'equals' | 'notEquals' | 'greater' | 'less' | 'greaterOrEqual' | 'lessOrEqual' | 'contains' | 'startsWith' | 'endsWith' | 'matches';
 
 interface HttpCondition {
   type: 'http';
@@ -1163,9 +1154,7 @@ type AsyncCondition =
 logic: [
   {
     type: 'hidden',
-    condition: {
-      /* when to hide */
-    },
+    condition: {/* when to hide */},
   },
 ];
 ```
@@ -1176,15 +1165,11 @@ logic: [
 logic: [
   {
     type: 'hidden',
-    condition: {
-      /* when to hide */
-    },
+    condition: {/* when to hide */},
   },
   {
     type: 'required',
-    condition: {
-      /* when to require */
-    },
+    condition: {/* when to require */},
   },
 ];
 ```
@@ -1197,14 +1182,7 @@ logic: [
     type: 'hidden',
     condition: {
       type: 'and', // or 'or'
-      conditions: [
-        {
-          /* condition 1 */
-        },
-        {
-          /* condition 2 */
-        },
-      ],
+      conditions: [{/* condition 1 */}, {/* condition 2 */}],
     },
   },
 ];

--- a/apps/docs/public/content/examples/paginated-form.md
+++ b/apps/docs/public/content/examples/paginated-form.md
@@ -380,38 +380,28 @@ fields: [
   {
     key: 'basicInfo',
     type: 'page',
-    fields: [
-      /* lightweight fields */
-    ],
+    fields: [/* lightweight fields */],
   },
   {
     key: 'contact',
     type: 'page',
-    fields: [
-      /* lightweight fields */
-    ],
+    fields: [/* lightweight fields */],
   },
   {
     key: 'address',
     type: 'page',
-    fields: [
-      /* lightweight fields */
-    ],
+    fields: [/* lightweight fields */],
   },
   // These won't load until user reaches page 2-4 (when idle)
   {
     key: 'preferences',
     type: 'page',
-    fields: [
-      /* heavy multi-checkbox with 100 options */
-    ],
+    fields: [/* heavy multi-checkbox with 100 options */],
   },
   {
     key: 'advanced',
     type: 'page',
-    fields: [
-      /* complex conditional logic */
-    ],
+    fields: [/* complex conditional logic */],
   },
 ];
 ```

--- a/apps/docs/public/content/getting-started.md
+++ b/apps/docs/public/content/getting-started.md
@@ -38,9 +38,7 @@ Every adapter uses the same `FormConfig` schema. Import `DynamicForm` and bind a
 })
 export class ContactComponent {
   config = {
-    fields: [
-      /* see Config tab below */
-    ],
+    fields: [/* see Config tab below */],
   } as const satisfies FormConfig;
 }
 ```

--- a/apps/docs/public/content/schema-validation/angular-schema.md
+++ b/apps/docs/public/content/schema-validation/angular-schema.md
@@ -200,9 +200,7 @@ const config = {
     required(path.email, { when: ({ valueOf }) => valueOf(path.preferredContact) === 'email' });
     required(path.phone, { when: ({ valueOf }) => valueOf(path.preferredContact) === 'phone' });
   },
-  fields: [
-    /* preferredContact, email, phone */
-  ],
+  fields: [/* preferredContact, email, phone */],
 } as const satisfies FormConfig;
 ```
 
@@ -221,9 +219,7 @@ const config = {
       valueOf(path.discountType) === 'fixed' && value() > valueOf(path.total) ? { kind: 'exceedsTotal' } : null,
     );
   },
-  fields: [
-    /* quantity, discount, discountType, total */
-  ],
+  fields: [/* quantity, discount, discountType, total */],
 } as const satisfies FormConfig;
 ```
 

--- a/apps/docs/public/content/schema-validation/overview.md
+++ b/apps/docs/public/content/schema-validation/overview.md
@@ -46,9 +46,7 @@ const config = {
       return null;
     });
   },
-  fields: [
-    /* ... */
-  ],
+  fields: [/* ... */],
 };
 ```
 
@@ -73,9 +71,7 @@ const passwordSchema = z
 
 const config = {
   schema: standardSchema(passwordSchema),
-  fields: [
-    /* ... */
-  ],
+  fields: [/* ... */],
 };
 ```
 

--- a/apps/docs/public/content/validation/custom-validators.md
+++ b/apps/docs/public/content/validation/custom-validators.md
@@ -867,9 +867,7 @@ const checkUsername: AsyncCustomValidator<string, { username: string }, { availa
 
 // HTTP validators with type parameters (advanced)
 const checkDomain: HttpCustomValidator<string, { valid: boolean }> = {
-  request: (ctx) => ({
-    /* ... */
-  }),
+  request: (ctx) => ({/* ... */}),
   onSuccess: (response, ctx) => {
     response.valid; // Type: boolean
     return response.valid ? null : { kind: 'invalidDomain' };

--- a/apps/docs/public/content/validation/reference.md
+++ b/apps/docs/public/content/validation/reference.md
@@ -199,11 +199,7 @@ interface DeclarativeHttpValidatorConfig {
 }
 
 type ValidatorConfig =
-  | BuiltInValidatorConfig
-  | CustomValidatorConfig
-  | AsyncValidatorConfig
-  | FunctionHttpValidatorConfig
-  | DeclarativeHttpValidatorConfig;
+  BuiltInValidatorConfig | CustomValidatorConfig | AsyncValidatorConfig | FunctionHttpValidatorConfig | DeclarativeHttpValidatorConfig;
 ```
 
 > **Note:** `FunctionHttpValidatorConfig` and `DeclarativeHttpValidatorConfig` both use `type: 'http'`. They are discriminated by property presence: `functionName` or `fn` indicates function-based, `http` + `responseMapping` indicates declarative.
@@ -290,25 +286,10 @@ interface OrCondition {
 }
 
 type ComparisonOperator =
-  | 'equals'
-  | 'notEquals'
-  | 'greater'
-  | 'less'
-  | 'greaterOrEqual'
-  | 'lessOrEqual'
-  | 'contains'
-  | 'startsWith'
-  | 'endsWith'
-  | 'matches';
+  'equals' | 'notEquals' | 'greater' | 'less' | 'greaterOrEqual' | 'lessOrEqual' | 'contains' | 'startsWith' | 'endsWith' | 'matches';
 
 type ConditionalExpression =
-  | FieldValueCondition
-  | CustomCondition
-  | JavascriptCondition
-  | HttpCondition
-  | AsyncCondition
-  | AndCondition
-  | OrCondition;
+  FieldValueCondition | CustomCondition | JavascriptCondition | HttpCondition | AsyncCondition | AndCondition | OrCondition;
 ```
 
 ## Validation Messages

--- a/apps/docs/src/app/pages/landing/landing.component.html
+++ b/apps/docs/src/app/pages/landing/landing.component.html
@@ -323,8 +323,7 @@
             >{{ '{' }}
   email: string;
   age: number;
-{{ '}' }}</pre
-          >
+{{ '}' }}</pre>
           <p class="payoff-note">Rename a field and this type follows along, without a cast or an <code>any</code> in sight.</p>
         </aside>
       </div>

--- a/apps/docs/src/app/services/api.service.ts
+++ b/apps/docs/src/app/services/api.service.ts
@@ -6,16 +6,7 @@ import { Observable, shareReplay, of, catchError } from 'rxjs';
 // ─── API Data Models ─────────────────────────────────────────────────────────
 
 export type DeclarationKind =
-  | 'class'
-  | 'interface'
-  | 'type'
-  | 'function'
-  | 'const'
-  | 'enum'
-  | 'component'
-  | 'directive'
-  | 'injectable'
-  | 'pipe';
+  'class' | 'interface' | 'type' | 'function' | 'const' | 'enum' | 'component' | 'directive' | 'injectable' | 'pipe';
 
 export interface ApiMember {
   name: string;

--- a/internal/dynamic-forms-zod/mcp/src/tools/validate-config.tool.ts
+++ b/internal/dynamic-forms-zod/mcp/src/tools/validate-config.tool.ts
@@ -515,8 +515,7 @@ function preValidateConfig(config: unknown): FormattedValidationError[] {
       });
 
     const firstPage = fields.find((f) => f && typeof f === 'object' && (f as Record<string, unknown>)['type'] === 'page') as
-      | Record<string, unknown>
-      | undefined;
+      Record<string, unknown> | undefined;
     const firstPageKey = firstPage?.['key'] as string | undefined;
 
     errors.push({

--- a/packages/dynamic-forms-ionic/src/lib/fields/slider/ionic-slider.type-test.ts
+++ b/packages/dynamic-forms-ionic/src/lib/fields/slider/ionic-slider.type-test.ts
@@ -13,17 +13,7 @@ import type { RequiredKeys } from '@ng-forge/utils';
 
 describe('IonicSliderProps - Exhaustive Whitelist', () => {
   type ExpectedKeys =
-    | 'min'
-    | 'max'
-    | 'step'
-    | 'dualKnobs'
-    | 'pin'
-    | 'pinFormatter'
-    | 'ticks'
-    | 'snaps'
-    | 'color'
-    | 'labelPlacement'
-    | 'hint';
+    'min' | 'max' | 'step' | 'dualKnobs' | 'pin' | 'pinFormatter' | 'ticks' | 'snaps' | 'color' | 'labelPlacement' | 'hint';
   type ActualKeys = keyof IonicSliderProps;
 
   it('should have exactly the expected keys', () => {

--- a/packages/dynamic-forms-material/src/lib/fields/datepicker/mat-datepicker.type-test.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/datepicker/mat-datepicker.type-test.ts
@@ -14,15 +14,7 @@ import type { RequiredKeys } from '@ng-forge/utils';
 
 describe('MatDatepickerProps - Exhaustive Whitelist', () => {
   type ExpectedKeys =
-    | 'appearance'
-    | 'color'
-    | 'disableRipple'
-    | 'subscriptSizing'
-    | 'floatLabel'
-    | 'hideRequiredMarker'
-    | 'startView'
-    | 'touchUi'
-    | 'hint';
+    'appearance' | 'color' | 'disableRipple' | 'subscriptSizing' | 'floatLabel' | 'hideRequiredMarker' | 'startView' | 'touchUi' | 'hint';
   type ActualKeys = keyof MatDatepickerProps;
 
   it('should have exactly the expected keys', () => {

--- a/packages/dynamic-forms-material/src/lib/fields/select/mat-select.type-test.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/select/mat-select.type-test.ts
@@ -22,14 +22,7 @@ import type { RequiredKeys } from '@ng-forge/utils';
 
 describe('MatSelectProps - Exhaustive Whitelist', () => {
   type ExpectedKeys =
-    | 'appearance'
-    | 'multiple'
-    | 'panelMaxHeight'
-    | 'subscriptSizing'
-    | 'floatLabel'
-    | 'hideRequiredMarker'
-    | 'compareWith'
-    | 'hint';
+    'appearance' | 'multiple' | 'panelMaxHeight' | 'subscriptSizing' | 'floatLabel' | 'hideRequiredMarker' | 'compareWith' | 'hint';
   type ActualKeys = keyof MatSelectProps;
 
   it('should have exactly the expected keys', () => {

--- a/packages/dynamic-forms/integration/src/definitions/input-field.ts
+++ b/packages/dynamic-forms/integration/src/definitions/input-field.ts
@@ -110,8 +110,7 @@ interface StringInputField<TProps extends { type?: string } = InputProps, TNulla
  * - If props.type is undefined/text/email/etc, only StringInputField matches (value: string)
  */
 type BuildInputFieldUnion<TProps extends { type?: string }, TNullable extends boolean = boolean> =
-  | NumberInputField<TProps, TNullable>
-  | StringInputField<TProps, TNullable>;
+  NumberInputField<TProps, TNullable> | StringInputField<TProps, TNullable>;
 
 /**
  * Input field with automatic type-safe value inference.

--- a/packages/dynamic-forms/integration/src/mappers/select/options-field-mapper.ts
+++ b/packages/dynamic-forms/integration/src/mappers/select/options-field-mapper.ts
@@ -7,9 +7,7 @@ import { resolveValueFieldContext, buildValueFieldInputs } from '../value/value-
 
 /** Field types that have an options property. */
 export type FieldWithOptions<T = unknown, TProps = unknown> =
-  | SelectField<T, TProps>
-  | RadioField<T, TProps>
-  | MultiCheckboxField<T, TProps>;
+  SelectField<T, TProps> | RadioField<T, TProps> | MultiCheckboxField<T, TProps>;
 
 /**
  * Maps a field with options (select, radio, multi-checkbox) to component inputs.

--- a/packages/dynamic-forms/internal/src/lib/models/expressions/conditional-expression.ts
+++ b/packages/dynamic-forms/internal/src/lib/models/expressions/conditional-expression.ts
@@ -4,16 +4,7 @@ import type { HttpRequestConfig } from '../http/http-request-config';
 
 /** Comparison operators for field value and form value conditions. */
 export type ComparisonOperator =
-  | 'equals'
-  | 'notEquals'
-  | 'greater'
-  | 'less'
-  | 'greaterOrEqual'
-  | 'lessOrEqual'
-  | 'contains'
-  | 'startsWith'
-  | 'endsWith'
-  | 'matches';
+  'equals' | 'notEquals' | 'greater' | 'less' | 'greaterOrEqual' | 'lessOrEqual' | 'contains' | 'startsWith' | 'endsWith' | 'matches';
 
 /** Condition that compares a specific field's value against an expected value. */
 export interface FieldValueCondition {
@@ -129,10 +120,4 @@ export interface OrCondition {
 
 /** Discriminated union of all conditional expression types. */
 export type ConditionalExpression =
-  | FieldValueCondition
-  | CustomCondition
-  | JavascriptCondition
-  | HttpCondition
-  | AsyncCondition
-  | AndCondition
-  | OrCondition;
+  FieldValueCondition | CustomCondition | JavascriptCondition | HttpCondition | AsyncCondition | AndCondition | OrCondition;

--- a/packages/dynamic-forms/internal/src/lib/models/validation/validator-config.ts
+++ b/packages/dynamic-forms/internal/src/lib/models/validation/validator-config.ts
@@ -128,11 +128,7 @@ export interface DeclarativeHttpValidatorConfig extends BaseValidatorConfig {
  * Discriminated union type for type-safe validator configuration.
  */
 export type ValidatorConfig =
-  | BuiltInValidatorConfig
-  | CustomValidatorConfig
-  | AsyncValidatorConfig
-  | FunctionHttpValidatorConfig
-  | DeclarativeHttpValidatorConfig;
+  BuiltInValidatorConfig | CustomValidatorConfig | AsyncValidatorConfig | FunctionHttpValidatorConfig | DeclarativeHttpValidatorConfig;
 
 /** Type guard to distinguish function-based HTTP validators from declarative ones. */
 export function isFunctionHttpValidator(

--- a/packages/dynamic-forms/internal/src/lib/models/validation/validator-config.type-test.ts
+++ b/packages/dynamic-forms/internal/src/lib/models/validation/validator-config.type-test.ts
@@ -397,11 +397,7 @@ describe('DeclarativeHttpValidatorConfig - Usage Examples', () => {
 describe('ValidatorConfig - Discriminated Union', () => {
   it('should be union of all validator config types', () => {
     type ExpectedUnion =
-      | BuiltInValidatorConfig
-      | CustomValidatorConfig
-      | AsyncValidatorConfig
-      | FunctionHttpValidatorConfig
-      | DeclarativeHttpValidatorConfig;
+      BuiltInValidatorConfig | CustomValidatorConfig | AsyncValidatorConfig | FunctionHttpValidatorConfig | DeclarativeHttpValidatorConfig;
     expectTypeOf<ValidatorConfig>().toEqualTypeOf<ExpectedUnion>();
   });
 

--- a/packages/openapi-generator/src/generator/interface-generator.ts
+++ b/packages/openapi-generator/src/generator/interface-generator.ts
@@ -220,8 +220,7 @@ function schemaToTsType(
     if (unionSchemas) {
       // Check if this is a discriminator schema — use mapping keys for distinct variant names
       const disc = (schema as Record<string, unknown>)['discriminator'] as
-        | { propertyName: string; mapping?: Record<string, string> }
-        | undefined;
+        { propertyName: string; mapping?: Record<string, string> } | undefined;
       const mappingKeys = disc?.mapping ? Object.keys(disc.mapping) : undefined;
 
       const types = unionSchemas


### PR DESCRIPTION
Main is red at 48deb45 after the linting group bump (#554). Prettier 3.9.6 reformats 21 files that were already in the tree, mostly collapsing union types onto a single line under the repo printWidth of 140.

## Why the branch check missed it

The two prettier steps in `_build-test.yml` ran different commands:

- branch runs checked only files changed against main
- main runs checked the whole repo

A prettier version bump changes how existing files are formatted without touching those files, so nothing formattable showed up as affected. #554 changed only `package.json` and `pnpm-lock.yaml`, its branch check reported "All matched files use Prettier code style!", and the same tree failed on main 40 minutes later.

## Changes

- reformat the 21 files with prettier 3.9.6
- run the same full-repo check in both jobs, so a branch cannot pass a formatting check that main then fails

The full check takes about 20 seconds, so scoping it to affected files was not buying much.

Verified locally with prettier 3.9.6 from the updated lockfile: `prettier --check` over the full glob exits 0.