### PR TITLE
fix(dynamic-forms): include container children in page validity check

### DIFF
--- a/packages/dynamic-forms/src/lib/core/page-orchestrator/page-orchestrator.component.spec.ts
+++ b/packages/dynamic-forms/src/lib/core/page-orchestrator/page-orchestrator.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { PageOrchestratorComponent } from './page-orchestrator.component';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { firstValueFrom, race, timer } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -189,6 +191,188 @@ describe('PageOrchestratorComponent', () => {
       await waitForFormInit(fixture);
 
       expect(pageChangeCount).toBe(0);
+    });
+
+    it('blocks navigation when a required field inside a container is empty', async () => {
+      const config: FormConfig = {
+        fields: [
+          {
+            key: 'page1',
+            type: 'page',
+            fields: [
+              {
+                key: 'detailsBlock',
+                type: 'container',
+                wrappers: [],
+                fields: [{ key: 'nickname', type: 'input', label: 'Nickname', required: true }],
+              },
+            ],
+          },
+          { key: 'page2', type: 'page', fields: [{ key: 'confirm', type: 'input', label: 'Confirm' }] },
+        ],
+      } as unknown as FormConfig;
+
+      const fixture = createForm(config, {});
+      await waitForFormInit(fixture);
+      const eventBus = fixture.debugElement.injector.get(EventBus);
+
+      let pageChangeCount = 0;
+      eventBus.on<PageChangeEvent>('page-change').subscribe(() => pageChangeCount++);
+
+      eventBus.dispatch(NextPageEvent);
+      fixture.detectChanges();
+      await waitForFormInit(fixture);
+
+      expect(pageChangeCount).toBe(0);
+    });
+
+    it('blocks navigation when a required field inside a nested container is empty', async () => {
+      const config: FormConfig = {
+        fields: [
+          {
+            key: 'page1',
+            type: 'page',
+            fields: [
+              {
+                key: 'outerBlock',
+                type: 'container',
+                wrappers: [],
+                fields: [
+                  {
+                    key: 'innerRow',
+                    type: 'row',
+                    fields: [
+                      {
+                        key: 'innerBlock',
+                        type: 'container',
+                        wrappers: [],
+                        fields: [{ key: 'nickname', type: 'input', label: 'Nickname', required: true }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          { key: 'page2', type: 'page', fields: [{ key: 'confirm', type: 'input', label: 'Confirm' }] },
+        ],
+      } as unknown as FormConfig;
+
+      const fixture = createForm(config, {});
+      await waitForFormInit(fixture);
+      const eventBus = fixture.debugElement.injector.get(EventBus);
+
+      let pageChangeCount = 0;
+      eventBus.on<PageChangeEvent>('page-change').subscribe(() => pageChangeCount++);
+
+      eventBus.dispatch(NextPageEvent);
+      fixture.detectChanges();
+      await waitForFormInit(fixture);
+
+      expect(pageChangeCount).toBe(0);
+    });
+
+    it('blocks navigation when a required field inside a group nested in a container is empty', async () => {
+      const config: FormConfig = {
+        fields: [
+          {
+            key: 'page1',
+            type: 'page',
+            fields: [
+              {
+                key: 'detailsBlock',
+                type: 'container',
+                wrappers: [],
+                fields: [
+                  {
+                    key: 'profile',
+                    type: 'group',
+                    fields: [{ key: 'nickname', type: 'input', label: 'Nickname', required: true }],
+                  },
+                ],
+              },
+            ],
+          },
+          { key: 'page2', type: 'page', fields: [{ key: 'confirm', type: 'input', label: 'Confirm' }] },
+        ],
+      } as unknown as FormConfig;
+
+      const fixture = createForm(config, {});
+      await waitForFormInit(fixture);
+      const eventBus = fixture.debugElement.injector.get(EventBus);
+
+      let pageChangeCount = 0;
+      eventBus.on<PageChangeEvent>('page-change').subscribe(() => pageChangeCount++);
+
+      eventBus.dispatch(NextPageEvent);
+      fixture.detectChanges();
+      await waitForFormInit(fixture);
+
+      expect(pageChangeCount).toBe(0);
+    });
+
+    it('reports the page invalid to currentPageValid when a container child is invalid', async () => {
+      // `currentPageValid` is the signal both consumers read: the navigateToNextPage() gate
+      // and resolveNextButtonDisabled (which keeps the next button enabled when it is true).
+      const config: FormConfig = {
+        fields: [
+          {
+            key: 'page1',
+            type: 'page',
+            fields: [
+              {
+                key: 'detailsBlock',
+                type: 'container',
+                wrappers: [],
+                fields: [{ key: 'nickname', type: 'input', label: 'Nickname', required: true }],
+              },
+            ],
+          },
+          { key: 'page2', type: 'page', fields: [{ key: 'confirm', type: 'input', label: 'Confirm' }] },
+        ],
+      } as unknown as FormConfig;
+
+      const fixture = createForm(config, {});
+      await waitForFormInit(fixture);
+
+      const orchestrator = fixture.debugElement.query(By.directive(PageOrchestratorComponent))
+        .componentInstance as PageOrchestratorComponent;
+
+      expect(orchestrator.currentPageValid()).toBe(false);
+    });
+
+    it('allows navigation when every field inside a container is valid', async () => {
+      const config: FormConfig = {
+        fields: [
+          {
+            key: 'page1',
+            type: 'page',
+            fields: [
+              {
+                key: 'detailsBlock',
+                type: 'container',
+                wrappers: [],
+                fields: [{ key: 'nickname', type: 'input', label: 'Nickname', required: true, value: 'Robin' }],
+              },
+            ],
+          },
+          { key: 'page2', type: 'page', fields: [{ key: 'confirm', type: 'input', label: 'Confirm' }] },
+        ],
+      } as unknown as FormConfig;
+
+      const fixture = createForm(config, { nickname: 'Robin' });
+      await waitForFormInit(fixture);
+      const eventBus = fixture.debugElement.injector.get(EventBus);
+
+      let pageChangeEvent: PageChangeEvent | null = null;
+      eventBus.on<PageChangeEvent>('page-change').subscribe((e) => (pageChangeEvent = e));
+
+      eventBus.dispatch(NextPageEvent);
+      fixture.detectChanges();
+      await waitForFormInit(fixture);
+
+      expect(pageChangeEvent).toBeTruthy();
+      expect(pageChangeEvent!.currentPageIndex).toBe(1);
     });
 
     it('renders a large page > group > many rows shape without standalone injector errors', async () => {

--- a/packages/dynamic-forms/src/lib/core/page-orchestrator/page-orchestrator.component.ts
+++ b/packages/dynamic-forms/src/lib/core/page-orchestrator/page-orchestrator.component.ts
@@ -17,6 +17,7 @@ import { FunctionRegistryService } from '@ng-forge/dynamic-forms/internal';
 import { FieldContextRegistryService } from '@ng-forge/dynamic-forms/internal';
 import { FieldDef } from '@ng-forge/dynamic-forms/internal';
 import { isRowField } from '@ng-forge/dynamic-forms/internal';
+import { isGenericContainerField } from '@ng-forge/dynamic-forms/internal';
 import { PAGE_PRELOAD_WINDOW } from '../../providers/features/page-preload/page-preload.token';
 import { clampWindowSize } from '../../providers/features/clamp-window';
 
@@ -465,15 +466,20 @@ export class PageOrchestratorComponent {
   }
 }
 
-/** Recursively collects form-tree keys for all value-bearing nodes on a page. */
+/**
+ * Recursively collects form-tree keys for all value-bearing nodes on a page.
+ *
+ * Layout containers (`row`, `container`) are flattened by `mapFieldToForm`, so no form
+ * node exists under their own key — traverse their children instead. `group` and `array`
+ * own a node whose `valid()` already aggregates descendants, so their key is used as-is.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accepts any field shape for recursive traversal
 function collectLeafFieldKeys(fields: readonly FieldDef<any>[]): string[] {
   const keys: string[] = [];
 
   for (const field of fields) {
-    if (isRowField(field)) {
-      // Row children are at the same form-tree level as the row itself
-      keys.push(...collectLeafFieldKeys(field.fields));
+    if (isRowField(field) || isGenericContainerField(field)) {
+      keys.push(...collectLeafFieldKeys(field.fields as readonly FieldDef<unknown>[]));
     } else if (field.key) {
       keys.push(field.key);
     }


### PR DESCRIPTION
Fixes #563

## Problem

`collectLeafFieldKeys` (feeding `PageOrchestratorComponent.currentPageValid`) only recursed into `row` fields. For any other keyed field it pushed the field's own key.

A `container` is a layout-only wrapper: `mapFieldToForm` flattens its children onto the parent path, so no form node exists under the container's key. Pushing that key meant `form[containerKey]` resolved to `undefined`, the validity check skipped it, and the container's children were never visited.

Result: a required field inside a container did not disable the next button and did not block `navigateToNextPage()`. The same field placed directly on the page, or inside a `row`, was gated correctly.

Overall form validity and submit gating were unaffected.

## Fix

Recurse into `container` alongside `row`. `group` and `array` keep their existing treatment: they own a form node whose `valid()` already aggregates descendant validity.

This matches how the rest of the codebase treats layout containers. `form-mapping.ts`, `field-flattener.ts` and `page-field.ts` all pair `isRowField` with `isGenericContainerField`; the orchestrator was the only place that did not.

## Tests

Added to `page-orchestrator.component.spec.ts`, all confirmed failing before the fix:

- required field inside a container blocks next-page navigation
- required field inside a nested container (container > row > container) blocks navigation
- required field inside a group nested in a container blocks navigation
- `currentPageValid` reports `false` for an invalid container child (the signal `resolveNextButtonDisabled` reads, covering the button consumer)

Plus a positive control: a container whose fields are all valid still navigates.

`nx test dynamic-forms` 3252 passed, `nx lint dynamic-forms` and `nx build dynamic-forms` clean.