### PR TITLE
fix(docs): point the sitemap at the split ai-integration pages

### DIFF
--- a/apps/docs/scripts/generate-sitemap.spec.ts
+++ b/apps/docs/scripts/generate-sitemap.spec.ts
@@ -1,5 +1,6 @@
+import { existsSync } from 'node:fs';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
-import { generateSitemap, getGitLastmod } from './generate-sitemap';
+import { collectEntries, generateSitemap, getGitLastmod } from './generate-sitemap';
 
 // generateSitemap() shells out to `git log` once per content file (60+ calls),
 // so a full run is several seconds of real subprocess I/O and scales with the
@@ -31,6 +32,25 @@ describe('generateSitemap', () => {
 
   it('includes the migration guide under /material/', () => {
     expect(xml).toContain('<loc>https://ng-forge.com/dynamic-forms/material/migrating-from-ngx-formly</loc>');
+  });
+
+  // A slug whose content file has been renamed or removed still emits a <url>,
+  // but its lastmod falls back to build time — which makes the sitemap
+  // non-deterministic (and, on a shallow CI clone, differ between two calls in
+  // the same run). Catch the drift here instead of in the stability test.
+  it('points every entry at a content file that exists on disk', () => {
+    const missing = collectEntries()
+      .filter(({ filePath }) => filePath && !existsSync(filePath))
+      .map(({ slug, filePath }) => `${slug} -> ${filePath}`);
+    expect(missing).toEqual([]);
+  });
+
+  it('includes the AI integration pages', () => {
+    for (const page of ['mcp-server', 'skills', 'webmcp']) {
+      expect(xml).toContain(`<loc>https://ng-forge.com/dynamic-forms/material/ai-integration/${page}</loc>`);
+    }
+    // The section index is a nav grouping, not a rendered page — same as recipes/validation.
+    expect(xml).not.toContain('<loc>https://ng-forge.com/dynamic-forms/material/ai-integration</loc>');
   });
 
   it('includes the addons pages', () => {

--- a/apps/docs/scripts/generate-sitemap.ts
+++ b/apps/docs/scripts/generate-sitemap.ts
@@ -59,13 +59,13 @@ function contentFile(slug: string): string {
   return resolve(CONTENT_DIR, `${slug}.md`);
 }
 
-interface SitemapEntry {
+export interface SitemapEntry {
   slug: string;
   /** Absolute path used to resolve `lastmod` via git. Empty string omits lastmod. */
   filePath: string;
 }
 
-function collectEntries(): SitemapEntry[] {
+export function collectEntries(): SitemapEntry[] {
   const entries: SitemapEntry[] = [];
 
   // Landing page
@@ -136,8 +136,18 @@ function collectEntries(): SitemapEntry[] {
     entries.push({ slug: `material/recipes/${page}`, filePath: contentFile(`recipes/${page}`) });
   }
 
-  // AI integration / OpenAPI generator
-  entries.push({ slug: 'material/ai-integration', filePath: contentFile('ai-integration') });
+  // AI integration — discover from directory. These pages were split out of a
+  // single ai-integration.md and get added per feature, so a hand-kept list
+  // drifts: a stale entry points at a file git has no history for, and its
+  // lastmod silently falls back to build time (non-deterministic output).
+  for (const file of readdirSync(resolve(CONTENT_DIR, 'ai-integration'))
+    .filter((f) => f.endsWith('.md'))
+    .sort()) {
+    const name = file.replace('.md', '');
+    entries.push({ slug: `material/ai-integration/${name}`, filePath: resolve(CONTENT_DIR, 'ai-integration', file) });
+  }
+
+  // OpenAPI generator
   entries.push({ slug: 'material/openapi-generator', filePath: contentFile('openapi-generator') });
 
   // API reference — content is generated at build time from packages/* sources,


### PR DESCRIPTION
## Problem

CI on `main` is red: `docs:test` fails on `generate-sitemap.spec.ts > produces identical output across two in-process invocations`, with the two runs differing only in the `lastmod` of `/dynamic-forms/material/ai-integration`.

#573 renamed `ai-integration.md` to `ai-integration/mcp-server.md` and added `webmcp.md` (`skills.md` came in #585), but `collectEntries()` kept a single `material/ai-integration` entry pointing at the deleted file. `git log -1 -- <path>` returns nothing for that path on CI's shallow clone, so `getGitLastmod` falls back to `new Date()` and two calls in the same run produce different timestamps.

It does not reproduce locally because a full clone still has the deletion commit in history, which makes the fallback path unreachable.

## Fix

- Discover the AI integration pages from the content directory, the same way the examples section already does. The three pages now appear in the sitemap under `material/ai-integration/{mcp-server,skills,webmcp}`; the section index is a nav grouping rather than a rendered page, so it is not a URL (same as recipes and validation).
- Add a test asserting every entry resolves to a file that exists on disk. This turns the next rename into a named failure with the offending slug instead of a timestamp diff that only shows up on shallow clones.

## Verification

`nx test docs` on Node 24: 15 files, 235 tests passed (was 233 with 1 failing). `nx lint docs` and `prettier --check` clean on both changed files.