### PR TITLE
chore(release): bump version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,42 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and uses [Conventional Commits](https://www.conventionalcommits.org/).
+
+## [1.2.0](https://github.com/ng-forge/ng-forge/compare/v1.1.0...v1.2.0) (2026-09-05)
+
+### Features
+
+- **dynamic-forms:** expose forms to browser AI agents through opt-in WebMCP integration ([#573](https://github.com/ng-forge/ng-forge/pull/573)).
+- **dynamic-forms:** support validators on group and array containers ([#577](https://github.com/ng-forge/ng-forge/pull/577)).
+- **dynamic-forms:** add programmatic page navigation, deep links, and session resume for paged forms ([#574](https://github.com/ng-forge/ng-forge/pull/574), [#578](https://github.com/ng-forge/ng-forge/pull/578)).
+- **dynamic-forms:** apply server validation errors returned by submission actions ([#571](https://github.com/ng-forge/ng-forge/pull/571)).
+- **material:** support prefix and suffix addons on select, textarea, and datepicker fields ([#592](https://github.com/ng-forge/ng-forge/pull/592)).
+
+### Performance
+
+- **dynamic-forms:** add configurable page preloading, fine-grained subscriptions, and opt-in field windowing for large forms ([#541](https://github.com/ng-forge/ng-forge/pull/541)).
+- **dynamic-forms:** lazy-load adapter fields and preserve hidden views ([#591](https://github.com/ng-forge/ng-forge/pull/591)).
+- **dynamic-forms:** suspend change detection for offscreen fields when parking is enabled, and preload field and wrapper chunks in parallel ([#593](https://github.com/ng-forge/ng-forge/pull/593)).
+- **dynamic-forms:** discriminate the recursive field union by field type to improve TypeScript performance ([#594](https://github.com/ng-forge/ng-forge/pull/594)).
+
+### Fixes
+
+- **dynamic-forms:** include nested container children when checking page validity ([#569](https://github.com/ng-forge/ng-forge/pull/569)).
+- **dynamic-forms:** align container configuration validation with the TypeScript contracts ([#584](https://github.com/ng-forge/ng-forge/pull/584)).
+- **dynamic-forms:** accept Unicode identifiers in expressions and treat validation message placeholder names literally ([#566](https://github.com/ng-forge/ng-forge/pull/566), [#572](https://github.com/ng-forge/ng-forge/pull/572)).
+- **openapi-generator:** preserve non-ASCII letters in generated names ([#570](https://github.com/ng-forge/ng-forge/pull/570)).
+- **docs:** correct package homepage and README documentation links ([#501](https://github.com/ng-forge/ng-forge/pull/501)).
+
+### Tooling and Maintenance
+
+- **cli:** add a standalone form validation CLI and generated agent skills for use without an MCP server ([#583](https://github.com/ng-forge/ng-forge/pull/583)).
+- **mcp:** derive configuration validation and adapter-specific agent references from the type system ([#585](https://github.com/ng-forge/ng-forge/pull/585)).
+- **config:** fix the core package exemption in the internal import guard across ESLint base paths ([#604](https://github.com/ng-forge/ng-forge/pull/604)).
+- **deps:** update dependencies, including Nx 23, Vite 8, and ESLint 10, and raise Undici overrides to address security advisories ([#603](https://github.com/ng-forge/ng-forge/pull/603), [#567](https://github.com/ng-forge/ng-forge/pull/567)).
+- **tests:** add performance regression gates for field windowing and page preloading ([#542](https://github.com/ng-forge/ng-forge/pull/542)).
+
 ## [1.1.0](https://github.com/ng-forge/ng-forge/compare/v1.0.0...v1.1.0) (2026-07-22)
 
 ### 🚀 Features
@@ -30,12 +69,6 @@
 ### ❤️ Thank You
 
 - Antim Prisacaru @antimprisacaru
-
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and uses [Conventional Commits](https://www.conventionalcommits.org/).
 
 ## [1.0.0](https://github.com/ng-forge/ng-forge/compare/v0.9.0...v1.0.0) (2026-06-17)
 

--- a/internal/dynamic-forms-validation/descriptor/generated/bootstrap.json
+++ b/internal/dynamic-forms-validation/descriptor/generated/bootstrap.json
@@ -2,12 +2,12 @@
   "adapter": {
     "id": "bootstrap",
     "package": "@ng-forge/dynamic-forms-bootstrap",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "formatVersion": "1.0",
   "generator": {
     "name": "@ng-forge/dynamic-forms-validation",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "props": {
     "add-array-item": {

--- a/internal/dynamic-forms-validation/descriptor/generated/core.json
+++ b/internal/dynamic-forms-validation/descriptor/generated/core.json
@@ -4048,7 +4048,7 @@
   "formatVersion": "1.0",
   "generator": {
     "name": "@ng-forge/dynamic-forms-validation",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "objects": {
     "AndCondition": {

--- a/internal/dynamic-forms-validation/descriptor/generated/ionic.json
+++ b/internal/dynamic-forms-validation/descriptor/generated/ionic.json
@@ -2,12 +2,12 @@
   "adapter": {
     "id": "ionic",
     "package": "@ng-forge/dynamic-forms-ionic",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "formatVersion": "1.0",
   "generator": {
     "name": "@ng-forge/dynamic-forms-validation",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "props": {
     "add-array-item": {

--- a/internal/dynamic-forms-validation/descriptor/generated/material.json
+++ b/internal/dynamic-forms-validation/descriptor/generated/material.json
@@ -2,12 +2,12 @@
   "adapter": {
     "id": "material",
     "package": "@ng-forge/dynamic-forms-material",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "formatVersion": "1.0",
   "generator": {
     "name": "@ng-forge/dynamic-forms-validation",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "props": {
     "add-array-item": {

--- a/internal/dynamic-forms-validation/descriptor/generated/primeng.json
+++ b/internal/dynamic-forms-validation/descriptor/generated/primeng.json
@@ -2,12 +2,12 @@
   "adapter": {
     "id": "primeng",
     "package": "@ng-forge/dynamic-forms-primeng",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "formatVersion": "1.0",
   "generator": {
     "name": "@ng-forge/dynamic-forms-validation",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "props": {
     "add-array-item": {

--- a/internal/dynamic-forms-validation/package.json
+++ b/internal/dynamic-forms-validation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ng-forge/dynamic-forms-validation",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Internal: Zod schemas, FormConfig validation, source discovery, and report formatting shared by the MCP server and the validation CLI.",
   "type": "module",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ng-forge/source",
   "type": "module",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/packages/dynamic-form-mcp/package.json
+++ b/packages/dynamic-form-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-form-mcp",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "MCP server for ng-forge dynamic forms - AI-assisted form schema generation",
   "type": "module",
   "license": "MIT",
@@ -53,11 +53,11 @@
     "zod": "^4.5.4"
   },
   "devDependencies": {
-    "@ng-forge/dynamic-forms": "^1.1.0",
-    "@ng-forge/dynamic-forms-bootstrap": "^1.1.0",
-    "@ng-forge/dynamic-forms-ionic": "^1.1.0",
-    "@ng-forge/dynamic-forms-material": "^1.1.0",
-    "@ng-forge/dynamic-forms-primeng": "^1.1.0",
+    "@ng-forge/dynamic-forms": "^1.2.0",
+    "@ng-forge/dynamic-forms-bootstrap": "^1.2.0",
+    "@ng-forge/dynamic-forms-ionic": "^1.2.0",
+    "@ng-forge/dynamic-forms-material": "^1.2.0",
+    "@ng-forge/dynamic-forms-primeng": "^1.2.0",
     "tsx": "^4.19.0"
   }
 }

--- a/packages/dynamic-forms-bootstrap/package.json
+++ b/packages/dynamic-forms-bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-bootstrap",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Bootstrap 5 integration for @ng-forge/dynamic-forms. Pre-built Bootstrap form components.",
   "type": "module",
   "license": "MIT",
@@ -37,7 +37,7 @@
     "@angular/common": "^22.0.0",
     "@angular/core": "^22.0.0",
     "@angular/forms": "^22.0.0",
-    "@ng-forge/dynamic-forms": "~1.1.0",
+    "@ng-forge/dynamic-forms": "~1.2.0",
     "rxjs": ">=7.0.0"
   },
   "dependencies": {

--- a/packages/dynamic-forms-cli/package.json
+++ b/packages/dynamic-forms-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-cli",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Command-line and runtime validator for @ng-forge/dynamic-forms FormConfig objects",
   "type": "module",
   "license": "MIT",

--- a/packages/dynamic-forms-ionic/package.json
+++ b/packages/dynamic-forms-ionic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-ionic",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Ionic integration for @ng-forge/dynamic-forms. Pre-built Ionic form components for mobile and desktop.",
   "type": "module",
   "license": "MIT",
@@ -39,7 +39,7 @@
     "@angular/core": "^22.0.0",
     "@angular/forms": "^22.0.0",
     "@ionic/angular": ">=8.0.0",
-    "@ng-forge/dynamic-forms": "~1.1.0",
+    "@ng-forge/dynamic-forms": "~1.2.0",
     "rxjs": ">=7.0.0"
   },
   "dependencies": {

--- a/packages/dynamic-forms-material/package.json
+++ b/packages/dynamic-forms-material/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-material",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Angular Material integration for @ng-forge/dynamic-forms. Pre-built Material Design form components.",
   "type": "module",
   "license": "MIT",
@@ -38,7 +38,7 @@
     "@angular/core": "^22.0.0",
     "@angular/forms": "^22.0.0",
     "@angular/material": "^22.0.0",
-    "@ng-forge/dynamic-forms": "~1.1.0",
+    "@ng-forge/dynamic-forms": "~1.2.0",
     "rxjs": ">=7.0.0"
   },
   "dependencies": {

--- a/packages/dynamic-forms-primeng/package.json
+++ b/packages/dynamic-forms-primeng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms-primeng",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "PrimeNG integration for @ng-forge/dynamic-forms. Pre-built PrimeNG form components.",
   "type": "module",
   "license": "MIT",
@@ -37,7 +37,7 @@
     "@angular/common": "^22.0.0",
     "@angular/core": "^22.0.0",
     "@angular/forms": "^22.0.0",
-    "@ng-forge/dynamic-forms": "~1.1.0",
+    "@ng-forge/dynamic-forms": "~1.2.0",
     "primeng": ">=21.0.0",
     "rxjs": ">=7.0.0"
   },

--- a/packages/dynamic-forms/package.json
+++ b/packages/dynamic-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/dynamic-forms",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Type-safe, signal-powered dynamic forms for Angular. Build complex forms from configuration with full TypeScript inference.",
   "type": "module",
   "license": "MIT",

--- a/packages/openapi-generator/package.json
+++ b/packages/openapi-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ng-forge/openapi-generator",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Generate @ng-forge/dynamic-forms configurations from OpenAPI specs",
   "type": "module",
   "license": "MIT",

--- a/skills/dynamic-forms-bootstrap/SKILL.md
+++ b/skills/dynamic-forms-bootstrap/SKILL.md
@@ -9,7 +9,7 @@ description: Bootstrap specific field properties for @ng-forge/dynamic-forms. Us
 
 Adapter specific `props` for `@ng-forge/dynamic-forms-bootstrap`.
 
-This skill documents version **1.1.0**.
+This skill documents version **1.2.0**.
 
 ## Use with the core skill
 

--- a/skills/dynamic-forms-bootstrap/references/props.md
+++ b/skills/dynamic-forms-bootstrap/references/props.md
@@ -30,7 +30,7 @@ These keys go inside `props`. Everything else about a field — its `key`,
 `type`, `label`, validation and logic — is adapter independent and documented
 in the core skill.
 
-Derived from `@ng-forge/dynamic-forms-bootstrap` 1.1.0, so this list is
+Derived from `@ng-forge/dynamic-forms-bootstrap` 1.2.0, so this list is
 what the types actually declare rather than a copy maintained beside them.
 
 ## `add-array-item`

--- a/skills/dynamic-forms-ionic/SKILL.md
+++ b/skills/dynamic-forms-ionic/SKILL.md
@@ -9,7 +9,7 @@ description: Ionic specific field properties for @ng-forge/dynamic-forms. Use al
 
 Adapter specific `props` for `@ng-forge/dynamic-forms-ionic`.
 
-This skill documents version **1.1.0**.
+This skill documents version **1.2.0**.
 
 ## Use with the core skill
 

--- a/skills/dynamic-forms-ionic/references/props.md
+++ b/skills/dynamic-forms-ionic/references/props.md
@@ -30,7 +30,7 @@ These keys go inside `props`. Everything else about a field — its `key`,
 `type`, `label`, validation and logic — is adapter independent and documented
 in the core skill.
 
-Derived from `@ng-forge/dynamic-forms-ionic` 1.1.0, so this list is
+Derived from `@ng-forge/dynamic-forms-ionic` 1.2.0, so this list is
 what the types actually declare rather than a copy maintained beside them.
 
 ## `add-array-item`

--- a/skills/dynamic-forms-material/SKILL.md
+++ b/skills/dynamic-forms-material/SKILL.md
@@ -9,7 +9,7 @@ description: Angular Material specific field properties for @ng-forge/dynamic-fo
 
 Adapter specific `props` for `@ng-forge/dynamic-forms-material`.
 
-This skill documents version **1.1.0**.
+This skill documents version **1.2.0**.
 
 ## Use with the core skill
 

--- a/skills/dynamic-forms-material/references/props.md
+++ b/skills/dynamic-forms-material/references/props.md
@@ -30,7 +30,7 @@ These keys go inside `props`. Everything else about a field — its `key`,
 `type`, `label`, validation and logic — is adapter independent and documented
 in the core skill.
 
-Derived from `@ng-forge/dynamic-forms-material` 1.1.0, so this list is
+Derived from `@ng-forge/dynamic-forms-material` 1.2.0, so this list is
 what the types actually declare rather than a copy maintained beside them.
 
 ## `add-array-item`

--- a/skills/dynamic-forms-primeng/SKILL.md
+++ b/skills/dynamic-forms-primeng/SKILL.md
@@ -9,7 +9,7 @@ description: PrimeNG specific field properties for @ng-forge/dynamic-forms. Use 
 
 Adapter specific `props` for `@ng-forge/dynamic-forms-primeng`.
 
-This skill documents version **1.1.0**.
+This skill documents version **1.2.0**.
 
 ## Use with the core skill
 

--- a/skills/dynamic-forms-primeng/references/props.md
+++ b/skills/dynamic-forms-primeng/references/props.md
@@ -30,7 +30,7 @@ These keys go inside `props`. Everything else about a field — its `key`,
 `type`, `label`, validation and logic — is adapter independent and documented
 in the core skill.
 
-Derived from `@ng-forge/dynamic-forms-primeng` 1.1.0, so this list is
+Derived from `@ng-forge/dynamic-forms-primeng` 1.2.0, so this list is
 what the types actually declare rather than a copy maintained beside them.
 
 ## `add-array-item`

--- a/skills/dynamic-forms/SKILL.md
+++ b/skills/dynamic-forms/SKILL.md
@@ -9,7 +9,7 @@ description: Write and validate @ng-forge/dynamic-forms FormConfig objects for A
 
 Authoring guidance for `@ng-forge/dynamic-forms` FormConfig objects.
 
-This skill documents version **1.1.0**.
+This skill documents version **1.2.0**.
 
 ## Before you start
 
@@ -24,8 +24,8 @@ is a dev dependency. Reading `dependencies` from the nearest package.json
 reports a range like `^1.2.0` rather than what is installed, and misses both
 cases.
 
-If it does not match 1.1.0, say so before generating a config. The rules
-below track 1.1.0 and some of them have changed between releases.
+If it does not match 1.2.0, say so before generating a config. The rules
+below track 1.2.0 and some of them have changed between releases.
 
 ## The loop
 


### PR DESCRIPTION
## Summary

Prepare the 1.2.0 release from main. Bump all eight published packages, the root manifest, and the internal validation package from 1.1.0 to 1.2.0. Update inter-package dependency ranges and regenerate descriptor and agent skill version references.

## Validation

- `pnpm build:libs`: passed for all eight packages and their dependencies.
- `pnpm version:check`: every version anchor agrees on 1.2.0.
- Descriptor and generated skill checks: passed.
- Changelog formatting and `git diff --check`: passed.
- Full unit and E2E suites were not run locally for this metadata-only change; CI is pending.

## Release notes

## [1.2.0](https://github.com/ng-forge/ng-forge/compare/v1.1.0...v1.2.0) (2026-09-05)

### Features

- **dynamic-forms:** expose forms to browser AI agents through opt-in WebMCP integration ([#573](https://github.com/ng-forge/ng-forge/pull/573)).
- **dynamic-forms:** support validators on group and array containers ([#577](https://github.com/ng-forge/ng-forge/pull/577)).
- **dynamic-forms:** add programmatic page navigation, deep links, and session resume for paged forms ([#574](https://github.com/ng-forge/ng-forge/pull/574), [#578](https://github.com/ng-forge/ng-forge/pull/578)).
- **dynamic-forms:** apply server validation errors returned by submission actions ([#571](https://github.com/ng-forge/ng-forge/pull/571)).
- **material:** support prefix and suffix addons on select, textarea, and datepicker fields ([#592](https://github.com/ng-forge/ng-forge/pull/592)).

### Performance

- **dynamic-forms:** add configurable page preloading, fine-grained subscriptions, and opt-in field windowing for large forms ([#541](https://github.com/ng-forge/ng-forge/pull/541)).
- **dynamic-forms:** lazy-load adapter fields and preserve hidden views ([#591](https://github.com/ng-forge/ng-forge/pull/591)).
- **dynamic-forms:** suspend change detection for offscreen fields when parking is enabled, and preload field and wrapper chunks in parallel ([#593](https://github.com/ng-forge/ng-forge/pull/593)).
- **dynamic-forms:** discriminate the recursive field union by field type to improve TypeScript performance ([#594](https://github.com/ng-forge/ng-forge/pull/594)).

### Fixes

- **dynamic-forms:** include nested container children when checking page validity ([#569](https://github.com/ng-forge/ng-forge/pull/569)).
- **dynamic-forms:** align container configuration validation with the TypeScript contracts ([#584](https://github.com/ng-forge/ng-forge/pull/584)).
- **dynamic-forms:** accept Unicode identifiers in expressions and treat validation message placeholder names literally ([#566](https://github.com/ng-forge/ng-forge/pull/566), [#572](https://github.com/ng-forge/ng-forge/pull/572)).
- **openapi-generator:** preserve non-ASCII letters in generated names ([#570](https://github.com/ng-forge/ng-forge/pull/570)).
- **docs:** correct package homepage and README documentation links ([#501](https://github.com/ng-forge/ng-forge/pull/501)).

### Tooling and Maintenance

- **cli:** add a standalone form validation CLI and generated agent skills for use without an MCP server ([#583](https://github.com/ng-forge/ng-forge/pull/583)).
- **mcp:** derive configuration validation and adapter-specific agent references from the type system ([#585](https://github.com/ng-forge/ng-forge/pull/585)).
- **config:** fix the core package exemption in the internal import guard across ESLint base paths ([#604](https://github.com/ng-forge/ng-forge/pull/604)).
- **deps:** update dependencies, including Nx 23, Vite 8, and ESLint 10, and raise Undici overrides to address security advisories ([#603](https://github.com/ng-forge/ng-forge/pull/603), [#567](https://github.com/ng-forge/ng-forge/pull/567)).
- **tests:** add performance regression gates for field windowing and page preloading ([#542](https://github.com/ng-forge/ng-forge/pull/542)).


## Publishing

After merging, manually run the Release workflow in publish mode. This PR does not publish packages or create a release tag.
