### PR TITLE
fix(openapi-generator): keep non-ASCII letters in generated names

### DIFF
--- a/packages/openapi-generator/src/generator/interface-generator.spec.ts
+++ b/packages/openapi-generator/src/generator/interface-generator.spec.ts
@@ -717,4 +717,39 @@ describe('generateInterface', () => {
       expect(result).toContain('export interface');
     });
   });
+
+  describe('non-ASCII property names', () => {
+    it('should name a nested interface after the property, diacritics included', () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        type: 'object',
+        properties: {
+          bestellgröße: { type: 'object', properties: { wert: { type: 'string' } } },
+        },
+      };
+
+      const result = generateInterface(schema, defaultOptions);
+
+      expect(result).toContain('export interface CreatePetFormValueBestellgröße {');
+      expect(result).toContain('  bestellgröße?: CreatePetFormValueBestellgröße;');
+    });
+
+    it('should not collapse sibling properties that differ only by a diacritic', () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        type: 'object',
+        properties: {
+          größe: { type: 'object', properties: { wert: { type: 'string' } } },
+          grüße: { type: 'object', properties: { text: { type: 'string' } } },
+        },
+      };
+
+      const result = generateInterface(schema, defaultOptions);
+
+      expect(result).toContain('export interface CreatePetFormValueGröße {');
+      expect(result).toContain('export interface CreatePetFormValueGrüße {');
+
+      // Two declarations of one name would not compile in the generated file.
+      const declaredNames = [...result.matchAll(/export interface (\S+) \{/gu)].map((m) => m[1]);
+      expect(new Set(declaredNames).size).toBe(declaredNames.length);
+    });
+  });
 });

--- a/packages/openapi-generator/src/utils/naming.spec.ts
+++ b/packages/openapi-generator/src/utils/naming.spec.ts
@@ -175,3 +175,70 @@ describe('toInterfaceName', () => {
     expect(toInterfaceName('POST', '/pets')).toBe('PostPetsFormValue');
   });
 });
+
+describe('non-ASCII names', () => {
+  describe('toPascalCase', () => {
+    it('should preserve letters with diacritics', () => {
+      expect(toPascalCase('größe')).toBe('Größe');
+      expect(toPascalCase('țară')).toBe('Țară');
+      expect(toPascalCase('élève')).toBe('Élève');
+      expect(toPascalCase('διεύθυνση')).toBe('Διεύθυνση');
+    });
+
+    it('should keep names that differ only by diacritic distinct', () => {
+      expect(toPascalCase('größe')).not.toBe(toPascalCase('grüße'));
+    });
+
+    it('should split camelCase boundaries at non-ASCII uppercase letters', () => {
+      expect(toPascalCase('straßeÜberweg')).toBe('StraßeÜberweg');
+      expect(toPascalCase('adresseÉlectronique')).toBe('AdresseÉlectronique');
+    });
+
+    it('should still separate words at non-letter characters', () => {
+      expect(toPascalCase('POST:/größen')).toBe('PostGrößen');
+    });
+  });
+
+  describe('toCamelCase', () => {
+    it('should preserve letters with diacritics', () => {
+      expect(toCamelCase('Bestellgröße')).toBe('bestellgröße');
+      expect(toCamelCase('Țară de ședere')).toBe('țarăDeȘedere');
+    });
+  });
+
+  describe('toKebabCase', () => {
+    it('should preserve letters with diacritics', () => {
+      expect(toKebabCase('Größe')).toBe('größe');
+      expect(toKebabCase('BestellGröße')).toBe('bestell-größe');
+    });
+
+    it('should keep names that differ only by diacritic distinct', () => {
+      expect(toKebabCase('Größe')).not.toBe(toKebabCase('Grüße'));
+    });
+  });
+
+  describe('toLabel', () => {
+    it('should capitalize words starting with a non-ASCII letter', () => {
+      expect(toLabel('nom_élève')).toBe('Nom Élève');
+      expect(toLabel('țara_de_ședere')).toBe('Țara De Ședere');
+    });
+  });
+
+  describe('toEnumLabel', () => {
+    it('should humanize SCREAMING_SNAKE_CASE containing non-ASCII letters', () => {
+      expect(toEnumLabel('ÉLÈVE_ACTIF')).toBe('Élève Actif');
+    });
+
+    it('should still uppercase known acronyms alongside accented words', () => {
+      expect(toEnumLabel('élève_sms')).toBe('Élève SMS');
+    });
+  });
+
+  describe('generated names', () => {
+    it('should build config, file and interface names from a non-ASCII operationId', () => {
+      expect(toFormConfigName('POST', '/größen', 'createGröße')).toBe('createGrößeFormConfig');
+      expect(toFormFileName('POST', '/größen', 'createGröße')).toBe('create-größe.form.ts');
+      expect(toInterfaceName('POST', '/größen', 'createGröße')).toBe('CreateGrößeFormValue');
+    });
+  });
+});

--- a/packages/openapi-generator/src/utils/naming.ts
+++ b/packages/openapi-generator/src/utils/naming.ts
@@ -4,9 +4,9 @@
  */
 export function toLabel(name: string): string {
   return name
-    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/(\p{Ll})(\p{Lu})/gu, '$1 $2')
     .replace(/[_-]/g, ' ')
-    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .replace(/(^|\s)(\p{L})/gu, (_, separator, letter: string) => separator + letter.toUpperCase())
     .trim();
 }
 
@@ -64,7 +64,7 @@ const KNOWN_ACRONYMS = new Set([
  */
 export function toEnumLabel(value: string): string {
   // Handle SCREAMING_SNAKE_CASE: lowercase before processing
-  if (/^[A-Z][A-Z0-9_-]*$/.test(value)) {
+  if (/^\p{Lu}[\p{Lu}\p{N}_-]*$/u.test(value)) {
     if (value.length <= 3 && !/[_-]/.test(value)) {
       return value;
     }
@@ -74,7 +74,7 @@ export function toEnumLabel(value: string): string {
   const label = toLabel(value);
 
   // Replace known acronyms with their uppercase form
-  return label.replace(/\b\w+\b/g, (word) => {
+  return label.replace(/[\p{L}\p{N}]+/gu, (word) => {
     if (KNOWN_ACRONYMS.has(word.toLowerCase())) {
       return word.toUpperCase();
     }
@@ -84,12 +84,14 @@ export function toEnumLabel(value: string): string {
 
 /**
  * Convert a string to PascalCase.
- * Examples: "create pet" → "CreatePet", "POST:/pets" → "PostPets"
+ * Letters outside ASCII are kept — they are valid in TypeScript identifiers, and
+ * dropping them would collapse names that differ only by a diacritic.
+ * Examples: "create pet" → "CreatePet", "POST:/pets" → "PostPets", "größe" → "Größe"
  */
 export function toPascalCase(str: string): string {
   return str
-    .replace(/([a-z0-9])([A-Z])/g, '$1 $2') // Split camelCase boundaries
-    .replace(/[^a-zA-Z0-9]/g, ' ')
+    .replace(/([\p{Ll}\p{N}])(\p{Lu})/gu, '$1 $2') // Split camelCase boundaries
+    .replace(/[^\p{L}\p{N}]/gu, ' ')
     .split(/\s+/)
     .filter(Boolean)
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
@@ -108,8 +110,8 @@ export function toCamelCase(str: string): string {
  */
 export function toKebabCase(str: string): string {
   return str
-    .replace(/([a-z])([A-Z])/g, '$1-$2')
-    .replace(/[^a-zA-Z0-9]/g, '-')
+    .replace(/(\p{Ll})(\p{Lu})/gu, '$1-$2')
+    .replace(/[^\p{L}\p{N}]/gu, '-')
     .replace(/-+/g, '-')
     .toLowerCase()
     .replace(/^-|-$/g, '');


### PR DESCRIPTION
Follow-up to #566, which fixed the same ASCII assumption in the expression tokenizer. This is the generator side of it.

## Problem

`toPascalCase`, `toCamelCase` and `toKebabCase` replaced every character outside `[a-zA-Z0-9]` with a separator. Letters with diacritics were deleted rather than kept:

```
"Größe"        -> "GrE"         | "gr-e"
"Grüße"        -> "GrE"         | "gr-e"
"Bestellgröße" -> "BestellgrE"  | "bestellgr-e"
```

Names that differ only by a diacritic collapse onto the same identifier. `toPascalCase` also names nested interfaces from property names in `interface-generator.ts`, so a schema with sibling properties `größe` and `grüße` emitted two interfaces called `CreatePetFormValueGrE` in one file, which does not compile.

`toLabel` was worse than a no-op on accented text. It capitalized with `\b\w`, and since an accented character is not a `\w`, every letter following one sat on a word boundary:

```
toLabel('nom_élève') -> 'Nom éLèVe'
```

`toEnumLabel` inherited that, and its `SCREAMING_SNAKE_CASE` detection (`^[A-Z][A-Z0-9_-]*$`) never matched accented values, so `ÉLÈVE_ACTIF` came out shouting.

## Fix

Letters are matched with `\p{L}`/`\p{N}` and camelCase boundaries with `\p{Ll}`/`\p{Lu}`. Accented letters now survive into identifiers and file names, which TypeScript and every modern filesystem accept:

```
"Größe"         -> "Größe"        | "größe"
"Grüße"         -> "Grüße"        | "grüße"
"straßeÜberweg" -> "StraßeÜberweg"
toLabel('nom_élève')       -> 'Nom Élève'
toEnumLabel('ÉLÈVE_ACTIF') -> 'Élève Actif'
```

Transliteration was the alternative. It needs per-language rules (German `ö` to `oe`, Swedish `ö` to `o`), a maintained table for letters that do not decompose, and it can still collide with a genuine ASCII name. Preserving the letters keeps the generated name traceable to the spec and removes the collision entirely.

## Tests

Written first, confirmed failing against the old implementation (13 red, including the two interface-generator cases):

- `naming.spec.ts`: diacritics preserved through all three case converters, names differing only by a diacritic stay distinct, camelCase boundaries split at non-ASCII uppercase, word separation at non-letters unchanged, label capitalization, accented `SCREAMING_SNAKE_CASE`, acronyms still uppercased next to accented words, and end-to-end config/file/interface names from a non-ASCII `operationId`.
- `interface-generator.spec.ts`: a nested interface keeps the property's diacritics, and sibling properties differing only by a diacritic produce distinct interface names with no duplicate declaration in the file.

`nx test openapi-generator`: 409 passed (396 pre-existing, unchanged). `nx lint` and `nx build` pass.
