### PR TITLE
fix(config): make the /internal import guard exempt core under any eslint base path

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,10 +28,11 @@ export default [
   {
     // Guard the unsupported `/internal` deep-import. It ships at runtime for single
     // compiled identity, but it is not part of the public API. Adapter-tier code must
-    // import from `/integration`. The `dynamic-forms` package owns `/internal`, so it
-    // is exempt.
+    // import from `/integration`. The `dynamic-forms` package owns `/internal` and turns
+    // this rule off in its own `eslint.config.mjs` -- a path-based `ignores` here would
+    // only work when eslint runs with the workspace root as its base path, so it silently
+    // stopped applying whenever eslint resolved the per-project config instead.
     files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-    ignores: ['packages/dynamic-forms/**'],
     rules: {
       'no-restricted-imports': [
         'error',

--- a/packages/dynamic-forms/eslint.config.mjs
+++ b/packages/dynamic-forms/eslint.config.mjs
@@ -37,6 +37,14 @@ export default [
     },
   },
   {
+    // This package owns `@ng-forge/dynamic-forms/internal`, so the base config's
+    // deep-import guard does not apply to its own sources.
+    files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
+    rules: {
+      'no-restricted-imports': 'off',
+    },
+  },
+  {
     files: ['**/*.html'],
     // Override or add rules here
     rules: {},


### PR DESCRIPTION
## Problem

Staging any file under `packages/dynamic-forms/src/` that imports from `@ng-forge/dynamic-forms/internal` fails the lefthook `pre-commit` `lint` step:

```
error  '@ng-forge/dynamic-forms/internal' import is restricted from being used by a pattern.
no-restricted-imports
```

218 files in the core package import from `/internal`, so this blocked commits across most of the package. It was worked around once with `LEFTHOOK_EXCLUDE=lint`.

`nx run dynamic-forms:lint` passed on the same files, and so did CI.

## Cause

The exemption already existed in the root config as `ignores: ['packages/dynamic-forms/**']`. ESLint 10 resolves the config file relative to the file being linted rather than the cwd, so the same config array gets loaded through two different base paths:

| Invocation | Config loaded | Base path | Result |
| --- | --- | --- | --- |
| `nx run dynamic-forms:lint` (passes `--config <project config>`) | project | workspace root | glob matches, rule exempt |
| `pnpm eslint packages/dynamic-forms/src/x.ts` (the hook) | project | `packages/dynamic-forms/` | glob matches nothing, rule fires |

Confirmed with `--print-config` on a core file: `@angular-eslint` rules are present in both cases, so the project config is what loads either way. The only difference is the base path the relative `ignores` glob resolves against.

This also means the hook is no longer running at root scope; it already picks up per-project configs. Routing it through nx would have hidden a config bug and made every commit lint whole projects, so the config is fixed instead and `lefthook.yml` is untouched.

## Change

Path-based scoping inside a base config that nested configs import is fragile for this reason, so the exemption moves to where it is base-path independent:

- `eslint.config.mjs`: drop the `ignores` glob, and record in the comment why the path form does not hold.
- `packages/dynamic-forms/eslint.config.mjs`: turn `no-restricted-imports` off for its own sources with `files: ['**/*.ts', ...]`, which matches under any base path.

## Verification

- Hook end to end: staged 3 core files importing `/internal` plus both configs, `lefthook run pre-commit` exits 0 (2 pre-existing warnings in `dynamic-form.component.spec.ts`).
- Core file passes under both bare `eslint` and `eslint --config`.
- Guard still bites: a temporary `packages/dynamic-forms-material/src/__guard-probe.ts` importing `/internal` errors under both invocation styles. Probe deleted afterwards.
- `nx run-many -t lint --skip-nx-cache`: 23 of 23 projects successful.
