### PR TITLE
fix(dynamic-forms): treat message placeholder names literally

### DIFF
--- a/packages/dynamic-forms/internal/src/lib/utils/interpolate-params.spec.ts
+++ b/packages/dynamic-forms/internal/src/lib/utils/interpolate-params.spec.ts
@@ -164,6 +164,48 @@ describe('interpolateParams', () => {
     expect(result).toBe('Expected valid, got invalid');
   });
 
+  describe('keys containing regex metacharacters', () => {
+    it('should not treat a dot in the key as a wildcard', () => {
+      const error = { kind: 'custom', 'user.email': 'taken' } as unknown as ValidationError;
+
+      expect(interpolateParams('Value {{userXemail}} is invalid', error)).toBe('Value {{userXemail}} is invalid');
+      expect(interpolateParams('Value {{user.email}} is invalid', error)).toBe('Value taken is invalid');
+    });
+
+    it('should not treat brackets in the key as a character class', () => {
+      const error = { kind: 'custom', 'items[0]': 'missing' } as unknown as ValidationError;
+
+      expect(interpolateParams('Problem: {{items0}}', error)).toBe('Problem: {{items0}}');
+      expect(interpolateParams('Problem: {{items[0]}}', error)).toBe('Problem: missing');
+    });
+
+    it('should not throw when the key contains an unbalanced group', () => {
+      const error = { kind: 'custom', 'amount(': 3 } as unknown as ValidationError;
+
+      expect(() => interpolateParams('Value {{amount(}}', error)).not.toThrow();
+    });
+  });
+
+  describe('values containing replacement patterns', () => {
+    it('should insert a value containing $& literally', () => {
+      const error = { kind: 'custom', field: '$&' } as unknown as ValidationError;
+
+      expect(interpolateParams('Got {{field}}', error)).toBe('Got $&');
+    });
+
+    it('should not interpolate a placeholder that appears inside another value', () => {
+      const error = { kind: 'custom', outer: '{{inner}}', inner: 'leaked' } as unknown as ValidationError;
+
+      expect(interpolateParams('Value {{outer}}', error)).toBe('Value {{inner}}');
+    });
+  });
+
+  it('should leave inherited object properties uninterpolated', () => {
+    const error = { kind: 'required' } as ValidationError;
+
+    expect(interpolateParams('Oops {{constructor}} {{toString}}', error)).toBe('Oops {{constructor}} {{toString}}');
+  });
+
   // Angular Signal Forms compatibility tests
   describe('Angular Signal Forms format', () => {
     it('should handle minLength property (Signal Forms format) with requiredLength placeholder', () => {

--- a/packages/dynamic-forms/internal/src/lib/utils/interpolate-params.ts
+++ b/packages/dynamic-forms/internal/src/lib/utils/interpolate-params.ts
@@ -1,5 +1,8 @@
 import { ValidationError } from '../models/validation-types';
 
+/** Matches a `{{ param }}` placeholder, capturing the name for trimming. */
+const PLACEHOLDER_PATTERN = /\{\{([^{}]*)\}\}/g;
+
 /**
  * Interpolates {{param}} placeholders in message with error values
  *
@@ -8,15 +11,15 @@ import { ValidationError } from '../models/validation-types';
  * @returns Message with interpolated parameters
  */
 export function interpolateParams(message: string, error: ValidationError): string {
-  let result = message;
   const params = extractErrorParams(error);
 
-  Object.entries(params).forEach(([key, value]) => {
-    const placeholder = new RegExp(`{{\\s*${key}\\s*}}`, 'g');
-    result = result.replace(placeholder, safeToString(value));
+  // Scanning the message once, rather than building a regex per key, keeps param
+  // names literal (they may contain regex metacharacters) and stops an interpolated
+  // value from being re-read as a placeholder.
+  return message.replace(PLACEHOLDER_PATTERN, (placeholder, rawKey: string) => {
+    const key = rawKey.trim();
+    return Object.hasOwn(params, key) ? safeToString(params[key]) : placeholder;
   });
-
-  return result;
 }
 
 /**


### PR DESCRIPTION
Third of the sweep that started with #566. Unrelated to the Unicode work; found while checking whether other code made assumptions about key characters.

## Problem

`interpolateParams` built one `RegExp` per parameter name and interpolated the name into the source unescaped:

```ts
const placeholder = new RegExp(`{{\\s*${key}\\s*}}`, 'g');
result = result.replace(placeholder, safeToString(value));
```

Parameter names are not a fixed set. `extractErrorParams` copies every own property off the error object, so any custom validator can contribute a name containing regex syntax. Three consequences, all reproduced as tests before the fix:

1. **Wrong placeholder matched.** An error property `items[0]` compiles to a character class, so the message `Problem: {{items0}}` was interpolated while `{{items[0]}}` was left alone. A property `user.email` matched `{{userXemail}}` for any `X`.
2. **Crash.** A property containing an unbalanced group threw out of the message pipeline: `SyntaxError: Invalid regular expression: /{{\s*amount(\s*}}/g: Unterminated group`.
3. **Replacement patterns in values.** The replacement was a string, so `$&`, `` $` `` and friends in a *value* were expanded rather than inserted. A value of `$&` rendered as `{{field}}`.

Iterating per key also meant an already-substituted value was rescanned by later keys, so a value that happened to contain `{{inner}}` was itself interpolated.

## Fix

Scan the message once and look each name up as a literal key:

```ts
const PLACEHOLDER_PATTERN = /\{\{([^{}]*)\}\}/g;

return message.replace(PLACEHOLDER_PATTERN, (placeholder, rawKey: string) => {
  const key = rawKey.trim();
  return Object.hasOwn(params, key) ? safeToString(params[key]) : placeholder;
});
```

No regex is built from user data, so names are literal by construction rather than by escaping. The replacer is a function, so `$` sequences in values are inserted verbatim. One pass means a substituted value is never re-read. `Object.hasOwn` keeps inherited names such as `{{constructor}}` uninterpolated, matching the previous `Object.entries` behavior.

Also cheaper: one scan of the message instead of one scan per parameter.

## Behavior changes

Both are edge cases that previously produced wrong output, but `interpolateParams` is exported from the public API, so calling them out:

- A value containing `{{name}}` is no longer expanded further. Previously it was, depending on key iteration order.
- A placeholder whose name matched a key only by regex coincidence is no longer substituted.

The MCP registry documents the plain `{{param}}` form only, so nothing there needed syncing.

## Tests

Six added, five confirmed red against the old implementation (the sixth pins the inherited-property behavior my rewrite had to preserve): dot-as-wildcard, brackets-as-character-class, unbalanced group not throwing, `$&` inserted literally, no re-interpolation of values, and inherited properties left alone.

`nx test dynamic-forms`: 3329 passed, with all 24 pre-existing `interpolateParams` tests unchanged. `nx lint` and `nx build` pass.
