### PR TITLE
feat(material): add prefix/suffix addon support to select, textarea, …

### DIFF
--- a/apps/docs/public/content/addons/overview.md
+++ b/apps/docs/public/content/addons/overview.md
@@ -6,7 +6,7 @@ description: "Render icons, buttons, or text inside a field's prefix and suffix 
 
 Addons decorate a field with inline content (a search icon, a clear button, a currency symbol, a password-visibility toggle) placed in the field's `prefix` or `suffix` slot. They're typed, JSON-safe, and ship as a first-class feature of every UI adapter.
 
-> **Prerequisites.** Addons attach to a field, not the form. You need a working ng-forge setup first: `provideDynamicForm(...with{Adapter}Fields())` at the application config and a `[dynamic-form]`-bearing form using a field type that supports addons (today: every adapter's `input`). See [Getting Started](/getting-started) if you're new to ng-forge.
+> **Prerequisites.** Addons attach to a field, not the form. You need a working ng-forge setup first: `provideDynamicForm(...with{Adapter}Fields())` at the application config and a `[dynamic-form]`-bearing form using a field type that supports addons (today: every adapter's `input`, plus Material's `select`, `textarea`, and `datepicker`). See [Getting Started](/getting-started) if you're new to ng-forge.
 
 ## Quickstart
 

--- a/apps/docs/public/content/addons/presets-and-actions.md
+++ b/apps/docs/public/content/addons/presets-and-actions.md
@@ -14,7 +14,7 @@ Pick the leftmost variant that covers your case. Most addon buttons map to a pre
 
 ## Built-in presets
 
-Five presets ship with the library, available in every adapter:
+Five presets ship with the library. Adapter input fields provide the built-in preset handler. Material `select`, `textarea`, and `datepicker` support addon rendering, but use `actionRef` or `action` for click behavior:
 
 | Preset                         | Behaviour                                                                                                                                                                                       |
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/etc/dynamic-forms-material.api.md
+++ b/etc/dynamic-forms-material.api.md
@@ -162,6 +162,7 @@ export type MatDatepickerField = DatepickerField<MatDatepickerProps>;
 export class MatDatepickerFieldComponent {
     // (undocumented)
     readonly appearance: _angular_core.Signal<_angular_material_form_field.MatFormFieldAppearance>;
+    readonly fieldInputs: _angular_core.InputSignal<WrapperFieldInputs | undefined>;
     // (undocumented)
     readonly floatLabel: _angular_core.Signal<_angular_material_form_field.FloatLabelType>;
     // (undocumented)
@@ -173,13 +174,15 @@ export class MatDatepickerFieldComponent {
     // (undocumented)
     protected readonly ngf: _ng_forge_dynamic_forms_integration.TypedNgForgeField<string>;
     // (undocumented)
+    protected readonly ngfa: _ng_forge_dynamic_forms_integration.TypedNgForgeAddons<_ng_forge_dynamic_forms.AnyAddon>;
+    // (undocumented)
     readonly props: _angular_core.InputSignal<MatDatepickerProps | undefined>;
     // (undocumented)
     readonly startAt: _angular_core.InputSignal<Date | null>;
     // (undocumented)
     readonly subscriptSizing: _angular_core.Signal<_angular_material_form_field.SubscriptSizing>;
     // (undocumented)
-    static ɵcmp: _angular_core.ɵɵComponentDeclaration<MatDatepickerFieldComponent, "df-mat-datepicker", never, { "minDate": { "alias": "minDate"; "required": false; "isSignal": true; }; "maxDate": { "alias": "maxDate"; "required": false; "isSignal": true; }; "startAt": { "alias": "startAt"; "required": false; "isSignal": true; }; "props": { "alias": "props"; "required": false; "isSignal": true; }; }, {}, never, never, true, [{ directive: typeof _ng_forge_dynamic_forms_integration.NgForgeFieldHost; inputs: {}; outputs: {}; }]>;
+    static ɵcmp: _angular_core.ɵɵComponentDeclaration<MatDatepickerFieldComponent, "df-mat-datepicker", never, { "minDate": { "alias": "minDate"; "required": false; "isSignal": true; }; "maxDate": { "alias": "maxDate"; "required": false; "isSignal": true; }; "startAt": { "alias": "startAt"; "required": false; "isSignal": true; }; "props": { "alias": "props"; "required": false; "isSignal": true; }; "fieldInputs": { "alias": "fieldInputs"; "required": false; "isSignal": true; }; }, {}, never, never, true, [{ directive: typeof _ng_forge_dynamic_forms_integration.NgForgeFieldHost; inputs: {}; outputs: {}; }, { directive: typeof _ng_forge_dynamic_forms_integration.NgForgeAddons; inputs: {}; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<MatDatepickerFieldComponent, never>;
 }
@@ -438,6 +441,7 @@ export class MatSelectFieldComponent {
     readonly appearance: _angular_core.Signal<_angular_material_form_field.MatFormFieldAppearance>;
     // (undocumented)
     defaultCompare: (value1: any, value2: any) => boolean;
+    readonly fieldInputs: _angular_core.InputSignal<WrapperFieldInputs | undefined>;
     // (undocumented)
     readonly floatLabel: _angular_core.Signal<_angular_material_form_field.FloatLabelType>;
     // (undocumented)
@@ -445,13 +449,15 @@ export class MatSelectFieldComponent {
     // (undocumented)
     protected readonly ngf: _ng_forge_dynamic_forms_integration.TypedNgForgeField<ValueType>;
     // (undocumented)
+    protected readonly ngfa: _ng_forge_dynamic_forms_integration.TypedNgForgeAddons<_ng_forge_dynamic_forms.AnyAddon>;
+    // (undocumented)
     readonly options: _angular_core.InputSignal<FieldOption<ValueType>[]>;
     // (undocumented)
     readonly props: _angular_core.InputSignal<MatSelectProps | undefined>;
     // (undocumented)
     readonly subscriptSizing: _angular_core.Signal<_angular_material_form_field.SubscriptSizing>;
     // (undocumented)
-    static ɵcmp: _angular_core.ɵɵComponentDeclaration<MatSelectFieldComponent, "df-mat-select", never, { "options": { "alias": "options"; "required": false; "isSignal": true; }; "props": { "alias": "props"; "required": false; "isSignal": true; }; }, {}, never, never, true, [{ directive: typeof _ng_forge_dynamic_forms_integration.NgForgeFieldHost; inputs: {}; outputs: {}; }]>;
+    static ɵcmp: _angular_core.ɵɵComponentDeclaration<MatSelectFieldComponent, "df-mat-select", never, { "options": { "alias": "options"; "required": false; "isSignal": true; }; "fieldInputs": { "alias": "fieldInputs"; "required": false; "isSignal": true; }; "props": { "alias": "props"; "required": false; "isSignal": true; }; }, {}, never, never, true, [{ directive: typeof _ng_forge_dynamic_forms_integration.NgForgeFieldHost; inputs: {}; outputs: {}; }, { directive: typeof _ng_forge_dynamic_forms_integration.NgForgeAddons; inputs: {}; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<MatSelectFieldComponent, never>;
 }
@@ -529,6 +535,7 @@ export type MatTextareaField = TextareaField<MatTextareaProps>;
 export class MatTextareaFieldComponent {
     // (undocumented)
     readonly appearance: _angular_core.Signal<_angular_material_form_field.MatFormFieldAppearance>;
+    readonly fieldInputs: _angular_core.InputSignal<WrapperFieldInputs | undefined>;
     // (undocumented)
     readonly floatLabel: _angular_core.Signal<_angular_material_form_field.FloatLabelType>;
     // (undocumented)
@@ -536,11 +543,13 @@ export class MatTextareaFieldComponent {
     // (undocumented)
     protected readonly ngf: _ng_forge_dynamic_forms_integration.TypedNgForgeField<string>;
     // (undocumented)
+    protected readonly ngfa: _ng_forge_dynamic_forms_integration.TypedNgForgeAddons<_ng_forge_dynamic_forms.AnyAddon>;
+    // (undocumented)
     readonly props: _angular_core.InputSignal<MatTextareaProps | undefined>;
     // (undocumented)
     readonly subscriptSizing: _angular_core.Signal<_angular_material_form_field.SubscriptSizing>;
     // (undocumented)
-    static ɵcmp: _angular_core.ɵɵComponentDeclaration<MatTextareaFieldComponent, "df-mat-textarea", never, { "props": { "alias": "props"; "required": false; "isSignal": true; }; }, {}, never, never, true, [{ directive: typeof _ng_forge_dynamic_forms_integration.NgForgeFieldHost; inputs: {}; outputs: {}; }]>;
+    static ɵcmp: _angular_core.ɵɵComponentDeclaration<MatTextareaFieldComponent, "df-mat-textarea", never, { "props": { "alias": "props"; "required": false; "isSignal": true; }; "fieldInputs": { "alias": "fieldInputs"; "required": false; "isSignal": true; }; }, {}, never, never, true, [{ directive: typeof _ng_forge_dynamic_forms_integration.NgForgeFieldHost; inputs: {}; outputs: {}; }, { directive: typeof _ng_forge_dynamic_forms_integration.NgForgeAddons; inputs: {}; outputs: {}; }]>;
     // (undocumented)
     static ɵfac: _angular_core.ɵɵFactoryDeclaration<MatTextareaFieldComponent, never>;
 }

--- a/packages/dynamic-form-mcp/src/registry/addons.ts
+++ b/packages/dynamic-form-mcp/src/registry/addons.ts
@@ -486,6 +486,21 @@ export const FIELD_ADDON_SUPPORT: FieldAddonSupportInfo[] = [
     slots: ['prefix', 'suffix'],
   },
   {
+    fieldType: 'select',
+    adapter: 'material',
+    slots: ['prefix', 'suffix'],
+  },
+  {
+    fieldType: 'textarea',
+    adapter: 'material',
+    slots: ['prefix', 'suffix'],
+  },
+  {
+    fieldType: 'datepicker',
+    adapter: 'material',
+    slots: ['prefix', 'suffix'],
+  },
+  {
     fieldType: 'input',
     adapter: 'bootstrap',
     slots: ['prefix', 'suffix'],

--- a/packages/dynamic-form-mcp/src/registry/addons.ts
+++ b/packages/dynamic-form-mcp/src/registry/addons.ts
@@ -268,7 +268,8 @@ export const ADDON_TYPES: AddonTypeInfo[] = [
       preset: {
         name: 'preset',
         type: "'clear' | 'reset' | 'paste' | 'copy' | 'toggle-password-visibility' | string",
-        description: 'Built-in preset action. Mutually exclusive with `actionRef` and `action`.',
+        description:
+          'Built-in preset action for Material input fields. Other Material addon-capable fields should use `actionRef` or `action`. Mutually exclusive with `actionRef` and `action`.',
         required: false,
       },
       actionRef: {

--- a/packages/dynamic-forms-material/src/lib/config/material-field-config.ts
+++ b/packages/dynamic-forms-material/src/lib/config/material-field-config.ts
@@ -54,6 +54,9 @@ export const MATERIAL_FIELD_TYPES: FieldTypeDefinition[] = [
     loadComponent: () => import('../fields/select/mat-select.component'),
     mapper: optionsFieldMapper,
     scope: 'single-select',
+    addons: {
+      slots: ['prefix', 'suffix'],
+    },
     ...VALUE_FIELD_TYPES_BASE,
   },
   {
@@ -129,6 +132,9 @@ export const MATERIAL_FIELD_TYPES: FieldTypeDefinition[] = [
     mapper: valueFieldMapper,
     propsToMeta: ['rows', 'cols'],
     scope: 'text-input',
+    addons: {
+      slots: ['prefix', 'suffix'],
+    },
     ...VALUE_FIELD_TYPES_BASE,
   },
   {
@@ -150,6 +156,9 @@ export const MATERIAL_FIELD_TYPES: FieldTypeDefinition[] = [
     loadComponent: () => import('../fields/datepicker/mat-datepicker.component'),
     mapper: datepickerFieldMapper,
     scope: 'date',
+    addons: {
+      slots: ['prefix', 'suffix'],
+    },
     ...VALUE_FIELD_TYPES_BASE,
   },
   {

--- a/packages/dynamic-forms-material/src/lib/fields/datepicker/mat-datepicker-with-addons.component.spec.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/datepicker/mat-datepicker-with-addons.component.spec.ts
@@ -1,13 +1,6 @@
-import { Injector, signal } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { type AddonTypeDefinition, DynamicFormLogger } from '@ng-forge/dynamic-forms';
-import {
-  ADDON_ACTION_REGISTRY,
-  ADDON_TYPE_COMPONENT_CACHE,
-  ADDON_TYPE_REGISTRY,
-  FIELD_SIGNAL_CONTEXT,
-  type FieldSignalContext,
-} from '@ng-forge/dynamic-forms/integration';
+import { ADDON_ACTION_REGISTRY, ADDON_TYPE_COMPONENT_CACHE, ADDON_TYPE_REGISTRY } from '@ng-forge/dynamic-forms/integration';
 import type { Type } from '@angular/core';
 import { createNgForgeFieldFixture, provideTestValidationMessages } from '@ng-forge/dynamic-forms/integration';
 import { describe, expect, it, vi } from 'vitest';
@@ -33,15 +26,6 @@ function makeTypeRegistry(): ReadonlyMap<string, AddonTypeDefinition> {
   ]);
 }
 
-function stubFieldSignalContext(): FieldSignalContext {
-  return {
-    injector: undefined as unknown as Injector,
-    value: signal<Record<string, unknown> | undefined>({}),
-    defaultValues: () => ({}),
-    form: {} as FieldSignalContext['form'],
-  };
-}
-
 function createFixture(addons: ReadonlyArray<AnyAddon>) {
   return createNgForgeFieldFixture<MatDatepickerFieldComponent, string>(MatDatepickerFieldComponent, {
     key: 'field-1',
@@ -52,7 +36,6 @@ function createFixture(addons: ReadonlyArray<AnyAddon>) {
       { provide: ADDON_TYPE_REGISTRY, useValue: makeTypeRegistry() },
       { provide: ADDON_TYPE_COMPONENT_CACHE, useFactory: () => new Map<string, Type<unknown>>() },
       { provide: ADDON_ACTION_REGISTRY, useValue: new Map() },
-      { provide: FIELD_SIGNAL_CONTEXT, useFactory: stubFieldSignalContext },
       { provide: DynamicFormLogger, useValue: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() } },
       provideTestValidationMessages({}),
     ],
@@ -77,7 +60,6 @@ describe('MatDatepickerFieldComponent — addon rendering', () => {
       slot: 'suffix',
       icon: 'close',
       ariaLabel: 'Clear',
-      preset: 'clear',
     };
     const { fixture } = createFixture([suffix]);
     fixture.detectChanges();
@@ -95,7 +77,7 @@ describe('MatDatepickerFieldComponent — addon rendering', () => {
   it('renders both prefix and suffix slots when both addons are supplied', async () => {
     const addons: AnyAddon[] = [
       { type: 'mat-icon', slot: 'prefix', icon: 'event', ariaLabel: 'Date' },
-      { type: 'mat-button', slot: 'suffix', icon: 'close', ariaLabel: 'Clear', preset: 'clear' },
+      { type: 'mat-button', slot: 'suffix', icon: 'close', ariaLabel: 'Clear' },
     ];
     const { fixture } = createFixture(addons);
     fixture.detectChanges();

--- a/packages/dynamic-forms-material/src/lib/fields/datepicker/mat-datepicker-with-addons.component.spec.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/datepicker/mat-datepicker-with-addons.component.spec.ts
@@ -1,0 +1,117 @@
+import { Injector, signal } from '@angular/core';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { type AddonTypeDefinition, DynamicFormLogger } from '@ng-forge/dynamic-forms';
+import {
+  ADDON_ACTION_REGISTRY,
+  ADDON_TYPE_COMPONENT_CACHE,
+  ADDON_TYPE_REGISTRY,
+  FIELD_SIGNAL_CONTEXT,
+  type FieldSignalContext,
+} from '@ng-forge/dynamic-forms/integration';
+import type { Type } from '@angular/core';
+import { createNgForgeFieldFixture, provideTestValidationMessages } from '@ng-forge/dynamic-forms/integration';
+import { describe, expect, it, vi } from 'vitest';
+import { MatButtonAddonComponent } from '../../addons/mat-button-addon.component';
+import { MatIconAddonComponent } from '../../addons/mat-icon-addon.component';
+import type { MatButtonAddon, MatIconAddon } from '../../types/addons';
+import type { AnyAddon } from '@ng-forge/dynamic-forms';
+import MatDatepickerFieldComponent from './mat-datepicker.component';
+
+const MAT_ICON_KIND: AddonTypeDefinition = {
+  type: 'mat-icon',
+  loadComponent: () => Promise.resolve(MatIconAddonComponent),
+};
+const MAT_BUTTON_KIND: AddonTypeDefinition = {
+  type: 'mat-button',
+  loadComponent: () => Promise.resolve(MatButtonAddonComponent),
+};
+
+function makeTypeRegistry(): ReadonlyMap<string, AddonTypeDefinition> {
+  return new Map<string, AddonTypeDefinition>([
+    ['mat-icon', MAT_ICON_KIND],
+    ['mat-button', MAT_BUTTON_KIND],
+  ]);
+}
+
+function stubFieldSignalContext(): FieldSignalContext {
+  return {
+    injector: undefined as unknown as Injector,
+    value: signal<Record<string, unknown> | undefined>({}),
+    defaultValues: () => ({}),
+    form: {} as FieldSignalContext['form'],
+  };
+}
+
+function createFixture(addons: ReadonlyArray<AnyAddon>) {
+  return createNgForgeFieldFixture<MatDatepickerFieldComponent, string>(MatDatepickerFieldComponent, {
+    key: 'field-1',
+    value: '',
+    inputs: { addons },
+    providers: [
+      provideAnimations(),
+      { provide: ADDON_TYPE_REGISTRY, useValue: makeTypeRegistry() },
+      { provide: ADDON_TYPE_COMPONENT_CACHE, useFactory: () => new Map<string, Type<unknown>>() },
+      { provide: ADDON_ACTION_REGISTRY, useValue: new Map() },
+      { provide: FIELD_SIGNAL_CONTEXT, useFactory: stubFieldSignalContext },
+      { provide: DynamicFormLogger, useValue: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() } },
+      provideTestValidationMessages({}),
+    ],
+  });
+}
+
+describe('MatDatepickerFieldComponent — addon rendering', () => {
+  it('renders <df-addon-slot matPrefix> for a prefix-slot addon', async () => {
+    const prefix: MatIconAddon = { type: 'mat-icon', slot: 'prefix', icon: 'event', ariaLabel: 'Date' };
+    const { fixture } = createFixture([prefix]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const slot = fixture.nativeElement.querySelector('df-addon-slot[matprefix]');
+    expect(slot).toBeTruthy();
+  });
+
+  it('renders <df-addon-slot matSuffix> for a suffix-slot addon alongside the calendar toggle', async () => {
+    const suffix: MatButtonAddon = {
+      type: 'mat-button',
+      slot: 'suffix',
+      icon: 'close',
+      ariaLabel: 'Clear',
+      preset: 'clear',
+    };
+    const { fixture } = createFixture([suffix]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // User suffix addon renders...
+    const slot = fixture.nativeElement.querySelector('df-addon-slot[matsuffix]');
+    expect(slot).toBeTruthy();
+    // ...and the native calendar toggle is still present.
+    const toggle = fixture.nativeElement.querySelector('mat-datepicker-toggle');
+    expect(toggle).toBeTruthy();
+  });
+
+  it('renders both prefix and suffix slots when both addons are supplied', async () => {
+    const addons: AnyAddon[] = [
+      { type: 'mat-icon', slot: 'prefix', icon: 'event', ariaLabel: 'Date' },
+      { type: 'mat-button', slot: 'suffix', icon: 'close', ariaLabel: 'Clear', preset: 'clear' },
+    ];
+    const { fixture } = createFixture(addons);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const prefixSlots = fixture.nativeElement.querySelectorAll('df-addon-slot[matprefix]');
+    const suffixSlots = fixture.nativeElement.querySelectorAll('df-addon-slot[matsuffix]');
+    expect(prefixSlots.length).toBe(1);
+    expect(suffixSlots.length).toBe(1);
+  });
+
+  it('renders no df-addon-slot when addons is empty (toggle still renders)', () => {
+    const { fixture } = createFixture([]);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('df-addon-slot')).toBeNull();
+    expect(fixture.nativeElement.querySelector('mat-datepicker-toggle')).toBeTruthy();
+  });
+});

--- a/packages/dynamic-forms-material/src/lib/fields/datepicker/mat-datepicker.component.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/datepicker/mat-datepicker.component.ts
@@ -1,10 +1,18 @@
 import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { FormField } from '@angular/forms/signals';
-import { MatError, MatFormField, MatLabel, MatSuffix } from '@angular/material/form-field';
+import { MatError, MatFormField, MatLabel, MatPrefix, MatSuffix } from '@angular/material/form-field';
 import { MatHint, MatInput } from '@angular/material/input';
 import { MatDatepicker, MatDatepickerInput, MatDatepickerToggle } from '@angular/material/datepicker';
 import { DynamicTextPipe } from '@ng-forge/dynamic-forms/integration';
-import { NgForgeControl, injectNgForgeField, NgForgeFieldHost } from '@ng-forge/dynamic-forms/integration';
+import {
+  DfAddonSlot,
+  injectNgForgeAddons,
+  injectNgForgeField,
+  NgForgeAddons,
+  NgForgeControl,
+  NgForgeFieldHost,
+  WrapperFieldInputs,
+} from '@ng-forge/dynamic-forms/integration';
 import { MatDatepickerProps } from './mat-datepicker.type';
 import { provideNativeDateAdapter } from '@angular/material/core';
 import { AsyncPipe } from '@angular/common';
@@ -21,13 +29,15 @@ import { MATERIAL_CONFIG } from '../../models/material-config.token';
     MatDatepickerInput,
     MatDatepickerToggle,
     MatSuffix,
+    MatPrefix,
     FormField,
     MatError,
     DynamicTextPipe,
     AsyncPipe,
     NgForgeControl,
+    DfAddonSlot,
   ],
-  hostDirectives: [NgForgeFieldHost],
+  hostDirectives: [NgForgeFieldHost, NgForgeAddons],
   template: `
     @let inputId = ngf.key() + '-input';
 
@@ -41,6 +51,15 @@ import { MATERIAL_CONFIG } from '../../models/material-config.token';
         <mat-label>{{ label | dynamicText | async }}</mat-label>
       }
 
+      @for (a of ngfa.prefixAddons(); track $index) {
+        <df-addon-slot
+          matPrefix
+          [class.df-mat-addon-text]="a.type === 'text'"
+          [addon]="a"
+          [fieldInputs]="fieldInputs()"
+          [hidden]="ngfa.hiddenSignalCache().get(a)"
+        />
+      }
       <input
         matInput
         ngForgeControl
@@ -52,6 +71,15 @@ import { MATERIAL_CONFIG } from '../../models/material-config.token';
         [min]="minDate()"
         [max]="maxDate()"
       />
+      @for (a of ngfa.suffixAddons(); track $index) {
+        <df-addon-slot
+          matSuffix
+          [class.df-mat-addon-text]="a.type === 'text'"
+          [addon]="a"
+          [fieldInputs]="fieldInputs()"
+          [hidden]="ngfa.hiddenSignalCache().get(a)"
+        />
+      }
 
       <mat-datepicker-toggle matIconSuffix [for]="picker" />
       <mat-datepicker #picker [startAt]="startAt()" [startView]="props()?.startView || 'month'" [touchUi]="props()?.touchUi ?? false" />
@@ -78,11 +106,18 @@ export default class MatDatepickerFieldComponent {
   private materialConfig = inject(MATERIAL_CONFIG, { optional: true });
 
   protected readonly ngf = injectNgForgeField<string>();
+  protected readonly ngfa = injectNgForgeAddons();
 
   readonly minDate = input<Date | null>(null);
   readonly maxDate = input<Date | null>(null);
   readonly startAt = input<Date | null>(null);
   readonly props = input<MatDatepickerProps>();
+  /**
+   * Wrapper-style host bag pushed by `DfFieldOutlet`. Declared at the
+   * component level so `setInputIfDeclared` (which uses
+   * `reflectComponentType`) can write it.
+   */
+  readonly fieldInputs = input<WrapperFieldInputs | undefined>();
 
   readonly appearance = computed(() => this.props()?.appearance ?? this.materialConfig?.appearance ?? 'outline');
 

--- a/packages/dynamic-forms-material/src/lib/fields/input/mat-input.component.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/input/mat-input.component.ts
@@ -93,43 +93,6 @@ import { MatInputAddon, MatInputProps } from './mat-input.type';
       :host([hidden]) {
         display: none !important;
       }
-      /* matPrefix/matSuffix elements have no default Material spacing.
-         All four sides + the text-type variants are independent CSS custom
-         properties so consumers can tune each individually:
-           prefix-outer = prefix slot's left (border-facing) padding
-           prefix-inner = prefix slot's right (text-facing) padding
-           suffix-inner = suffix slot's left (text-facing) padding
-           suffix-outer = suffix slot's right (border-facing) padding
-         Text variants override only the INNER side because <mat-icon> has
-         ~4-6px optical padding inside its glyph box (so it looks "padded"
-         even with a small CSS value) while text glyphs sit flush against
-         their bounding box and need the extra room to match. */
-      :host {
-        --df-mat-addon-prefix-outer-padding: 0.75em;
-        --df-mat-addon-prefix-inner-padding: 0.5em;
-        --df-mat-addon-suffix-inner-padding: 0.5em;
-        --df-mat-addon-suffix-outer-padding: 0.75em;
-        --df-mat-addon-prefix-text-outer-padding: 1em;
-        --df-mat-addon-prefix-text-inner-padding: 1em;
-        --df-mat-addon-suffix-text-inner-padding: 1em;
-        --df-mat-addon-suffix-text-outer-padding: 1em;
-      }
-      df-addon-slot[matprefix] {
-        padding-left: var(--df-mat-addon-prefix-outer-padding);
-        padding-right: var(--df-mat-addon-prefix-inner-padding);
-      }
-      df-addon-slot[matsuffix] {
-        padding-left: var(--df-mat-addon-suffix-inner-padding);
-        padding-right: var(--df-mat-addon-suffix-outer-padding);
-      }
-      df-addon-slot[matprefix].df-mat-addon-text {
-        padding-left: var(--df-mat-addon-prefix-text-outer-padding);
-        padding-right: var(--df-mat-addon-prefix-text-inner-padding);
-      }
-      df-addon-slot[matsuffix].df-mat-addon-text {
-        padding-left: var(--df-mat-addon-suffix-text-inner-padding);
-        padding-right: var(--df-mat-addon-suffix-text-outer-padding);
-      }
     `,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/packages/dynamic-forms-material/src/lib/fields/select/mat-select-with-addons.component.spec.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/select/mat-select-with-addons.component.spec.ts
@@ -1,13 +1,6 @@
-import { Injector, signal } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { type AddonTypeDefinition, DynamicFormLogger } from '@ng-forge/dynamic-forms';
-import {
-  ADDON_ACTION_REGISTRY,
-  ADDON_TYPE_COMPONENT_CACHE,
-  ADDON_TYPE_REGISTRY,
-  FIELD_SIGNAL_CONTEXT,
-  type FieldSignalContext,
-} from '@ng-forge/dynamic-forms/integration';
+import { ADDON_ACTION_REGISTRY, ADDON_TYPE_COMPONENT_CACHE, ADDON_TYPE_REGISTRY } from '@ng-forge/dynamic-forms/integration';
 import type { Type } from '@angular/core';
 import { createNgForgeFieldFixture, provideTestValidationMessages } from '@ng-forge/dynamic-forms/integration';
 import { describe, expect, it, vi } from 'vitest';
@@ -33,26 +26,22 @@ function makeTypeRegistry(): ReadonlyMap<string, AddonTypeDefinition> {
   ]);
 }
 
-function stubFieldSignalContext(): FieldSignalContext {
-  return {
-    injector: undefined as unknown as Injector,
-    value: signal<Record<string, unknown> | undefined>({}),
-    defaultValues: () => ({}),
-    form: {} as FieldSignalContext['form'],
-  };
-}
-
 function createFixture(addons: ReadonlyArray<AnyAddon>) {
   return createNgForgeFieldFixture<MatSelectFieldComponent, string>(MatSelectFieldComponent, {
     key: 'field-1',
     value: '',
-    inputs: { addons, options: [] },
+    inputs: {
+      addons,
+      options: [
+        { value: 'one', label: 'One' },
+        { value: 'two', label: 'Two' },
+      ],
+    },
     providers: [
       provideAnimations(),
       { provide: ADDON_TYPE_REGISTRY, useValue: makeTypeRegistry() },
       { provide: ADDON_TYPE_COMPONENT_CACHE, useFactory: () => new Map<string, Type<unknown>>() },
       { provide: ADDON_ACTION_REGISTRY, useValue: new Map() },
-      { provide: FIELD_SIGNAL_CONTEXT, useFactory: stubFieldSignalContext },
       { provide: DynamicFormLogger, useValue: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() } },
       provideTestValidationMessages({}),
     ],
@@ -77,7 +66,6 @@ describe('MatSelectFieldComponent — addon rendering', () => {
       slot: 'suffix',
       icon: 'close',
       ariaLabel: 'Clear',
-      preset: 'clear',
     };
     const { fixture } = createFixture([suffix]);
     fixture.detectChanges();
@@ -91,7 +79,7 @@ describe('MatSelectFieldComponent — addon rendering', () => {
   it('renders both prefix and suffix slots when both addons are supplied', async () => {
     const addons: AnyAddon[] = [
       { type: 'mat-icon', slot: 'prefix', icon: 'search', ariaLabel: 'Search' },
-      { type: 'mat-button', slot: 'suffix', icon: 'close', ariaLabel: 'Clear', preset: 'clear' },
+      { type: 'mat-button', slot: 'suffix', icon: 'close', ariaLabel: 'Clear' },
     ];
     const { fixture } = createFixture(addons);
     fixture.detectChanges();
@@ -102,6 +90,45 @@ describe('MatSelectFieldComponent — addon rendering', () => {
     const suffixSlots = fixture.nativeElement.querySelectorAll('df-addon-slot[matsuffix]');
     expect(prefixSlots.length).toBe(1);
     expect(suffixSlots.length).toBe(1);
+  });
+
+  it('dispatches addon actions without opening the panel, while the native trigger still opens it', async () => {
+    const prefixAction = vi.fn();
+    const suffixAction = vi.fn();
+    const { fixture } = createFixture([
+      { type: 'mat-button', slot: 'prefix', icon: 'search', ariaLabel: 'Search', action: prefixAction },
+      { type: 'mat-button', slot: 'suffix', icon: 'close', ariaLabel: 'Clear', action: suffixAction },
+    ]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const select = fixture.nativeElement.querySelector('mat-select') as HTMLElement;
+    await vi.waitFor(() => {
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelectorAll('df-addon-slot button')).toHaveLength(2);
+    });
+    const addonButtons = fixture.nativeElement.querySelectorAll('df-addon-slot button') as NodeListOf<HTMLButtonElement>;
+    const trigger = select.querySelector('.mat-mdc-select-trigger') as HTMLElement;
+
+    expect(select.getAttribute('aria-expanded')).toBe('false');
+    addonButtons[0].click();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(prefixAction).toHaveBeenCalledTimes(1);
+    expect(select.getAttribute('aria-expanded')).toBe('false');
+
+    addonButtons[1].click();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(suffixAction).toHaveBeenCalledTimes(1);
+    expect(select.getAttribute('aria-expanded')).toBe('false');
+
+    trigger.click();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(select.getAttribute('aria-expanded')).toBe('true');
+    expect(document.body.querySelector('.mat-mdc-select-panel')).toBeTruthy();
   });
 
   it('renders no df-addon-slot when addons is empty', () => {

--- a/packages/dynamic-forms-material/src/lib/fields/select/mat-select-with-addons.component.spec.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/select/mat-select-with-addons.component.spec.ts
@@ -1,0 +1,114 @@
+import { Injector, signal } from '@angular/core';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { type AddonTypeDefinition, DynamicFormLogger } from '@ng-forge/dynamic-forms';
+import {
+  ADDON_ACTION_REGISTRY,
+  ADDON_TYPE_COMPONENT_CACHE,
+  ADDON_TYPE_REGISTRY,
+  FIELD_SIGNAL_CONTEXT,
+  type FieldSignalContext,
+} from '@ng-forge/dynamic-forms/integration';
+import type { Type } from '@angular/core';
+import { createNgForgeFieldFixture, provideTestValidationMessages } from '@ng-forge/dynamic-forms/integration';
+import { describe, expect, it, vi } from 'vitest';
+import { MatButtonAddonComponent } from '../../addons/mat-button-addon.component';
+import { MatIconAddonComponent } from '../../addons/mat-icon-addon.component';
+import type { MatButtonAddon, MatIconAddon } from '../../types/addons';
+import type { AnyAddon } from '@ng-forge/dynamic-forms';
+import MatSelectFieldComponent from './mat-select.component';
+
+const MAT_ICON_KIND: AddonTypeDefinition = {
+  type: 'mat-icon',
+  loadComponent: () => Promise.resolve(MatIconAddonComponent),
+};
+const MAT_BUTTON_KIND: AddonTypeDefinition = {
+  type: 'mat-button',
+  loadComponent: () => Promise.resolve(MatButtonAddonComponent),
+};
+
+function makeTypeRegistry(): ReadonlyMap<string, AddonTypeDefinition> {
+  return new Map<string, AddonTypeDefinition>([
+    ['mat-icon', MAT_ICON_KIND],
+    ['mat-button', MAT_BUTTON_KIND],
+  ]);
+}
+
+function stubFieldSignalContext(): FieldSignalContext {
+  return {
+    injector: undefined as unknown as Injector,
+    value: signal<Record<string, unknown> | undefined>({}),
+    defaultValues: () => ({}),
+    form: {} as FieldSignalContext['form'],
+  };
+}
+
+function createFixture(addons: ReadonlyArray<AnyAddon>) {
+  return createNgForgeFieldFixture<MatSelectFieldComponent, string>(MatSelectFieldComponent, {
+    key: 'field-1',
+    value: '',
+    inputs: { addons, options: [] },
+    providers: [
+      provideAnimations(),
+      { provide: ADDON_TYPE_REGISTRY, useValue: makeTypeRegistry() },
+      { provide: ADDON_TYPE_COMPONENT_CACHE, useFactory: () => new Map<string, Type<unknown>>() },
+      { provide: ADDON_ACTION_REGISTRY, useValue: new Map() },
+      { provide: FIELD_SIGNAL_CONTEXT, useFactory: stubFieldSignalContext },
+      { provide: DynamicFormLogger, useValue: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() } },
+      provideTestValidationMessages({}),
+    ],
+  });
+}
+
+describe('MatSelectFieldComponent — addon rendering', () => {
+  it('renders <df-addon-slot matPrefix> for a prefix-slot addon', async () => {
+    const prefix: MatIconAddon = { type: 'mat-icon', slot: 'prefix', icon: 'search', ariaLabel: 'Search' };
+    const { fixture } = createFixture([prefix]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const slot = fixture.nativeElement.querySelector('df-addon-slot[matprefix]');
+    expect(slot).toBeTruthy();
+  });
+
+  it('renders <df-addon-slot matSuffix> for a suffix-slot addon', async () => {
+    const suffix: MatButtonAddon = {
+      type: 'mat-button',
+      slot: 'suffix',
+      icon: 'close',
+      ariaLabel: 'Clear',
+      preset: 'clear',
+    };
+    const { fixture } = createFixture([suffix]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const slot = fixture.nativeElement.querySelector('df-addon-slot[matsuffix]');
+    expect(slot).toBeTruthy();
+  });
+
+  it('renders both prefix and suffix slots when both addons are supplied', async () => {
+    const addons: AnyAddon[] = [
+      { type: 'mat-icon', slot: 'prefix', icon: 'search', ariaLabel: 'Search' },
+      { type: 'mat-button', slot: 'suffix', icon: 'close', ariaLabel: 'Clear', preset: 'clear' },
+    ];
+    const { fixture } = createFixture(addons);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const prefixSlots = fixture.nativeElement.querySelectorAll('df-addon-slot[matprefix]');
+    const suffixSlots = fixture.nativeElement.querySelectorAll('df-addon-slot[matsuffix]');
+    expect(prefixSlots.length).toBe(1);
+    expect(suffixSlots.length).toBe(1);
+  });
+
+  it('renders no df-addon-slot when addons is empty', () => {
+    const { fixture } = createFixture([]);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('df-addon-slot')).toBeNull();
+    // The mat-form-field with select still renders.
+    expect(fixture.nativeElement.querySelector('mat-select')).toBeTruthy();
+  });
+});

--- a/packages/dynamic-forms-material/src/lib/fields/select/mat-select.component.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/select/mat-select.component.ts
@@ -56,6 +56,7 @@ import { MATERIAL_CONFIG } from '../../models/material-config.token';
           [addon]="a"
           [fieldInputs]="fieldInputs()"
           [hidden]="ngfa.hiddenSignalCache().get(a)"
+          (click)="$event.stopPropagation()"
         />
       }
       <mat-select
@@ -79,6 +80,7 @@ import { MATERIAL_CONFIG } from '../../models/material-config.token';
           [addon]="a"
           [fieldInputs]="fieldInputs()"
           [hidden]="ngfa.hiddenSignalCache().get(a)"
+          (click)="$event.stopPropagation()"
         />
       }
 

--- a/packages/dynamic-forms-material/src/lib/fields/select/mat-select.component.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/select/mat-select.component.ts
@@ -1,19 +1,41 @@
 import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { FormField } from '@angular/forms/signals';
-import { MatError, MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatError, MatFormField, MatLabel, MatPrefix, MatSuffix } from '@angular/material/form-field';
 import { MatOption, MatSelect } from '@angular/material/select';
 import { MatHint } from '@angular/material/input';
 import { FieldOption, ValueType } from '@ng-forge/dynamic-forms';
 import { DynamicTextPipe } from '@ng-forge/dynamic-forms/integration';
-import { NgForgeControl, injectNgForgeField, NgForgeFieldHost } from '@ng-forge/dynamic-forms/integration';
+import {
+  DfAddonSlot,
+  injectNgForgeAddons,
+  injectNgForgeField,
+  NgForgeAddons,
+  NgForgeControl,
+  NgForgeFieldHost,
+  WrapperFieldInputs,
+} from '@ng-forge/dynamic-forms/integration';
 import { MatSelectProps } from './mat-select.type';
 import { AsyncPipe } from '@angular/common';
 import { MATERIAL_CONFIG } from '../../models/material-config.token';
 
 @Component({
   selector: 'df-mat-select',
-  imports: [MatFormField, MatLabel, MatSelect, MatOption, MatHint, FormField, MatError, DynamicTextPipe, AsyncPipe, NgForgeControl],
-  hostDirectives: [NgForgeFieldHost],
+  imports: [
+    MatFormField,
+    MatLabel,
+    MatSelect,
+    MatOption,
+    MatHint,
+    FormField,
+    MatError,
+    MatPrefix,
+    MatSuffix,
+    DynamicTextPipe,
+    AsyncPipe,
+    NgForgeControl,
+    DfAddonSlot,
+  ],
+  hostDirectives: [NgForgeFieldHost, NgForgeAddons],
   template: `
     @let selectId = ngf.key() + '-select';
 
@@ -27,6 +49,15 @@ import { MATERIAL_CONFIG } from '../../models/material-config.token';
         <mat-label>{{ label | dynamicText | async }}</mat-label>
       }
 
+      @for (a of ngfa.prefixAddons(); track $index) {
+        <df-addon-slot
+          matPrefix
+          [class.df-mat-addon-text]="a.type === 'text'"
+          [addon]="a"
+          [fieldInputs]="fieldInputs()"
+          [hidden]="ngfa.hiddenSignalCache().get(a)"
+        />
+      }
       <mat-select
         ngForgeControl
         [id]="selectId"
@@ -41,6 +72,15 @@ import { MATERIAL_CONFIG } from '../../models/material-config.token';
           </mat-option>
         }
       </mat-select>
+      @for (a of ngfa.suffixAddons(); track $index) {
+        <df-addon-slot
+          matSuffix
+          [class.df-mat-addon-text]="a.type === 'text'"
+          [addon]="a"
+          [fieldInputs]="fieldInputs()"
+          [hidden]="ngfa.hiddenSignalCache().get(a)"
+        />
+      }
 
       @if (ngf.errorsToDisplay()[0]; as error) {
         <mat-error [id]="ngf.errorId()">{{ error.message }}</mat-error>
@@ -63,8 +103,15 @@ export default class MatSelectFieldComponent {
   private materialConfig = inject(MATERIAL_CONFIG, { optional: true });
 
   protected readonly ngf = injectNgForgeField<ValueType>();
+  protected readonly ngfa = injectNgForgeAddons();
 
   readonly options = input<FieldOption<ValueType>[]>([]);
+  /**
+   * Wrapper-style host bag pushed by `DfFieldOutlet`. Declared at the
+   * component level so `setInputIfDeclared` (which uses
+   * `reflectComponentType`) can write it.
+   */
+  readonly fieldInputs = input<WrapperFieldInputs | undefined>();
   readonly props = input<MatSelectProps>();
 
   readonly appearance = computed(() => this.props()?.appearance ?? this.materialConfig?.appearance ?? 'outline');

--- a/packages/dynamic-forms-material/src/lib/fields/textarea/mat-textarea-with-addons.component.spec.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/textarea/mat-textarea-with-addons.component.spec.ts
@@ -1,13 +1,6 @@
-import { Injector, signal } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { type AddonTypeDefinition, DynamicFormLogger } from '@ng-forge/dynamic-forms';
-import {
-  ADDON_ACTION_REGISTRY,
-  ADDON_TYPE_COMPONENT_CACHE,
-  ADDON_TYPE_REGISTRY,
-  FIELD_SIGNAL_CONTEXT,
-  type FieldSignalContext,
-} from '@ng-forge/dynamic-forms/integration';
+import { ADDON_ACTION_REGISTRY, ADDON_TYPE_COMPONENT_CACHE, ADDON_TYPE_REGISTRY } from '@ng-forge/dynamic-forms/integration';
 import type { Type } from '@angular/core';
 import { createNgForgeFieldFixture, provideTestValidationMessages } from '@ng-forge/dynamic-forms/integration';
 import { describe, expect, it, vi } from 'vitest';
@@ -33,15 +26,6 @@ function makeTypeRegistry(): ReadonlyMap<string, AddonTypeDefinition> {
   ]);
 }
 
-function stubFieldSignalContext(): FieldSignalContext {
-  return {
-    injector: undefined as unknown as Injector,
-    value: signal<Record<string, unknown> | undefined>({}),
-    defaultValues: () => ({}),
-    form: {} as FieldSignalContext['form'],
-  };
-}
-
 function createFixture(addons: ReadonlyArray<AnyAddon>) {
   return createNgForgeFieldFixture<MatTextareaFieldComponent, string>(MatTextareaFieldComponent, {
     key: 'field-1',
@@ -52,7 +36,6 @@ function createFixture(addons: ReadonlyArray<AnyAddon>) {
       { provide: ADDON_TYPE_REGISTRY, useValue: makeTypeRegistry() },
       { provide: ADDON_TYPE_COMPONENT_CACHE, useFactory: () => new Map<string, Type<unknown>>() },
       { provide: ADDON_ACTION_REGISTRY, useValue: new Map() },
-      { provide: FIELD_SIGNAL_CONTEXT, useFactory: stubFieldSignalContext },
       { provide: DynamicFormLogger, useValue: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() } },
       provideTestValidationMessages({}),
     ],
@@ -77,7 +60,6 @@ describe('MatTextareaFieldComponent — addon rendering', () => {
       slot: 'suffix',
       icon: 'close',
       ariaLabel: 'Clear',
-      preset: 'clear',
     };
     const { fixture } = createFixture([suffix]);
     fixture.detectChanges();
@@ -91,7 +73,7 @@ describe('MatTextareaFieldComponent — addon rendering', () => {
   it('renders both prefix and suffix slots when both addons are supplied', async () => {
     const addons: AnyAddon[] = [
       { type: 'mat-icon', slot: 'prefix', icon: 'search', ariaLabel: 'Search' },
-      { type: 'mat-button', slot: 'suffix', icon: 'close', ariaLabel: 'Clear', preset: 'clear' },
+      { type: 'mat-button', slot: 'suffix', icon: 'close', ariaLabel: 'Clear' },
     ];
     const { fixture } = createFixture(addons);
     fixture.detectChanges();

--- a/packages/dynamic-forms-material/src/lib/fields/textarea/mat-textarea-with-addons.component.spec.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/textarea/mat-textarea-with-addons.component.spec.ts
@@ -1,0 +1,114 @@
+import { Injector, signal } from '@angular/core';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { type AddonTypeDefinition, DynamicFormLogger } from '@ng-forge/dynamic-forms';
+import {
+  ADDON_ACTION_REGISTRY,
+  ADDON_TYPE_COMPONENT_CACHE,
+  ADDON_TYPE_REGISTRY,
+  FIELD_SIGNAL_CONTEXT,
+  type FieldSignalContext,
+} from '@ng-forge/dynamic-forms/integration';
+import type { Type } from '@angular/core';
+import { createNgForgeFieldFixture, provideTestValidationMessages } from '@ng-forge/dynamic-forms/integration';
+import { describe, expect, it, vi } from 'vitest';
+import { MatButtonAddonComponent } from '../../addons/mat-button-addon.component';
+import { MatIconAddonComponent } from '../../addons/mat-icon-addon.component';
+import type { MatButtonAddon, MatIconAddon } from '../../types/addons';
+import type { AnyAddon } from '@ng-forge/dynamic-forms';
+import MatTextareaFieldComponent from './mat-textarea.component';
+
+const MAT_ICON_KIND: AddonTypeDefinition = {
+  type: 'mat-icon',
+  loadComponent: () => Promise.resolve(MatIconAddonComponent),
+};
+const MAT_BUTTON_KIND: AddonTypeDefinition = {
+  type: 'mat-button',
+  loadComponent: () => Promise.resolve(MatButtonAddonComponent),
+};
+
+function makeTypeRegistry(): ReadonlyMap<string, AddonTypeDefinition> {
+  return new Map<string, AddonTypeDefinition>([
+    ['mat-icon', MAT_ICON_KIND],
+    ['mat-button', MAT_BUTTON_KIND],
+  ]);
+}
+
+function stubFieldSignalContext(): FieldSignalContext {
+  return {
+    injector: undefined as unknown as Injector,
+    value: signal<Record<string, unknown> | undefined>({}),
+    defaultValues: () => ({}),
+    form: {} as FieldSignalContext['form'],
+  };
+}
+
+function createFixture(addons: ReadonlyArray<AnyAddon>) {
+  return createNgForgeFieldFixture<MatTextareaFieldComponent, string>(MatTextareaFieldComponent, {
+    key: 'field-1',
+    value: '',
+    inputs: { addons },
+    providers: [
+      provideAnimations(),
+      { provide: ADDON_TYPE_REGISTRY, useValue: makeTypeRegistry() },
+      { provide: ADDON_TYPE_COMPONENT_CACHE, useFactory: () => new Map<string, Type<unknown>>() },
+      { provide: ADDON_ACTION_REGISTRY, useValue: new Map() },
+      { provide: FIELD_SIGNAL_CONTEXT, useFactory: stubFieldSignalContext },
+      { provide: DynamicFormLogger, useValue: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() } },
+      provideTestValidationMessages({}),
+    ],
+  });
+}
+
+describe('MatTextareaFieldComponent — addon rendering', () => {
+  it('renders <df-addon-slot matPrefix> for a prefix-slot addon', async () => {
+    const prefix: MatIconAddon = { type: 'mat-icon', slot: 'prefix', icon: 'search', ariaLabel: 'Search' };
+    const { fixture } = createFixture([prefix]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const slot = fixture.nativeElement.querySelector('df-addon-slot[matprefix]');
+    expect(slot).toBeTruthy();
+  });
+
+  it('renders <df-addon-slot matSuffix> for a suffix-slot addon', async () => {
+    const suffix: MatButtonAddon = {
+      type: 'mat-button',
+      slot: 'suffix',
+      icon: 'close',
+      ariaLabel: 'Clear',
+      preset: 'clear',
+    };
+    const { fixture } = createFixture([suffix]);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const slot = fixture.nativeElement.querySelector('df-addon-slot[matsuffix]');
+    expect(slot).toBeTruthy();
+  });
+
+  it('renders both prefix and suffix slots when both addons are supplied', async () => {
+    const addons: AnyAddon[] = [
+      { type: 'mat-icon', slot: 'prefix', icon: 'search', ariaLabel: 'Search' },
+      { type: 'mat-button', slot: 'suffix', icon: 'close', ariaLabel: 'Clear', preset: 'clear' },
+    ];
+    const { fixture } = createFixture(addons);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const prefixSlots = fixture.nativeElement.querySelectorAll('df-addon-slot[matprefix]');
+    const suffixSlots = fixture.nativeElement.querySelectorAll('df-addon-slot[matsuffix]');
+    expect(prefixSlots.length).toBe(1);
+    expect(suffixSlots.length).toBe(1);
+  });
+
+  it('renders no df-addon-slot when addons is empty', () => {
+    const { fixture } = createFixture([]);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('df-addon-slot')).toBeNull();
+    // The mat-form-field with textarea still renders.
+    expect(fixture.nativeElement.querySelector('textarea[matInput]')).toBeTruthy();
+  });
+});

--- a/packages/dynamic-forms-material/src/lib/fields/textarea/mat-textarea.component.ts
+++ b/packages/dynamic-forms-material/src/lib/fields/textarea/mat-textarea.component.ts
@@ -1,17 +1,38 @@
 import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { FormField } from '@angular/forms/signals';
-import { MatError, MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatError, MatFormField, MatLabel, MatPrefix, MatSuffix } from '@angular/material/form-field';
 import { MatHint, MatInput } from '@angular/material/input';
 import { DynamicTextPipe } from '@ng-forge/dynamic-forms/integration';
-import { NgForgeControl, injectNgForgeField, NgForgeFieldHost } from '@ng-forge/dynamic-forms/integration';
+import {
+  DfAddonSlot,
+  injectNgForgeAddons,
+  injectNgForgeField,
+  NgForgeAddons,
+  NgForgeControl,
+  NgForgeFieldHost,
+  WrapperFieldInputs,
+} from '@ng-forge/dynamic-forms/integration';
 import { MatTextareaProps } from './mat-textarea.type';
 import { AsyncPipe } from '@angular/common';
 import { MATERIAL_CONFIG } from '../../models/material-config.token';
 
 @Component({
   selector: 'df-mat-textarea',
-  imports: [MatFormField, MatLabel, MatInput, MatHint, FormField, MatError, DynamicTextPipe, AsyncPipe, NgForgeControl],
-  hostDirectives: [NgForgeFieldHost],
+  imports: [
+    MatFormField,
+    MatLabel,
+    MatInput,
+    MatHint,
+    FormField,
+    MatError,
+    MatPrefix,
+    MatSuffix,
+    DynamicTextPipe,
+    AsyncPipe,
+    NgForgeControl,
+    DfAddonSlot,
+  ],
+  hostDirectives: [NgForgeFieldHost, NgForgeAddons],
   template: `
     @let textareaId = ngf.key() + '-textarea';
 
@@ -25,6 +46,15 @@ import { MATERIAL_CONFIG } from '../../models/material-config.token';
         <mat-label>{{ ngf.label() | dynamicText | async }}</mat-label>
       }
 
+      @for (a of ngfa.prefixAddons(); track $index) {
+        <df-addon-slot
+          matPrefix
+          [class.df-mat-addon-text]="a.type === 'text'"
+          [addon]="a"
+          [fieldInputs]="fieldInputs()"
+          [hidden]="ngfa.hiddenSignalCache().get(a)"
+        />
+      }
       <textarea
         ngForgeControl
         matInput
@@ -34,6 +64,15 @@ import { MATERIAL_CONFIG } from '../../models/material-config.token';
         [attr.tabindex]="ngf.tabIndex()"
         [style.resize]="props()?.resize || 'vertical'"
       ></textarea>
+      @for (a of ngfa.suffixAddons(); track $index) {
+        <df-addon-slot
+          matSuffix
+          [class.df-mat-addon-text]="a.type === 'text'"
+          [addon]="a"
+          [fieldInputs]="fieldInputs()"
+          [hidden]="ngfa.hiddenSignalCache().get(a)"
+        />
+      }
 
       @if (ngf.errorsToDisplay()[0]; as error) {
         <mat-error [id]="ngf.errorId()">{{ error.message }}</mat-error>
@@ -56,8 +95,15 @@ export default class MatTextareaFieldComponent {
   private materialConfig = inject(MATERIAL_CONFIG, { optional: true });
 
   protected readonly ngf = injectNgForgeField<string>();
+  protected readonly ngfa = injectNgForgeAddons();
 
   readonly props = input<MatTextareaProps>();
+  /**
+   * Wrapper-style host bag pushed by `DfFieldOutlet`. Declared at the
+   * component level so `setInputIfDeclared` (which uses
+   * `reflectComponentType`) can write it.
+   */
+  readonly fieldInputs = input<WrapperFieldInputs | undefined>();
 
   readonly appearance = computed(() => this.props()?.appearance ?? this.materialConfig?.appearance ?? 'outline');
   readonly subscriptSizing = computed(() => this.props()?.subscriptSizing ?? this.materialConfig?.subscriptSizing ?? 'dynamic');

--- a/packages/dynamic-forms-material/src/lib/styles/_form-field.scss
+++ b/packages/dynamic-forms-material/src/lib/styles/_form-field.scss
@@ -49,3 +49,34 @@
   color: var(--df-error-color, #f44336);
   font-size: var(--df-error-font-size, 0.875rem);
 }
+
+/* Prefix/suffix addon spacing shared by every mat-form-field-based field
+   (input, select, textarea, datepicker). Selectors only match where a
+   <df-addon-slot> is projected, so standalone controls (checkbox, toggle,
+   radio, slider) are unaffected. */
+:host {
+  --df-mat-addon-prefix-outer-padding: 0.75em;
+  --df-mat-addon-prefix-inner-padding: 0.5em;
+  --df-mat-addon-suffix-inner-padding: 0.5em;
+  --df-mat-addon-suffix-outer-padding: 0.75em;
+  --df-mat-addon-prefix-text-outer-padding: 1em;
+  --df-mat-addon-prefix-text-inner-padding: 1em;
+  --df-mat-addon-suffix-text-inner-padding: 1em;
+  --df-mat-addon-suffix-text-outer-padding: 1em;
+}
+df-addon-slot[matprefix] {
+  padding-left: var(--df-mat-addon-prefix-outer-padding);
+  padding-right: var(--df-mat-addon-prefix-inner-padding);
+}
+df-addon-slot[matsuffix] {
+  padding-left: var(--df-mat-addon-suffix-inner-padding);
+  padding-right: var(--df-mat-addon-suffix-outer-padding);
+}
+df-addon-slot[matprefix].df-mat-addon-text {
+  padding-left: var(--df-mat-addon-prefix-text-outer-padding);
+  padding-right: var(--df-mat-addon-prefix-text-inner-padding);
+}
+df-addon-slot[matsuffix].df-mat-addon-text {
+  padding-left: var(--df-mat-addon-suffix-text-inner-padding);
+  padding-right: var(--df-mat-addon-suffix-text-outer-padding);
+}


### PR DESCRIPTION
# Pull Request

## Description

Add prefix and suffix addon support to Material `select`, `textarea`, and `datepicker` fields.

## Type of Change

- [x] New feature
- [x] Test update

## Related Issues

N/A

## Changes Made

- Render prefix and suffix addons in Material `select`, `textarea`, and `datepicker` fields.
- Register addon support in the Material field configuration and MCP registry.
- Keep the datepicker toggle at the far right when suffix addons are present.
- Share addon spacing styles across all four Material form-field controls.
- Add component specs for addon rendering and datepicker toggle coexistence.

## Testing

- [x] Unit tests added/updated
- [x] Tested manually in the Material examples app
- [x] Tested datepicker suffix addon with calendar toggle
- [x] `nx run skills:check`
- [ ] All tests pass locally
- [ ] Full library build completed

## Screenshots / Videos

Visual testing was performed locally using a temporary Material examples route covering:

- `input`
- `select`
- `textarea`
- `datepicker`

## Documentation

- [ ] Documentation updated

## Checklist

- [ ] Code follows the coding standards
- [ ] No linting errors
- [ ] Build succeeds
- [x] Commit follows conventional commit format
- [x] Self-review completed
- [x] Type safety maintained

## Additional Notes

This PR intentionally covers Material controls rendered inside `<mat-form-field>`:

- `input`
- `select`
- `textarea`
- `datepicker`

Material's `matPrefix` and `matSuffix` directives use the form field's content projection API.

The remaining Material controls, including checkbox, radio, slider, toggle, multi-checkbox, and button, use different control primitives and do not provide a compatible form-field projection surface. Supporting addons for those controls needs separate field-specific rendering and interaction rules, so it is outside this PR.
