### PR TITLE
ci(deps): bump github/codeql-action to 4.37.9 and group its updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -88,3 +88,10 @@ updates:
       - 'dependencies'
       - 'ci'
       - 'automated'
+    groups:
+      # github/codeql-action/init and /analyze must stay on the same version.
+      # Separate PRs bump only one of them and always fail with
+      # "Loaded a configuration file for version 'X', but running version 'Y'".
+      codeql:
+        patterns:
+          - 'github/codeql-action*'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           languages: javascript-typescript
           config: |
@@ -38,6 +38,6 @@ jobs:
               - 'internal/**'
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           category: '/language:javascript-typescript'


### PR DESCRIPTION
# Pull Request

## Description

`github/codeql-action/init` and `github/codeql-action/analyze` must run the same version. Dependabot opened the 4.37.7 to 4.37.9 bump as two separate PRs, each moving only one half, so both failed:

- #596 bumped `analyze` only: `Loaded a configuration file for version '4.37.7', but running version '4.37.9'`
- #598 bumped `init` only: `Loaded a configuration file for version '4.37.9', but running version '4.37.7'`

Neither could pass on its own. Both jobs ended with `CodeQL job status was configuration error`.

This bumps both refs in one commit and adds a dependabot group so future `codeql-action` updates arrive as a single PR.

## Type of Change

- [x] 🔧 Build/tooling update

## Related Issues

Supersedes #596 and #598.

## Changes Made

- `.github/workflows/codeql.yml`: bump `codeql-action/init` and `codeql-action/analyze` from `ff2f1c6` to `cdf488f` (v4.37.9) together
- `.github/dependabot.yml`: add a `codeql` group to the `github-actions` ecosystem matching `github/codeql-action*`, with a comment explaining why the two must move in lockstep

## Testing

- [x] Tested manually

Both files parse as valid YAML. The target SHA is confirmed as 4.37.9 by the CI logs on the original PRs: each reported `CODEQL_ACTION_VERSION: 4.37.9` for whichever step ran `cdf488f`. The real check is the Analyze job on this PR, where both steps run the same version for the first time.

## Documentation

- [x] Documentation updated (if needed)

No user-facing docs affected.

## Checklist

- [x] Commits follow conventional commit format
- [x] Self-review completed
- [x] No commented-out code or console.log() statements

## Additional Notes

The three green dependabot PRs from this batch are already merged: #595, #599, #597.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ea7dbT263w76tQmFNa239a)_