### PR TITLE
fix(dynamic-forms): accept unicode identifiers in expressions

### DIFF
--- a/packages/dynamic-forms/internal/src/lib/core/cross-field/cross-field-detector.spec.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/cross-field/cross-field-detector.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { extractExpressionDependencies, extractStringDependencies, isCrossFieldExpression } from './cross-field-detector';
+
+describe('cross-field-detector', () => {
+  describe('extractStringDependencies', () => {
+    it('should extract dot-notation dependencies', () => {
+      expect(extractStringDependencies('formValue.firstName + formValue.lastName')).toEqual(['firstName', 'lastName']);
+    });
+
+    it('should extract nested paths as root and full path', () => {
+      expect(extractStringDependencies('formValue.person.age')).toEqual(['person', 'person.age']);
+    });
+
+    it('should extract bracket-notation dependencies', () => {
+      expect(extractStringDependencies(`formValue['firstName'] + formValue["lastName"]`)).toEqual(['firstName', 'lastName']);
+    });
+
+    it('should extract dependencies whose keys contain non-ASCII letters', () => {
+      expect(extractStringDependencies('!!formValue.bestellgröße')).toEqual(['bestellgröße']);
+    });
+
+    it('should extract non-ASCII dependencies from bracket notation', () => {
+      expect(extractStringDependencies(`formValue['bestellgröße']`)).toEqual(['bestellgröße']);
+      expect(extractStringDependencies(`formValue["bestellgröße"]`)).toEqual(['bestellgröße']);
+    });
+
+    it('should extract nested non-ASCII paths as root and full path', () => {
+      expect(extractStringDependencies('formValue.lieferung.bestellgröße')).toEqual(['lieferung', 'lieferung.bestellgröße']);
+    });
+  });
+
+  describe('extractExpressionDependencies', () => {
+    it('should extract dependencies from a javascript condition with non-ASCII keys', () => {
+      const deps = extractExpressionDependencies({
+        type: 'javascript',
+        expression: '!!formValue.bestellgröße && externalData.isAuthenticated',
+      });
+
+      expect(deps).toEqual(['bestellgröße']);
+    });
+  });
+
+  describe('isCrossFieldExpression', () => {
+    it('should detect formValue access with non-ASCII keys', () => {
+      expect(
+        isCrossFieldExpression({
+          type: 'javascript',
+          expression: '!!formValue.bestellgröße',
+        }),
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/dynamic-forms/internal/src/lib/core/cross-field/cross-field-detector.spec.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/cross-field/cross-field-detector.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { extractExpressionDependencies, extractStringDependencies, isCrossFieldExpression } from './cross-field-detector';
 
+/** Zero-width non-joiner: an identifier part that carries no glyph. */
+const ZWNJ = '\u200C';
+
 describe('cross-field-detector', () => {
   describe('extractStringDependencies', () => {
     it('should extract dot-notation dependencies', () => {
@@ -26,6 +29,31 @@ describe('cross-field-detector', () => {
 
     it('should extract nested non-ASCII paths as root and full path', () => {
       expect(extractStringDependencies('formValue.lieferung.bestellgröße')).toEqual(['lieferung', 'lieferung.bestellgröße']);
+    });
+
+    it('should ignore dot segments that cannot start an identifier', () => {
+      // These are not parseable expressions; extracting a "dependency" from them
+      // only pollutes the dependency set with keys no field can ever have.
+      expect(extractStringDependencies('formValue.123name')).toEqual([]);
+      expect(extractStringDependencies('formValue..name')).toEqual([]);
+    });
+
+    it('should ignore a trailing dot rather than emitting a partial path', () => {
+      expect(extractStringDependencies('formValue.name.')).toEqual(['name']);
+    });
+
+    it('should still accept identifiers starting with underscore or dollar', () => {
+      expect(extractStringDependencies('formValue._private')).toEqual(['_private']);
+      expect(extractStringDependencies('formValue.$special')).toEqual(['$special']);
+      expect(extractStringDependencies('formValue._outer.$inner')).toEqual(['_outer', '_outer.$inner']);
+    });
+
+    it('should extract keys containing a zero-width non-joiner', () => {
+      // Persian compounds join words with U+200C, which is a valid identifier part.
+      const key = `نام${ZWNJ}خانوادگی`;
+
+      expect(extractStringDependencies(`formValue.${key}`)).toEqual([key]);
+      expect(extractStringDependencies(`formValue["${key}"]`)).toEqual([key]);
     });
 
     it.each([

--- a/packages/dynamic-forms/internal/src/lib/core/cross-field/cross-field-detector.spec.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/cross-field/cross-field-detector.spec.ts
@@ -27,6 +27,33 @@ describe('cross-field-detector', () => {
     it('should extract nested non-ASCII paths as root and full path', () => {
       expect(extractStringDependencies('formValue.lieferung.bestellgröße')).toEqual(['lieferung', 'lieferung.bestellgröße']);
     });
+
+    it.each([
+      ['Romanian', 'țaraDeȘedere'],
+      ['Romanian (cedilla variants)', 'ştiinţă'],
+      ['French', 'adresseÉlectronique'],
+      ['French (ligature)', 'cœurBattant'],
+      ['German', 'überprüfungsgröße'],
+      ['Spanish', 'añoDeNacimiento'],
+      ['Portuguese', 'endereçoIrmão'],
+      ['Polish', 'nazwiskoŻółć'],
+      ['Czech', 'příjmeníŘeka'],
+      ['Hungarian', 'születésiDátum'],
+      ['Turkish', 'kimlikNumarası'],
+      ['Nordic', 'blåbærFødt'],
+      ['Greek', 'διεύθυνση'],
+      ['Cyrillic', 'фамилия'],
+      ['Vietnamese', 'điệnThoại'],
+      ['Hebrew', 'כתובת'],
+      ['Arabic', 'العنوان'],
+      ['CJK', '住所'],
+    ])('should extract a key with %s characters, composed and decomposed', (_language, key) => {
+      expect(extractStringDependencies(`formValue.${key}`)).toEqual([key]);
+      expect(extractStringDependencies(`formValue["${key}"]`)).toEqual([key]);
+
+      const decomposed = key.normalize('NFD');
+      expect(extractStringDependencies(`formValue.${decomposed}`)).toEqual([decomposed]);
+    });
   });
 
   describe('extractExpressionDependencies', () => {

--- a/packages/dynamic-forms/internal/src/lib/core/cross-field/cross-field-detector.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/cross-field/cross-field-detector.ts
@@ -11,8 +11,12 @@ import { CustomFunctionScope } from '../expressions/custom-function-types';
  */
 const FORM_VALUE_ACCESS_PATTERN = /\bformValue\s*(?:\.|\[)/;
 
-/** Combined regex for extracting field paths from formValue expressions. */
-const FORM_VALUE_PATTERN = /\bformValue\s*(?:\.([\w.]+)|\[\s*'([\w.-]+)'\s*\]|\[\s*"([\w.-]+)"\s*\])/g;
+/**
+ * Combined regex for extracting field paths from formValue expressions.
+ * Field keys may contain any ECMA-262 identifier character, not just ASCII.
+ */
+const FORM_VALUE_PATTERN =
+  /\bformValue\s*(?:\.([\p{ID_Continue}$.]+)|\[\s*'([\p{ID_Continue}$.-]+)'\s*\]|\[\s*"([\p{ID_Continue}$.-]+)"\s*\])/gu;
 
 /** Context for cross-field detection, providing access to function scope information. */
 export interface CrossFieldDetectionContext {

--- a/packages/dynamic-forms/internal/src/lib/core/cross-field/cross-field-detector.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/cross-field/cross-field-detector.ts
@@ -11,12 +11,24 @@ import { CustomFunctionScope } from '../expressions/custom-function-types';
  */
 const FORM_VALUE_ACCESS_PATTERN = /\bformValue\s*(?:\.|\[)/;
 
+/** ECMA-262 identifier characters, not just ASCII. Composed into the path pattern below. */
+const ID_START = String.raw`[\p{ID_Start}$_]`;
+const ID_PART = String.raw`[\p{ID_Continue}$]`;
+
+/** A dotted path of identifiers: every segment must be able to start one. */
+const DOTTED_PATH = String.raw`${ID_START}${ID_PART}*(?:\.${ID_START}${ID_PART}*)*`;
+
+/** Bracket keys are string literals, so they admit characters an identifier cannot (e.g. `-`). */
+const BRACKET_KEY = String.raw`[\p{ID_Continue}$.\-]+`;
+
 /**
  * Combined regex for extracting field paths from formValue expressions.
- * Field keys may contain any ECMA-262 identifier character, not just ASCII.
+ * Matches formValue.a.b, formValue['a-b'] and formValue["a-b"].
  */
-const FORM_VALUE_PATTERN =
-  /\bformValue\s*(?:\.([\p{ID_Continue}$.]+)|\[\s*'([\p{ID_Continue}$.-]+)'\s*\]|\[\s*"([\p{ID_Continue}$.-]+)"\s*\])/gu;
+const FORM_VALUE_PATTERN = new RegExp(
+  String.raw`\bformValue\s*(?:\.(${DOTTED_PATH})|\[\s*'(${BRACKET_KEY})'\s*\]|\[\s*"(${BRACKET_KEY})"\s*\])`,
+  'gu',
+);
 
 /** Context for cross-field detection, providing access to function scope information. */
 export interface CrossFieldDetectionContext {

--- a/packages/dynamic-forms/internal/src/lib/core/expressions/condition-evaluator.spec.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/expressions/condition-evaluator.spec.ts
@@ -227,6 +227,21 @@ describe('condition-evaluator', () => {
         expect(result).toBe(true);
       });
 
+      it('should evaluate expressions referencing field keys with non-ASCII letters', () => {
+        const context: EvaluationContext = {
+          ...mockContext,
+          formValue: { bestellgröße: 'L' },
+          externalData: { isAuthenticated: true },
+        };
+        const expression: ConditionalExpression = {
+          type: 'javascript',
+          expression: '!!formValue.bestellgröße && externalData.isAuthenticated',
+        };
+
+        expect(evaluateCondition(expression, context)).toBe(true);
+        expect(mockLogger.error).not.toHaveBeenCalled();
+      });
+
       it('should convert result to boolean', () => {
         const testCases = [
           { expression: '1', expected: true },

--- a/packages/dynamic-forms/internal/src/lib/core/expressions/parser/expression-parser.spec.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/expressions/parser/expression-parser.spec.ts
@@ -305,6 +305,31 @@ describe('ExpressionParser', () => {
       const scope4 = { formValue: { user: { profile: { firstName: 'John' } } } };
       expect(ExpressionParser.evaluate('formValue.user.profile.firstName', scope4)).toBe('John');
     });
+
+    it('should access properties whose keys contain non-ASCII letters', () => {
+      const scope = {
+        formValue: { bestellgröße: 'L' },
+        externalData: { isAuthenticated: true },
+      };
+
+      expect(ExpressionParser.evaluate('formValue.bestellgröße', scope)).toBe('L');
+      expect(ExpressionParser.evaluate('!!formValue.bestellgröße && externalData.isAuthenticated', scope)).toBe(true);
+    });
+
+    it('should access non-ASCII keys through optional chaining', () => {
+      const scope = { formValue: { lieferung: { bestellgröße: 'L' } } };
+
+      expect(ExpressionParser.evaluate('formValue.lieferung?.bestellgröße', scope)).toBe('L');
+      expect(ExpressionParser.evaluate('formValue.abholung?.bestellgröße', scope)).toBeUndefined();
+    });
+
+    it('should treat dot and bracket notation as equivalent for non-ASCII keys', () => {
+      const scope = { formValue: { bestellgröße: 'L' } };
+
+      expect(ExpressionParser.evaluate('formValue.bestellgröße', scope)).toBe(
+        ExpressionParser.evaluate('formValue["bestellgröße"]', scope),
+      );
+    });
   });
 
   describe('arithmetic operations', () => {

--- a/packages/dynamic-forms/internal/src/lib/core/expressions/parser/expression-parser.spec.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/expressions/parser/expression-parser.spec.ts
@@ -330,6 +330,41 @@ describe('ExpressionParser', () => {
         ExpressionParser.evaluate('formValue["bestellgröße"]', scope),
       );
     });
+
+    describe.each([
+      ['Romanian', 'țaraDeȘedere'],
+      ['Romanian (cedilla variants)', 'ştiinţă'],
+      ['French', 'adresseÉlectronique'],
+      ['French (ligature)', 'cœurBattant'],
+      ['German', 'überprüfungsgröße'],
+      ['Spanish', 'añoDeNacimiento'],
+      ['Portuguese', 'endereçoIrmão'],
+      ['Polish', 'nazwiskoŻółć'],
+      ['Czech', 'příjmeníŘeka'],
+      ['Hungarian', 'születésiDátum'],
+      ['Turkish', 'kimlikNumarası'],
+      ['Nordic', 'blåbærFødt'],
+      ['Greek', 'διεύθυνση'],
+      ['Cyrillic', 'фамилия'],
+      ['Vietnamese', 'điệnThoại'],
+      ['Hebrew', 'כתובת'],
+      ['Arabic', 'العنوان'],
+      ['CJK', '住所'],
+    ])('key with %s characters', (_language, key) => {
+      it('should read the key by dot access, matching bracket access', () => {
+        const scope = { formValue: { [key]: 'value' } };
+
+        expect(ExpressionParser.evaluate(`formValue.${key}`, scope)).toBe('value');
+        expect(ExpressionParser.evaluate(`formValue.${key}`, scope)).toBe(ExpressionParser.evaluate(`formValue["${key}"]`, scope));
+      });
+
+      it('should read the key in decomposed (NFD) form', () => {
+        const decomposed = key.normalize('NFD');
+        const scope = { formValue: { [decomposed]: 'value' } };
+
+        expect(ExpressionParser.evaluate(`formValue.${decomposed}`, scope)).toBe('value');
+      });
+    });
   });
 
   describe('arithmetic operations', () => {

--- a/packages/dynamic-forms/internal/src/lib/core/expressions/parser/tokenizer.spec.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/expressions/parser/tokenizer.spec.ts
@@ -184,6 +184,43 @@ describe('Tokenizer', () => {
       expect(tokens[0].type).toBe(TokenType.IDENTIFIER);
       expect(tokens[0].value).toBe('trueValue');
     });
+
+    it('should tokenize identifier with umlauts', () => {
+      const tokenizer = new Tokenizer('bestellgröße');
+      const tokens = tokenizer.tokenize();
+
+      expect(tokens[0]).toEqual({ type: TokenType.IDENTIFIER, value: 'bestellgröße', position: 0 });
+    });
+
+    it('should tokenize identifier starting with a non-ASCII letter', () => {
+      const tokenizer = new Tokenizer('Ärger');
+      const tokens = tokenizer.tokenize();
+
+      expect(tokens[0]).toEqual({ type: TokenType.IDENTIFIER, value: 'Ärger', position: 0 });
+    });
+
+    it('should tokenize identifiers in non-Latin scripts', () => {
+      const tokenizer = new Tokenizer('日本語 имя');
+      const tokens = tokenizer.tokenize();
+
+      expect(tokens[0]).toEqual({ type: TokenType.IDENTIFIER, value: '日本語', position: 0 });
+      expect(tokens[1]).toEqual({ type: TokenType.IDENTIFIER, value: 'имя', position: 4 });
+    });
+
+    it('should tokenize member access on a non-ASCII identifier', () => {
+      const tokenizer = new Tokenizer('formValue.bestellgröße');
+      const tokens = tokenizer.tokenize();
+
+      expect(tokens[0].value).toBe('formValue');
+      expect(tokens[1].type).toBe(TokenType.DOT);
+      expect(tokens[2]).toEqual({ type: TokenType.IDENTIFIER, value: 'bestellgröße', position: 10 });
+      expect(tokens[3].type).toBe(TokenType.EOF);
+    });
+
+    it('should still reject characters that are not identifier parts', () => {
+      expect(() => new Tokenizer('formValue.€betrag').tokenize()).toThrow(/Unexpected character/);
+      expect(() => new Tokenizer('a # b').tokenize()).toThrow(/Unexpected character/);
+    });
   });
 
   describe('operators', () => {

--- a/packages/dynamic-forms/internal/src/lib/core/expressions/parser/tokenizer.spec.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/expressions/parser/tokenizer.spec.ts
@@ -217,6 +217,15 @@ describe('Tokenizer', () => {
       expect(tokens[3].type).toBe(TokenType.EOF);
     });
 
+    it('should tokenize an identifier containing a zero-width non-joiner', () => {
+      // Persian compounds join words with U+200C, which ECMA-262 allows inside identifiers.
+      const key = 'نام‌خانوادگی';
+      const tokens = new Tokenizer(key).tokenize();
+
+      expect(tokens[0]).toEqual({ type: TokenType.IDENTIFIER, value: key, position: 0 });
+      expect(tokens[1].type).toBe(TokenType.EOF);
+    });
+
     it('should still reject characters that are not identifier parts', () => {
       expect(() => new Tokenizer('formValue.€betrag').tokenize()).toThrow(/Unexpected character/);
       expect(() => new Tokenizer('a # b').tokenize()).toThrow(/Unexpected character/);

--- a/packages/dynamic-forms/internal/src/lib/core/expressions/parser/tokenizer.ts
+++ b/packages/dynamic-forms/internal/src/lib/core/expressions/parser/tokenizer.ts
@@ -1,5 +1,11 @@
 import { Token, TokenType, ExpressionParserError } from './types';
 
+/** Characters that may start an identifier, per ECMA-262 IdentifierStart. */
+const IDENTIFIER_START = /[\p{ID_Start}$_]/u;
+
+/** Characters that may continue an identifier, per ECMA-262 IdentifierPart. */
+const IDENTIFIER_PART = /[\p{ID_Continue}$]/u;
+
 /** Tokenizes an expression string into tokens */
 export class Tokenizer {
   private position = 0;
@@ -48,7 +54,7 @@ export class Tokenizer {
     }
 
     // Identifiers and keywords
-    if (/[a-zA-Z_$]/.test(char)) {
+    if (IDENTIFIER_START.test(this.codePointAt(this.position))) {
       return this.readIdentifierOrKeyword();
     }
 
@@ -122,14 +128,24 @@ export class Tokenizer {
     const start = this.position;
     let value = '';
 
-    while (this.position < this.expression.length && /[a-zA-Z0-9_$]/.test(this.expression[this.position])) {
-      value += this.expression[this.position];
-      this.position++;
+    while (this.position < this.expression.length) {
+      const char = this.codePointAt(this.position);
+      if (!IDENTIFIER_PART.test(char)) {
+        break;
+      }
+      value += char;
+      this.position += char.length;
     }
 
     // Check for keywords
     const type = this.getKeywordType(value);
     return { type, value, position: start };
+  }
+
+  /** Reads the whole code point at `position`, keeping surrogate pairs intact. */
+  private codePointAt(position: number): string {
+    const codePoint = this.expression.codePointAt(position);
+    return codePoint === undefined ? '' : String.fromCodePoint(codePoint);
   }
 
   private getKeywordType(value: string): TokenType {


### PR DESCRIPTION
Closes #561

## Problem

The AST tokenizer behind `javascript` conditions and expression derivations only accepted ASCII identifier characters. A field key such as `bestellgröße` parsed fine as a config key, in `formValue`, and in bracket notation, but `formValue.bestellgröße` threw:

```
ExpressionParserError: [Dynamic Forms] Unexpected character: ö at position 21
```

The error was caught and logged, so the logic it belonged to was silently skipped and the field kept its previous state.

The same assumption existed in the `formValue` path regex used for implicit dependency tracking, so even a bracket-notation workaround did not register the field as a dependency.

## Fix

- Tokenizer identifier rules now follow ECMA-262: `\p{ID_Start}` plus `$` and `_` to start, `\p{ID_Continue}` plus `$` to continue. Identifiers are read code point by code point, so surrogate pairs stay intact.
- `FORM_VALUE_PATTERN` in the cross-field detector uses the same character class, for dot and both bracket forms, so dependency extraction picks up these keys.

Characters that are not identifier parts (`€`, `#`, ...) still throw as before, and the property blocklist in the evaluator is unchanged.

## Tests

Written first and confirmed failing before the fix:

- `tokenizer.spec.ts`: identifiers with umlauts, a leading non-ASCII letter, non-Latin scripts, member access after a dot, plus a case pinning that non-identifier characters still throw.
- `expression-parser.spec.ts`: property access, optional chaining, and dot/bracket equivalence for non-ASCII keys.
- `condition-evaluator.spec.ts`: a `javascript` condition of the reported shape evaluates to `true` and logs no error.
- `cross-field-detector.spec.ts` (new file): dependency extraction for dot notation, both bracket forms, and nested paths, alongside the existing ASCII behaviour.

`nx test dynamic-forms`: 3264 passed. `nx lint dynamic-forms` and `nx build dynamic-forms` pass.